### PR TITLE
ci: bound hermetic backend scope checkout (rebase of #10945)

### DIFF
--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -47,6 +47,8 @@ jobs:
           PR_BASE_REF: origin/${{ github.base_ref }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
+          set -euo pipefail
+
           case "$EVENT_NAME" in
             pull_request) base_sha="$PR_BASE_REF" ;;
             merge_group) base_sha="$MERGE_GROUP_BASE_SHA" ;;
@@ -60,11 +62,17 @@ jobs:
               ;;
           esac
 
+          # Fail closed: if the scope base cannot be resolved (missing event sha,
+          # shallow/failed no-blob history fetch, or on-demand missing object),
+          # fail the job rather than silently treating the repo as out of scope.
+          # A silent `applies=false` would skip the hermetic backend gate.
           if [[ -z "$base_sha" ]] || ! git cat-file -e "${base_sha}^{commit}"; then
             echo "Cannot resolve hermetic backend scope base: ${base_sha:-<empty>}" >&2
             exit 1
           fi
 
+          # set -euo pipefail aborts here if the (partial-clone) history fetch
+          # fails mid-diff; a failed diff must never yield empty -> applies=false.
           changed_files="$(git diff --name-only "$base_sha"...HEAD)"
           printf '%s\n' "$changed_files"
           if grep -Eq '^(backend/|package\.json$|package-lock\.json$|\.github/workflows/backend-hermetic-e2e\.yml$)' <<<"$changed_files"; then

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -24,6 +24,8 @@ jobs:
     # and the merge gate correctly failed closed on "scope cancelled" with no
     # code failure. Bound generously like the apt steps below: the cap is a
     # hang backstop, not a budget the legitimate path must fit under.
+    # filter: blob:none keeps the history cheap while still enabling name-only
+    # diffs against the live base SHA.
     timeout-minutes: 10
     outputs:
       applies: ${{ steps.scope.outputs.applies }}
@@ -32,6 +34,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
 
       - name: Decide whether hermetic backend coverage applies
         id: scope

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -115,7 +115,7 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     assert 'github.event.pull_request.base.sha' not in scope
     assert 'PR_BASE_REF: origin/${{ github.base_ref }}' in scope
     assert 'github.event.merge_group.base_sha' in scope
-    assert 'timeout-minutes: 5' in scope
+    assert 'timeout-minutes: 10' in scope
     assert 'fetch-depth: 0' in scope
     assert 'filter: blob:none' in scope
     assert 'git diff --name-only "$base_sha"...HEAD' in scope

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -115,6 +115,9 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     assert 'github.event.pull_request.base.sha' not in scope
     assert 'PR_BASE_REF: origin/${{ github.base_ref }}' in scope
     assert 'github.event.merge_group.base_sha' in scope
+    assert 'timeout-minutes: 5' in scope
+    assert 'fetch-depth: 0' in scope
+    assert 'filter: blob:none' in scope
     assert 'git diff --name-only "$base_sha"...HEAD' in scope
     assert "^(backend/|package\\.json$|package-lock\\.json$|\\.github/workflows/backend-hermetic-e2e\\.yml$)" in scope
 

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -121,6 +121,21 @@ def test_backend_hermetic_gate_is_always_reported_and_fails_closed() -> None:
     assert 'git diff --name-only "$base_sha"...HEAD' in scope
     assert "^(backend/|package\\.json$|package-lock\\.json$|\\.github/workflows/backend-hermetic-e2e\\.yml$)" in scope
 
+    # #10945: fail closed on unresolvable scope base or a failed (partial-clone)
+    # history fetch. The scope job must FAIL rather than silently emit
+    # applies=false, which would skip the hermetic backend gate entirely.
+    run_block = scope.split('run: |', 1)[1]
+    assert 'set -euo pipefail' in run_block
+    assert 'if [[ -z "$base_sha" ]] || ! git cat-file -e "${base_sha}^{commit}"; then' in run_block
+    assert 'Cannot resolve hermetic backend scope base' in run_block
+    assert 'exit 1' in run_block
+    assert 'a failed diff must never yield empty -> applies=false' in run_block
+    # applies=false must be reachable only AFTER a successful diff, never as a fallback.
+    diff_index = run_block.index('changed_files="$(git diff')
+    applies_false_index = run_block.index('echo "applies=false" >> "$GITHUB_OUTPUT"')
+    assert diff_index < applies_false_index
+    # The two exit-1 guards precede the diff; a failed scope never reaches applies=false.
+
     for job_name in ('hermetic-e2e', 'listen-pusher-stack-gauntlet', 'sync-cloud-tasks-stack-gauntlet'):
         job = workflow.split(f'  {job_name}:\n', 1)[1]
         assert 'needs: scope' in job


### PR DESCRIPTION
## Summary
- Rebase of #10945 onto current main.
- Keep main's `timeout-minutes: 10` hang backstop for the scope job.
- Add `filter: blob:none` to the full-history scope checkout.
- Fail closed with `set -euo pipefail` + explicit base SHA resolution (never silent `applies=false`).
- Pin the contract in `test_listen_pusher_stack_ci_wiring.py`.

Supersedes #10945 whose GitHub head stayed stuck on `c70fdd` after force-push.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI merge-gate scope logic; incorrect fail-closed or partial-clone behavior could block PRs or, if broken the other way, skip hermetic checks.
> 
> **Overview**
> Tightens the **Detect Hermetic Backend Scope** job in `backend-hermetic-e2e.yml` so scope detection is cheaper and cannot quietly skip the hermetic merge gate.
> 
> The scope checkout keeps **full history** (`fetch-depth: 0`) but adds **`filter: blob:none`** so the fetch stays lighter while `git diff --name-only` against the live base still works. The scope shell script now runs under **`set -euo pipefail`**, verifies the base ref with **`git cat-file`** before diffing, and **exits with failure** when the base is missing or the diff cannot run—instead of treating errors as “out of scope” (`applies=false`).
> 
> Unit tests in `test_listen_pusher_stack_ci_wiring.py` pin the checkout options and assert that **`applies=false` only appears after a successful diff**, matching issue **#10945**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa9af446883424b98f1fc3ec9c3e1bd944f11dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->