### PR TITLE
fix(backend): drop marketplace records with no id before the shared catalog reads them

### DIFF
--- a/backend/tests/unit/test_apps_catalog_missing_id_guard.py
+++ b/backend/tests/unit/test_apps_catalog_missing_id_guard.py
@@ -1,0 +1,67 @@
+"""The shared marketplace catalog must drop a record with no id, not 500 every listing.
+
+`get_approved_available_apps` reads `app['id']` unguarded — once to build the ids for the installs
+and reviews lookups, and again per app inside the loop. One legacy document without that field
+therefore raises KeyError out of the shared builder, which is worse than the same record reaching
+`search_apps`: this list is Redis- and process-cached and serves the marketplace to every user, so
+a single bad document takes out browse for everyone rather than one person's search page.
+
+`search_apps` was already hardened against exactly this (test_apps_search_poison_guard.py), and
+`_safe_build_app` skips a record the App model rejects. Neither helps here: the KeyError is raised
+before any model is built, on the reduced dicts the cache hands back.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from utils import apps as apps_utils  # noqa: E402
+
+
+class _PassThroughCache:
+    """Memory cache stand-in that always runs the fetcher, so the builder itself is exercised."""
+
+    def get_or_fetch(self, _key, fetcher, ttl=None):
+        return fetcher()
+
+    def delete(self, _key):
+        return None
+
+
+def _valid_app(app_id='a1'):
+    return {
+        'id': app_id,
+        'name': 'Good App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+        'approved': True,
+        'private': False,
+    }
+
+
+def _catalog(monkeypatch, records):
+    monkeypatch.setattr(apps_utils, 'get_memory_cache', _PassThroughCache)
+    monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: None)
+    monkeypatch.setattr(apps_utils, 'set_generic_cache', lambda *a, **kw: None)
+    monkeypatch.setattr(apps_utils, 'get_public_approved_apps_db', lambda: [dict(r) for r in records])
+    monkeypatch.setattr(apps_utils, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_utils, 'get_apps_reviews', lambda ids: {})
+    return apps_utils.get_approved_available_apps()
+
+
+def test_catalog_drops_a_record_without_an_id(monkeypatch):
+    no_id = {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone'}
+
+    apps = _catalog(monkeypatch, [no_id, _valid_app('a1')])
+
+    assert [app.id for app in apps] == ['a1']
+
+
+def test_catalog_still_returns_every_well_formed_record(monkeypatch):
+    apps = _catalog(monkeypatch, [_valid_app('a1'), _valid_app('a2')])
+
+    assert sorted(app.id for app in apps) == ['a1', 'a2']

--- a/backend/tests/unit/test_apps_catalog_missing_id_guard.py
+++ b/backend/tests/unit/test_apps_catalog_missing_id_guard.py
@@ -1,20 +1,24 @@
-"""The shared marketplace catalog must drop a record with no id, not 500 every listing.
+"""The shared marketplace catalogs must drop a record with no id, not 500 every listing.
 
-`get_approved_available_apps` reads `app['id']` unguarded — once to build the ids for the installs
-and reviews lookups, and again per app inside the loop. One legacy document without that field
-therefore raises KeyError out of the shared builder, which is worse than the same record reaching
-`search_apps`: this list is Redis- and process-cached and serves the marketplace to every user, so
-a single bad document takes out browse for everyone rather than one person's search page.
+`get_approved_available_apps` and `get_available_apps` both read `app['id']` unguarded — once to
+batch the installs and reviews lookups, and again per app inside the loop. One legacy document
+without that field therefore raises KeyError out of a shared builder. Both builders are Redis- and
+process-cached off the same key and serve `/v1/apps` and the browse endpoints, so a single bad
+document takes out the app list for everyone rather than one person's search page.
 
 `search_apps` was already hardened against exactly this (test_apps_search_poison_guard.py), and
 `_safe_build_app` skips a record the App model rejects. Neither helps here: the KeyError is raised
-before any model is built, on the reduced dicts the cache hands back.
+before any model is built, on the reduced dicts the cache hands back. These tests therefore drive
+both the DB branch and the Redis-cached branch, since the reported failure is a poisoned cache
+entry and a guard applied to only one branch would leave it live.
 """
 
 import os
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
 
 from utils import apps as apps_utils  # noqa: E402
 
@@ -43,25 +47,68 @@ def _valid_app(app_id='a1'):
     }
 
 
-def _catalog(monkeypatch, records):
+def _no_id_app():
+    return {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone'}
+
+
+def _unreachable_db():
+    raise AssertionError('the DB branch must not run when the Redis cache is populated')
+
+
+def _patch_public_set(monkeypatch, records, *, from_cache):
+    """Serve `records` from Redis or from Firestore, never both, so each branch is proven alone."""
     monkeypatch.setattr(apps_utils, 'get_memory_cache', _PassThroughCache)
-    monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: None)
     monkeypatch.setattr(apps_utils, 'set_generic_cache', lambda *a, **kw: None)
-    monkeypatch.setattr(apps_utils, 'get_public_approved_apps_db', lambda: [dict(r) for r in records])
+    if from_cache:
+        monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: [dict(r) for r in records])
+        monkeypatch.setattr(apps_utils, 'get_public_approved_apps_db', _unreachable_db)
+    else:
+        monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: None)
+        monkeypatch.setattr(apps_utils, 'get_public_approved_apps_db', lambda: [dict(r) for r in records])
     monkeypatch.setattr(apps_utils, 'get_apps_installs_count', lambda ids: {})
     monkeypatch.setattr(apps_utils, 'get_apps_reviews', lambda ids: {})
+
+
+def _catalog(monkeypatch, records, *, from_cache=False):
+    """The browse listing: `get_approved_available_apps`."""
+    _patch_public_set(monkeypatch, records, from_cache=from_cache)
     return apps_utils.get_approved_available_apps()
 
 
-def test_catalog_drops_a_record_without_an_id(monkeypatch):
-    no_id = {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone'}
+def _available(monkeypatch, records, *, from_cache=False):
+    """The `/v1/apps` listing: `get_available_apps`, which reads the same cache key."""
+    _patch_public_set(monkeypatch, records, from_cache=from_cache)
+    monkeypatch.setattr(apps_utils, 'is_tester', lambda uid: False)
+    monkeypatch.setattr(apps_utils, 'get_private_apps', lambda uid: [])
+    monkeypatch.setattr(apps_utils, 'get_public_unapproved_apps', lambda uid: [])
+    monkeypatch.setattr(apps_utils, 'get_apps_for_tester_db', lambda uid: [])
+    monkeypatch.setattr(apps_utils, 'get_enabled_apps', lambda uid: [])
+    return apps_utils.get_available_apps('uid-1')
 
-    apps = _catalog(monkeypatch, [no_id, _valid_app('a1')])
+
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_catalog_drops_a_record_without_an_id(monkeypatch, from_cache):
+    apps = _catalog(monkeypatch, [_no_id_app(), _valid_app('a1')], from_cache=from_cache)
 
     assert [app.id for app in apps] == ['a1']
 
 
-def test_catalog_still_returns_every_well_formed_record(monkeypatch):
-    apps = _catalog(monkeypatch, [_valid_app('a1'), _valid_app('a2')])
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_available_apps_drops_a_record_without_an_id(monkeypatch, from_cache):
+    apps = _available(monkeypatch, [_no_id_app(), _valid_app('a1')], from_cache=from_cache)
+
+    assert [app.id for app in apps] == ['a1']
+
+
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_catalog_still_returns_every_well_formed_record(monkeypatch, from_cache):
+    apps = _catalog(monkeypatch, [_valid_app('a1'), _valid_app('a2')], from_cache=from_cache)
+
+    assert sorted(app.id for app in apps) == ['a1', 'a2']
+
+
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_available_apps_still_returns_every_well_formed_record(monkeypatch, from_cache):
+    apps = _available(monkeypatch, [_valid_app('a1'), _valid_app('a2')], from_cache=from_cache)
 
     assert sorted(app.id for app in apps) == ['a1', 'a2']

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -88,6 +88,21 @@ _reviewers_env: Optional[str] = os.getenv('MARKETPLACE_APP_REVIEWERS')
 MarketplaceAppReviewUIDs: List[str] = _reviewers_env.split(',') if _reviewers_env else []
 
 
+def _records_with_ids(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop marketplace records with no id, logging how many were skipped.
+
+    `_safe_build_app` already skips a record the `App` model rejects, but every list builder reads
+    `app['id']` first — to batch the installs and reviews lookups, and again per app — on the raw
+    dicts the Redis cache hands back. That is upstream of any model construction, so one legacy
+    document without an id raises KeyError out of a builder that is cached and shared across users.
+    """
+    usable = [record for record in records if record.get('id')]
+    skipped = len(records) - len(usable)
+    if skipped:
+        logger.warning("Skipping %d marketplace app record(s) without an id", skipped)
+    return usable
+
+
 def _safe_build_app(app_dict: dict[str, Any]) -> Optional[App]:
     """Build an App from a raw marketplace record, skipping (not raising on) a malformed one.
 
@@ -370,7 +385,9 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
     tester_apps: List[Dict[str, Any]] = cast(List[Dict[str, Any]], user_slice.get('tester_apps', []))
 
     user_enabled: Set[str] = set(get_enabled_apps(uid))
-    all_apps: List[Dict[str, Any]] = private_data + public_approved_data + public_unapproved_data + tester_apps
+    all_apps: List[Dict[str, Any]] = _records_with_ids(
+        private_data + public_approved_data + public_unapproved_data + tester_apps
+    )
     apps: List[App] = []
 
     app_ids = [app['id'] for app in all_apps]
@@ -383,7 +400,7 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
         # Copy dict to avoid mutating cached objects
         app_dict = dict(app)
         app_dict['enabled'] = app['id'] in user_enabled
-        app_dict['rejected'] = app['approved'] is False
+        app_dict['rejected'] = app.get('approved') is False
         app_dict['installs'] = apps_install.get(app['id'], 0)
         if include_reviews:
             reviews = apps_review.get(app['id'], {})
@@ -519,14 +536,7 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
             set_generic_cache(redis_cache_key, reduced_apps, 60 * 10)  # 10 minutes cached
             all_apps = reduced_apps
 
-        # Drop any record missing an id before the lookups below. `_safe_build_app` already skips a
-        # record the App model rejects, but `id` is read unguarded to build app_ids and again per
-        # app — upstream of any model construction — so one legacy document without it raises
-        # KeyError and 500s the whole marketplace listing for every user.
-        usable_apps = [app for app in all_apps if app.get('id')]
-        skipped_no_id = len(all_apps) - len(usable_apps)
-        if skipped_no_id:
-            logger.warning("Skipping %d marketplace app record(s) without an id", skipped_no_id)
+        usable_apps = _records_with_ids(all_apps)
 
         # Process apps (add installs, reviews, etc.)
         app_ids = [app['id'] for app in usable_apps]

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -519,13 +519,22 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
             set_generic_cache(redis_cache_key, reduced_apps, 60 * 10)  # 10 minutes cached
             all_apps = reduced_apps
 
+        # Drop any record missing an id before the lookups below. `_safe_build_app` already skips a
+        # record the App model rejects, but `id` is read unguarded to build app_ids and again per
+        # app — upstream of any model construction — so one legacy document without it raises
+        # KeyError and 500s the whole marketplace listing for every user.
+        usable_apps = [app for app in all_apps if app.get('id')]
+        skipped_no_id = len(all_apps) - len(usable_apps)
+        if skipped_no_id:
+            logger.warning("Skipping %d marketplace app record(s) without an id", skipped_no_id)
+
         # Process apps (add installs, reviews, etc.)
-        app_ids = [app['id'] for app in all_apps]
+        app_ids = [app['id'] for app in usable_apps]
         apps_installs = get_apps_installs_count(app_ids)
         apps_reviews = get_apps_reviews(app_ids) if include_reviews else {}
 
         apps: List[App] = []
-        for app in all_apps:
+        for app in usable_apps:
             if app.get('disabled'):
                 continue
             app_dict = app


### PR DESCRIPTION
## What

Both shared marketplace list builders now drop a record with no `id` before using it, through one helper (`_records_with_ids`), and log how many they dropped. Two files: the guard and its regression test.

## Why one record matters

`app['id']` is dereferenced on the raw dicts the cache hands back — once to batch the installs and reviews lookups, once per app in the loop. A single legacy document without that field raises `KeyError` out of the builder.

Both builders are Redis- and process-cached off the same key, `PUBLIC_APPROVED_APPS_CACHE_KEY`:

| Builder | Serves | Unguarded read |
|---|---|---|
| `get_available_apps` | `GET /v1/apps` (`routers/apps.py:492`) and app_integrations | `utils/apps.py:376` |
| `get_approved_available_apps` | the three browse endpoints (`routers/apps.py` 535, 616, 796) | `utils/apps.py:523` |

It is not one user's page that breaks; it is the app list for everyone, for the life of the cache entry.

## Why the existing guards don't cover it

| Guard | Where it sits | Why it misses this |
|---|---|---|
| `_safe_build_app` (#8924) | `App(**app_dict)` construction | The `KeyError` is raised before any model is built |
| `search_apps` poison guard | the search path | Narrower path; neither shared builder was covered |
| `database/read_boundary.py` | Firestore snapshot → model | These builders read reduced dicts out of Redis, upstream of the boundary |

#8924 is titled "Skip a malformed app record instead of 500ing the whole marketplace listing." That is the same contract. It fixed the half of each function below the model boundary; this is the half above it.

## Why not a primitive

`read_boundary.py` is the right primitive for this class — for snapshot-to-model reads. This deref happens on a reduced-dict cache payload, two layers above where a model exists, so there is nothing for the boundary to parse. Routing the marketplace cache through it would mean re-modelling the cached shape: a design change, not a bug fix.

Within this file the guard *is* shared: one helper, both builders, so the two paths cannot drift apart.

## Also fixed

`app['approved']` was dereferenced one line below the id reads, on the same records. A document missing that field raises the same `KeyError` before `_safe_build_app` can skip it. Now `.get()`.

## Verification

Base: `upstream/main` @ `f31b004408`.

Every failure case fails on unpatched code and passes here. Each is parameterised over both branches, because the reported failure is a poisoned *cache* entry and a guard applied only to the Firestore branch would leave it live:

| Case | Unpatched | This branch |
|---|---|---|
| browse listing, record from Firestore | `KeyError: 'id'` @ `apps.py:523` | passes |
| browse listing, record from Redis | `KeyError: 'id'` @ `apps.py:523` | passes |
| `/v1/apps`, record from Firestore | `KeyError: 'id'` @ `apps.py:376` | passes |
| `/v1/apps`, record from Redis | `KeyError: 'id'` @ `apps.py:376` | passes |

The four well-formed-record controls pass on both sides, so the suite pins the guard and not the return shape. The cached cases assert the Firestore branch never runs.

| Check | Result |
|---|---|
| `./test.sh`, 6 affected files, each isolated | **70 passed, 0 failed** |
| `black --line-length 120 --skip-string-normalization --check` | 2 files unchanged |
| `scripts/pr-preflight --base upstream/main` | **26 checks passed** |

Files in the 70-test run: `test_apps_catalog_missing_id_guard` (8), `test_apps_marketplace_poison_guard` (2), `test_app_visibility_cache_invalidation` (4), `test_firestore_read_ops_cache` (47), `test_apps_search_reads_cached_public_set` (6), `test_apps_search_poison_guard` (3).

The tests drive the real builders through their cache seam — behavioral, not a source-string tripwire.

**I have not exercised the real user-facing path.** Reproducing it needs a Firestore app document with no `id`, which I cannot create against production data. The evidence above is the isolated-suite proof only.

## Product invariants

`scripts/pr-preflight --suggest` reports none affected by this diff.

## Failure class

Failure-Class: FC-malformed-doc-read

Its `violated_contract` — "A malformed persisted document must not turn a read path into a 500 response" — describes this exactly.

Line-Count-Exception: backend/utils/apps.py | 1664 -> 1683 | The guard is a shared helper used by both list builders in this file, which is what FC-malformed-doc-read's canonical prevention prescribes and what review asked for; splitting a 1664-line module is not something a bug fix should carry.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pEhHaD3Mjxwn1hYUTHbQM
