### PR TITLE
feat(desktop): Hide control on the notch hover surface, synced with the Settings switch

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -184,3 +184,10 @@ extension FloatingControlBarManager {
     }
   }
 }
+
+extension Notification.Name {
+  /// Posted on the main thread when `FloatingControlBarManager.isEnabled` actually changes value,
+  /// from whichever surface changed it. Mirrors of the preference (the Settings switch) re-read
+  /// `isEnabled` on receipt instead of trusting their own last write.
+  static let floatingBarEnabledDidChange = Notification.Name("floatingBarEnabledDidChange")
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -295,7 +295,7 @@ struct FloatingControlBarView: View {
           // Shortcut legend + capture controls, hugging the trailing edge of the
           // expanded surface — the notch's right side, revealed on hover.
           VStack {
-            NotchSystemControlsView(progress: notchSwitcherProgress)
+            NotchSystemControlsView(progress: notchSwitcherProgress, onHide: hideNotchFromControls)
               .padding(
                 .top,
                 notchChromeHeight
@@ -1099,6 +1099,18 @@ struct FloatingControlBarView: View {
         .scaledFont(size: OmiType.caption)
         .foregroundColor(.secondary)
     }
+  }
+
+  /// The hover surface's Hide control. Closes the hover rows first so the island retracts as
+  /// the collapsed header rather than the expanded panel, then runs the bar's own hide path —
+  /// retract, order out, persist `isEnabled = false` — the same end state as switching
+  /// "Show floating bar" off in Settings.
+  private func hideNotchFromControls() {
+    agentSwitcherCollapseWorkItem?.cancel()
+    agentSwitcherCollapseWorkItem = nil
+    state.setNotchHoverMenuOpen(false)
+    notchLogoHovering = false
+    onHide()
   }
 
   private func setAgentSwitcherHovering(_ hovering: Bool) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3008,6 +3008,11 @@ class FloatingControlBarManager {
 
   /// Whether the user has enabled the Ask Omi bar (persisted across launches).
   /// Defaults to true for new users.
+  ///
+  /// Several surfaces write this — the Settings switch, the notch's Hide control, the bar's own
+  /// hide path, a Push-to-Talk reveal — so a change is announced through
+  /// `.floatingBarEnabledDidChange` and any switch that mirrors it re-reads rather than
+  /// remembering its last write.
   var isEnabled: Bool {
     get {
       // Default to true if never set
@@ -3017,7 +3022,12 @@ class FloatingControlBarManager {
       return UserDefaults.standard.bool(forKey: Self.kAskOmiEnabled)
     }
     set {
+      let changed = newValue != isEnabled
       UserDefaults.standard.set(newValue, forKey: Self.kAskOmiEnabled)
+      if changed {
+        log("FloatingControlBarManager: isEnabled -> \(newValue)")
+        NotificationCenter.default.post(name: .floatingBarEnabledDidChange, object: nil)
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/NotchSystemControlsView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/NotchSystemControlsView.swift
@@ -8,8 +8,15 @@ import SwiftUI
 /// and audio — without going to the menu bar. Those are the same two toggles the status
 /// item owns; both surfaces route through `SystemCaptureControls` so the paywall and
 /// permission gates cannot drift between them.
+///
+/// The third control hides the notch itself. It is the same durable preference as the
+/// "Show floating bar" switch in Settings — the notch stays hidden across launches until
+/// the next Push-to-Talk press or the switch brings it back — so it must go through the
+/// caller's hide path rather than merely ordering the window out.
 struct NotchSystemControlsView: View {
   let progress: CGFloat
+  /// Hides the notch and persists that preference; wired by the bar to its own hide path.
+  let onHide: () -> Void
 
   @ObservedObject private var shortcuts = ShortcutSettings.shared
   /// Toggle state lives in UserDefaults and plugin state rather than in an observable, so
@@ -30,6 +37,9 @@ struct NotchSystemControlsView: View {
       shortcutLegend
 
       HStack(spacing: OmiSpacing.xs) {
+        // Hide leads: it acts on the notch itself, so it sits apart from the two capture
+        // toggles rather than reading as a third input the user could switch on.
+        hideButton
         controlButton(
           icon: "rectangle.dashed.badge.record",
           label: "Screen",
@@ -146,6 +156,30 @@ struct NotchSystemControlsView: View {
     .accessibilityValue(isOn ? "On" : "Off")
     .accessibilityHint("Toggles whether Omi captures \(label.lowercased())")
     .help("\(label) capture is \(isOn ? "on" : "off")")
+  }
+
+  /// Hides the notch. Styled as the capture toggles' quiet sibling rather than as an "on"
+  /// pill: it is an action, not a state, so it never reads as lit.
+  private var hideButton: some View {
+    Button(action: onHide) {
+      HStack(spacing: OmiSpacing.xxs) {
+        Image(systemName: "eye.slash")
+          .font(.system(size: 9, weight: .semibold))
+        Text("Hide")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+      }
+      .foregroundColor(NotchGlass.controlLabel(isActive: false))
+      .padding(.horizontal, OmiSpacing.sm)
+      .padding(.vertical, OmiSpacing.xxs)
+      .background(
+        Capsule().fill(NotchGlass.controlFill(isActive: false, isHovering: false))
+      )
+      .contentShape(Capsule())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Hide notch")
+    .accessibilityHint("Hides Omi until you press Push-to-Talk or turn the floating bar back on in Settings")
+    .help("Hide the notch. Push-to-Talk or the Settings switch brings it back.")
   }
 
   // MARK: - Actions

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+FloatingBarAndChat.swift
@@ -19,6 +19,9 @@ extension SettingsContentView {
             .toggleStyle(OmiToggleStyle())
             .labelsHidden()
             .onChange(of: showAskOmiBar) { _, newValue in
+              // A change that merely mirrors the preference (arriving via
+              // `.floatingBarEnabledDidChange`) is already applied; only a user flip acts.
+              guard newValue != FloatingControlBarManager.shared.isEnabled else { return }
               if newValue {
                 FloatingControlBarManager.shared.show()
               } else {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -684,6 +684,11 @@ struct SettingsContentView: View {
       appState.checkNotificationPermission()
       screenCaptureHealth = ProactiveAssistantsPlugin.shared.screenCaptureHealth
     }
+    .onReceive(NotificationCenter.default.publisher(for: .floatingBarEnabledDidChange)) { _ in
+      // The notch's Hide control, the bar's own hide path, and a Push-to-Talk reveal all move
+      // this preference without going through the switch; keep the switch honest.
+      showAskOmiBar = FloatingControlBarManager.shared.isEnabled
+    }
     .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) {
       notification in
       if let userInfo = notification.userInfo, let state = userInfo["isMonitoring"] as? Bool {

--- a/desktop/macos/Desktop/Tests/FloatingBarEnabledSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarEnabledSyncTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The notch's Hide control and the Settings "Show floating bar" switch write one preference. The
+/// switch cannot poll it, so the preference announces its own changes and the switch re-reads.
+final class FloatingBarEnabledSyncTests: XCTestCase {
+  /// Posts arrive synchronously on the posting thread; the box exists only so the observer closure
+  /// has no captured `var`.
+  private final class AnnouncementCounter: @unchecked Sendable {
+    private(set) var count = 0
+    func increment() { count += 1 }
+  }
+
+  @MainActor
+  func testChangingTheEnabledPreferenceAnnouncesItselfOncePerRealChange() {
+    let manager = FloatingControlBarManager.shared
+    let previous = manager.isEnabled
+    defer { manager.isEnabled = previous }
+
+    let announcements = AnnouncementCounter()
+    let observer = NotificationCenter.default.addObserver(
+      forName: .floatingBarEnabledDidChange, object: nil, queue: nil
+    ) { _ in announcements.increment() }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    manager.isEnabled = true
+    let afterArming = announcements.count
+
+    manager.isEnabled = false
+    XCTAssertEqual(announcements.count, afterArming + 1, "hiding is a change the Settings switch must hear")
+    XCTAssertFalse(manager.isEnabled)
+
+    manager.isEnabled = false
+    XCTAssertEqual(announcements.count, afterArming + 1, "re-writing the same value is not a change")
+
+    manager.isEnabled = true
+    XCTAssertEqual(announcements.count, afterArming + 2, "a Push-to-Talk reveal flips it back and must be heard too")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260905-notch-hide-button.json
+++ b/desktop/macos/changelog/unreleased/20260905-notch-hide-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Hide button to the notch hover panel. It hides the notch like the Show floating bar switch in Settings, which now stays in sync, and Push-to-Talk brings it back."
+}


### PR DESCRIPTION

<img width="332" height="103" alt="Screenshot 2026-09-05 at 12 28 29 PM" src="https://github.com/user-attachments/assets/0d63a846-87c8-4a04-b2d7-ea562435d93d" />



## Summary
Adds a **Hide** control to the notch hover panel, leading the row ahead of Screen and Audio. It runs the bar's existing hide path (retract, order out, persist `isEnabled = false`), landing in the same state as turning off "Show floating bar" in Settings; Push-to-Talk brings the notch back. `FloatingControlBarManager.isEnabled` now posts `.floatingBarEnabledDidChange` on a real change so the Settings switch stays in sync from any surface.

## Verification
- `xcrun swift test --filter 'FloatingBarEnabledSyncTests|FloatingGlassChromeTests|FloatingBarNotchPersistTests'` → 29 tests, 0 failures
- swift-format lint and `scripts/check_desktop_test_quality.py` clean
- Live battery on the `omi-hide-notch-button` bundle (signed in, notch island): Hide → hidden + preference off; pointer over the notch and bridge hover while hidden → stays hidden; PTT → visible + preference on; repeated Hide/PTT cycles; rapid double-click Hide → hidden, no crash; relaunch while hidden → stays hidden and PTT restores; Settings switch mirrors both directions with the page open; the new preference-change log line showed one transition per action and no spurious flips
- Known, pre-existing: the hover surface is suppressed for ~4 s after a PTT reveal (voice-hint presentation), so Hide is briefly unreachable then

## Product invariants affected
- INV-CHAT-1

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3158 -> 3170 | one private hide handler for the new hover-panel control; the view owns the hover-menu state it must close first
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5896 -> 5906 | isEnabled setter announces and logs real changes so the Settings switch mirrors the preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fydURVkJ4CMomvtt7aW53



