### PR TITLE
Recaps: say why generation declined, and schedule desktop-only owners

### DIFF
--- a/backend/database/notifications.py
+++ b/backend/database/notifications.py
@@ -94,6 +94,20 @@ def get_user_time_zone(uid: str) -> Optional[str]:
     return None
 
 
+def set_user_time_zone_if_missing(uid: str, time_zone: str) -> bool:
+    """Write ``time_zone`` on the user document only when it has none. Returns True when it wrote.
+
+    ``save_token`` above is otherwise the only writer, and it runs from the mobile app's FCM
+    registration. A desktop-only owner never registers a token, so their document never carried
+    the field — and ``get_users_for_daily_summary`` selects users *by* it, so the daily-summary
+    cron never saw them. Mobile stays authoritative: a zone already present is never replaced here.
+    """
+    if get_user_time_zone(uid):
+        return False
+    db.collection('users').document(uid).set({'time_zone': time_zone}, merge=True)
+    return True
+
+
 # **************************************
 # *** Daily Summary Time Preferences ***
 # **************************************

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1777,6 +1777,10 @@ def test_daily_summary(
 DesktopUsageSeconds = Annotated[int, Field(strict=True, ge=0, le=86400)]
 DesktopUsageCount = Annotated[int, Field(strict=True, ge=0, le=10000)]
 
+# How long the desktop-usage heartbeat may assume the user document's ``time_zone`` state is
+# unchanged before it checks again.
+_DESKTOP_TIME_ZONE_RECHECK_SECONDS = 6 * 60 * 60
+
 
 class DesktopDailyUsageRequest(BaseModel):
     date: str
@@ -1846,6 +1850,15 @@ def record_desktop_daily_usage(
             'ptt_turns': data.ptt_turns,
         },
     )
+    # The daily-summary cron selects owners by the user document's ``time_zone``, and the only
+    # other writer of that field is the mobile FCM registration — so a desktop-only owner was
+    # never scheduled, and their on-demand recap was bounded to the UTC day. This heartbeat already
+    # carries a validated IANA zone; fill the gap once. The Redis flag keeps a five-minute heartbeat
+    # from re-reading the user document all day; a zone mobile already wrote is left alone.
+    time_zone_known_key = f'desktop_usage_time_zone_known:{uid}'
+    if not get_generic_cache(time_zone_known_key):
+        notification_db.set_user_time_zone_if_missing(uid, data.timezone)
+        set_generic_cache(time_zone_known_key, {'time_zone': data.timezone}, ttl=_DESKTOP_TIME_ZONE_RECHECK_SECONDS)
     return {'ok': True}
 
 

--- a/backend/tests/unit/test_desktop_daily_usage.py
+++ b/backend/tests/unit/test_desktop_daily_usage.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 
 import database.daily_summaries as daily_summaries_db
 import database.memories as memories_db
+import database.notifications as notifications_db
+import routers.users as users_router
 
 
 def _usage_db(existing=None):
@@ -117,3 +119,66 @@ def test_memories_created_counts_canonical_and_legacy_shapes_without_duplicates(
         result = memories_db.count_memories_created('uid1', start, end, firestore_client=fake_db)
 
     assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# The heartbeat is the desktop's only route to the user document's time_zone
+# ---------------------------------------------------------------------------
+
+
+def _user_doc_db(existing_user: dict | None):
+    fake_db = MagicMock()
+    user_ref = fake_db.collection.return_value.document.return_value
+    snapshot = MagicMock()
+    snapshot.exists = existing_user is not None
+    snapshot.to_dict.return_value = existing_user
+    user_ref.get.return_value = snapshot
+    return fake_db, user_ref
+
+
+def test_set_user_time_zone_if_missing_writes_for_a_document_without_one():
+    fake_db, user_ref = _user_doc_db({'email': 'desktop-only@example.com'})
+    with patch.object(notifications_db, 'db', fake_db):
+        assert notifications_db.set_user_time_zone_if_missing('uid1', 'America/New_York') is True
+    user_ref.set.assert_called_once_with({'time_zone': 'America/New_York'}, merge=True)
+
+
+def test_set_user_time_zone_if_missing_leaves_a_mobile_written_zone_alone():
+    fake_db, user_ref = _user_doc_db({'time_zone': 'Asia/Tokyo'})
+    with patch.object(notifications_db, 'db', fake_db):
+        assert notifications_db.set_user_time_zone_if_missing('uid1', 'America/New_York') is False
+    user_ref.set.assert_not_called()
+
+
+def _heartbeat_request(users_router):
+    return users_router.DesktopDailyUsageRequest(
+        date=datetime.now(timezone.utc).strftime('%Y-%m-%d'),
+        timezone='UTC',
+        client_device_id='macos_abc123',
+        watching_seconds=10,
+        listening_seconds=0,
+        proactive_cards_shown=0,
+        proactive_cards_acted=0,
+        ptt_turns=0,
+    )
+
+
+def test_heartbeat_fills_a_missing_time_zone_once_and_then_trusts_the_flag():
+    patches = {
+        'daily_summaries_db': MagicMock(),
+        'notification_db': MagicMock(),
+        'get_generic_cache': MagicMock(side_effect=[None, {'time_zone': 'UTC'}]),
+        'set_generic_cache': MagicMock(),
+    }
+    with patch.multiple(users_router, **patches):
+        users_router.record_desktop_daily_usage(_heartbeat_request(users_router), uid='u1')
+        users_router.record_desktop_daily_usage(_heartbeat_request(users_router), uid='u1')
+
+    patches['daily_summaries_db'].upsert_desktop_daily_usage.assert_called()
+    assert patches['daily_summaries_db'].upsert_desktop_daily_usage.call_count == 2
+    # One document read across two heartbeats: the flag carries the answer for the second.
+    patches['notification_db'].set_user_time_zone_if_missing.assert_called_once_with('u1', 'UTC')
+    patches['set_generic_cache'].assert_called_once()
+    key, value = patches['set_generic_cache'].call_args.args[:2]
+    assert key == 'desktop_usage_time_zone_known:u1'
+    assert value == {'time_zone': 'UTC'}

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryPresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryPresentation.swift
@@ -194,4 +194,28 @@ enum ChatDailySummaryPresentation {
     MainChatNavigationRequestStore.shared.request(draft: question)
     AnalyticsManager.shared.trackDailySummary(.followUpTapped)
   }
+
+  // MARK: - Generation failures
+
+  /// The one line a recap writer shows when the server did not produce a record.
+  ///
+  /// The backend's status codes are the contract, and three of them are answers rather than
+  /// failures: 400 is a decline — the day carries no conversation the recap can be written from;
+  /// 409 is another writer (almost always the nightly run) mid-generation; 429 is the spend
+  /// cooldown. Folding those into "Couldn't generate" read as a broken button on exactly the
+  /// days where the button had worked and the honest answer was "nothing recorded yet".
+  /// Anything else — a 5xx, a dropped connection, a decode failure — is `fallback`.
+  static func generationFailureMessage(for error: Error, fallback: String) -> String {
+    guard case APIError.httpError(let statusCode, _) = error else { return fallback }
+    switch statusCode {
+    case 400:
+      return "Nothing to summarize yet — a recap needs a recorded conversation from this day."
+    case 409:
+      return "Already being generated — check back in a moment."
+    case 429:
+      return "Just generated — wait a moment before trying again."
+    default:
+      return fallback
+    }
+  }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DailyRecapPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DailyRecapPage.swift
@@ -394,7 +394,9 @@ struct DailyRecapPage: View {
       store.upsert(updated, isOwnerStillCurrent: isOwnerStillCurrent)
       current = updated
     } catch {
-      regenerateError = "Couldn't regenerate this recap."
+      log("DailyRecapPage: regenerate failed for \(record.id): \(error)")
+      regenerateError = ChatDailySummaryPresentation.generationFailureMessage(
+        for: error, fallback: "Couldn't regenerate this recap.")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeDailySummaryStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeDailySummaryStore.swift
@@ -115,6 +115,11 @@ final class HomeDailySummaryStore: ObservableObject {
         self.summaryHour = resolvedHour
         self.lastError = nil
         self.lastRefresh = self.now()
+        // Counts, not content. A refresh that succeeds with nothing is the one outcome this store
+        // otherwise leaves invisible, and it is indistinguishable in the UI from "never fetched".
+        log(
+          "HomeDailySummaryStore: loaded \(summaries.count) summaries"
+            + " (\(self.byDate.count) dated, latest=\(self.latest?.date ?? "none"), summaryHour=\(resolvedHour))")
       } catch {
         // Bounded: the message is for the local log and an inline hint, never for analytics.
         self.lastError = "Couldn't load your daily summary."

--- a/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineDayRecapRow.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Spine/SpineDayRecapRow.swift
@@ -169,12 +169,13 @@ struct SpineDayRecapRow: View {
     do {
       let record = try await APIClient.shared.createDailySummary(date: dateKey)
       store.upsert(record, isOwnerStillCurrent: isOwnerStillCurrent)
-    } catch APIError.httpError(statusCode: 409, detail: _) {
-      // The scheduled run for this day is mid-flight. Saying "couldn't generate" would be a
-      // false negative at the one moment the recap is actually on its way.
-      errorMessage = "Already being generated — check back in a moment."
     } catch {
-      errorMessage = "Couldn't generate this recap."
+      // The transport logs only the request line, so without this the local log cannot tell a
+      // server decline from a dead network — which is exactly the question a "couldn't
+      // generate" report raises.
+      log("SpineDayRecapRow: generate failed for \(dateKey): \(error)")
+      errorMessage = ChatDailySummaryPresentation.generationFailureMessage(
+        for: error, fallback: "Couldn't generate this recap.")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
@@ -137,6 +137,41 @@ final class ChatDailySummaryTests: XCTestCase {
       "Your day in review")
   }
 
+  // MARK: - Generation failures say what the server said
+
+  /// The three statuses the backend uses as *answers* each get their own line; the reader on
+  /// a quiet day was told "couldn't generate" and read it as a broken button.
+  func testServerDeclinesAreNotReportedAsFailures() {
+    let fallback = "Couldn't generate this recap."
+    func message(_ status: Int) -> String {
+      ChatDailySummaryPresentation.generationFailureMessage(
+        for: APIError.httpError(statusCode: status, detail: "Nothing to summarize for 2026-09-04"),
+        fallback: fallback)
+    }
+    XCTAssertTrue(message(400).contains("Nothing to summarize"))
+    XCTAssertTrue(message(409).contains("Already being generated"))
+    XCTAssertTrue(message(429).contains("wait a moment"))
+    for status in [400, 409, 429] {
+      XCTAssertNotEqual(message(status), fallback, "status \(status) is an answer, not a failure")
+    }
+  }
+
+  func testGenuineFailuresKeepTheCallersFallback() {
+    let fallback = "Couldn't regenerate this recap."
+    XCTAssertEqual(
+      ChatDailySummaryPresentation.generationFailureMessage(
+        for: APIError.httpError(statusCode: 500, detail: nil), fallback: fallback),
+      fallback)
+    XCTAssertEqual(
+      ChatDailySummaryPresentation.generationFailureMessage(
+        for: APIError.httpError(statusCode: 404, detail: "Daily summary not found"), fallback: fallback),
+      fallback)
+    XCTAssertEqual(
+      ChatDailySummaryPresentation.generationFailureMessage(
+        for: URLError(.notConnectedToInternet), fallback: fallback),
+      fallback)
+  }
+
   // MARK: - Sections render only what is there
 
   func testEmptySectionsAreDroppedRatherThanDrawnEmpty() {

--- a/desktop/macos/changelog/unreleased/20260905-recap-decline-reasons.json
+++ b/desktop/macos/changelog/unreleased/20260905-recap-decline-reasons.json
@@ -1,0 +1,3 @@
+{
+  "change": "Daily recap generation now explains itself: days the backend declines say \"Nothing to summarize yet\" instead of a generic failure, and recap scheduling reaches owners who only use Omi on the Mac"
+}


### PR DESCRIPTION
## Summary

Two recap failures were indistinguishable on beta, and one of them was structural.

**The button spoke in one voice.** Clicking "Generate recap" on a day the backend declines answered "Couldn't generate this recap." for every outcome: the 400 decline (no conversation with recorded speech + summary content that day), the 409 mid-generation retry, the 429 spend cooldown, and genuine 5xx/network faults. Nothing reached the local log either, so a "the button is broken" report carried no evidence. Now one shared rule (`ChatDailySummaryPresentation.generationFailureMessage`) maps 400/409/429 to their own lines — used by both the spine row and the recap page's regenerate — and both writers log the underlying error. `HomeDailySummaryStore` also logs what a successful fetch returned (count, latest date, summary hour): a refresh that succeeds with an empty list was previously indistinguishable from "never fetched", which is exactly the case this PR's diagnosis turned on.

**A desktop-only owner was never scheduled.** The nightly cron selects users by the user document's `time_zone` (`get_users_for_daily_summary` queries `time_zone in [...]`), and that field's only writer was the mobile FCM registration. An account used only from the Mac never carried it, so it never got a scheduled recap — and its on-demand recap was bounded to the *UTC* day (`local_day_bounds_utc` with no zone). The desktop already sends a validated IANA timezone on `POST /v1/users/desktop-usage/daily` every five minutes; the handler now writes `time_zone` when the user document has none. It is Redis-flagged to a six-hour recheck so the heartbeat does not re-read the user document all day, and it never overwrites a zone mobile wrote — mobile stays authoritative.

Failure-Class: FC-typed-failure-collapsed-to-generic

Instance fix at a new site: the recap writers received typed HTTP failures from the transport and collapsed every class into one generic line with no log trace, so the true cause was unrecoverable from a user report; the fix classifies at the catch boundary through one shared rule and logs the error. The second half of the PR — the desktop-usage heartbeat filling a missing user `time_zone` — is a scheduling-eligibility gap, included here because the same investigation found it and the same log-visibility remedy covers it.

## Diagnosis trail (for the record)

- Beta (`david@scalingforever.com`, plan Operator, 24/500) clicked Generate for 2026-09-04 → POST left the client, no response logging existed, spine showed "No recap for this day".
- The account list fetch did not fail (no store error, no decode error in `/tmp/omi-beta.log`), and the account has no stored recaps — while the same machine's gmail session has them (beta defaults still hold that owner's last-seen summary id).
- Structural cause for such accounts: no `time_zone` on the user document → cron-never-scheduled + UTC day bounds on demand; the exact server decline (nothing-to-summarize vs 5xx) was unobservable until this PR's logging.

## Testing

- Backend: `pytest tests/unit/test_desktop_daily_usage.py tests/unit/test_daily_summary_generation.py` — 28 passed (new: fills-missing-zone writes once + trusts the flag; mobile-written zone left alone; db helper writes-only-when-missing).
- Desktop: `ChatDailySummaryTests` new failure-mapping cases pass; `SpineDayRecapTests` 8/8; `xcrun swift build -c debug` clean; swift-format 602.0.0 clean.

Line-Count-Exception: backend/routers/users.py | 2463 -> 2476 | the desktop-usage heartbeat gains the time_zone backfill (guarded constant + 6 handler lines); splitting users.py is out of scope for this fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

