### PR TITLE
fix(jit): align desktop pacing with the server budget timezone

### DIFF
--- a/backend/routers/jit_rollout.py
+++ b/backend/routers/jit_rollout.py
@@ -97,6 +97,11 @@ class JITTriggerSnapshotEnvelope(BaseModel):
     rows: list[JITTriggerSnapshotRowEnvelope]
     policy: TriggerRuntimePolicy = DEFAULT_TRIGGER_RUNTIME_POLICY
     failure_reason: str | None = None
+    # Matches the timezone authority used by the reservation transaction. Both
+    # are optional for old/synthetic user records; reservations still fail
+    # closed when the profile has no usable timezone.
+    budget_day: str | None = Field(default=None, pattern=r"^\d{4}-\d{2}-\d{2}$")
+    budget_timezone: str | None = Field(default=None, min_length=1, max_length=64)
 
 
 class JITTriggerFeedbackRequest(BaseModel):
@@ -233,6 +238,8 @@ async def get_jit_trigger_snapshot(
         ],
         policy=snapshot.policy,
         failure_reason=snapshot.failure_reason,
+        budget_day=snapshot.budget_day,
+        budget_timezone=snapshot.budget_timezone,
     )
 
 

--- a/backend/tests/unit/test_jit_rollout.py
+++ b/backend/tests/unit/test_jit_rollout.py
@@ -802,6 +802,8 @@ def test_trigger_snapshot_is_owner_authenticated_default_off_and_never_reads_mem
         'rows': [],
         'policy': DEFAULT_TRIGGER_RUNTIME_POLICY.model_dump(mode='json'),
         'failure_reason': 'rollout_not_enabled',
+        'budget_day': None,
+        'budget_timezone': None,
     }
 
 
@@ -836,6 +838,8 @@ def test_trigger_snapshot_serializes_exhaustive_action_receipt(monkeypatch):
                 snoozed_until=datetime(2026, 8, 25, tzinfo=timezone.utc),
             ),
         ),
+        budget_day='2026-08-24',
+        budget_timezone='America/New_York',
     )
 
     async def immediate(_executor, function, uid):
@@ -858,6 +862,8 @@ def test_trigger_snapshot_serializes_exhaustive_action_receipt(monkeypatch):
         'prompt': 'Give the next release step.',
     }
     assert payload['rows'][0]['snoozed_until'] == '2026-08-25T00:00:00Z'
+    assert payload['budget_day'] == '2026-08-24'
+    assert payload['budget_timezone'] == 'America/New_York'
     assert payload['policy'] == DEFAULT_TRIGGER_RUNTIME_POLICY.model_dump(mode='json')
     assert '"action"' in payload['rows'][0]['trigger_condition_json']
     assert observed == [False, True]
@@ -910,6 +916,8 @@ def test_trigger_snapshot_final_authority_fence_discards_scan_after_disable(monk
         'rows': [],
         'policy': DEFAULT_TRIGGER_RUNTIME_POLICY.model_dump(mode='json'),
         'failure_reason': 'rollout_not_enabled',
+        'budget_day': None,
+        'budget_timezone': None,
     }
 
 

--- a/backend/tests/unit/test_jit_trigger_snapshot.py
+++ b/backend/tests/unit/test_jit_trigger_snapshot.py
@@ -14,11 +14,30 @@ from models.product_memory import (
     ProcessingState,
 )
 from utils.memory.jit_trigger_snapshot import (
+    _budget_authority,
     is_authoritative_trigger_for_paid_work,
     read_authoritative_trigger_snapshot,
 )
 
 NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+
+
+def test_budget_authority_uses_profile_timezone_across_local_midnight_and_dst():
+    class _ProfileClient:
+        def document(self, path):
+            assert path == 'users/owner'
+            return _Document(_Snapshot('owner', {'time_zone': 'America/Los_Angeles'}))
+
+    # 05:30 UTC is already Aug 24 in New York but still Aug 23 in Los Angeles.
+    assert _budget_authority('owner', datetime(2026, 8, 24, 5, 30, tzinfo=timezone.utc), _ProfileClient()) == (
+        '2026-08-23',
+        'America/Los_Angeles',
+    )
+    # The DST jump does not change the local-day contract.
+    assert _budget_authority('owner', datetime(2026, 3, 8, 8, 30, tzinfo=timezone.utc), _ProfileClient()) == (
+        '2026-03-08',
+        'America/Los_Angeles',
+    )
 
 
 class _Snapshot:
@@ -227,7 +246,7 @@ def test_missing_head_returns_complete_empty_watchlist():
     assert result.rows == ()
     assert result.failure_reason is None
     assert len(result.snapshot_revision) == 64
-    assert client.head_reads == 2, 'absence must be fenced by a trailing re-read'
+    assert client.head_reads == 3, 'absence must be fenced by a trailing re-read and budget authority read'
 
 
 def test_empty_watchlist_revision_is_stable_and_owner_bound():

--- a/backend/utils/memory/jit_trigger_snapshot.py
+++ b/backend/utils/memory/jit_trigger_snapshot.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 import hashlib
 import json
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -54,6 +55,11 @@ class AuthoritativeTriggerSnapshot:
     rows: tuple[AuthoritativeTriggerRow, ...]
     failure_reason: str | None = None
     policy: TriggerRuntimePolicy = DEFAULT_TRIGGER_RUNTIME_POLICY
+    # The reservation store owns the budget window using the profile's IANA
+    # timezone.  Returning the same authority lets clients pace their local
+    # mirror under that window instead of silently using the host timezone.
+    budget_day: str | None = None
+    budget_timezone: str | None = None
 
 
 @dataclass(frozen=True)
@@ -170,6 +176,30 @@ def _empty_watchlist_revision(uid: str, account_generation: int) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _budget_authority(uid: str, at: datetime, client: Any) -> tuple[str, str] | None:
+    """Read the content-free profile timezone used by JIT reservations.
+
+    Some old or synthetic users have no timezone yet.  Keep the snapshot
+    readable for compatibility; the client will use its legacy fallback and
+    the paid reservation remains the final authority.  A malformed timezone is
+    never projected as a plausible value.
+    """
+
+    try:
+        snapshot = client.document(f'users/{uid}').get()
+        payload = snapshot.to_dict() if getattr(snapshot, 'exists', False) else None
+        timezone_name = payload.get('time_zone') if isinstance(payload, dict) else None
+        if not isinstance(timezone_name, str):
+            return None
+        timezone_name = timezone_name.strip()
+        if not timezone_name:
+            return None
+        zone = ZoneInfo(timezone_name)
+        return at.astimezone(zone).date().isoformat(), timezone_name
+    except Exception:
+        return None
+
+
 def read_authoritative_trigger_snapshot(
     uid: str,
     *,
@@ -200,6 +230,7 @@ def read_authoritative_trigger_snapshot(
         trailing = read_memory_v3_trusted_account_generation(uid=uid, db_client=client)
         if trailing.read_error_reason is not V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
             return AuthoritativeTriggerSnapshot(uid, 0, '', 0, '', False, (), 'generation_unavailable')
+        budget_authority = _budget_authority(uid, datetime.now(timezone.utc), client)
         return AuthoritativeTriggerSnapshot(
             owner_id=uid,
             account_generation=0,
@@ -208,6 +239,8 @@ def read_authoritative_trigger_snapshot(
             snapshot_revision=_empty_watchlist_revision(uid, 0),
             complete=True,
             rows=(),
+            budget_day=budget_authority[0] if budget_authority else None,
+            budget_timezone=budget_authority[1] if budget_authority else None,
         )
     except Exception:
         return AuthoritativeTriggerSnapshot(uid, 0, '', 0, '', False, (), 'generation_unavailable')
@@ -283,6 +316,9 @@ def read_authoritative_trigger_snapshot(
 
     revision = _revision(uid, account_generation, head_commit_id, commit_sequence, items, rows)
     rows.sort(key=lambda row: row.memory_id)
+    # Keep the projected day tied to the same instant as the fenced snapshot.
+    # A second clock read here could straddle a profile-local midnight.
+    budget_authority = _budget_authority(uid, authority_time, client)
     return AuthoritativeTriggerSnapshot(
         owner_id=uid,
         account_generation=account_generation,
@@ -291,6 +327,8 @@ def read_authoritative_trigger_snapshot(
         snapshot_revision=revision,
         complete=True,
         rows=tuple(rows),
+        budget_day=budget_authority[0] if budget_authority else None,
+        budget_timezone=budget_authority[1] if budget_authority else None,
     )
 
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
@@ -226,7 +226,9 @@ actor JITProactivityRuntime {
         guard let snoozedUntil = trigger.snoozedUntil else { return true }
         return now >= snoozedUntil
       }
-      let day = day(for: now)
+      guard let day = day(for: now, budgetTimezone: snapshot.budgetTimezone) else {
+        return .suppressed(reason: "budget_authority_unavailable")
+      }
       let counts = try await wakeupCounts(
         triggerIDs: eligibleTriggers.map(\.id), budgetDay: day, now: now)
       let receiptMatchesSnapshot =
@@ -266,6 +268,7 @@ actor JITProactivityRuntime {
           context: ambient,
           observation: observation,
           receipt: receipt,
+          budgetTimezone: snapshot.budgetTimezone,
           authorizationSnapshot: authorizationSnapshot)
       case .boundedPlannedTriage:
         guard let ambiguous = runtimeResult.ambiguous.first,
@@ -283,6 +286,7 @@ actor JITProactivityRuntime {
             context: ambient,
             observation: observation,
             receipt: receipt,
+            budgetTimezone: snapshot.budgetTimezone,
             authorizationSnapshot: authorizationSnapshot)
         }
         return .suppressed(reason: "planned_runtime_rejected")
@@ -458,6 +462,7 @@ actor JITProactivityRuntime {
     context: JITAmbientRuntimeContext?,
     observation: KnowledgeLedgerTriggerObservation,
     receipt: JITTriggerMirrorReceipt,
+    budgetTimezone: String?,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
   ) async -> JITProactivityDecision {
     guard let context, context.permitsNanoTriage else {
@@ -471,7 +476,9 @@ actor JITProactivityRuntime {
       locallyRelevant: context.locallyRelevant,
       boundedEvidence: context.boundedEvidence)
     let now = observation.occurredAt ?? Date()
-    let day = day(for: now)
+    guard let day = day(for: now, budgetTimezone: budgetTimezone) else {
+      return .suppressed(reason: "budget_authority_unavailable")
+    }
     if let deniedAt = ambientServerDenials[day],
       now.timeIntervalSince(deniedAt) < Self.ambientServerDenialBackoff
     {
@@ -678,8 +685,14 @@ actor JITProactivityRuntime {
     JITProactivityReservation.identifier("ambient-context", contextID)
   }
 
-  private func day(for date: Date) -> String {
-    let timezone = TimeZone.current
+  private func day(for date: Date, budgetTimezone: String? = nil) -> String? {
+    let timezone: TimeZone
+    if let budgetTimezone {
+      guard let resolved = TimeZone(identifier: budgetTimezone) else { return nil }
+      timezone = resolved
+    } else {
+      timezone = TimeZone.current
+    }
     if let cached = cachedDayFormatter, cached.timezone == timezone {
       return cached.formatter.string(from: date)
     }
@@ -691,4 +704,5 @@ actor JITProactivityRuntime {
     cachedDayFormatter = (timezone, formatter)
     return formatter.string(from: date)
   }
+
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITTriggerMirror.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITTriggerMirror.swift
@@ -219,6 +219,10 @@ struct JITTriggerSnapshot: Codable, Equatable, Sendable {
   let rows: [JITTriggerSnapshotRow]
   let policy: JITTriggerRuntimePolicy
   let failureReason: String?
+  /// The profile timezone and current budget day used by the server's
+  /// reservation transaction. Optional for compatibility with older servers.
+  let budgetDay: String?
+  let budgetTimezone: String?
 
   enum CodingKeys: String, CodingKey {
     case ownerID = "owner_id"
@@ -228,12 +232,15 @@ struct JITTriggerSnapshot: Codable, Equatable, Sendable {
     case snapshotRevision = "snapshot_revision"
     case complete, rows, policy
     case failureReason = "failure_reason"
+    case budgetDay = "budget_day"
+    case budgetTimezone = "budget_timezone"
   }
 
   init(
     ownerID: String, accountGeneration: Int, headCommitID: String, commitSequence: Int,
     snapshotRevision: String, complete: Bool, rows: [JITTriggerSnapshotRow],
-    policy: JITTriggerRuntimePolicy = .ratifiedV1, failureReason: String?
+    policy: JITTriggerRuntimePolicy = .ratifiedV1, failureReason: String?,
+    budgetDay: String? = nil, budgetTimezone: String? = nil
   ) {
     self.ownerID = ownerID
     self.accountGeneration = accountGeneration
@@ -244,6 +251,8 @@ struct JITTriggerSnapshot: Codable, Equatable, Sendable {
     self.rows = rows
     self.policy = policy
     self.failureReason = failureReason
+    self.budgetDay = budgetDay
+    self.budgetTimezone = budgetTimezone
   }
 }
 

--- a/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
@@ -167,6 +167,50 @@ final class JITProactivityRuntimeTests: XCTestCase {
     XCTAssertEqual(days.count, 1, "pacing must read today's usage exactly once before spending")
   }
 
+  func testAmbientPacingUsesAuthoritativeProfileTimezoneForBudgetDay() async throws {
+    let usageReads = UsageReadProbe()
+    // 05:30 UTC is Aug 24 in New York but still Aug 23 in Los Angeles. The
+    // server reservation uses the profile timezone, so the local mirror must
+    // make the same day choice before it paces or claims nano work.
+    let runtime = try wiredRuntime(
+      triggers: [],
+      budgetTimezone: "America/Los_Angeles",
+      ambientNanoUsage: { day, _ in
+        await usageReads.record(day)
+        return JITAmbientNanoUsage(used: 8, lastSpentAt: nil)
+      })
+
+    let decision = await runtime.admission(
+      authorizationSnapshot: try snapshot(),
+      observation: .init(
+        text: "lunch", occurredAt: Date(timeIntervalSince1970: 1_787_549_400)),
+      ambient: validAmbient())
+
+    XCTAssertEqual(decision, .suppressed(reason: "ambient_nano_budget"))
+    let days = await usageReads.days
+    XCTAssertEqual(days, ["2026-08-23"])
+  }
+
+  func testMalformedAuthoritativeTimezoneFailsClosedBeforeAmbientSpend() async throws {
+    let usageReads = UsageReadProbe()
+    let runtime = try wiredRuntime(
+      triggers: [],
+      budgetTimezone: "Mars/Olympus_Mons",
+      ambientNanoUsage: { day, _ in
+        await usageReads.record(day)
+        return JITAmbientNanoUsage(used: 0, lastSpentAt: nil)
+      })
+
+    let decision = await runtime.admission(
+      authorizationSnapshot: try snapshot(),
+      observation: .init(text: "lunch", occurredAt: Date(timeIntervalSince1970: 1_787_549_400)),
+      ambient: validAmbient())
+
+    XCTAssertEqual(decision, .suppressed(reason: "budget_authority_unavailable"))
+    let days = await usageReads.days
+    XCTAssertTrue(days.isEmpty)
+  }
+
   func testAmbientPacingDefersUnmatchedContextInsideSpacingWithoutSpend() async throws {
     let now = Date(timeIntervalSince1970: 1_777_248_000)
     let runtime = try wiredRuntime(
@@ -703,6 +747,7 @@ final class JITProactivityRuntimeTests: XCTestCase {
     triggers: [KnowledgeLedgerCompiledTrigger],
     receiptOwner: String = "owner",
     receiptRevision: String = "revision",
+    budgetTimezone: String? = nil,
     authorizationCurrent: Bool = true,
     claim: JITProactivityRuntime.ClaimWakeup? = nil,
     begin: JITProactivityRuntime.BeginPlannedExecution? = nil,
@@ -715,7 +760,8 @@ final class JITProactivityRuntimeTests: XCTestCase {
     claimAmbientNano: JITProactivityRuntime.ClaimAmbientNano? = nil
   ) throws -> JITProactivityRuntime {
     let rows = try triggers.map { try snapshotRow(for: $0) }
-    let serverSnapshot = serverSnapshot(sequence: 4, revision: "revision", rows: rows)
+    let serverSnapshot = serverSnapshot(
+      sequence: 4, revision: "revision", rows: rows, budgetTimezone: budgetTimezone)
     let receipt = JITTriggerMirrorReceipt(
       ownerID: receiptOwner,
       accountGeneration: 3,
@@ -794,12 +840,12 @@ final class JITProactivityRuntimeTests: XCTestCase {
   }
 
   private func serverSnapshot(
-    sequence: Int, revision: String, rows: [JITTriggerSnapshotRow]
+    sequence: Int, revision: String, rows: [JITTriggerSnapshotRow], budgetTimezone: String? = nil
   ) -> JITTriggerSnapshot {
     JITTriggerSnapshot(
       ownerID: "owner", accountGeneration: 3, headCommitID: "head-\(sequence)",
       commitSequence: sequence, snapshotRevision: revision, complete: true, rows: rows,
-      failureReason: nil)
+      failureReason: nil, budgetTimezone: budgetTimezone)
   }
 
   private func snapshotRow(

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -459,6 +459,48 @@ final class ProactiveLaneClientTests: XCTestCase {
     XCTAssertEqual(attempts, 1, "the ledger mirror must still be attempted exactly once")
   }
 
+  func testTriggerSnapshotDecodesServerBudgetAuthority() async throws {
+    ProactiveLaneURLStub.reset()
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try triggerSnapshotBody(
+        ownerID: "owner", budgetDay: "2026-08-23", budgetTimezone: "America/Los_Angeles"))
+    let client = makeJITAuthorityClient()
+
+    let snapshot = try await client.fetchJITTriggerSnapshot(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertEqual(snapshot.budgetDay, "2026-08-23")
+    XCTAssertEqual(snapshot.budgetTimezone, "America/Los_Angeles")
+  }
+
+  func testTriggerSnapshotRefreshAdoptsTimezoneChangeWithUnchangedRevision() async throws {
+    ProactiveLaneURLStub.reset()
+    // A profile timezone update does not necessarily change the ledger head or
+    // snapshot revision. The mirror must still consume the new budget authority
+    // returned by the next refresh rather than treating the revision as a cache key.
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try triggerSnapshotBody(
+        ownerID: "owner", budgetDay: "2026-08-23", budgetTimezone: "America/Los_Angeles"))
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try triggerSnapshotBody(
+        ownerID: "owner", budgetDay: "2026-08-24", budgetTimezone: "America/New_York"))
+    let client = makeJITAuthorityClient()
+
+    let first = try await client.fetchJITTriggerSnapshot(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+    let second = try await client.fetchJITTriggerSnapshot(
+      authorizationSnapshot: try jitAuthorizationSnapshot())
+
+    XCTAssertEqual(first.snapshotRevision, second.snapshotRevision)
+    XCTAssertEqual(first.budgetTimezone, "America/Los_Angeles")
+    XCTAssertEqual(second.budgetTimezone, "America/New_York")
+    XCTAssertEqual(first.budgetDay, "2026-08-23")
+    XCTAssertEqual(second.budgetDay, "2026-08-24")
+  }
+
   func testDisabledTriggerSnapshotReturnsContentFreeReceiptWithoutTouchingTheMirror() async throws {
     ProactiveLaneURLStub.reset()
     ProactiveLaneURLStub.enqueue(
@@ -627,9 +669,10 @@ final class ProactiveLaneClientTests: XCTestCase {
   }
 
   private func triggerSnapshotBody(
-    ownerID: String, complete: Bool = true, failureReason: String? = nil
+    ownerID: String, complete: Bool = true, failureReason: String? = nil,
+    budgetDay: String? = nil, budgetTimezone: String? = nil
   ) throws -> Data {
-    try JSONSerialization.data(withJSONObject: [
+    var object: [String: Any] = [
       "owner_id": ownerID,
       "snapshot_revision": "revision-4",
       "account_generation": 3,
@@ -639,7 +682,10 @@ final class ProactiveLaneClientTests: XCTestCase {
       "rows": [] as [[String: Any]],
       "policy": ratifiedPolicyWireJSON(),
       "failure_reason": (failureReason as Any?) ?? NSNull(),
-    ])
+    ]
+    if let budgetDay { object["budget_day"] = budgetDay }
+    if let budgetTimezone { object["budget_timezone"] = budgetTimezone }
+    return try JSONSerialization.data(withJSONObject: object)
   }
   private func ratifiedPolicyWireJSON() -> [String: Any] {
     [

--- a/desktop/macos/changelog/unreleased/20260905-jit-budget-timezone.json
+++ b/desktop/macos/changelog/unreleased/20260905-jit-budget-timezone.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved proactive notification timing when your device and profile use different time zones"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2540,6 +2540,8 @@ export interface JITTriggerFeedbackRequest {
 
 export interface JITTriggerSnapshotEnvelope {
   account_generation: number;
+  budget_day?: string | null;
+  budget_timezone?: string | null;
   commit_sequence: number;
   complete: boolean;
   failure_reason?: string | null;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -15833,6 +15833,31 @@
             "title": "Account Generation",
             "type": "integer"
           },
+          "budget_day": {
+            "anyOf": [
+              {
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Day"
+          },
+          "budget_timezone": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Timezone"
+          },
           "commit_sequence": {
             "minimum": 0.0,
             "title": "Commit Sequence",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2540,6 +2540,8 @@ export interface JITTriggerFeedbackRequest {
 
 export interface JITTriggerSnapshotEnvelope {
   account_generation: number;
+  budget_day?: string | null;
+  budget_timezone?: string | null;
   commit_sequence: number;
   complete: boolean;
   failure_reason?: string | null;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2540,6 +2540,8 @@ export interface JITTriggerFeedbackRequest {
 
 export interface JITTriggerSnapshotEnvelope {
   account_generation: number;
+  budget_day?: string | null;
+  budget_timezone?: string | null;
   commit_sequence: number;
   complete: boolean;
   failure_reason?: string | null;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2540,6 +2540,8 @@ export interface JITTriggerFeedbackRequest {
 
 export interface JITTriggerSnapshotEnvelope {
   account_generation: number;
+  budget_day?: string | null;
+  budget_timezone?: string | null;
   commit_sequence: number;
   complete: boolean;
   failure_reason?: string | null;


### PR DESCRIPTION
Desktop JIT pacing used the Mac's timezone while the server charged reservations against the account profile's timezone. Around midnight, the client could read the wrong day's usage and repeatedly request work the server would deny.

Return the server's budget timezone/day in the trigger snapshot and use that timezone for local pacing. Refresh budget authority even when the ledger revision stays the same. Invalid timezones fail closed; older servers retain the existing fallback. Hard notification and model-call caps are unchanged, and this adds no model calls.

Validation: focused backend, Swift and OpenAPI tests; midnight/DST, malformed-timezone and same-revision refresh cases; generated-client checks; full Swift build; exact-head repository pre-push gate. Runtime proof will use a named app against dev.

Product invariants affected: INV-MEM-1, INV-MEM-4.

Failure-Class: FC-day-bucket-key-recomputed
