### PR TITLE
feat(rewind): pastel timeline track with blended seams, honest gaps, and deeper zoom

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindPalette.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindPalette.swift
@@ -46,6 +46,8 @@ enum RewindPalette {
     let hueStart: Double
     let hueEnd: Double
     let brightness: Double
+    /// The brightness the timeline track draws this family at — see `trackSaturation`.
+    let trackBrightness: Double
   }
 
   /// A colour this palette can emit, as the three numbers that produce it.
@@ -103,13 +105,13 @@ enum RewindPalette {
   /// *lightness as well as hue* whichever pair of apps happen to sit next to each other, which is
   /// what the eye actually reads at 4 pt wide.
   static let bands: [Band] = [
-    Band(name: "red", hueStart: 2, hueEnd: 16, brightness: 1.00),  // bright
-    Band(name: "orange", hueStart: 26, hueEnd: 36, brightness: 0.68),  // deep
-    Band(name: "lime", hueStart: 90, hueEnd: 104, brightness: 0.65),  // bright
-    Band(name: "green", hueStart: 126, hueEnd: 142, brightness: 0.50),  // deep
-    Band(name: "teal", hueStart: 156, hueEnd: 170, brightness: 0.65),  // bright
-    Band(name: "cyan", hueStart: 188, hueEnd: 200, brightness: 0.65),  // deep
-    Band(name: "blue", hueStart: 206, hueEnd: 218, brightness: 0.99),  // bright
+    Band(name: "red", hueStart: 2, hueEnd: 16, brightness: 1.00, trackBrightness: 1.00),  // bright
+    Band(name: "orange", hueStart: 26, hueEnd: 36, brightness: 0.68, trackBrightness: 0.94),  // deep
+    Band(name: "lime", hueStart: 90, hueEnd: 104, brightness: 0.65, trackBrightness: 0.85),  // bright
+    Band(name: "green", hueStart: 126, hueEnd: 142, brightness: 0.50, trackBrightness: 0.86),  // deep
+    Band(name: "teal", hueStart: 156, hueEnd: 170, brightness: 0.65, trackBrightness: 0.85),  // bright
+    Band(name: "cyan", hueStart: 188, hueEnd: 200, brightness: 0.65, trackBrightness: 0.92),  // deep
+    Band(name: "blue", hueStart: 206, hueEnd: 218, brightness: 0.99, trackBrightness: 1.00),  // bright
   ]
 
   /// The wall no band may reach, in degrees.
@@ -215,8 +217,44 @@ enum RewindPalette {
   /// per-app border or badge accent should use.
   static func color(forApp appName: String) -> Color { color(swatch(forApp: appName)) }
 
-  /// The same colour for the AppKit layers that draw the timeline track.
+  /// The same colour for AppKit — the timeline badge's monogram disc.
   static func nsColor(forApp appName: String) -> NSColor { nsColor(swatch(forApp: appName)) }
+
+  // MARK: - The track's pastel
+
+  /// The saturation the timeline **track** draws every hue at; brightness is per band.
+  ///
+  /// The vivid swatches above are tuned for white type sitting on them; nothing sits on a track
+  /// segment (badges carry their own vivid disc inside a white ring), so the track is free to be
+  /// what the glass it lies on asks for: pale and light, a pastel rainbow rather than a test card.
+  /// Hue is the palette's — an app keeps its identity — and only the two axes the type cap was
+  /// pinning move.
+  ///
+  /// **Brightness is per band for the same reason it is above: HSB brightness is not lightness.**
+  /// One brightness for every family put lime and teal at a relative luminance near 0.8 — a
+  /// hair off the glass they lie on, reading as empty stretches — while red and blue sat near 0.45.
+  /// Each band's `trackBrightness` is the value that lands its span's mean luminance on 0.58 at
+  /// this saturation; red and blue cannot get there and take the largest brightness there is.
+  /// Measured over all 2 503 emittable swatches the track spans luminance 0.457–0.632, and
+  /// `RewindTrackGradientTests` pins that window.
+  static let trackSaturation: Double = 0.42
+
+  /// The pastel projection of a bucket: the palette's hue, the track's saturation, the band's
+  /// track brightness.
+  static func trackSwatch(bucket: UInt64) -> Swatch {
+    Swatch(
+      hue: swatch(bucket: bucket).hue,
+      saturation: trackSaturation,
+      brightness: band(bucket: bucket).trackBrightness)
+  }
+
+  static func trackSwatch(forApp appName: String) -> Swatch {
+    let key = appName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return trackSwatch(bucket: stableHash(key) % hueBuckets)
+  }
+
+  /// The colour a track segment is drawn in.
+  static func trackNSColor(forApp appName: String) -> NSColor { nsColor(trackSwatch(forApp: appName)) }
 
   /// Both renderers, keyed on a swatch rather than on a name, so a guard can render a colour it
   /// chose rather than hunting for a name that hashes to one.

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
@@ -44,7 +44,7 @@ final class RewindTrackNSView: NSView {
   private(set) var searchResultIndices: Set<Int>?
   var trackStart: Double = 0
   var trackSpan: Double = 1
-  var spanBounds: ClosedRange<Double> = 60...86_400
+  var spanBounds: ClosedRange<Double> = RewindTrackWindow.minimumSpan...86_400
   var playheadAt: Double?
 
   /// Called with an index while the user scrubs. Coalesced to one call per display frame — see
@@ -64,7 +64,12 @@ final class RewindTrackNSView: NSView {
   private var isScrubbing = false
   private var lastReportedIndex: Int?
   private var pendingScrubIndex: Int?
-  private var pinch: (anchor: Double, fraction: Double, startSpan: Double)?
+  /// The pinch in progress: the instant under the fingers when it began, where along the bar that
+  /// was, the span it began from, and the gesture's magnification summed so far.
+  private var pinch: (anchor: Double, fraction: Double, startSpan: Double, magnification: Double)?
+  /// How far one unit of summed `NSEvent.magnification` zooms, in octaves: a full pinch out
+  /// (+1.0) shows an eighth of the time, a full pinch in (-1.0) eight times as much.
+  static let pinchOctavesPerUnit: Double = 3
   private var colorCache: [String: NSColor] = [:]
 
   override var isFlipped: Bool { true }
@@ -166,7 +171,7 @@ final class RewindTrackNSView: NSView {
 
     NSGraphicsContext.saveGraphicsState()
     shape.addClip()
-    for block in blocks { draw(block, in: bar) }
+    for index in blocks.indices { draw(at: index, in: bar) }
     if let searchResultIndices, !searchResultIndices.isEmpty {
       drawSearchMarkers(searchResultIndices, in: bar)
     }
@@ -218,24 +223,50 @@ final class RewindTrackNSView: NSView {
     return placed
   }
 
-  private func draw(_ block: RewindActivityBlock, in bar: NSRect) {
+  /// One segment, eased into its neighbours — see `RewindTrackGradient`.
+  ///
+  /// The blend is anchored to the segment's real ends, so its geometry is computed at full extent;
+  /// the paint itself is bounded to the visible part of the bar. A segment that is hours long at
+  /// minute zoom is hundreds of thousands of points wide, and only the slice on screen is drawn.
+  private func draw(at index: Int, in bar: NSRect) {
+    let block = blocks[index]
     let left = x(for: block.startedAt)
     let right = x(for: block.endedAt)
     guard right >= 0, left <= bounds.width else { return }
-    let clippedLeft = max(0, left)
     // A sub-pixel block still happened; give it a visible sliver rather than nothing.
-    let width = max(2, min(bounds.width, right) - clippedLeft)
-    color(forApp: block.app).setFill()
-    NSRect(x: clippedLeft, y: bar.minY, width: width, height: bar.height).fill()
+    let width = max(2, right - left)
+    let rect = NSRect(x: left, y: bar.minY, width: width, height: bar.height)
+    let visible = rect.intersection(NSRect(x: -1, y: bar.minY, width: bounds.width + 2, height: bar.height))
+    guard !visible.isEmpty else { return }
+    let body = color(forApp: block.app)
+    let edges = RewindTrackGradient.edges(
+      for: block,
+      previous: index > blocks.startIndex ? blocks[index - 1] : nil,
+      next: index + 1 < blocks.endIndex ? blocks[index + 1] : nil,
+      width: width,
+      colour: color(forApp:))
+    guard let gradient = RewindTrackGradient.gradient(body: body, edges: edges, width: width) else {
+      body.setFill()
+      visible.fill()
+      return
+    }
+    NSGraphicsContext.saveGraphicsState()
+    visible.clip()
+    gradient.draw(
+      from: NSPoint(x: rect.minX, y: rect.midY),
+      to: NSPoint(x: rect.maxX, y: rect.midY),
+      options: [.drawsBeforeStartingLocation, .drawsAfterEndingLocation])
+    NSGraphicsContext.restoreGraphicsState()
   }
 
   /// The app's track colour, memoised for the length of this view's life.
   ///
   /// `RewindPalette` is the single definition of the hue — this only remembers the answer, because
   /// deriving it involves a string hash and the drawing loop asks the same question every redraw.
+  /// The track's pastel, not the badge's vivid disc: nothing is lettered onto a segment.
   private func color(forApp app: String) -> NSColor {
     if let hit = colorCache[app] { return hit }
-    let colour = RewindPalette.nsColor(forApp: app)
+    let colour = RewindPalette.trackNSColor(forApp: app)
     colorCache[app] = colour
     return colour
   }
@@ -358,7 +389,7 @@ final class RewindTrackNSView: NSView {
 
   static func tickInterval(forSpan span: Double) -> Double {
     let candidates: [Double] = [
-      60, 300, 600, 900, 1800, 3600, 2 * 3600, 3 * 3600, 6 * 3600, 12 * 3600,
+      1, 2, 5, 10, 15, 30, 60, 300, 600, 900, 1800, 3600, 2 * 3600, 3 * 3600, 6 * 3600, 12 * 3600,
     ]
     return candidates.first { span / $0 <= 12 } ?? 24 * 3600
   }
@@ -370,13 +401,15 @@ final class RewindTrackNSView: NSView {
   /// looks like just after midnight — the ladder picks a one-minute interval and every label on the
   /// track reads `12 AM`. Five identical labels are worse than none: they say the axis is not moving.
   /// Below an hour the minutes are the information, and the hour is the one thing the reader can
-  /// infer from the pill under the frame.
+  /// infer from the pill under the frame. Below a minute the same argument repeats one rung down:
+  /// the seconds are the information, so the label carries them.
   /// Both are built once. `drawHourTicks` runs on every redraw, and a redraw happens on every pointer
   /// sample of a scrub; constructing a `DateFormatter` there would put a locale lookup on the frame
   /// budget this rebuild exists to protect.
   static func tickFormatter(forInterval interval: Double) -> DateFormatter {
     if interval >= 24 * 3600 { return dayTickFormatter }
-    return interval >= 3600 ? hourTickFormatter : minuteTickFormatter
+    if interval >= 3600 { return hourTickFormatter }
+    return interval >= 60 ? minuteTickFormatter : secondTickFormatter
   }
 
   private static let hourTickFormatter: DateFormatter = {
@@ -388,6 +421,11 @@ final class RewindTrackNSView: NSView {
   private static let minuteTickFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "h:mm"
+    return formatter
+  }()
+  private static let secondTickFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:mm:ss"
     return formatter
   }()
 
@@ -526,10 +564,16 @@ final class RewindTrackNSView: NSView {
     }
     if phase.contains(.began) || pinch == nil {
       let fraction = min(max(0, Double(x / bounds.width)), 1)
-      pinch = (trackStart + fraction * trackSpan, fraction, trackSpan)
+      pinch = (trackStart + fraction * trackSpan, fraction, trackSpan, 0)
     }
-    guard let gesture = pinch else { return }
-    let span = min(max(gesture.startSpan / (1 + delta * 4), spanBounds.lowerBound), spanBounds.upperBound)
+    guard var gesture = pinch else { return }
+    // `NSEvent.magnification` is the change since the previous event, not the gesture's total.
+    // Reading it as the total made every event zoom from the start span by a few percent, so a
+    // pinch hardly moved and could never reach the floor however far the fingers travelled.
+    gesture.magnification += delta
+    pinch = gesture
+    let zoomed = gesture.startSpan * pow(2, -gesture.magnification * Self.pinchOctavesPerUnit)
+    let span = min(max(zoomed, spanBounds.lowerBound), spanBounds.upperBound)
     onZoom?(gesture.anchor - gesture.fraction * span, span)
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackGradient.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackGradient.swift
@@ -1,0 +1,77 @@
+import AppKit
+
+/// How one track segment's colour meets the next.
+///
+/// Segments used to butt against each other as solid fills, so a day read as a row of hard
+/// colour switches. Adjacent segments now ease into each other: each edge is drawn in the colour
+/// halfway between the two apps, and both segments blend toward that shared colour over a short
+/// run, so the seam is continuous from either side. The body of a segment stays its own colour —
+/// the blend is an edge treatment, not a wash, and a segment's identity is still readable at its
+/// centre.
+///
+/// Pure arithmetic over `RewindActivityBlock`s and colours, so a hermetic test can drive it without
+/// a window server; `RewindTrackNSView` only asks it what to draw.
+enum RewindTrackGradient {
+  /// Neighbours further apart than this many seconds are not one stretch of the day and keep a
+  /// hard edge. `RewindTrackWindow.blocks` tiles its output, so on a real track this is only ever
+  /// exceeded by a deliberately sparse input.
+  static let contiguousGap: Double = 90
+
+  /// The widest run, in points, over which an edge eases toward its neighbour. Kept short: a wide
+  /// blend on a narrow segment would leave it with no body colour at all.
+  static let maximumBlendWidth: CGFloat = 28
+
+  /// The colours a segment's two edges are drawn in, and how far in each blend reaches.
+  struct Edges: Equatable {
+    let leading: NSColor
+    let trailing: NSColor
+    let blendWidth: CGFloat
+  }
+
+  static func isContiguous(_ earlier: RewindActivityBlock, _ later: RewindActivityBlock) -> Bool {
+    later.startedAt - earlier.endedAt <= contiguousGap
+  }
+
+  /// The midpoint of two colours in device RGB — the one colour both sides of a seam agree on.
+  static func blend(_ a: NSColor, _ b: NSColor) -> NSColor {
+    guard let a = a.usingColorSpace(.deviceRGB), let b = b.usingColorSpace(.deviceRGB) else { return a }
+    return NSColor(
+      deviceRed: (a.redComponent + b.redComponent) / 2,
+      green: (a.greenComponent + b.greenComponent) / 2,
+      blue: (a.blueComponent + b.blueComponent) / 2,
+      alpha: 1)
+  }
+
+  /// The edges for `block`, given its neighbours on the track and its drawn width.
+  ///
+  /// An edge blends only toward a neighbour that is contiguous *and* a different app; a same-app
+  /// neighbour (a sparse sample can split one stretch) is the same colour, and a hard edge into the
+  /// same colour is invisible anyway. `width` bounds the blend so it never exceeds half the segment.
+  static func edges(
+    for block: RewindActivityBlock,
+    previous: RewindActivityBlock?,
+    next: RewindActivityBlock?,
+    width: CGFloat,
+    colour: (String) -> NSColor
+  ) -> Edges {
+    let body = colour(block.app)
+    var leading = body
+    if let previous, previous.app != block.app, isContiguous(previous, block) {
+      leading = blend(colour(previous.app), body)
+    }
+    var trailing = body
+    if let next, next.app != block.app, isContiguous(block, next) {
+      trailing = blend(body, colour(next.app))
+    }
+    return Edges(leading: leading, trailing: trailing, blendWidth: min(maximumBlendWidth, max(0, width) / 2))
+  }
+
+  /// The gradient that paints a segment left to right: its leading edge easing into the body over
+  /// `blendWidth`, the body, then the body easing into the trailing edge.
+  static func gradient(body: NSColor, edges: Edges, width: CGFloat) -> NSGradient? {
+    guard width > 0 else { return nil }
+    let inset = min(0.5, edges.blendWidth / width)
+    return NSGradient(
+      colorsAndLocations: (edges.leading, 0), (body, inset), (body, 1 - inset), (edges.trailing, 1))
+  }
+}

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
@@ -58,9 +58,13 @@ enum RewindTimelineNavigation {
 /// a pure function of timestamps that a hermetic test can drive without a window server.
 enum RewindTrackWindow {
 
-  /// The narrowest window a zoom may reach — a minute across the bar is already finer than the
-  /// capture interval, so anything below it zooms into empty space.
-  static let minimumSpan: Double = 60
+  /// The narrowest window a zoom may reach.
+  ///
+  /// Ten seconds across the bar: at the default three-second capture interval that is three or
+  /// four frames, each a wide, individually scrubbable segment. The floor used to be a minute,
+  /// which left the last zoom steps feeling stuck when what the user wanted was to land on one
+  /// exact frame among a dense burst of app switches.
+  static let minimumSpan: Double = 10
 
   /// Exact retained-history bounds, padded enough that the end captures are not flush against the
   /// track. This range stays global while viewport samples come and go beneath it.
@@ -71,20 +75,38 @@ enum RewindTrackWindow {
     return lower...upper
   }
 
+  /// A gap between consecutive captures longer than this is a break in capture — the machine was
+  /// asleep, capture was off, the app was quit — rather than the space between two samples.
+  ///
+  /// Measured against the larger of this and three sampling intervals, so the rule holds at every
+  /// zoom: a viewport is a bounded sample (`RewindViewModel.timelineSampleTarget`), and at all-time
+  /// zoom the samples themselves sit further apart than fifteen minutes.
+  static let maximumTiledGap: Double = 15 * 60
+
   /// Contiguous same-app stretches, in capture order.
   ///
-  /// Blocks tile: each one ends where the next begins, so the bar has no seams the data did not put
-  /// there. The last block is given the run's median sampling interval so a day still in progress
-  /// does not end in a zero-width segment.
+  /// Blocks tile across the gaps sampling puts between captures: each one ends where the next
+  /// begins, so the bar has no seams the data did not put there. A block does **not** reach across
+  /// a break in capture (`maximumTiledGap`); it ends one sampling interval after its last capture
+  /// and the gap stays the empty channel.
+  ///
+  /// That distinction is what keeps the bar honest across zoom levels. A viewport loads only the
+  /// captures inside it, so a block stretched to the next capture painted a lunch break as the app
+  /// used before it at day zoom, and painted the same hours grey once the viewport no longer
+  /// contained that earlier capture — colour that disappeared as the user panned. The last block
+  /// gets the same one-interval tail so a day still in progress does not end in a zero-width
+  /// segment.
   static func blocks(from instants: [Double], apps: [String]) -> [RewindActivityBlock] {
     guard instants.count == apps.count, !instants.isEmpty else { return [] }
-    let tail = medianInterval(of: instants)
+    let tail = samplingInterval(of: instants)
+    let breakAfter = max(maximumTiledGap, 3 * tail)
     var result: [RewindActivityBlock] = []
     var startIndex = 0
     for index in 1...instants.count {
       let ended = index == instants.count
-      if ended || apps[index] != apps[startIndex] {
-        let endedAt = ended ? instants[instants.count - 1] + tail : instants[index]
+      let breaks = !ended && instants[index] - instants[index - 1] > breakAfter
+      if ended || breaks || apps[index] != apps[startIndex] {
+        let endedAt = ended || breaks ? instants[index - 1] + tail : instants[index]
         result.append(
           RewindActivityBlock(
             app: apps[startIndex], startedAt: instants[startIndex], endedAt: endedAt))
@@ -121,6 +143,29 @@ enum RewindTrackWindow {
 
   /// The median gap between consecutive captures — the run's own sampling interval, measured rather
   /// than assumed, because Rewind's capture rate is a user setting.
+  /// The spacing between samples, for `blocks` — the quantity a break has to be measured against.
+  ///
+  /// Not the median. In a short history — a day just after midnight, a window over one working
+  /// session — a single outage can be half the gaps or more, and a median that has absorbed it
+  /// makes the break threshold three outages long, so the outage tiles as the app before it. The
+  /// lower quartile is the gap that is typical of the *samples*, which the odd outage cannot move;
+  /// a sparse all-time sample, where every gap is wide, still measures its own spacing. With fewer
+  /// than four gaps there is no quartile to speak of, so the smallest gap stands in and the fixed
+  /// cutoff caps it: two frames an hour apart are a break, not a sampling rate.
+  static func samplingInterval(of instants: [Double]) -> Double {
+    guard instants.count > 1 else { return 60 }
+    var gaps: [Double] = []
+    gaps.reserveCapacity(instants.count - 1)
+    for index in 1..<instants.count {
+      let gap = instants[index] - instants[index - 1]
+      if gap > 0 { gaps.append(gap) }
+    }
+    guard !gaps.isEmpty else { return 60 }
+    gaps.sort()
+    guard gaps.count >= 4 else { return min(gaps[0], maximumTiledGap) }
+    return gaps[gaps.count / 4]
+  }
+
   static func medianInterval(of instants: [Double]) -> Double {
     guard instants.count > 1 else { return 60 }
     var gaps: [Double] = []

--- a/desktop/macos/Desktop/Tests/RewindTrackGradientTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackGradientTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// The timeline track blends adjacent segments into each other and draws every app as a pastel of
+/// its palette hue. Both are arithmetic, so both are asserted here without a window server.
+final class RewindTrackGradientTests: XCTestCase {
+  private let red = NSColor(deviceRed: 1, green: 0, blue: 0, alpha: 1)
+  private let blue = NSColor(deviceRed: 0, green: 0, blue: 1, alpha: 1)
+
+  private func colour(_ app: String) -> NSColor { app == "A" ? red : blue }
+
+  private func components(_ colour: NSColor) throws -> [CGFloat] {
+    let rgb = try XCTUnwrap(colour.usingColorSpace(.deviceRGB))
+    return [rgb.redComponent, rgb.greenComponent, rgb.blueComponent]
+  }
+
+  private func assertSameColour(_ a: NSColor, _ b: NSColor, _ message: String, line: UInt = #line) throws {
+    for (x, y) in zip(try components(a), try components(b)) {
+      XCTAssertEqual(x, y, accuracy: 0.001, message, line: line)
+    }
+  }
+
+  // MARK: - Seams
+
+  func testContiguousNeighboursMeetAtOneSharedColour() throws {
+    let a = RewindActivityBlock(app: "A", startedAt: 0, endedAt: 100)
+    let b = RewindActivityBlock(app: "B", startedAt: 100, endedAt: 200)
+
+    let aEdges = RewindTrackGradient.edges(for: a, previous: nil, next: b, width: 200, colour: colour)
+    let bEdges = RewindTrackGradient.edges(for: b, previous: a, next: nil, width: 200, colour: colour)
+
+    let midpoint = RewindTrackGradient.blend(red, blue)
+    try assertSameColour(aEdges.trailing, midpoint, "A's trailing edge is the colour halfway to B")
+    try assertSameColour(bEdges.leading, midpoint, "B's leading edge is that same colour — the seam is continuous")
+    try assertSameColour(aEdges.leading, red, "an edge with no neighbour stays the body colour")
+    try assertSameColour(bEdges.trailing, blue, "an edge with no neighbour stays the body colour")
+    XCTAssertEqual(try components(midpoint), [0.5, 0, 0.5])
+  }
+
+  func testAGapWiderThanAStretchKeepsAHardEdge() throws {
+    let a = RewindActivityBlock(app: "A", startedAt: 0, endedAt: 100)
+    let b = RewindActivityBlock(
+      app: "B", startedAt: 100 + RewindTrackGradient.contiguousGap + 1, endedAt: 400)
+
+    let aEdges = RewindTrackGradient.edges(for: a, previous: nil, next: b, width: 200, colour: colour)
+    try assertSameColour(aEdges.trailing, red, "a lunch break is a gap, not a seam to blend across")
+  }
+
+  func testASameAppNeighbourIsNotBlendedInto() throws {
+    let first = RewindActivityBlock(app: "A", startedAt: 0, endedAt: 100)
+    let second = RewindActivityBlock(app: "A", startedAt: 100, endedAt: 200)
+    let edges = RewindTrackGradient.edges(for: first, previous: nil, next: second, width: 200, colour: colour)
+    try assertSameColour(edges.trailing, red, "one app split across two samples is one colour")
+  }
+
+  func testTheBlendNeverEatsMoreThanHalfASegment() throws {
+    let block = RewindActivityBlock(app: "A", startedAt: 0, endedAt: 1)
+    let wide = RewindTrackGradient.edges(for: block, previous: nil, next: nil, width: 400, colour: colour)
+    XCTAssertEqual(wide.blendWidth, RewindTrackGradient.maximumBlendWidth)
+    let narrow = RewindTrackGradient.edges(for: block, previous: nil, next: nil, width: 10, colour: colour)
+    XCTAssertEqual(narrow.blendWidth, 5, "a narrow segment keeps its centre in its own colour")
+
+    let gradient = try? XCTUnwrap(
+      RewindTrackGradient.gradient(body: red, edges: narrow, width: 10))
+    XCTAssertEqual(gradient?.numberOfColorStops, 4)
+    XCTAssertNil(RewindTrackGradient.gradient(body: red, edges: narrow, width: 0))
+  }
+
+  // MARK: - The pastel
+
+  /// Same hue as the vivid swatch (an app keeps its identity), lighter than it (it is a pastel), and
+  /// still inside the brand's hue ceiling — over every colour the palette can emit, not a sample.
+  func testTheTrackPastelKeepsTheHueAndLightensEverySwatch() throws {
+    for bucket in 0..<RewindPalette.hueBuckets {
+      let vivid = RewindPalette.swatch(bucket: bucket)
+      let pastel = RewindPalette.trackSwatch(bucket: bucket)
+      XCTAssertEqual(pastel.hue, vivid.hue, "bucket \(bucket) changed hue on the track")
+      XCTAssertLessThan(pastel.hue, RewindPalette.hueCeiling)
+      XCTAssertGreaterThan(
+        Self.relativeLuminance(RewindPalette.nsColor(pastel)),
+        Self.relativeLuminance(RewindPalette.nsColor(vivid)),
+        "the track pastel for bucket \(bucket) is not lighter than the badge swatch")
+      // The per-band track brightness lands every family in one lightness window: measured
+      // 0.457–0.632 over the whole domain (red and blue at the floor, where the largest brightness
+      // there is still cannot lift them further at this saturation). A family that drifted above
+      // it would sit a hair off the glass and read as an empty stretch.
+      let luminance = Self.relativeLuminance(RewindPalette.nsColor(pastel))
+      XCTAssertGreaterThan(luminance, 0.44, "bucket \(bucket) is too dark to read as pastel")
+      XCTAssertLessThan(luminance, 0.66, "bucket \(bucket) is washing toward the glass")
+    }
+  }
+
+  func testTheTrackColourIsTheSamePastelForTheSameApp() throws {
+    let a = RewindPalette.trackNSColor(forApp: "Google Chrome")
+    let b = RewindPalette.trackNSColor(forApp: "google chrome ")
+    try assertSameColour(a, b, "the track folds names the same way the palette does")
+  }
+
+  // MARK: - Helpers
+
+  private static func relativeLuminance(_ colour: NSColor) -> Double {
+    guard let rgb = colour.usingColorSpace(.deviceRGB) else { return 0 }
+    func linear(_ channel: CGFloat) -> Double {
+      let c = Double(channel)
+      return c <= 0.03928 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * linear(rgb.redComponent) + 0.7152 * linear(rgb.greenComponent)
+      + 0.0722 * linear(rgb.blueComponent)
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindTrackTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackTests.swift
@@ -107,14 +107,61 @@ final class RewindTrackTests: XCTestCase {
 
   // MARK: - Blocks
 
-  func testBlocksGroupContiguousAppsAndTile() {
+  func testBlocksGroupContiguousAppsAndLeaveABreakInCaptureUncovered() {
     let day = gappedDay()
     let blocks = RewindTrackWindow.blocks(from: day.instants, apps: day.apps)
     XCTAssertEqual(blocks.map(\.app), ["Xcode", "Safari"])
-    // The first block ends where the second begins — no seam the data did not put there.
-    XCTAssertEqual(blocks[0].endedAt, blocks[1].startedAt)
+    // Three hours with no capture is a break, not a seam: Xcode ends one sampling interval after
+    // its last capture and Safari starts at its first, so the gap stays the empty channel at every
+    // zoom instead of reading as Xcode at day zoom and as nothing once the viewport moves on.
+    XCTAssertEqual(blocks[0].endedAt, day.instants[4] + 60, accuracy: 0.001)
+    XCTAssertEqual(blocks[1].startedAt, day.instants[5])
+    XCTAssertLessThan(blocks[0].endedAt, blocks[1].startedAt)
     // The last block is given the run's own sampling interval rather than zero width.
     XCTAssertEqual(blocks[1].endedAt, day.instants[day.instants.count - 1] + 60, accuracy: 0.001)
+  }
+
+  /// The space between two samples is tiled; the space where capture stopped is not — and a run of
+  /// one app across a break is two blocks of that app.
+  func testBlocksTileSamplingGapsButBreakAtACaptureGap() {
+    let base = 1_700_000_000.0
+    // Xcode every 60 s, a 5-minute gap into Safari (tiled), then an hour of nothing before Xcode again.
+    let instants = [base, base + 60, base + 120, base + 420, base + 480, base + 4_080, base + 4_140]
+    let apps = ["Xcode", "Xcode", "Xcode", "Safari", "Safari", "Xcode", "Xcode"]
+    let blocks = RewindTrackWindow.blocks(from: instants, apps: apps)
+    XCTAssertEqual(blocks.map(\.app), ["Xcode", "Safari", "Xcode"])
+    XCTAssertEqual(blocks[0].endedAt, blocks[1].startedAt, "a five-minute sampling gap is tiled")
+    XCTAssertEqual(blocks[1].endedAt, base + 480 + 60, accuracy: 0.001, "an hour of nothing ends the run")
+    XCTAssertEqual(blocks[2].startedAt, base + 4_080)
+  }
+
+  /// A short history with one outage: the outage is most of the gaps, so a median would absorb it
+  /// and the block would reach across it. The sampling estimate must come from the samples.
+  func testAShortHistoryWithOneOutageStillBreaksAtTheOutage() {
+    let base = 1_700_000_000.0
+    let instants = [base, base + 60, base + 120, base + 3_600, base + 3_660]
+    let apps = ["Xcode", "Xcode", "Xcode", "Xcode", "Xcode"]
+    let blocks = RewindTrackWindow.blocks(from: instants, apps: apps)
+    XCTAssertEqual(blocks.count, 2, "an hour with no capture splits one app's run")
+    XCTAssertEqual(blocks[0].endedAt, base + 120 + 60, accuracy: 0.001)
+    XCTAssertEqual(blocks[1].startedAt, base + 3_600)
+
+    // Two frames an hour apart are a break, not a sampling rate.
+    let pair = RewindTrackWindow.blocks(from: [base, base + 3_600], apps: ["Xcode", "Xcode"])
+    XCTAssertEqual(pair.count, 2)
+    XCTAssertEqual(pair[0].endedAt, base + RewindTrackWindow.maximumTiledGap, accuracy: 0.001)
+  }
+
+  /// A sparse all-time sample is legitimately spaced wider than the cutoff; its own spacing is not
+  /// a break, so the day still reads as one stretch rather than a row of dashes.
+  func testASparseUniformSampleTilesItsOwnSpacing() {
+    let base = 1_700_000_000.0
+    let spacing = 1_210.0
+    let instants = (0..<40).map { base + Double($0) * spacing }
+    let apps = Array(repeating: "Safari", count: 40)
+    let blocks = RewindTrackWindow.blocks(from: instants, apps: apps)
+    XCTAssertEqual(blocks.count, 1)
+    XCTAssertEqual(blocks[0].endedAt, instants[39] + spacing, accuracy: 0.001)
   }
 
   func testBlocksSurviveAlternatingApps() {
@@ -126,6 +173,47 @@ final class RewindTrackTests: XCTestCase {
     XCTAssertTrue(RewindTrackWindow.blocks(from: [], apps: []).isEmpty)
   }
 
+  // MARK: - Pinch
+
+  /// `NSEvent.magnification` arrives as per-event deltas. The pinch has to sum them: read as totals,
+  /// ten small steps zoomed from the start span by the last step alone and the gesture went nowhere.
+  func testAPinchSumsItsDeltasAndAnchorsUnderTheFingers() throws {
+    let day = gappedDay()
+    let view = track(day.instants, day.apps)
+    let start = view.trackStart
+    let span = view.trackSpan
+    var zoomed: (start: Double, span: Double)?
+    view.onZoom = { zoomed = ($0, $1) }
+
+    view.handleMagnification(0, phase: .began, atX: 500)
+    for _ in 0..<10 { view.handleMagnification(0.1, phase: .changed, atX: 500) }
+    let result = try XCTUnwrap(zoomed)
+    XCTAssertEqual(result.span, span / 8, accuracy: 0.01, "a full pinch out shows an eighth of the time")
+    // The instant under the fingers stays under the fingers.
+    XCTAssertEqual(result.start + 0.5 * result.span, start + 0.5 * span, accuracy: 0.01)
+    view.handleMagnification(0, phase: .ended, atX: 500)
+
+    // The page applies the zoom back to the track; the next pinch composes from there.
+    view.apply(
+      blocks: RewindTrackWindow.blocks(from: day.instants, apps: day.apps), instants: day.instants,
+      searchResultIndices: nil, trackStart: result.start, trackSpan: result.span,
+      spanBounds: RewindTrackWindow.minimumSpan...span, playheadAt: nil)
+    view.handleMagnification(-0.5, phase: .began, atX: 500)
+    XCTAssertEqual(
+      try XCTUnwrap(zoomed).span, result.span * pow(2, 1.5), accuracy: 0.01,
+      "a pinch in composes with where the last pinch left the track")
+  }
+
+  func testAPinchStopsAtTheZoomFloor() throws {
+    let day = gappedDay()
+    let view = track(day.instants, day.apps)
+    var zoomed: (start: Double, span: Double)?
+    view.onZoom = { zoomed = ($0, $1) }
+    view.handleMagnification(0, phase: .began, atX: 500)
+    for _ in 0..<60 { view.handleMagnification(0.2, phase: .changed, atX: 500) }
+    XCTAssertEqual(try XCTUnwrap(zoomed).span, RewindTrackWindow.minimumSpan, accuracy: 0.001)
+  }
+
   // MARK: - Tick ladder
 
   func testTickLadderPicksTheFirstIntervalYieldingTwelveMarksOrFewer() {
@@ -133,6 +221,9 @@ final class RewindTrackTests: XCTestCase {
     XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: 24 * 3600), 2 * 3600)
     // An hour is minute marks only until there are more than twelve of them.
     XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: 600), 60)
+    // Below a minute the ladder keeps stepping down, so the floor still shows a dozen marks.
+    XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: 60), 5)
+    XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: RewindTrackWindow.minimumSpan), 1)
     XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: 3600), 300)
     XCTAssertEqual(RewindTrackNSView.tickInterval(forSpan: 6 * 3600), 1800)
     // Past the ladder's top the marks are a day apart rather than absent.
@@ -151,6 +242,11 @@ final class RewindTrackTests: XCTestCase {
       minutes.string(from: noon),
       minutes.string(from: noon.addingTimeInterval(60)),
       "two ticks a minute apart must not carry the same label")
+    let seconds = RewindTrackNSView.tickFormatter(forInterval: 5)
+    XCTAssertNotEqual(
+      seconds.string(from: noon),
+      seconds.string(from: noon.addingTimeInterval(5)),
+      "two ticks five seconds apart must not carry the same label")
   }
 
   func testAllTimeDayTicksNameDatesRatherThanRepeatingMidnight() {
@@ -283,7 +379,7 @@ final class RewindTrackTests: XCTestCase {
     XCTAssertEqual(tooNarrow.span, RewindTrackWindow.minimumSpan, accuracy: 0.001)
   }
 
-  func testZoomOutProgressivelyReachesAllHistoryAndZoomInStopsAtAMinute() {
+  func testZoomOutProgressivelyReachesAllHistoryAndZoomInStopsAtTheFloor() {
     let model = RewindTrackWindowModel()
     model.adopt(range: 0...14_400, initialWindow: 10_800...14_400)
     XCTAssertEqual(model.span, 3600, accuracy: 0.001, "first paint stays on the recent window")

--- a/desktop/macos/changelog/unreleased/20260905-rewind-pastel-timeline.json
+++ b/desktop/macos/changelog/unreleased/20260905-rewind-pastel-timeline.json
@@ -1,0 +1,3 @@
+{
+  "change": "The Rewind timeline now draws apps in soft pastel colors that blend into each other instead of switching hard from one color to the next"
+}

--- a/desktop/macos/changelog/unreleased/20260905-rewind-zoom-floor.json
+++ b/desktop/macos/changelog/unreleased/20260905-rewind-zoom-floor.json
@@ -1,0 +1,3 @@
+{
+  "change": "The Rewind timeline can now zoom in six times further, down to ten seconds across the bar, with second-by-second tick labels"
+}

--- a/desktop/macos/e2e/flows/rewind.yaml
+++ b/desktop/macos/e2e/flows/rewind.yaml
@@ -12,6 +12,7 @@ covers:
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindSurfaceLayout.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/AppIconView.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindTrack.swift
+  - desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackGradient.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindPage+CaptureHealth.swift
@@ -68,6 +69,14 @@ steps:
   - id: S3b
     name: Verify per-app colour identity and scrub smoothness
     do: "With the timeline showing, find an app badge whose real icon could not be resolved — it draws as a letter monogram on a filled circle. Verify the circle is a solid, saturated colour (not grey) and that the letter is white and legible on it. Verify two different apps get two different colours, and that the same app keeps its colour after quitting and relaunching the app (RewindPalette hashes the name, so the colour must not change across launches). Hold the left/right arrow keys to scrub several frames and verify the stage image keeps up. Then place the pointer on the timeline track: swipe right and verify the playhead moves right/newer, swipe left and verify it moves left/older; swiping over the frame or day popover must not move the track."
+    expect:
+      interactive_count: { min: 1 }
+
+  - id: S3b2
+    name: The track is a pastel strip with continuous seams and honest gaps
+    # RewindTrackGradient: segments are drawn in the track pastel (RewindPalette.trackSwatch) and
+    # neighbouring apps ease into each other; a break in capture is the empty channel at every zoom.
+    do: "Zoom the track out to the whole day (⊖ button or pinch in). Verify the segments are soft pastel tints rather than saturated blocks, and that where one app hands over to the next the colours blend across a short run instead of switching hard. Find a stretch with no capture (an hour or more) and verify it draws as the empty grey channel, not as the colour of the app before it. Zoom into that same stretch (⊕ or pinch out) and verify it is still grey, and that a captured stretch beside it keeps the same pastel it had at day zoom while you pan across the boundary."
     expect:
       interactive_count: { min: 1 }
 


### PR DESCRIPTION
## Summary
The Rewind timeline track is redrawn to match the glass it sits on, and its zoom now goes where the fingers take it.

**Colour.** Each app is drawn in a pastel projection of its palette hue (same hue, saturation 0.42, and a per-band brightness that lands every family in one lightness window, measured luminance 0.457–0.632 over the whole domain), so the strip reads as a soft continuous rainbow rather than half of it washing toward the glass. Adjacent segments ease into each other through the colour halfway between the two apps over a short run (at most 28 pt, never more than half a segment) instead of switching hard. Badges keep the vivid swatch for white monogram type. `RewindTrackGradient` holds the seam arithmetic; the painter bounds its paint to the visible bar while keeping the blend anchored to the segment's true ends.

**Gaps.** Blocks no longer tile across a real break in capture (longer than fifteen minutes, or three sampling intervals so the rule holds at all-time zoom; the interval is the lower quartile of the gaps, so one outage in a short history cannot absorb itself into the threshold). A gap is the empty channel at every zoom, instead of reading as the previous app at day zoom and going grey once the viewport panned past that capture, which looked like colour vanishing while scrolling.

**Zoom.** The floor drops from a minute to ten seconds across the bar; the tick ladder gains sub-minute rungs labelled `h:mm:ss`. A trackpad pinch now sums its per-event magnification deltas instead of reading each as the gesture total, so it zooms as far as the fingers travel (a full pinch out shows an eighth of the time), anchored under the fingers and composing with the previous pinch.

## Verification
- `xcrun swift test --filter 'RewindTrackTests|RewindTrackGradientTests|RewindPaletteTests|RewindSurfaceLayoutTests'` → 0 failures on the rebased tree: pastel keeps hue, stays under the brand hue ceiling and lightens every emittable swatch inside the 0.44–0.66 luminance window; seams share one colour; sampling gaps tile, capture gaps break, a short history with one outage breaks at it, a sparse uniform sample tiles its own spacing; the ladder reaches 1 s; a pinch sums to span/8, composes, and clamps at the floor
- `e2e/flows/rewind.yaml` gains a step (S3b2) that exercises the pastel strip, the seam blend, and the grey gap across zoom levels, which is what its `covers:` entry for `RewindTrackGradient.swift` now stands on
- swift-format, SwiftLint, `scripts/check_desktop_test_quality.py` clean; `scripts/pr-preflight` green (23 checks)
- Live on `omi-gradient-rewind` (signed in, seeded history): day view is a pastel strip with continuous seams; reproduced the pan-to-grey before the gap change and confirmed both zoom levels agree after it; panning with posted scroll-wheel events left every captured stretch painted; pinch reaches the ten-second floor with second labels

## Product invariants affected
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fydURVkJ4CMomvtt7aW53
