### PR TITLE
fix(memory): preserve explicit user saves after JIT ledger cutover

### DIFF
--- a/.github/failure-classes/FC-compatibility-writer-survives-ledger-cutover.json
+++ b/.github/failure-classes/FC-compatibility-writer-survives-ledger-cutover.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "id": "FC-compatibility-writer-survives-ledger-cutover",
+  "violated_contract": "When an authenticated explicit user fact reaches an account with fresh JIT ingress and stable ledger mode, the write route must select the canonical knowledge-ledger writer. Leaving that route on the compatibility writer reports an unavailable service and prevents the user's fact from becoming durable canonical state even though the account has completed cutover.",
+  "canonical_prevention": "Require an opaque direct-user route capability together with a fresh per-account JIT ingress decision and stable ledger control before selecting the direct ledger writer; preserve required-processing behavior for external, connector, and system writes. Prove the route through a real Firestore emulator with a manual POST that creates and reads back a ledger fact, plus fail-closed kill, unknown, mixed-batch, malformed-batch, forged-authority, and lifecycle cases.",
+  "canonical_prevention_artifact": [
+    "backend/scripts/jit_ledger_user_write_emulator_test.py",
+    "backend/utils/memory/memory_service.py",
+    "backend/utils/memory/knowledge_ledger.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/routers/memories.py",
+    "backend/scripts/jit_ledger_user_write_emulator_test.py",
+    "backend/utils/memory/canonical_memory_adapter.py",
+    "backend/utils/memory/knowledge_ledger.py",
+    "backend/utils/memory/memory_service.py"
+  ],
+  "status": "open"
+}

--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -25,6 +25,7 @@
         "scripts/deploy_status_report.py",
         "scripts/export_openapi.py",
         "scripts/firestore_python_apply_emulator_test.py",
+        "scripts/jit_ledger_user_write_emulator_test.py",
         "scripts/jit_proactivity_reservation_emulator_test.py",
         "scripts/knowledge_ledger_migration_emulator_test.py",
         "scripts/legacy_memory_retirement_readiness.py",

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -22,6 +22,7 @@ from utils.memory.memory_service import (
     MemoryService,
     fetch_memory_dict,
 )
+from utils.memory.canonical_memory_adapter import mint_direct_user_write_authority
 from utils.observability.fallback import record_fallback
 from utils.feedback import record_memory_feedback
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
@@ -376,6 +377,7 @@ async def create_memory(
             operation="create_memory",
             upsert_vector=False,
             require_canonical_promotion=True,
+            direct_user_authority=mint_direct_user_write_authority(),
         )
     except Exception:
         logger.exception("MemoryService create_memory failed uid=%s", uid)
@@ -472,6 +474,7 @@ async def create_memories_batch(
             operation="batch_create_memory",
             upsert_vectors=False,
             require_canonical_promotion=True,
+            direct_user_authority=mint_direct_user_write_authority(),
         )
     except Exception:
         logger.exception("MemoryService create_memories_batch failed uid=%s count=%s", uid, len(memory_dbs))

--- a/backend/scripts/jit_ledger_user_write_emulator_test.py
+++ b/backend/scripts/jit_ledger_user_write_emulator_test.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Exercise authenticated memory writes against the real Firestore emulator.
+
+This is intentionally an API-to-apply proof.  It keeps the explicit user
+memory route, the batch route, and the evidence-only import route separate so
+the ledger cutover cannot be proven by calling the apply adapter in isolation.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: E402 -- emulator safety/env bootstrapping must precede backend imports.
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+PROJECT_ID = os.environ.setdefault("GOOGLE_CLOUD_PROJECT", os.environ.get("GCLOUD_PROJECT", "demo-memory"))
+os.environ.setdefault("GCLOUD_PROJECT", PROJECT_ID)
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_jit_user_write_emulator_key_32_bytes")
+os.environ.setdefault("MEMORY_ENABLED", "on")
+os.environ.setdefault("MEMORY_MODE", "read")
+os.environ.setdefault("PROVIDER_MODE", "offline")
+os.environ.setdefault("GOOGLE_AUTH_DISABLE_GCE_CHECK", "true")
+os.environ.setdefault("GCE_METADATA_HOST", "127.0.0.1:9")
+os.environ.setdefault("MEMORY_BELIEF_MODEL_ENABLED", "false")
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from google.cloud import firestore
+
+from database.memory_collections import MemoryCollections
+from models.memory_apply import MemoryControlState, WriterMode
+from utils.jit_rollout import JIT_ADMISSION_ALLOWLIST
+
+UID = sorted(JIT_ADMISSION_ALLOWLIST)[0]
+INITIAL_HEAD = "jit-user-write-emulator-head"
+MANUAL_CONTENT = "[emulator] user explicitly prefers morning meetings"
+REJECTED_CONTENT = "[emulator] user rejects the afternoon meeting claim"
+EXTERNAL_CONTENT = "[emulator] connector observed a morning meeting"
+IMPORT_EXTERNAL_ID = "jit-user-write-import-artifact"
+
+
+def _assert_emulator_only() -> None:
+    host = (os.environ.get("FIRESTORE_EMULATOR_HOST") or "").strip()
+    if not host:
+        raise RuntimeError("FIRESTORE_EMULATOR_HOST is required; run through Firebase emulators:exec")
+    hostname = host.rsplit(":", 1)[0].strip("[]").lower()
+    if hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise RuntimeError(f"refusing non-loopback Firestore emulator host: {hostname}")
+    if not PROJECT_ID.startswith("demo-"):
+        raise RuntimeError(f"refusing non-demo Firestore project: {PROJECT_ID}")
+
+
+def _docs(db_client: Any, collection_path: str) -> list[dict[str, Any]]:
+    return [snapshot.to_dict() or {} for snapshot in db_client.collection(collection_path).stream()]
+
+
+def _clear_user(db_client: Any, collections: MemoryCollections) -> None:
+    for path in collections.all_collection_paths():
+        for snapshot in db_client.collection(path).stream():
+            snapshot.reference.delete()
+    db_client.document(collections.user_root).delete()
+
+
+def _seed_ledger_control(db_client: Any, collections: MemoryCollections) -> None:
+    control = MemoryControlState(
+        uid=UID,
+        head_commit_id=INITIAL_HEAD,
+        account_generation=7,
+        source_generation=11,
+        writer_mode=WriterMode.ledger,
+        writer_epoch=1,
+    )
+    db_client.document(collections.memory_apply_control_state).set(control.model_dump(mode="json"))
+
+
+def _app() -> FastAPI:
+    # Import after the emulator-only environment is established.  The route's
+    # rate-limit dependency still resolves, but its authenticated UID is
+    # supplied by this test's FastAPI dependency override.
+    from routers import memories
+    from utils.other import endpoints as auth
+
+    app = FastAPI()
+    app.include_router(memories.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: UID
+    return app
+
+
+def _expect(failures: list[str], condition: bool, message: str) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def main() -> int:
+    _assert_emulator_only()
+    db_client: Any = firestore.Client(project=PROJECT_ID)
+    collections = MemoryCollections(uid=UID)
+    failures: list[str] = []
+    _clear_user(db_client, collections)
+    _seed_ledger_control(db_client, collections)
+
+    try:
+        with TestClient(_app(), raise_server_exceptions=False) as client:
+            # A manual POST is an authenticated explicit user assertion.  In
+            # ledger mode it must reach save_fact/canonical apply and return a
+            # durable fact rather than a pending required-processing row.
+            single = client.post(
+                "/v3/memories",
+                json={"content": MANUAL_CONTENT, "category": "manual"},
+            )
+            _expect(failures, single.status_code == 200, f"manual POST status={single.status_code}")
+
+            items_after_single = _docs(db_client, collections.memory_items)
+            _expect(failures, len(items_after_single) == 1, "manual POST did not materialize exactly one item")
+            if items_after_single:
+                item = items_after_single[0]
+                _expect(
+                    failures,
+                    item.get("ledger_schema_version") == "knowledge_ledger.v1",
+                    "manual POST item is not a knowledge-ledger row",
+                )
+                _expect(failures, item.get("kind") == "fact", "manual POST item is not a fact")
+                _expect(
+                    failures,
+                    item.get("write_reason") == "direct_user_statement",
+                    "manual POST item lacks direct-user write reason",
+                )
+                _expect(failures, item.get("processing_state") == "processed", "manual POST remained pending")
+
+            operations_after_single = _docs(db_client, collections.memory_operations)
+            _expect(
+                failures,
+                len(operations_after_single) == 1
+                and operations_after_single[0].get("operation_type") == "ledger_mutation",
+                "manual POST did not use one ledger mutation operation",
+            )
+
+            # A retry after the account head advances still resolves to the
+            # active row for the same request identity.  It must not create a
+            # second fact merely because the first operation's response was
+            # lost.
+            retry = client.post(
+                "/v3/memories",
+                json={"content": MANUAL_CONTENT, "category": "manual"},
+            )
+            _expect(failures, retry.status_code == 200, f"active retry status={retry.status_code}")
+            _expect(
+                failures,
+                len(_docs(db_client, collections.memory_items)) == 1,
+                "active retry created a duplicate ledger row",
+            )
+
+            # A closed row is retained as history.  A retry with its old
+            # content-derived identity must fail honestly rather than
+            # resurrecting that row.  A distinct explicit action identity can
+            # still save the same text as a new user assertion.
+            from utils.memory.canonical_memory_adapter import (
+                close_canonical_ledger_item,
+                mint_direct_user_write_authority,
+                update_canonical_memory_review,
+            )
+            from utils.memory.knowledge_ledger import LedgerProvenance, save_fact
+            from models.product_memory import LedgerWriteReason
+
+            closed_item_id = items_after_single[0].get("memory_id") or items_after_single[0].get("id")
+            if isinstance(closed_item_id, str):
+                close_canonical_ledger_item(UID, closed_item_id, db_client=db_client)
+                closed_retry = client.post(
+                    "/v3/memories",
+                    json={"content": MANUAL_CONTENT, "category": "manual"},
+                )
+                _expect(
+                    failures,
+                    closed_retry.status_code == 503,
+                    f"closed same-content retry should fail closed status={closed_retry.status_code}",
+                )
+                _expect(
+                    failures,
+                    len(_docs(db_client, collections.memory_items)) == 1,
+                    "closed same-content retry resurrected or duplicated a row",
+                )
+                distinct_intent_id = save_fact(
+                    UID,
+                    MANUAL_CONTENT,
+                    provenance=LedgerProvenance(
+                        source_id="v3_manual:explicit-second-intent",
+                        source_type="explicit_user_statement",
+                        source_version="v3_memory_create.v1",
+                        action_id="v3_manual:explicit-second-intent",
+                    ),
+                    write_reason=LedgerWriteReason.direct_user_statement,
+                    db_client=db_client,
+                    _direct_user_authority=mint_direct_user_write_authority(),
+                )
+                _expect(
+                    failures,
+                    distinct_intent_id != closed_item_id,
+                    "distinct explicit same-content intent reused the closed row id",
+                )
+
+            # Rejection is an active audit row, so status-only duplicate
+            # handling is insufficient.  Retrying the old identity must not
+            # return the rejected row as if it were a successful current fact.
+            rejected = client.post(
+                "/v3/memories",
+                json={"content": REJECTED_CONTENT, "category": "manual"},
+            )
+            _expect(failures, rejected.status_code == 200, f"rejection fixture status={rejected.status_code}")
+            rejected_items = [
+                item for item in _docs(db_client, collections.memory_items) if item.get("content") == REJECTED_CONTENT
+            ]
+            if rejected_items:
+                rejected_id = rejected_items[0].get("memory_id") or rejected_items[0].get("id")
+                if isinstance(rejected_id, str):
+                    update_canonical_memory_review(UID, rejected_id, False, db_client=db_client)
+                    rejected_retry = client.post(
+                        "/v3/memories",
+                        json={"content": REJECTED_CONTENT, "category": "manual"},
+                    )
+                    _expect(
+                        failures,
+                        rejected_retry.status_code == 503,
+                        f"rejected same-content retry should fail closed status={rejected_retry.status_code}",
+                    )
+
+            # A kill-switch or unavailable/unknown JIT result never grants the
+            # direct ledger seam.  Under a ledger writer the compatibility
+            # fallback consequently fails closed without creating a row.
+            from utils.memory import memory_service as memory_service_module
+
+            original_resolver = memory_service_module.resolve_jit_rollout_sync
+            try:
+                for denial in ("kill_switch", "unknown_authority"):
+                    memory_service_module.resolve_jit_rollout_sync = lambda *_args, **_kwargs: SimpleNamespace(
+                        permits_work=False
+                    )
+                    before_denial_items = len(_docs(db_client, collections.memory_items))
+                    denied = client.post(
+                        "/v3/memories",
+                        json={"content": f"[emulator] denied {denial}", "category": "manual"},
+                    )
+                    _expect(
+                        failures, denied.status_code == 503, f"{denial} should fail closed status={denied.status_code}"
+                    )
+                    _expect(
+                        failures,
+                        len(_docs(db_client, collections.memory_items)) == before_denial_items,
+                        f"{denial} created a ledger row",
+                    )
+            finally:
+                memory_service_module.resolve_jit_rollout_sync = original_resolver
+
+            # A manual-only batch has the same explicit-user contract and must
+            # remain retry-stable.  The mixed batch is checked before writes so
+            # an external connector item cannot silently gain ledger authority
+            # by sharing a request with a manual item.
+            manual_batch = client.post(
+                "/v3/memories/batch",
+                json={"memories": [{"content": "[emulator] user prefers concise agendas", "category": "manual"}]},
+            )
+            _expect(failures, manual_batch.status_code == 200, f"manual batch status={manual_batch.status_code}")
+
+            # Ledger batch validation runs before any commit.  Whitespace-only
+            # content is accepted by the API model but rejected by LedgerWrite;
+            # placing it second catches the old valid-first/invalid-later
+            # partial-commit failure.
+            before_invalid_batch = len(_docs(db_client, collections.memory_items))
+            invalid_batch = client.post(
+                "/v3/memories/batch",
+                json={
+                    "memories": [
+                        {"content": "[emulator] valid batch item", "category": "manual"},
+                        {"content": "   ", "category": "manual"},
+                    ]
+                },
+            )
+            _expect(
+                failures,
+                invalid_batch.status_code == 503,
+                f"invalid direct batch should fail closed status={invalid_batch.status_code}",
+            )
+            _expect(
+                failures,
+                len(_docs(db_client, collections.memory_items)) == before_invalid_batch,
+                "invalid direct batch partially committed its valid first item",
+            )
+
+            # A forged non-capability value cannot select the direct writer or
+            # reach canonical apply, even when the caller supplies ledger data.
+            before_forged_authority = len(_docs(db_client, collections.memory_items))
+            try:
+                save_fact(
+                    UID,
+                    "[emulator] forged authority must not write",
+                    provenance=LedgerProvenance(
+                        source_id="forged-authority",
+                        source_type="explicit_user_statement",
+                        source_version="v3_memory_create.v1",
+                        action_id="forged-authority",
+                    ),
+                    write_reason=LedgerWriteReason.direct_user_statement,
+                    db_client=db_client,
+                    _direct_user_authority=object(),
+                )
+            except ValueError:
+                pass
+            else:
+                failures.append("forged direct-user authority was accepted")
+            _expect(
+                failures,
+                len(_docs(db_client, collections.memory_items)) == before_forged_authority,
+                "forged direct-user authority committed a ledger row",
+            )
+
+            item_count_before_mixed = len(_docs(db_client, collections.memory_items))
+            mixed_batch = client.post(
+                "/v3/memories/batch",
+                json={
+                    "memories": [
+                        {"content": "[emulator] user prefers concise agendas", "category": "manual"},
+                        {"content": EXTERNAL_CONTENT, "category": "interesting"},
+                    ]
+                },
+            )
+            _expect(
+                failures,
+                mixed_batch.status_code == 503,
+                f"ledger mixed batch should fail closed status={mixed_batch.status_code}",
+            )
+            _expect(
+                failures,
+                len(_docs(db_client, collections.memory_items)) == item_count_before_mixed,
+                "ledger mixed batch partially committed before rejecting connector input",
+            )
+
+            # Imports are evidence ingress.  They must remain accepted in
+            # ledger mode while creating no product memory or ledger row.
+            before_import_items = len(_docs(db_client, collections.memory_items))
+            import_response = client.post(
+                "/v3/memory-imports/batch",
+                json={
+                    "source_type": "local_files",
+                    "import_run_id": "jit-user-write-import-run",
+                    "items": [{"external_id": IMPORT_EXTERNAL_ID, "title": "[emulator] imported title"}],
+                },
+            )
+            _expect(
+                failures, import_response.status_code == 200, f"evidence import status={import_response.status_code}"
+            )
+            if import_response.status_code == 200:
+                payload = import_response.json()
+                _expect(failures, payload.get("artifacts_created") == 1, "evidence import did not create one artifact")
+                _expect(failures, payload.get("candidates_created") == 0, "evidence import created candidates")
+            _expect(
+                failures,
+                len(_docs(db_client, collections.memory_items)) == before_import_items,
+                "evidence import created a product memory",
+            )
+    finally:
+        _clear_user(db_client, collections)
+
+    if failures:
+        print("FAIL: JIT ledger direct-user API emulator proof")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: JIT ledger direct-user POST, batch fencing, and evidence-import emulator proof")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/run-emulator-proofs.sh
+++ b/backend/scripts/run-emulator-proofs.sh
@@ -100,6 +100,8 @@ run_proof "daily-sweep (crash / deletion / generation / paid-wipe)" \
   "$PYTHON" scripts/daily_memory_sweep_emulator_test.py
 run_proof "ledger correction, revert, standalone reopen, privacy fence" \
   "$PYTHON" scripts/knowledge_ledger_correction_emulator_test.py
+run_proof "direct-user ledger API writes / lifecycle / batch fence" \
+  "$PYTHON" scripts/jit_ledger_user_write_emulator_test.py
 run_proof_for_signal_only "planned + ambient proactivity arbitration" \
   "$PYTHON" scripts/jit_proactivity_reservation_emulator_test.py
 # Module execution, not a file path: this older proof has no sys.path bootstrap

--- a/backend/tests/unit/test_firestore_emulator_harness_wiring.py
+++ b/backend/tests/unit/test_firestore_emulator_harness_wiring.py
@@ -20,6 +20,32 @@ _DAILY_MEMORY_SWEEP_SCRIPT = _REPO_ROOT / "backend" / "scripts" / "daily_memory_
 _JIT_PROACTIVITY_RESERVATION_SCRIPT = (
     _REPO_ROOT / "backend" / "scripts" / "jit_proactivity_reservation_emulator_test.py"
 )
+_JIT_LEDGER_USER_WRITE_SCRIPT = _REPO_ROOT / "backend" / "scripts" / "jit_ledger_user_write_emulator_test.py"
+
+
+def test_jit_ledger_user_write_emulator_harness_is_wired_to_api_and_apply():
+    assert _JIT_LEDGER_USER_WRITE_SCRIPT.exists()
+    script = _JIT_LEDGER_USER_WRITE_SCRIPT.read_text()
+    for required in (
+        "TestClient",
+        "/v3/memories",
+        "/v3/memories/batch",
+        "/v3/memory-imports/batch",
+        "MemoryControlState",
+        "WriterMode.ledger",
+        "ledger_schema_version",
+        "ledger_mutation",
+        "candidates_created",
+        "FIRESTORE_EMULATOR_HOST",
+        "PASS: JIT ledger direct-user POST, batch fencing, and evidence-import emulator proof",
+    ):
+        assert required in script
+
+    package = json.loads((_REPO_ROOT / "package.json").read_text())
+    command = package["scripts"]["test:memory-jit-ledger-user-write:emulator"]
+    assert command.startswith("MEMORY_ENABLED=on npx --no-install firebase emulators:exec")
+    assert "--only firestore" in command
+    assert "backend/scripts/jit_ledger_user_write_emulator_test.py" in command
 
 
 def test_jit_proactivity_reservation_emulator_harness_uses_real_transactional_store() -> None:

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -2,6 +2,7 @@
 
 import os
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -205,6 +206,51 @@ def test_canonical_failure_does_not_fall_back_to_historical_writer(monkeypatch, 
             operation="create",
         )
     legacy_create.assert_not_called()
+
+
+def test_manual_memory_without_route_capability_stays_on_external_contract(service_mod):
+    service = service_mod.MemoryService(db_client=_FirestoreFake())
+    memory_db = service_mod.MemoryDB.model_validate(
+        _sample_memory_dict(memory_id="manual-memory", locked=False) | {"category": "manual", "manually_added": True}
+    )
+    compatibility_result = MagicMock(return_value=memory_db)
+    direct_result = MagicMock(return_value=memory_db)
+    service._canonical_write = compatibility_result
+    service._write_direct_user_fact = direct_result
+
+    result = service.create_external_memory(
+        "uid-test",
+        memory_db,
+        memory_system=service_mod.MemorySystem.CANONICAL,
+        consumer="internal-test",
+        operation="create",
+        direct_user_authority=None,
+    )
+
+    assert result is memory_db
+    compatibility_result.assert_called_once()
+    direct_result.assert_not_called()
+
+
+def test_direct_user_ledger_admission_requires_fresh_ingress_and_ledger_mode(monkeypatch, service_mod):
+    service = service_mod.MemoryService(db_client=_FirestoreFake())
+    authority = object()
+    calls = []
+    monkeypatch.setattr(service_mod, "is_direct_user_write_authority", lambda value: value is authority)
+
+    def resolve(uid, *, stage, force_refresh):
+        calls.append((uid, stage, force_refresh))
+        return SimpleNamespace(permits_work=True)
+
+    monkeypatch.setattr(service_mod, "resolve_jit_rollout_sync", resolve)
+    monkeypatch.setattr(
+        service_mod,
+        "ensure_canonical_apply_control_state",
+        lambda uid, *, db_client: SimpleNamespace(writer_mode=service_mod.WriterMode.ledger),
+    )
+
+    assert service._direct_user_ledger_admitted("uid-test", authority) is True
+    assert calls == [("uid-test", service_mod.JITDecisionStage.INGRESS, True)]
 
 
 def test_canonical_backend_preserves_released_adapter_signatures(service_mod):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -129,10 +129,30 @@ UserMutationPatchBuilder = Callable[[MemoryItem, datetime], Tuple[Payload, Paylo
 _LEDGER_WRITE_AUTHORITY = object()
 _DIRECT_USER_LEDGER_WRITE_AUTHORITY = object()
 _DIRECT_USER_LEDGER_EVIDENCE_TYPES = {
+    "explicit_user_statement",
     "explicit_user_correction",
     "explicit_user_reopen",
     "explicit_user_revert",
 }
+
+
+def mint_direct_user_write_authority() -> object:
+    """Mint the in-process capability held by authenticated user routes.
+
+    The returned object carries no user data and is intentionally checked by
+    identity.  Internal integration and extraction callers cannot opt into
+    the direct-user ledger seam by setting a payload field.
+    """
+
+    return _DIRECT_USER_LEDGER_WRITE_AUTHORITY
+
+
+def is_direct_user_write_authority(value: object | None) -> bool:
+    """Return whether ``value`` is the route-minted direct-user capability."""
+
+    return value is _DIRECT_USER_LEDGER_WRITE_AUTHORITY
+
+
 # ``knowledge_ledger`` imports this adapter, so the wire discriminator cannot
 # be imported back without a cycle. Keep this private copy contract-tested.
 _LEDGER_SCHEMA_VERSION = "knowledge_ledger.v1"
@@ -1488,6 +1508,11 @@ def _existing_identical_add_row(
     item = MemoryItem(**_snapshot_payload(snapshot))
     if item.status != MemoryItemStatus.active:
         return None
+    if (item.promotion or {}).get("user_review") is False:
+        # A rejected row remains active for audit/history, but it is not a
+        # successful retry target.  Reusing it would silently resurrect a
+        # user-rejected statement under the old content-derived identity.
+        return None
     if (item.content or "").strip() != (data.get("content") or "").strip():
         return None
     return item
@@ -1764,17 +1789,29 @@ def write_canonical_direct_user_knowledge_ledger_memory(
     required_source_item: Optional[MemoryItem] = None,
     ledger_reopen_receipt: Optional[MemoryLedgerReopenReceipt] = None,
 ) -> str:
-    """Dedicated append boundary for an explicit user correction, reopen, or revert."""
+    """Dedicated boundary for an explicit user fact or correction append."""
 
     evidence = _evidence_items_from_payload(data)
-    if (
-        data.get("ledger_schema_version") != _LEDGER_SCHEMA_VERSION
-        or data.get("write_reason") != LedgerWriteReason.direct_user_statement.value
-        or data.get("user_asserted") is not True
-        or (not data.get("supersedes") and ledger_reopen_receipt is None)
-        or not any(item.source_type in _DIRECT_USER_LEDGER_EVIDENCE_TYPES for item in evidence)
-    ):
-        raise ValueError("direct user ledger writes require an explicit correction, reopen, or revert append")
+    is_initial_user_fact = (
+        data.get("ledger_schema_version") == _LEDGER_SCHEMA_VERSION
+        and data.get("write_reason") == LedgerWriteReason.direct_user_statement.value
+        and data.get("user_asserted") is True
+        and not data.get("supersedes")
+        and ledger_reopen_receipt is None
+        and any(item.source_type == "explicit_user_statement" for item in evidence)
+    )
+    is_user_amendment = (
+        data.get("ledger_schema_version") == _LEDGER_SCHEMA_VERSION
+        and data.get("write_reason") == LedgerWriteReason.direct_user_statement.value
+        and data.get("user_asserted") is True
+        and (bool(data.get("supersedes")) or ledger_reopen_receipt is not None)
+        and any(
+            item.source_type in {"explicit_user_correction", "explicit_user_reopen", "explicit_user_revert"}
+            for item in evidence
+        )
+    )
+    if not (is_initial_user_fact or is_user_amendment):
+        raise ValueError("direct user ledger writes require an explicit user fact or append authority")
     client = db_client if db_client is not None else default_db_client
     evidence_items = (
         evidence if ledger_reopen_receipt is not None else _reissued_external_evidence(uid, evidence, db_client=client)

--- a/backend/utils/memory/knowledge_ledger.py
+++ b/backend/utils/memory/knowledge_ledger.py
@@ -37,6 +37,7 @@ from models.product_memory import (
 )
 from utils.memory.canonical_memory_adapter import (
     close_canonical_ledger_item,
+    is_direct_user_write_authority,
     memory_item_to_memorydb,
     read_canonical_memory_item,
     write_canonical_direct_user_knowledge_ledger_memory,
@@ -242,9 +243,14 @@ def save_ledger_write(
     }
     if ledger_reopen_receipt is not None:
         write_kwargs["ledger_reopen_receipt"] = ledger_reopen_receipt
+    direct_user_authorized = _direct_user_authority is _DIRECT_USER_AMEND_AUTHORITY or is_direct_user_write_authority(
+        _direct_user_authority
+    )
+    if _direct_user_authority is not None and not direct_user_authorized:
+        raise ValueError("unrecognized direct user write authority")
     write_memory = (
         write_canonical_direct_user_knowledge_ledger_memory
-        if _direct_user_authority is _DIRECT_USER_AMEND_AUTHORITY
+        if direct_user_authorized
         else write_canonical_knowledge_ledger_memory
     )
     return write_memory(
@@ -288,7 +294,12 @@ def save_fact(
     subject_scope: MemorySubjectScope = MemorySubjectScope.primary_user,
     subject_entity_id: Optional[str] = None,
     curation_weight: int = 0,
+    predicate: Optional[str] = None,
+    arguments: Optional[Dict[str, Any]] = None,
+    valid_from: Optional[datetime] = None,
+    visibility: Literal["private", "public", "shared"] = "private",
     db_client: Any = None,
+    _direct_user_authority: object | None = None,
 ) -> str:
     return save_ledger_write(
         uid,
@@ -301,8 +312,13 @@ def save_fact(
             subject_scope=subject_scope,
             subject_entity_id=subject_entity_id,
             curation_weight=curation_weight,
+            predicate=predicate,
+            arguments=dict(arguments or {}),
+            valid_from=valid_from,
+            visibility=visibility,
         ),
         db_client=db_client,
+        _direct_user_authority=_direct_user_authority,
     )
 
 

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -29,15 +29,16 @@ from models.knowledge_ledger_search import (
     is_ledger_row_admissible as is_ledger_row_admissible,
     ledger_row_is_rejected,
 )
+from models.memory_apply import WriterMode
 from models.product_memory import (
     MemoryAccessPolicy,
     MemoryConsumer,
     MemoryItem,
     MemoryItemStatus,
     MemoryKind,
+    MemorySubjectScope,
     LedgerWriteReason,
     MemoryTier,
-    MemorySubjectScope,
     ProcessingState,
     RESTRICTED_SENSITIVITY_LABELS,
     SourceState,
@@ -67,6 +68,7 @@ from utils.memory.canonical_memory_adapter import (
     update_canonical_memory_visibility,
     update_canonical_memory_product_fields,
     update_canonical_memory_review,
+    is_direct_user_write_authority,
     write_canonical_external_memory,
 )
 from utils.memory.product_memory_read_service import (
@@ -76,9 +78,11 @@ from utils.memory.product_memory_read_service import (
 from utils.memory.knowledge_ledger import (
     LEDGER_SCHEMA_VERSION,
     LedgerProvenance,
+    LedgerWrite,
     amend_user_fact as amend_fact,
     evidence_id_for_ledger_provenance,
     reopen_standalone_fact,
+    save_fact,
 )
 from utils.memory.ledger_history_policy import is_ledger_history_item
 from utils.memory.rejected_memory_feedback import clear_rejected_memory_feedback_cache
@@ -87,6 +91,8 @@ from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from utils.client_device import DeviceScopeRequest
 from utils.memory.device_scope_filter import memory_matches_device
 from utils.memory.memory_system import MemorySystem
+from utils.memory.memory_system import ensure_canonical_apply_control_state
+from utils.jit_rollout import JITDecisionStage, resolve_jit_rollout_sync
 from utils.memory.memory_api_contract import MemoryApiExposure, memory_api_payload
 from utils.memory.belief_model import public_belief_overlay_json
 from utils.memory.universal_list_cursor import (
@@ -3320,6 +3326,74 @@ class MemoryService:
             raise HTTPException(status_code=503, detail="Canonical memory write readback unavailable")
         return memory_item_to_memorydb(item)
 
+    def _direct_user_ledger_admitted(self, uid: str, authority: object | None) -> bool:
+        """Require route authority, fresh JIT ingress, and stable ledger mode."""
+        if not is_direct_user_write_authority(authority):
+            return False
+        decision = resolve_jit_rollout_sync(
+            uid,
+            stage=JITDecisionStage.INGRESS,
+            force_refresh=True,
+        )
+        if not decision.permits_work:
+            return False
+        control = ensure_canonical_apply_control_state(uid, db_client=self.db_client)
+        return control.writer_mode == WriterMode.ledger
+
+    def _write_direct_user_fact(
+        self,
+        uid: str,
+        memory_db: MemoryDB,
+        *,
+        consumer: str,
+        authority: object,
+    ) -> MemoryDB:
+        """Persist one explicitly typed memory through the ledger fact seam."""
+        provenance = self._direct_user_fact_provenance(memory_db, consumer=consumer)
+        memory_id = save_fact(
+            uid,
+            memory_db.content,
+            provenance=provenance,
+            write_reason=LedgerWriteReason.direct_user_statement,
+            subject_scope=memory_db.subject_scope or MemorySubjectScope.primary_user,
+            subject_entity_id=memory_db.subject_entity_id,
+            predicate=memory_db.predicate,
+            arguments=memory_db.arguments,
+            valid_from=memory_db.valid_at,
+            visibility=cast(Literal["private", "public", "shared"], memory_db.visibility or "private"),
+            db_client=self.db_client,
+            _direct_user_authority=authority,
+        )
+        item = read_canonical_memory_item(uid, memory_id, db_client=self.db_client)
+        if item is None:
+            raise HTTPException(status_code=503, detail="Canonical memory write readback unavailable")
+        return memory_item_to_memorydb(item)
+
+    @staticmethod
+    def _direct_user_fact_provenance(memory_db: MemoryDB, *, consumer: str) -> LedgerProvenance:
+        return LedgerProvenance(
+            source_id=f"{consumer}:{memory_db.id}",
+            source_type="explicit_user_statement",
+            source_version="v3_memory_create.v1",
+            action_id=f"{consumer}:memory:{memory_db.id}",
+            artifact_ref={"memory_id": memory_db.id},
+        )
+
+    def _validate_direct_user_fact(self, memory_db: MemoryDB, *, consumer: str) -> None:
+        """Run the same semantic model validation as save_fact without I/O."""
+        LedgerWrite(
+            kind=MemoryKind.fact,
+            content=memory_db.content,
+            provenance=self._direct_user_fact_provenance(memory_db, consumer=consumer),
+            write_reason=LedgerWriteReason.direct_user_statement,
+            subject_scope=memory_db.subject_scope or MemorySubjectScope.primary_user,
+            subject_entity_id=memory_db.subject_entity_id,
+            predicate=memory_db.predicate,
+            arguments=memory_db.arguments,
+            valid_from=memory_db.valid_at,
+            visibility=cast(Literal["private", "public", "shared"], memory_db.visibility or "private"),
+        )
+
     def write(self, uid: str, data: Dict[str, Any]) -> str:
         self.ensure_canonical_mutation_ready(uid)
         result = self._canonical.write(uid, data)
@@ -3873,9 +3947,19 @@ class MemoryService:
         operation: str,
         upsert_vector: bool = True,
         require_canonical_promotion: bool = True,
+        direct_user_authority: object | None = None,
     ) -> MemoryDB:
         del memory_system, operation, upsert_vector, require_canonical_promotion
-        result = self._canonical_write(uid, memory_db.model_dump(mode="python"), source_surface=consumer)
+        if memory_db.manually_added and self._direct_user_ledger_admitted(uid, direct_user_authority):
+            assert direct_user_authority is not None
+            result = self._write_direct_user_fact(
+                uid,
+                memory_db,
+                consumer=consumer,
+                authority=direct_user_authority,
+            )
+        else:
+            result = self._canonical_write(uid, memory_db.model_dump(mode="python"), source_surface=consumer)
         self._invalidate_prompt_cache(uid)
         return result
 
@@ -3889,9 +3973,31 @@ class MemoryService:
         operation: str,
         upsert_vectors: bool = True,
         require_canonical_promotion: bool = True,
+        direct_user_authority: object | None = None,
     ) -> List[MemoryDB]:
         del memory_system, operation, upsert_vectors, require_canonical_promotion
         self.ensure_canonical_mutation_ready(uid)
+        if direct_user_authority is not None and any(memory.manually_added for memory in memory_dbs):
+            if self._direct_user_ledger_admitted(uid, direct_user_authority):
+                assert direct_user_authority is not None
+                if not all(memory.manually_added for memory in memory_dbs):
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Mixed explicit-user and external memory batch is not admitted in ledger mode",
+                    )
+                for memory in memory_dbs:
+                    self._validate_direct_user_fact(memory, consumer=consumer)
+                results = [
+                    self._write_direct_user_fact(
+                        uid,
+                        memory,
+                        consumer=consumer,
+                        authority=direct_user_authority,
+                    )
+                    for memory in memory_dbs
+                ]
+                self._invalidate_prompt_cache(uid)
+                return results
         payloads = [
             required_processing_payload(memory.model_dump(mode="python"), source_surface=consumer)
             for memory in memory_dbs

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:memory-knowledge-ledger-correction:emulator": "MEMORY_ENABLED=on npx --no-install firebase emulators:exec --only firestore --project demo-memory \"backend/.venv/bin/python backend/scripts/knowledge_ledger_correction_emulator_test.py\"",
     "test:memory-daily-sweep:emulator": "MEMORY_ENABLED=on npx --no-install firebase emulators:exec --only firestore --project demo-daily-memory-sweep \"backend/.venv/bin/python backend/scripts/daily_memory_sweep_emulator_test.py\"",
     "test:memory-jit-proactivity-reservations:emulator": "MEMORY_ENABLED=on npx --no-install firebase emulators:exec --only firestore --project demo-memory \"backend/.venv/bin/python backend/scripts/jit_proactivity_reservation_emulator_test.py\"",
+    "test:memory-jit-ledger-user-write:emulator": "MEMORY_ENABLED=on npx --no-install firebase emulators:exec --only firestore --project demo-memory \"PYTHONPATH=backend MEMORY_MODE=read ENCRYPTION_SECRET=omi_jit_user_write_emulator_key_32_bytes backend/.venv/bin/python backend/scripts/jit_ledger_user_write_emulator_test.py\"",
     "test:listen-lifecycle:emulator": "firebase emulators:exec --only firestore --project demo-listen \"backend/.venv/bin/python backend/scripts/listen_lifecycle_emulator_test.py\"",
     "test:desktop-beta-admission:emulator": "bash backend/testing/desktop_beta_admission/run.sh",
     "test:listen-pusher-stack:emulator": "backend/testing/listen_pusher_stack/run.sh",


### PR DESCRIPTION
## Summary
After an admitted account enters ledger mode, POST /v3/memories currently returns 503 because the manual save is classified as a compatibility writer. Route authenticated explicit user facts through the JIT knowledge ledger with a fresh ingress decision and opaque route capability. Keep external and connector writes on required processing, fence mixed or malformed batches before writes, and prevent closed or rejected retries from being reported as current facts.

## Product invariants affected

- INV-MEM-3
- INV-MEM-4
- INV-MEM-1

## Validation

- 111 focused backend unit tests passed.
- Firestore emulator direct-user lifecycle proof passed.
- Shared backend emulator proof runner passed.
- Source pyright passed for changed production modules and emulator script.

Failure-Class: new
Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 3705 -> 3742 | direct user ledger retry and lifecycle safety boundary plus emulator proof
Line-Count-Exception: backend/utils/memory/memory_service.py | 3951 -> 4057 | direct user JIT admission and batch preflight boundary

A retry of a closed or rejected content-derived identity returns 503 rather than resurrecting it; explicit reopen remains the lifecycle path. Semantic batch validation occurs before writes, but storage-level batches remain sequential as before. This source change does not enable a cohort or deploy production. It is the manual-write prerequisite for #12546.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

