### PR TITLE
fix(desktop): project JIT ledger tools and type standing trigger input

### DIFF
--- a/backend/tests/unit/test_jit_trigger_contract.py
+++ b/backend/tests/unit/test_jit_trigger_contract.py
@@ -3,6 +3,7 @@ from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState
 from models.product_memory import (
@@ -33,6 +34,15 @@ from utils.retrieval.tools.knowledge_ledger_write_tools import build_paid_trigge
 NOW = datetime(2026, 8, 23, 14, 30, tzinfo=timezone.utc)
 SHARED_TRIGGER_MATRIX = (
     Path(__file__).resolve().parents[2].parent / "contracts" / "parity" / "jit_trigger_condition_matrix.json"
+)
+ADVERTISED_TOOL_MANIFEST = (
+    Path(__file__).resolve().parents[2].parent
+    / "desktop"
+    / "macos"
+    / "agent"
+    / "tests"
+    / "fixtures"
+    / "tool-manifest.json"
 )
 EMBEDDING = {
     "prototype_id": "release-review",
@@ -168,6 +178,34 @@ def test_shared_model_facing_trigger_payloads_compile_in_backend():
         compiled = build_paid_trigger_condition(payload["description"], payload["condition"])
         assert compiled["action"] == {"type": "agent_prompt", "prompt": payload["description"]}
         assert compiled["schema_version"] == "jit_trigger.v1"
+
+
+def test_shared_model_facing_trigger_payloads_validate_against_advertised_schema():
+    matrix = json.loads(SHARED_TRIGGER_MATRIX.read_text(encoding="utf-8"))
+    manifest = json.loads(ADVERTISED_TOOL_MANIFEST.read_text(encoding="utf-8"))
+    tool = next(entry for entry in manifest if entry["name"] == "create_standing_trigger")
+    validator = Draft202012Validator(tool["inputSchema"])
+    Draft202012Validator.check_schema(tool["inputSchema"])
+
+    for payload in matrix["valid_payloads"]:
+        errors = sorted(validator.iter_errors(payload), key=lambda error: list(error.path))
+        assert errors == [], [error.message for error in errors]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"description": "Watch for an incident", "condition": {"match_mode": "exact", "keywords": ["incident"]}},
+        {"description": "Watch for an incident", "condition": {"regex": {"pattern": "incident"}}},
+        {"description": "Watch for an incident", "condition": {"keywords": []}},
+    ],
+)
+def test_advertised_schema_rejects_historical_malformed_trigger_shapes(payload):
+    manifest = json.loads(ADVERTISED_TOOL_MANIFEST.read_text(encoding="utf-8"))
+    tool = next(entry for entry in manifest if entry["name"] == "create_standing_trigger")
+    validator = Draft202012Validator(tool["inputSchema"])
+
+    assert list(validator.iter_errors(payload))
 
 
 def test_all_conditions_match_and_double_run_is_byte_stable():

--- a/backend/tests/unit/test_jit_trigger_contract.py
+++ b/backend/tests/unit/test_jit_trigger_contract.py
@@ -1,4 +1,6 @@
+import json
 from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
 
 import pytest
 
@@ -26,8 +28,12 @@ from utils.memory.jit_trigger_contract import (
     evaluate_memory_item_trigger,
     evaluate_trigger,
 )
+from utils.retrieval.tools.knowledge_ledger_write_tools import build_paid_trigger_condition
 
 NOW = datetime(2026, 8, 23, 14, 30, tzinfo=timezone.utc)
+SHARED_TRIGGER_MATRIX = (
+    Path(__file__).resolve().parents[2].parent / "contracts" / "parity" / "jit_trigger_condition_matrix.json"
+)
 EMBEDDING = {
     "prototype_id": "release-review",
     "prototype_revision": "prototype-v1",
@@ -153,6 +159,15 @@ def test_trigger_action_is_bounded_typed_and_round_trips_with_selectors():
 def test_compiler_rejects_unbounded_or_ambiguous_schema(condition):
     with pytest.raises((TypeError, ValueError)):
         compile_trigger_condition(condition)
+
+
+def test_shared_model_facing_trigger_payloads_compile_in_backend():
+    matrix = json.loads(SHARED_TRIGGER_MATRIX.read_text(encoding="utf-8"))
+
+    for payload in matrix["valid_payloads"]:
+        compiled = build_paid_trigger_condition(payload["description"], payload["condition"])
+        assert compiled["action"] == {"type": "agent_prompt", "prompt": payload["description"]}
+        assert compiled["schema_version"] == "jit_trigger.v1"
 
 
 def test_all_conditions_match_and_double_run_is_byte_stable():

--- a/contracts/parity/jit_trigger_condition_matrix.json
+++ b/contracts/parity/jit_trigger_condition_matrix.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "description": "Model-facing standing-trigger payloads shared with the backend compiler.",
+  "valid_payloads": [
+    {
+      "description": "Notify me about incident discussions.",
+      "condition": {
+        "keywords": ["incident"]
+      }
+    },
+    {
+      "description": "Notify me when Slack mentions the budget.",
+      "condition": {
+        "match_mode": "all",
+        "apps": ["Slack"],
+        "keywords": ["budget"]
+      }
+    },
+    {
+      "description": "Notify me during release review hours.",
+      "condition": {
+        "time": {
+          "start": "09:00",
+          "end": "17:00",
+          "timezone": "UTC"
+        }
+      }
+    },
+    {
+      "description": "Notify me about release review meetings.",
+      "condition": {
+        "calendar": {
+          "event_keywords": ["release review"]
+        }
+      }
+    },
+    {
+      "description": "Notify me when the release owner is mentioned.",
+      "condition": {
+        "entity_aliases": {
+          "release_owner": ["David", "Dave"]
+        }
+      }
+    },
+    {
+      "description": "Notify me when an incident phrase appears.",
+      "condition": {
+        "regex": ["\\bincident\\b"]
+      }
+    },
+    {
+      "description": "Notify me in the release channel.",
+      "condition": {
+        "windows": ["#release"]
+      }
+    }
+  ]
+}

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -555,7 +555,7 @@ enum GeneratedToolCapabilities {
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
       "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
       "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
-      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description."
+      "For an exact phrase, use a keyword selector such as condition={keywords:[\"incident marker\"]} and describe the notification in description."
     ]
     ),
     Capability(

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -553,7 +553,9 @@ enum GeneratedToolCapabilities {
       "Only from explicit standing intent the user stated in this conversation, never an inferred habit.",
       "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
-      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead."
+      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
+      "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
+      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description."
     ]
     ),
     Capability(

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -56,8 +56,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:7659fe3706ce42b70ac470bc77e48cbc12c7530996196dd0e596dc7b3a9dbd5c"
-  static let chatFirstManifestDigest = "sha256:c1fb617335e228ac6358ec13355d33897a8d5e9949f7023327545fe74bae319a"
+  static let manifestDigest = "sha256:fe3c14f5515fa44710b2dd6568adc94457dc014b0d0bdb13b26b29e52c7a8eec"
+  static let chatFirstManifestDigest = "sha256:524661b519842cd5136a1e20fb129542f1afaa2b9c606786859f283e96210d2d"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -56,8 +56,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:fe3c14f5515fa44710b2dd6568adc94457dc014b0d0bdb13b26b29e52c7a8eec"
-  static let chatFirstManifestDigest = "sha256:524661b519842cd5136a1e20fb129542f1afaa2b9c606786859f283e96210d2d"
+  static let manifestDigest = "sha256:9bb306815a44abc53f245038cb490d7aca011478057ca0a10297b54d6e964886"
+  static let chatFirstManifestDigest = "sha256:ad430d643759d22ea438f4fdb7b770cf4821e1378d5724f049d3ab3b3693ef9f"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -491,7 +491,8 @@ export class PiMonoAdapter implements HarnessAdapter {
     surfaceKind?: string;
     chatFirstUi: boolean;
     controlGeneration: number | null;
-  } = { chatFirstUi: false, controlGeneration: null };
+    jitKnowledgeToolsEnabled: boolean;
+  } = { chatFirstUi: false, controlGeneration: null, jitKnowledgeToolsEnabled: false };
   private readonly sessionPrefix: string;
   /** True when a token refresh was deferred because a prompt was active */
   private pendingTokenRefresh = false;
@@ -588,6 +589,13 @@ export class PiMonoAdapter implements HarnessAdapter {
       delete env.OMI_SURFACE_KIND;
       delete env.OMI_CHAT_FIRST_UI;
       delete env.OMI_CHAT_FIRST_CONTROL_GENERATION;
+    }
+    // JIT knowledge-ledger tools are projected into Pi's process-local
+    // extension at spawn time. Always scrub the inherited environment first:
+    // an ambient true value must never survive a false per-turn gate.
+    delete env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED;
+    if (this.currentToolProjection.jitKnowledgeToolsEnabled) {
+      env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED = "true";
     }
     env.OMI_CONTEXT_FILE = this.contextFilePath;
     // User-authored skills from the Apps page: point pi's agent dir at the
@@ -723,11 +731,13 @@ export class PiMonoAdapter implements HarnessAdapter {
     surfaceKind?: string;
     chatFirstUi: boolean;
     controlGeneration: number | null;
+    jitKnowledgeToolsEnabled?: boolean;
   }): Promise<void> {
     const normalized: {
       surfaceKind?: string;
       chatFirstUi: boolean;
       controlGeneration: number | null;
+      jitKnowledgeToolsEnabled: boolean;
     } = projection.surfaceKind === "main_chat" || projection.surfaceKind === "floating_chat"
       ? {
           surfaceKind: projection.surfaceKind,
@@ -739,12 +749,18 @@ export class PiMonoAdapter implements HarnessAdapter {
             && (projection.controlGeneration ?? -1) >= 0
             ? projection.controlGeneration
             : null,
+          jitKnowledgeToolsEnabled: projection.jitKnowledgeToolsEnabled === true,
         }
-      : { chatFirstUi: false, controlGeneration: null };
+      : {
+          chatFirstUi: false,
+          controlGeneration: null,
+          jitKnowledgeToolsEnabled: projection.jitKnowledgeToolsEnabled === true,
+        };
     if (
       normalized.surfaceKind === this.currentToolProjection.surfaceKind
       && normalized.chatFirstUi === this.currentToolProjection.chatFirstUi
       && normalized.controlGeneration === this.currentToolProjection.controlGeneration
+      && normalized.jitKnowledgeToolsEnabled === this.currentToolProjection.jitKnowledgeToolsEnabled
     ) return;
     this.currentToolProjection = normalized;
     if (this.process) await this.stop();
@@ -1492,10 +1508,11 @@ function relayReasoningEffort(metadata: Record<string, unknown> | undefined): st
   return raw === "adaptive" || raw === "fast" ? raw : undefined;
 }
 
-function toolProjectionFromMetadata(metadata: Record<string, unknown> | undefined): {
+export function toolProjectionFromMetadata(metadata: Record<string, unknown> | undefined): {
   surfaceKind?: string;
   chatFirstUi: boolean;
   controlGeneration: number | null;
+  jitKnowledgeToolsEnabled: boolean;
 } {
   const generation = Number(metadata?.chatFirstControlGeneration);
   const typedSurface = metadata?.surfaceKind === "main_chat"
@@ -1508,8 +1525,17 @@ function toolProjectionFromMetadata(metadata: Record<string, unknown> | undefine
     && Number.isSafeInteger(generation)
     && generation >= 0;
   return typedSurface
-    ? { surfaceKind: typedSurface, chatFirstUi: enabled, controlGeneration: enabled ? generation : null }
-    : { chatFirstUi: false, controlGeneration: null };
+    ? {
+        surfaceKind: typedSurface,
+        chatFirstUi: enabled,
+        controlGeneration: enabled ? generation : null,
+        jitKnowledgeToolsEnabled: metadata?.jitKnowledgeToolsEnabled === true,
+      }
+    : {
+        chatFirstUi: false,
+        controlGeneration: null,
+        jitKnowledgeToolsEnabled: metadata?.jitKnowledgeToolsEnabled === true,
+      };
 }
 
 export class PiMonoRuntimeAdapter implements RuntimeAdapter {

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -181,6 +181,109 @@ function schema(properties: Record<string, unknown>, required: string[] = []): O
   };
 }
 
+/**
+ * The backend's TriggerCondition is a typed Pydantic contract even though the
+ * LangChain Dict annotation currently exposes it as an open object. Keep the
+ * desktop model-facing schema typed here so it can produce a payload the
+ * server compiler accepts on the first call. The backend remains the
+ * authority for selector bounds and safe-regex validation.
+ */
+const standingTriggerStringArray = (description: string, maxItems: number, maxLength = 80) => ({
+  type: "array",
+  items: { type: "string", minLength: 1, maxLength },
+  maxItems,
+  description,
+});
+
+const standingTriggerConditionSchema = {
+  type: "object",
+  properties: {
+    match_mode: {
+      type: "string",
+      enum: ["all", "any"],
+      default: "all",
+      description: "Whether every selector must match (all) or any one selector may match (any).",
+    },
+    entity_aliases: {
+      type: "object",
+      minProperties: 1,
+      maxProperties: 12,
+      additionalProperties: {
+        type: "array",
+        items: { type: "string", minLength: 1, maxLength: 80 },
+        minItems: 1,
+        maxItems: 16,
+      },
+      description: "Map an entity name to one or more aliases, e.g. {\"release_owner\":[\"David\",\"Dave\"]}.",
+    },
+    keywords: standingTriggerStringArray("Whole-word terms to match in captured context, e.g. [\"incident\", \"outage\"].", 32),
+    regex: standingTriggerStringArray(
+      "Safe regular expressions to match in captured context (no lookarounds, backreferences, or nested quantifiers).",
+      8,
+      160,
+    ),
+    apps: standingTriggerStringArray("Application names to match, e.g. [\"Slack\"].", 16),
+    windows: standingTriggerStringArray("Window titles to match, e.g. [\"#release\"].", 16, 120),
+    time: {
+      type: "object",
+      properties: {
+        weekdays: {
+          type: "array",
+          items: { type: "integer", minimum: 0, maximum: 6 },
+          maxItems: 7,
+          description: "Optional ISO weekday indexes 0 (Monday) through 6 (Sunday).",
+        },
+        start: {
+          type: "string",
+          pattern: "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?$",
+          description: "Inclusive local start time, e.g. 09:00.",
+        },
+        end: {
+          type: "string",
+          pattern: "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?$",
+          description: "Inclusive local end time, e.g. 17:00.",
+        },
+        timezone: {
+          type: "string",
+          minLength: 1,
+          description: "Optional installed IANA timezone; defaults to UTC, e.g. America/New_York.",
+        },
+      },
+      required: ["start", "end"],
+      additionalProperties: false,
+      description: "Time selector; start and end are both required when time is present.",
+    },
+    calendar: {
+      type: "object",
+      properties: {
+        event_keywords: standingTriggerStringArray("Calendar event title terms, e.g. [\"release review\"].", 32),
+        event_types: standingTriggerStringArray("Calendar event types, e.g. [\"meeting\"].", 32),
+      },
+      anyOf: [{ required: ["event_keywords"] }, { required: ["event_types"] }],
+      additionalProperties: false,
+      description: "Calendar selector; provide event_keywords or event_types (at least one).",
+    },
+  },
+  anyOf: [
+    { required: ["entity_aliases"] },
+    { required: ["keywords"] },
+    { required: ["regex"] },
+    { required: ["apps"] },
+    { required: ["windows"] },
+    { required: ["time"] },
+    { required: ["calendar"] },
+  ],
+  maxProperties: 8,
+  additionalProperties: false,
+  description:
+    "Typed deterministic selector payload. Examples: {\"keywords\":[\"incident\"]}; {\"apps\":[\"Slack\"],\"keywords\":[\"budget\"]}; {\"time\":{\"start\":\"09:00\",\"end\":\"17:00\",\"timezone\":\"UTC\"}}.",
+  examples: [
+    { keywords: ["incident"] },
+    { apps: ["Slack"], keywords: ["budget"] },
+    { time: { start: "09:00", end: "17:00", timezone: "UTC" } },
+  ],
+};
+
 function piAndStdio(condition: OmiToolCondition = "always"): Partial<Record<OmiToolAdapterId, OmiToolAdapterAvailability>> {
   return {
     "pi-mono": { advertised: condition !== "onboardingOnly", condition: condition === "always" ? undefined : condition },
@@ -1492,20 +1595,20 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
       "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
       "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
+      "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
+      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description.",
     ],
     latency: "fast network",
     inputSchema: schema(
       {
         description: {
           type: "string",
+          minLength: 1,
+          maxLength: 2000,
           description: "What to tell the user when this trigger fires, in your own words (at most 2000 characters).",
         },
         condition: {
-          type: "object",
-          properties: {},
-          additionalProperties: true,
-          description:
-            "Deterministic selector payload: match_mode, entity_aliases, keywords, regex, apps, windows, time, calendar.",
+          ...standingTriggerConditionSchema,
         },
       },
       ["description", "condition"],

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -191,6 +191,7 @@ function schema(properties: Record<string, unknown>, required: string[] = []): O
 const standingTriggerStringArray = (description: string, maxItems: number, maxLength = 80) => ({
   type: "array",
   items: { type: "string", minLength: 1, maxLength },
+  minItems: 1,
   maxItems,
   description,
 });
@@ -1596,7 +1597,7 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
       "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
       "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
-      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description.",
+      "For an exact phrase, use a keyword selector such as condition={keywords:[\"incident marker\"]} and describe the notification in description.",
     ],
     latency: "fast network",
     inputSchema: schema(

--- a/desktop/macos/agent/tests/fixtures/jit-knowledge-tool-gate-regression.json
+++ b/desktop/macos/agent/tests/fixtures/jit-knowledge-tool-gate-regression.json
@@ -1,0 +1,15 @@
+{
+  "prompt": "Please remember that I am running the synthetic JIT acceptance test marker JIT-QA-20260905-1808. Also create a standing trigger to notify me whenever that exact marker appears in a new conversation.",
+  "attemptedTool": {
+    "name": "create_memory",
+    "input": {
+      "content": "The user is running the synthetic JIT acceptance test marker JIT-QA-20260905-1808."
+    },
+    "resultCode": "memory_save_not_authorized"
+  },
+  "expected": {
+    "surfaceKind": "main_chat",
+    "jitKnowledgeToolsEnabled": true,
+    "toolName": "create_standing_trigger"
+  }
+}

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -4437,7 +4437,7 @@
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
       "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
       "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
-      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description."
+      "For an exact phrase, use a keyword selector such as condition={keywords:[\"incident marker\"]} and describe the notification in description."
     ],
     "latency": "fast network",
     "inputSchema": {
@@ -4484,6 +4484,7 @@
                 "minLength": 1,
                 "maxLength": 80
               },
+              "minItems": 1,
               "maxItems": 32,
               "description": "Whole-word terms to match in captured context, e.g. [\"incident\", \"outage\"]."
             },
@@ -4494,6 +4495,7 @@
                 "minLength": 1,
                 "maxLength": 160
               },
+              "minItems": 1,
               "maxItems": 8,
               "description": "Safe regular expressions to match in captured context (no lookarounds, backreferences, or nested quantifiers)."
             },
@@ -4504,6 +4506,7 @@
                 "minLength": 1,
                 "maxLength": 80
               },
+              "minItems": 1,
               "maxItems": 16,
               "description": "Application names to match, e.g. [\"Slack\"]."
             },
@@ -4514,6 +4517,7 @@
                 "minLength": 1,
                 "maxLength": 120
               },
+              "minItems": 1,
               "maxItems": 16,
               "description": "Window titles to match, e.g. [\"#release\"]."
             },
@@ -4563,6 +4567,7 @@
                     "minLength": 1,
                     "maxLength": 80
                   },
+                  "minItems": 1,
                   "maxItems": 32,
                   "description": "Calendar event title terms, e.g. [\"release review\"]."
                 },
@@ -4573,6 +4578,7 @@
                     "minLength": 1,
                     "maxLength": 80
                   },
+                  "minItems": 1,
                   "maxItems": 32,
                   "description": "Calendar event types, e.g. [\"meeting\"]."
                 }

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -4435,7 +4435,9 @@
     "promptGuidelines": [
       "Call this for an explicit standing-intent request such as 'watch for X and tell me' or 'let me know whenever Y happens'.",
       "Never call it from a pattern you merely noticed in passive behavior; an inferred habit is not standing intent.",
-      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead."
+      "Embedding/semantic selectors are not supported; use keywords, regex, apps, windows, time, or calendar selectors instead.",
+      "Use match_mode 'all' or 'any' (never 'exact'); regex must be an array of safe patterns; entity_aliases must be an object; time requires start and end; calendar requires event_keywords or event_types.",
+      "For an exact marker, use a keyword selector such as condition={keywords:[\"JIT-QA-20260905-1853\"]} and describe the notification in description."
     ],
     "latency": "fast network",
     "inputSchema": {
@@ -4443,13 +4445,216 @@
       "properties": {
         "description": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 2000,
           "description": "What to tell the user when this trigger fires, in your own words (at most 2000 characters)."
         },
         "condition": {
           "type": "object",
-          "properties": {},
-          "additionalProperties": true,
-          "description": "Deterministic selector payload: match_mode, entity_aliases, keywords, regex, apps, windows, time, calendar."
+          "properties": {
+            "match_mode": {
+              "type": "string",
+              "enum": [
+                "all",
+                "any"
+              ],
+              "default": "all",
+              "description": "Whether every selector must match (all) or any one selector may match (any)."
+            },
+            "entity_aliases": {
+              "type": "object",
+              "minProperties": 1,
+              "maxProperties": 12,
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 80
+                },
+                "minItems": 1,
+                "maxItems": 16
+              },
+              "description": "Map an entity name to one or more aliases, e.g. {\"release_owner\":[\"David\",\"Dave\"]}."
+            },
+            "keywords": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+              },
+              "maxItems": 32,
+              "description": "Whole-word terms to match in captured context, e.g. [\"incident\", \"outage\"]."
+            },
+            "regex": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              "maxItems": 8,
+              "description": "Safe regular expressions to match in captured context (no lookarounds, backreferences, or nested quantifiers)."
+            },
+            "apps": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80
+              },
+              "maxItems": 16,
+              "description": "Application names to match, e.g. [\"Slack\"]."
+            },
+            "windows": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 120
+              },
+              "maxItems": 16,
+              "description": "Window titles to match, e.g. [\"#release\"]."
+            },
+            "time": {
+              "type": "object",
+              "properties": {
+                "weekdays": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 6
+                  },
+                  "maxItems": 7,
+                  "description": "Optional ISO weekday indexes 0 (Monday) through 6 (Sunday)."
+                },
+                "start": {
+                  "type": "string",
+                  "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?$",
+                  "description": "Inclusive local start time, e.g. 09:00."
+                },
+                "end": {
+                  "type": "string",
+                  "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d)?$",
+                  "description": "Inclusive local end time, e.g. 17:00."
+                },
+                "timezone": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Optional installed IANA timezone; defaults to UTC, e.g. America/New_York."
+                }
+              },
+              "required": [
+                "start",
+                "end"
+              ],
+              "additionalProperties": false,
+              "description": "Time selector; start and end are both required when time is present."
+            },
+            "calendar": {
+              "type": "object",
+              "properties": {
+                "event_keywords": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  },
+                  "maxItems": 32,
+                  "description": "Calendar event title terms, e.g. [\"release review\"]."
+                },
+                "event_types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  },
+                  "maxItems": 32,
+                  "description": "Calendar event types, e.g. [\"meeting\"]."
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "event_keywords"
+                  ]
+                },
+                {
+                  "required": [
+                    "event_types"
+                  ]
+                }
+              ],
+              "additionalProperties": false,
+              "description": "Calendar selector; provide event_keywords or event_types (at least one)."
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "entity_aliases"
+              ]
+            },
+            {
+              "required": [
+                "keywords"
+              ]
+            },
+            {
+              "required": [
+                "regex"
+              ]
+            },
+            {
+              "required": [
+                "apps"
+              ]
+            },
+            {
+              "required": [
+                "windows"
+              ]
+            },
+            {
+              "required": [
+                "time"
+              ]
+            },
+            {
+              "required": [
+                "calendar"
+              ]
+            }
+          ],
+          "maxProperties": 8,
+          "additionalProperties": false,
+          "description": "Typed deterministic selector payload. Examples: {\"keywords\":[\"incident\"]}; {\"apps\":[\"Slack\"],\"keywords\":[\"budget\"]}; {\"time\":{\"start\":\"09:00\",\"end\":\"17:00\",\"timezone\":\"UTC\"}}.",
+          "examples": [
+            {
+              "keywords": [
+                "incident"
+              ]
+            },
+            {
+              "apps": [
+                "Slack"
+              ],
+              "keywords": [
+                "budget"
+              ]
+            },
+            {
+              "time": {
+                "start": "09:00",
+                "end": "17:00",
+                "timezone": "UTC"
+              }
+            }
+          ]
         }
       },
       "required": [

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -462,6 +462,39 @@ describe("omi tool manifest", () => {
       expect(byName.close_fact.inputSchema.required).toEqual(["memory_id", "reason"]);
     });
 
+    it("describes the typed backend standing-trigger condition contract", () => {
+      const tool = toolsForAdapter("pi-mono", { jitKnowledgeToolsEnabled: true }).find(
+        (entry) => entry.name === "create_standing_trigger",
+      );
+      const condition = tool?.inputSchema.properties.condition as Record<string, any>;
+      const properties = condition.properties as Record<string, any>;
+
+      expect(condition.additionalProperties).toBe(false);
+      expect(condition.anyOf).toEqual([
+        { required: ["entity_aliases"] },
+        { required: ["keywords"] },
+        { required: ["regex"] },
+        { required: ["apps"] },
+        { required: ["windows"] },
+        { required: ["time"] },
+        { required: ["calendar"] },
+      ]);
+      expect(properties.match_mode.enum).toEqual(["all", "any"]);
+      expect(properties.entity_aliases.additionalProperties.items.type).toBe("string");
+      expect(properties.keywords.items.type).toBe("string");
+      expect(properties.regex.items.type).toBe("string");
+      expect(properties.time.required).toEqual(["start", "end"]);
+      expect(properties.calendar.anyOf).toEqual([
+        { required: ["event_keywords"] },
+        { required: ["event_types"] },
+      ]);
+      expect(condition.examples).toEqual([
+        { keywords: ["incident"] },
+        { apps: ["Slack"], keywords: ["budget"] },
+        { time: { start: "09:00", end: "17:00", timezone: "UTC" } },
+      ]);
+    });
+
     it("steers durable facts, playbooks, standing intent, and closures away from generic tools", () => {
       const createMemory = omiToolManifest.find((entry) => entry.name === "create_memory");
       const searchKnowledge = omiToolManifest.find((entry) => entry.name === "search_knowledge");

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -482,12 +482,18 @@ describe("omi tool manifest", () => {
       expect(properties.match_mode.enum).toEqual(["all", "any"]);
       expect(properties.entity_aliases.additionalProperties.items.type).toBe("string");
       expect(properties.keywords.items.type).toBe("string");
+      expect(properties.keywords.minItems).toBe(1);
       expect(properties.regex.items.type).toBe("string");
+      expect(properties.regex.minItems).toBe(1);
+      expect(properties.apps.minItems).toBe(1);
+      expect(properties.windows.minItems).toBe(1);
       expect(properties.time.required).toEqual(["start", "end"]);
       expect(properties.calendar.anyOf).toEqual([
         { required: ["event_keywords"] },
         { required: ["event_types"] },
       ]);
+      expect(properties.calendar.properties.event_keywords.minItems).toBe(1);
+      expect(properties.calendar.properties.event_types.minItems).toBe(1);
       expect(condition.examples).toEqual([
         { keywords: ["incident"] },
         { apps: ["Slack"], keywords: ["budget"] },

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -8,6 +8,7 @@ import {
   PiMonoAdapter,
   PiMonoRuntimeAdapter,
   routePromptForPublicWeb,
+  toolProjectionFromMetadata,
 } from "../src/adapters/pi-mono.js";
 import { HarnessFeature, type AdapterAttemptContext, type HarnessConfig } from "../src/adapters/interface.js";
 import type { OutboundMessage } from "../src/protocol.js";
@@ -911,6 +912,40 @@ describe("PiMonoAdapter source-level invariants", () => {
   it("always scrubs ANTHROPIC_API_KEY from the child env", () => {
     expect(piMonoSrc).toMatch(/delete\s+env\.ANTHROPIC_API_KEY\s*;?/);
   });
+
+  it("preserves the explicit per-turn JIT gate in the adapter projection", () => {
+    expect(toolProjectionFromMetadata({
+      surfaceKind: "main_chat",
+      jitKnowledgeToolsEnabled: true,
+    }).jitKnowledgeToolsEnabled).toBe(true);
+    expect(toolProjectionFromMetadata({
+      surfaceKind: "main_chat",
+      jitKnowledgeToolsEnabled: "true",
+    }).jitKnowledgeToolsEnabled).toBe(false);
+    expect(toolProjectionFromMetadata({
+      surfaceKind: "main_chat",
+    }).jitKnowledgeToolsEnabled).toBe(false);
+  });
+
+  it("keeps the real failed JIT save attempt as an exact regression fixture", () => {
+    const fixture = JSON.parse(readFileSync(
+      fileURLToPath(new URL("./fixtures/jit-knowledge-tool-gate-regression.json", import.meta.url)),
+      "utf8",
+    )) as {
+      prompt: string;
+      attemptedTool: { name: string; input: { content: string }; resultCode: string };
+      expected: { surfaceKind: string; jitKnowledgeToolsEnabled: boolean; toolName: string };
+    };
+    expect(fixture.prompt).toBe(
+      "Please remember that I am running the synthetic JIT acceptance test marker JIT-QA-20260905-1808. Also create a standing trigger to notify me whenever that exact marker appears in a new conversation.",
+    );
+    expect(fixture.attemptedTool).toEqual({
+      name: "create_memory",
+      input: { content: "The user is running the synthetic JIT acceptance test marker JIT-QA-20260905-1808." },
+      resultCode: "memory_save_not_authorized",
+    });
+    expect(toolProjectionFromMetadata(fixture.expected).jitKnowledgeToolsEnabled).toBe(true);
+  });
 });
 
 describe("PiMonoAdapter spawn args (behavioral)", () => {
@@ -979,6 +1014,7 @@ describe("PiMonoAdapter spawn args (behavioral)", () => {
       surfaceKind: "main_chat",
       chatFirstUi: true,
       controlGeneration: 7,
+      jitKnowledgeToolsEnabled: true,
     });
     await adapter.start();
 
@@ -986,14 +1022,17 @@ describe("PiMonoAdapter spawn args (behavioral)", () => {
     expect(options.env.OMI_SURFACE_KIND).toBe("main_chat");
     expect(options.env.OMI_CHAT_FIRST_UI).toBe("true");
     expect(options.env.OMI_CHAT_FIRST_CONTROL_GENERATION).toBe("7");
-    await adapter.stop();
-
+    expect(options.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED).toBe("true");
     vi.mocked(spawn).mockClear();
     await adapter.setToolProjection({
       surfaceKind: "main_chat",
       chatFirstUi: false,
       controlGeneration: null,
+      jitKnowledgeToolsEnabled: false,
     });
+    expect(spawn).not.toHaveBeenCalled();
+    const previousJitGate = process.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED;
+    process.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED = "true";
     await adapter.start();
     const [, , legacyMainChatOptions] = vi.mocked(spawn).mock.calls[0] as [
       string,
@@ -1003,6 +1042,9 @@ describe("PiMonoAdapter spawn args (behavioral)", () => {
     expect(legacyMainChatOptions.env.OMI_SURFACE_KIND).toBe("main_chat");
     expect(legacyMainChatOptions.env.OMI_CHAT_FIRST_UI).toBeUndefined();
     expect(legacyMainChatOptions.env.OMI_CHAT_FIRST_CONTROL_GENERATION).toBeUndefined();
+    expect(legacyMainChatOptions.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED).toBeUndefined();
+    if (previousJitGate === undefined) delete process.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED;
+    else process.env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED = previousJitGate;
     await adapter.stop();
 
     vi.mocked(spawn).mockClear();

--- a/desktop/macos/changelog/unreleased/20260905-jit-knowledge-tools.json
+++ b/desktop/macos/changelog/unreleased/20260905-jit-knowledge-tools.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved proactive knowledge tools and standing notification setup in Chat"
+}

--- a/desktop/macos/pi-mono-extension/index.test.ts
+++ b/desktop/macos/pi-mono-extension/index.test.ts
@@ -34,6 +34,7 @@ import {
   __omiRelayCapabilityRefForTest,
   __omiPendingCallsForTest,
   __registerOmiToolsForTest,
+  omiToolProjectionContextFromEnv,
   __registerUserMcpToolsForTest,
   __resetOmiPipeForTest,
   __resetUserMcpForTest,
@@ -1168,6 +1169,26 @@ test("OMI_TOOLS: exact pi-mono projection from canonical manifest", () => {
     OMI_TOOLS.map((tool) => tool.name),
     toolNamesForAdapter("pi-mono"),
   );
+});
+
+test("OMI_TOOLS: the child env gate projects the JIT ledger catalog", () => {
+  const enabled = omiToolProjectionContextFromEnv({
+    OMI_EXECUTION_ROLE: "coordinator",
+    OMI_SURFACE_KIND: "main_chat",
+    OMI_JIT_KNOWLEDGE_TOOLS_ENABLED: "true",
+  });
+  const enabledNames = omiToolsForProjectionContext(enabled).map((tool) => tool.name);
+  assert.equal(enabled.jitKnowledgeToolsEnabled, true);
+  assert.ok(enabledNames.includes("create_standing_trigger"));
+
+  const disabled = omiToolProjectionContextFromEnv({
+    OMI_EXECUTION_ROLE: "coordinator",
+    OMI_SURFACE_KIND: "main_chat",
+    OMI_JIT_KNOWLEDGE_TOOLS_ENABLED: "false",
+  });
+  const disabledNames = omiToolsForProjectionContext(disabled).map((tool) => tool.name);
+  assert.equal(disabled.jitKnowledgeToolsEnabled, false);
+  assert.ok(!disabledNames.includes("create_standing_trigger"));
 });
 
 test("OMI_TOOLS: leaf projection omits every agent-management tool", () => {

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -816,16 +816,24 @@ function searchSkillsTool() {
   });
 }
 
-const executionRole = process.env.OMI_EXECUTION_ROLE === "leaf" ? "leaf" : "coordinator";
-const chatFirstControlGeneration = Number(process.env.OMI_CHAT_FIRST_CONTROL_GENERATION);
-const projectionContext = {
-  executionRole,
-  surfaceKind: process.env.OMI_SURFACE_KIND,
-  chatFirstUi: process.env.OMI_CHAT_FIRST_UI === "true" && process.env.OMI_SURFACE_KIND === "main_chat",
-  controlGeneration: Number.isSafeInteger(chatFirstControlGeneration) && chatFirstControlGeneration >= 0
-    ? chatFirstControlGeneration
-    : null,
-} as const;
+export function omiToolProjectionContextFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): OmiToolProjectionContext {
+  const chatFirstControlGeneration = Number(env.OMI_CHAT_FIRST_CONTROL_GENERATION);
+  return {
+    executionRole: env.OMI_EXECUTION_ROLE === "leaf" ? "leaf" : "coordinator",
+    surfaceKind: env.OMI_SURFACE_KIND,
+    chatFirstUi: env.OMI_CHAT_FIRST_UI === "true" && env.OMI_SURFACE_KIND === "main_chat",
+    controlGeneration: Number.isSafeInteger(chatFirstControlGeneration) && chatFirstControlGeneration >= 0
+      ? chatFirstControlGeneration
+      : null,
+    // Only an explicit string true can widen the client-side catalog. The
+    // backend still authorizes every relay independently.
+    jitKnowledgeToolsEnabled: env.OMI_JIT_KNOWLEDGE_TOOLS_ENABLED === "true",
+  };
+}
+
+const projectionContext = omiToolProjectionContextFromEnv();
 
 export function omiToolsForExecutionRole(role: "coordinator" | "leaf") {
   return omiToolsForProjectionContext({ executionRole: role });


### PR DESCRIPTION
## Problem
The JIT rollout gate reached the query and kernel paths, but the Pi process projection dropped `jitKnowledgeToolsEnabled`; Chat could start without the ledger catalog. Once the catalog was restored, the standing-trigger condition was too loose and model calls could send malformed selectors that failed before persistence.

## Change
- Carry the strict per-turn JIT knowledge gate through Pi projection and child environment; scrub inherited values and refresh the process/catalog on true/false transitions.
- Keep the extension and generated surfaces on the same strict gate and canonical manifest.
- Type `create_standing_trigger.condition` with all/any, non-empty selector arrays, safe regex guidance, alias maps, required time bounds, and valid calendar alternatives.
- Add `contracts/parity/jit_trigger_condition_matrix.json` and backend tests that compile every shared payload and validate it against the generated advertised JSON Schema with the existing `jsonschema` dependency.
- Refresh generated Swift and manifest fixtures.

## Evidence
- `desktop/macos/scripts/test-tool-surfaces.sh` with `VITEST_MAX_WORKERS=2`: 66 files / 802 agent tests and 131 extension tests passed.
- Backend `test_jit_trigger_contract.py`: 32 passed; manifest suite: 34 passed; TypeScript build and generated-surface `--check` passed.
- Named signed bundle `/Applications/omi-jit-beta-20260905.app`, executable SHA `2b0a34b74aa85c9967b677e1ca9991749a83adbcd6ce4de52350257ce0284687`, strict codesign verification passed.
- The real named Chat bridge advertised all seven JIT knowledge tools and emitted a valid keyword payload. The local backend contract accepted it; Cloud Logging still reports `WriterAdmissionError` at ledger persistence.

## Limitation
This change does not claim end-to-end trigger creation, firing, triage, agent action, visible notification, or feedback. The dev owner remains migration-incomplete/compatibility, `knowledge-ledger-drain-job` is absent, and live retries are paused pending ledger writer admission and drain deployment.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

Failure-Class: FC-surface-tool-authority-projection


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

