### PR TITLE
fix(firestore): exclude implicit document-key indexes from readiness requirements

### DIFF
--- a/.github/failure-classes/FC-implicit-index-requires-impossible-provisioning.json
+++ b/.github/failure-classes/FC-implicit-index-requires-impossible-provisioning.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-implicit-index-requires-impossible-provisioning",
+  "violated_contract": "A serving-schema readiness gate must distinguish an implicit document-key index from a provisionable composite. Turning a document-ID-only query into a one-field __name__ composite blocks deployment indefinitely even though the query succeeds and the provider rejects that composite shape.",
+  "canonical_prevention": "Keep the query registered while exempting only key-only ranges whose declared index fields contain exactly one directional __name__ field. Test that adding another ordering field still generates a composite requirement and that a genuinely missing multi-field index still blocks readiness.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_firestore_query_contract.py",
+    "backend/tests/unit/test_reconcile_firestore_indexes.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/database/firestore_index_registry.py",
+    "firestore.indexes.json"
+  ],
+  "status": "open"
+}

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1446,6 +1446,9 @@ def _query_spec_index_requirements() -> tuple[FirestoreIndexRequirement, ...]:
             document_id_range
             and bool(spec.filters)
             and all(query_filter.field_path == '__name__' for query_filter in spec.filters)
+            and len(spec.index_fields) == 1
+            and spec.index_fields[0].field_path == '__name__'
+            and spec.index_fields[0].order in {'ASCENDING', 'DESCENDING'}
         )
         if document_id_only_range:
             # Firestore serves collection-group ranges on the document key from

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1442,6 +1442,18 @@ def _query_spec_index_requirements() -> tuple[FirestoreIndexRequirement, ...]:
             query_filter.field_path == '__name__' and query_filter.operator not in ('==', 'in')
             for query_filter in spec.filters
         )
+        document_id_only_range = (
+            document_id_range
+            and bool(spec.filters)
+            and all(query_filter.field_path == '__name__' for query_filter in spec.filters)
+        )
+        if document_id_only_range:
+            # Firestore serves collection-group ranges on the document key from
+            # its built-in key index. A one-field __name__ composite is not a
+            # valid Firestore composite definition (composites require at least
+            # two fields); keep the query registered for coverage without
+            # turning it into an impossible provisioning requirement.
+            continue
         if not _index_fields_need_composite_manifest(spec.index_fields) and not document_id_range:
             continue
         signature = spec.index_requirement.signature

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 from google.cloud.firestore_v1 import FieldFilter
 
+import database.firestore_index_registry as firestore_index_registry
 import database.action_items as action_items_db
 import database.chat as chat_db
 import database.conversations as conversations_db
@@ -44,6 +45,8 @@ from database.firestore_index_registry import (
     UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY,
     QUERY_SPECS,
     FirestoreIndexField,
+    FirestoreQueryFilter,
+    FirestoreQuerySpec,
     _index_fields_need_composite_manifest,
     firebase_index_manifest,
 )
@@ -844,3 +847,21 @@ def test_document_id_only_collection_group_range_has_no_impossible_composite_req
         and index['fields'] == [{'fieldPath': '__name__', 'order': 'ASCENDING'}]
         for index in manifest['indexes']
     )
+
+
+def test_document_id_range_with_additional_ordering_field_still_requires_composite(monkeypatch):
+    spec = FirestoreQuerySpec(
+        identifier='synthetic_document_id_range_with_order',
+        collection_group='photos',
+        query_scope='COLLECTION_GROUP',
+        filters=(
+            FirestoreQueryFilter('__name__', '>=', 'start_key'),
+            FirestoreQueryFilter('__name__', '<=', 'end_key'),
+        ),
+        index_fields=(_asc('created_at'), _asc('__name__')),
+    )
+    monkeypatch.setattr(firestore_index_registry, 'QUERY_SPECS', (spec,))
+
+    requirements = firestore_index_registry._query_spec_index_requirements()
+
+    assert [requirement.identifier for requirement in requirements] == [spec.identifier]

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -17,6 +17,7 @@ from database.firestore_index_registry import (
     ACTIVE_ATTENTION_OVERRIDE_QUERY,
     CANONICAL_CONSOLIDATION_QUERY,
     CANONICAL_MEMORY_ATLAS_READ_QUERY,
+    CONVERSATION_PHOTOS_NAME_RANGE_QUERY,
     CONVERSATION_SOURCE_MEMORY_QUERY,
     CONVERSATIONS_ACTIVE_ORDERED_QUERY,
     DUE_MEMORY_OUTBOX_QUERY,
@@ -24,6 +25,7 @@ from database.firestore_index_registry import (
     EXPIRED_SHORT_TERM_LIFECYCLE_QUERY,
     EXPIRED_MEMORY_OUTBOX_LEASE_QUERY,
     INDEX_ONLY_REQUIREMENTS,
+    INDEX_REQUIREMENTS,
     MESSAGES_BY_APP_ORDERED_QUERY,
     MESSAGES_BY_SESSION_ORDERED_QUERY,
     POLICY_EXPIRED_SHORT_TERM_QUERY,
@@ -827,3 +829,18 @@ def test_every_composite_requiring_query_spec_is_declared_in_the_checked_in_mani
         if _platform_requires_composite(spec.index_fields) and spec.index_requirement.signature not in declared
     ]
     assert missing == []
+
+
+def test_document_id_only_collection_group_range_has_no_impossible_composite_requirement():
+    assert CONVERSATION_PHOTOS_NAME_RANGE_QUERY in QUERY_SPECS
+    assert all(
+        requirement.identifier != CONVERSATION_PHOTOS_NAME_RANGE_QUERY.identifier for requirement in INDEX_REQUIREMENTS
+    )
+
+    manifest = firebase_index_manifest()
+    assert not any(
+        index['collectionGroup'] == 'photos'
+        and index['queryScope'] == 'COLLECTION_GROUP'
+        and index['fields'] == [{'fieldPath': '__name__', 'order': 'ASCENDING'}]
+        for index in manifest['indexes']
+    )

--- a/backend/tests/unit/test_reconcile_firestore_indexes.py
+++ b/backend/tests/unit/test_reconcile_firestore_indexes.py
@@ -180,6 +180,19 @@ def test_check_only_does_not_propose_duplicate_creation_for_nonready_index(tmp_p
     assert proposal['blocking_indexes'][0]['state'] == 'CREATING'
 
 
+def test_missing_real_multifield_index_remains_blocking_after_document_id_exception():
+    manifest = firebase_index_manifest()
+    multi_field = next(index for index in manifest['indexes'] if len(index['fields']) > 1)
+    signature = reconcile_firestore_indexes._index_signature(multi_field)
+
+    assert reconcile_firestore_indexes.expected_index_states(
+        expected={signature},
+        live_indexes=[],
+        project='dev-project',
+        database='(default)',
+    ) == {signature: 'MISSING'}
+
+
 def test_schema_proposal_input_hash_is_stable_across_generation_times(tmp_path):
     manifest = firebase_index_manifest()
     states = {signature: 'MISSING' for signature in reconcile_firestore_indexes.expected_index_signatures(manifest)}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -747,16 +747,6 @@
       ]
     },
     {
-      "collectionGroup": "photos",
-      "queryScope": "COLLECTION_GROUP",
-      "fields": [
-        {
-          "fieldPath": "__name__",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
       "collectionGroup": "candidates",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Problem

The development Firestore readiness gate required a one-field composite for the `photos` collection-group query on `__name__`. Firestore composite definitions require at least two fields and reserve `__name__` as the implicit terminal key field, so the gate blocked backend delivery on an index that cannot be provisioned.

## Change

- Keep `conversation_photos_name_range_export` registered for query coverage.
- Skip composite-manifest requirements only for a key-only range whose declared index fields are exactly one ordered `__name__` field.
- Regenerate `firestore.indexes.json`, removing only the invalid `photos` entry.
- Add a registry regression test, a countercase for a key range with an additional ordering field, and a readiness test proving a real multi-field index remains `MISSING` when absent.

## Evidence

- `test_firestore_query_contract.py`, `test_reconcile_firestore_indexes.py`, and `test_firestore_indexes.py`: 84 passed.
- `python3 backend/scripts/generate_firestore_indexes.py --manifest firestore.indexes.json`: manifest matches registry.
- `python3 backend/scripts/firestore_query_coverage.py --check-ratchet`: exit 0; the existing raw-unregistered baseline notices remain unchanged.
- Agent and coordinator independently ran the bounded synthetic key-range query in based-hardware-dev: HTTP 200, no document returned, no missing-index error. The [official Index API contract](https://docs.cloud.google.com/firestore/docs/reference/rest/Shared.Types) requires at least two composite fields.

## Scope and safety

No Firestore index was created or deleted. The shared `based-hardware` data plane was not touched. The exact failing workflow was Auto Deploy Backend to Development run `33986921080` at `49de4c430555307d105fa73229fbd267dfeaf023`.

## Product invariants affected

none

Failure-Class: new

Line-Count-Exception: backend/database/firestore_index_registry.py | 1504 -> 1519 | narrow document-ID-only index derivation guard with explanatory contract comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

