### PR TITLE
fix(backend): drop id-less records from the popular-apps listing too

### DIFF
--- a/backend/tests/unit/test_apps_popular_missing_id_guard.py
+++ b/backend/tests/unit/test_apps_popular_missing_id_guard.py
@@ -1,0 +1,86 @@
+"""The popular-apps listing must drop a record with no id, not 500 the whole surface.
+
+`get_popular_apps` reads `app['id']` unguarded — once to batch the installs and reviews lookups,
+and twice more per app inside the loop. It streams the same raw Firestore documents as the two
+shared catalog builders (`_typed_doc` in database/apps.py, which returns the stored payload as-is
+and injects nothing), so one legacy document without that field raises KeyError the same way.
+
+The surface is separate: its own `get_popular_apps_data` cache key, its own 30-minute Redis TTL,
+and its own `/v1/apps/popular` endpoint. That means the catalog guard shipped alongside this one
+does not reach it — the builder is Redis- and process-cached and shared across users, so a single
+bad document takes out the popular list for everyone.
+
+These tests drive both the DB branch and the Redis-cached branch, since the reported failure mode
+is a poisoned cache entry and a guard applied to only one branch would leave it live.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+
+from utils import apps as apps_utils  # noqa: E402
+
+
+class _PassThroughCache:
+    """Memory cache stand-in that always runs the fetcher, so the builder itself is exercised."""
+
+    def get_or_fetch(self, _key, fetcher, ttl=None):
+        return fetcher()
+
+    def delete(self, _key):
+        return None
+
+
+def _valid_app(app_id='a1'):
+    return {
+        'id': app_id,
+        'name': 'Good App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+        'approved': True,
+        'private': False,
+        'is_popular': True,
+    }
+
+
+def _no_id_app():
+    return {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone', 'is_popular': True}
+
+
+def _unreachable_db():
+    raise AssertionError('the DB branch must not run when the Redis cache is populated')
+
+
+def _popular(monkeypatch, records, *, from_cache=False):
+    """The `/v1/apps/popular` listing: serve `records` from Redis or Firestore, never both."""
+    monkeypatch.setattr(apps_utils, 'get_memory_cache', _PassThroughCache)
+    monkeypatch.setattr(apps_utils, 'set_generic_cache', lambda *a, **kw: None)
+    if from_cache:
+        monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: [dict(r) for r in records])
+        monkeypatch.setattr(apps_utils, 'get_popular_apps_db', _unreachable_db)
+    else:
+        monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: None)
+        monkeypatch.setattr(apps_utils, 'get_popular_apps_db', lambda: [dict(r) for r in records])
+    monkeypatch.setattr(apps_utils, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_utils, 'get_apps_reviews', lambda ids: {})
+    return apps_utils.get_popular_apps()
+
+
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_popular_apps_drops_a_record_without_an_id(monkeypatch, from_cache):
+    apps = _popular(monkeypatch, [_no_id_app(), _valid_app('a1')], from_cache=from_cache)
+
+    assert [app.id for app in apps] == ['a1']
+
+
+@pytest.mark.parametrize('from_cache', [False, True], ids=['from_db', 'from_redis_cache'])
+def test_popular_apps_still_returns_every_well_formed_record(monkeypatch, from_cache):
+    apps = _popular(monkeypatch, [_valid_app('a1'), _valid_app('a2')], from_cache=from_cache)
+
+    assert sorted(app.id for app in apps) == ['a1', 'a2']

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -316,13 +316,15 @@ def get_popular_apps() -> List[App]:
             set_generic_cache(cache_key, reduced_apps, 60 * 30)  # 30 minutes cached
             popular_apps = reduced_apps
 
+        usable_apps = _records_with_ids(popular_apps)
+
         # Process apps (add installs, reviews, ratings)
-        app_ids = [app['id'] for app in popular_apps]
+        app_ids = [app['id'] for app in usable_apps]
         apps_install = get_apps_installs_count(app_ids)
         apps_reviews = get_apps_reviews(app_ids)
 
         apps: List[App] = []
-        for app in popular_apps:
+        for app in usable_apps:
             app_dict = app
             app_dict['installs'] = apps_install.get(app['id'], 0)
             reviews = apps_reviews.get(app['id'], {})


### PR DESCRIPTION
## What

`get_popular_apps` drops marketplace records with no `id` instead of raising `KeyError` and 500ing `/v1/apps/popular` for every user.

This is the follow-up @Git-on-my-level asked for while reviewing #12790, on the one surface that PR deliberately left alone.

## Why this is a separate surface

#12790 guarded the two shared catalog builders. `get_popular_apps` is the third builder over the same documents, and nothing that PR added reaches it:

| | `get_approved_available_apps` / `get_available_apps` | `get_popular_apps` |
|---|---|---|
| Cache key | `get_public_approved_apps_data` | `get_popular_apps_data` |
| Redis TTL | 10 min | 30 min |
| Endpoint | browse listing, `GET /v1/apps` | `GET /v1/apps/popular` (routers/apps.py:804) |
| Guarded by | #12790 | this PR |

Same documents, though. `get_popular_apps_db` returns `_typed_doc(doc)` (database/apps.py:94), which hands back the stored payload as-is and injects no `id` — exactly like `get_public_approved_apps_db` one function above it.

## The bug

`utils/apps.py:320`, before this change:

```python
# Process apps (add installs, reviews, ratings)
app_ids = [app['id'] for app in popular_apps]
```

Then twice more per app inside the loop, at `apps_install.get(app['id'], 0)` and `apps_reviews.get(app['id'], {})`.

The builder sits behind a singleflight and is Redis- and process-cached, so it is shared across users. One legacy document without an `id` takes out the popular list for everyone, not for one session.

## Why the existing guards don't cover it

| Guard | Why it misses this |
|---|---|
| `_safe_build_app` (#8924) | Skips a record the `App` model rejects. The `KeyError` fires ~15 lines earlier, on the raw dict, before any model is built. |
| `backend/database/read_boundary.py` | Parses Firestore *snapshots*. The deref here is on the reduced dicts the Redis cache hands back, downstream of any snapshot parsing. |
| `_records_with_ids` (#12790) | Applied to the two catalog builders only. This builder was out of that PR's stated contract. |
| `search_apps` poison guard | Different code path, already hardened separately. |

## Why not a primitive

The primitive already exists and this PR uses it. `_records_with_ids` was added in #12790 precisely so the catalog builders could not drift apart; this change routes the third builder through the same helper rather than adding a second check. No new guard, no new ratchet.

Placement matches the sibling builders exactly: after the cache write, before the first deref, downstream of `App.reduce_dict` (which is a pure key-filter and never touches `id`).

## Verification

Commands run, and what they showed. Rebased onto `main` now that #12790 has merged; this PR is a single commit against it.

**Red → Green**, `./test.sh`, each file isolated:

| Case | Unpatched | Patched |
|---|---|---|
| `test_popular_apps_drops_a_record_without_an_id[from_db]` | `KeyError: 'id'` @ `utils/apps.py:320` | passes |
| `test_popular_apps_drops_a_record_without_an_id[from_redis_cache]` | `KeyError: 'id'` @ `utils/apps.py:320` | passes |
| `test_popular_apps_still_returns_every_well_formed_record[from_db]` | passes | passes |
| `test_popular_apps_still_returns_every_well_formed_record[from_redis_cache]` | passes | passes |

The two controls pass on both sides, so the guard is not over-filtering.

Both branches are driven separately, because the reported failure mode is a poisoned *cache* entry and a guard applied to only one branch would still pass a DB-only test. In the cached case `get_popular_apps_db` is patched to raise, so the test fails if the DB branch is reached at all.

| Command | Result |
|---|---|
| `./test.sh` over 9 app/catalog unit files, each isolated | **50 passed, 0 failed** |
| `black --line-length 120 --skip-string-normalization --check` | both files unchanged |

**I have not exercised the real user-facing path.** Reproducing it needs a Firestore app document with no `id`, which I cannot create against production data. The regression tests drive the real builder through its cache and DB seams; that is the extent of the proof.

## Product invariants

No locked invariant path globs are matched by this diff. It touches `backend/utils/apps.py` and adds one `backend/tests/unit/` file.

## Failure class

Failure-Class: FC-malformed-doc-read

A malformed persisted document must not turn a read path into a 500. Same class as #12790, same canonical prevention, one more read boundary brought under it.

Line-Count-Exception: backend/utils/apps.py | 1683 -> 1685 | Two lines: one call to the `_records_with_ids` helper #12790 added to this file, and the blank line before it. Splitting a 1683-line module is not something a two-line bug fix should carry.

## History

Opened stacked on #12790, which has now merged. Rebased onto `main`, so this is a single commit, 2 files, +90/-2.

Thanks @Git-on-my-level for the original catch and for the review here — noted the point about the cached payload still holding id-less records until the key rebuilds; agreed that leaving cache invalidation untouched is the right trade. Also noted `get_available_app_by_id_with_reviews` (utils/apps.py:454); I'll take that as a separate pass rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pEhHaD3Mjxwn1hYUTHbQM
