### PR TITLE
fix(ci): allow cold LLM gateway smoke startup

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -363,17 +363,104 @@ runs:
       if: ${{ inputs.deploy_profile == 'auto-dev' }}
       shell: bash
       run: |
+        set -euo pipefail
         NAMESPACE="${{ inputs.runtime_env }}-omi-backend"
-        TOKEN="$(kubectl -n "$NAMESPACE" get secret ${{ inputs.runtime_env }}-omi-backend-secrets -o jsonpath='{.data.OMI_LLM_GATEWAY_SERVICE_TOKEN}' | base64 -d)"
-        METRICS_TOKEN="$(kubectl -n "$NAMESPACE" get secret ${{ inputs.runtime_env }}-omi-backend-secrets -o jsonpath='{.data.METRICS_SECRET}' | base64 -d)"
-        SMOKE_COMMAND="python scripts/smoke-llm-gateway.py --url \"\$SMOKE_URL\" --token \"\$SMOKE_TOKEN\" --check-metrics"
-        kubectl -n "$NAMESPACE" run "llm-gateway-smoke-${GITHUB_RUN_ID}" \
-          --rm -i --restart=Never \
-          --image "gcr.io/${{ inputs.project_id }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}" \
-          --env "SMOKE_URL=http://${{ inputs.runtime_env }}-omi-llm-gateway.${{ inputs.runtime_env }}-omi-backend.svc.cluster.local:8080" \
-          --env "SMOKE_TOKEN=$TOKEN" \
-          --env "METRICS_SECRET=$METRICS_TOKEN" \
-          --command -- sh -c "$SMOKE_COMMAND"
+        SMOKE_POD="llm-gateway-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}"
+        # Image pulls are independent of the smoke client's HTTP request
+        # deadline. A cold 800 MB image exceeded kubectl run's implicit
+        # one-minute pod-running timeout before the smoke process started.
+        SMOKE_STARTUP_BUDGET_SECONDS=300
+        SMOKE_PROBE_BUDGET_SECONDS=180
+
+        show_smoke_diagnostics() {
+          echo "=== llm-gateway smoke pod ==="
+          kubectl --request-timeout=30s -n "$NAMESPACE" get pod "$SMOKE_POD" -o wide || true
+          kubectl --request-timeout=30s -n "$NAMESPACE" get pod "$SMOKE_POD" -o jsonpath='{.status.phase}{"\n"}{range .status.containerStatuses[*]}{.name}{" ready="}{.ready}{" state="}{.state.waiting.reason}{.state.terminated.reason}{" exit="}{.state.terminated.exitCode}{"\n"}{end}' || true
+          kubectl --request-timeout=30s -n "$NAMESPACE" describe pod "$SMOKE_POD" || true
+          echo "=== llm-gateway smoke logs ==="
+          kubectl --request-timeout=30s -n "$NAMESPACE" logs "$SMOKE_POD" --all-containers=true || true
+          echo "=== llm-gateway smoke events ==="
+          kubectl --request-timeout=30s -n "$NAMESPACE" get events --field-selector "involvedObject.name=$SMOKE_POD" --sort-by=.lastTimestamp || true
+        }
+        cleanup_smoke_pod() {
+          kubectl --request-timeout=30s -n "$NAMESPACE" delete pod "$SMOKE_POD" --ignore-not-found=true --wait=false || true
+        }
+        trap cleanup_smoke_pod EXIT
+
+        if ! cat <<EOF | kubectl --request-timeout=30s -n "$NAMESPACE" apply -f -
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: $SMOKE_POD
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: smoke
+              image: gcr.io/${{ inputs.project_id }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}
+              command: ["sh", "-c", "python scripts/smoke-llm-gateway.py --url \"\$SMOKE_URL\" --token \"\$SMOKE_TOKEN\" --check-metrics"]
+              env:
+                - name: SMOKE_URL
+                  value: http://${{ inputs.runtime_env }}-omi-llm-gateway.${{ inputs.runtime_env }}-omi-backend.svc.cluster.local:8080
+                - name: SMOKE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${{ inputs.runtime_env }}-omi-backend-secrets
+                      key: OMI_LLM_GATEWAY_SERVICE_TOKEN
+                - name: METRICS_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${{ inputs.runtime_env }}-omi-backend-secrets
+                      key: METRICS_SECRET
+        EOF
+        then
+          echo "LLM gateway smoke pod could not be created" >&2
+          show_smoke_diagnostics
+          exit 1
+        fi
+
+        phase=""
+        startup_deadline=$((SECONDS + SMOKE_STARTUP_BUDGET_SECONDS))
+        while (( SECONDS < startup_deadline )); do
+          phase="$(kubectl --request-timeout=10s -n "$NAMESPACE" get pod "$SMOKE_POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+          case "$phase" in
+            Running)
+              break
+              ;;
+            Succeeded)
+              show_smoke_diagnostics
+              exit 0
+              ;;
+            Failed)
+              show_smoke_diagnostics
+              exit 1
+              ;;
+          esac
+          sleep 1
+        done
+        if [[ "$phase" != "Running" ]]; then
+          echo "LLM gateway smoke pod did not start within ${SMOKE_STARTUP_BUDGET_SECONDS}s" >&2
+          show_smoke_diagnostics
+          exit 1
+        fi
+
+        probe_deadline=$((SECONDS + SMOKE_PROBE_BUDGET_SECONDS))
+        while (( SECONDS < probe_deadline )); do
+          phase="$(kubectl --request-timeout=10s -n "$NAMESPACE" get pod "$SMOKE_POD" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+          case "$phase" in
+            Succeeded)
+              show_smoke_diagnostics
+              exit 0
+              ;;
+            Failed)
+              show_smoke_diagnostics
+              exit 1
+              ;;
+          esac
+          sleep 1
+        done
+        echo "LLM gateway smoke probe did not complete within ${SMOKE_PROBE_BUDGET_SECONDS}s after pod startup" >&2
+        show_smoke_diagnostics
+        exit 1
 
     - name: Probe LLM gateway from the Cloud Run VPC before promotion
       if: >-

--- a/backend/tests/unit/test_llm_gateway_deploy_contract.py
+++ b/backend/tests/unit/test_llm_gateway_deploy_contract.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
+import tempfile
 from typing import Any, cast
 
 import yaml
@@ -267,7 +269,7 @@ def test_gateway_auto_deploy_is_folded_into_the_admitted_backend_lifecycle():
     assert build < deploy < serving < smoke < vpc_probe < caller_render
     gateway_image = 'gcr.io/${{ inputs.project_id }}/llm-gateway:${{ steps.image-tag.outputs.short_sha }}'
     assert f'gateway_image="{gateway_image}"' in workflow
-    assert f'--image "{gateway_image}"' in workflow
+    assert f'image: {gateway_image}' in workflow
     assert 'runtime_image_contracts.py" smoke' in workflow
     assert (
         'IMAGE_TAG="${{ steps.image-tag.outputs.short_sha }}" "$DEPLOY_CONTROL_SCRIPTS/deploy-llm-gateway.sh"'
@@ -279,6 +281,114 @@ def test_gateway_auto_deploy_is_folded_into_the_admitted_backend_lifecycle():
     )
     assert '--lane omi:auto:public-shared-conversation-chat' in workflow
     assert '--check-metrics' in workflow
+
+
+def test_combined_gateway_smoke_allows_cold_pull_and_keeps_failure_diagnostics():
+    action = yaml.safe_load(DEPLOY_BACKEND_STACK_ACTION.read_text(encoding='utf-8'))
+    assert isinstance(action, dict)
+    steps = action['runs']['steps']
+    smoke_step = next(step for step in steps if step.get('name') == 'Smoke LLM Gateway')
+    smoke = str(smoke_step['run'])
+
+    # The pod startup budget covers scheduling and image pulls. The smoke
+    # client's own HTTP/retry deadline starts only after the pod is Running.
+    assert 'SMOKE_STARTUP_BUDGET_SECONDS=300' in smoke
+    assert 'SMOKE_PROBE_BUDGET_SECONDS=180' in smoke
+    assert 'startup_deadline=$((SECONDS + SMOKE_STARTUP_BUDGET_SECONDS))' in smoke
+    assert 'while (( SECONDS < startup_deadline )); do' in smoke
+    assert 'probe_deadline=$((SECONDS + SMOKE_PROBE_BUDGET_SECONDS))' in smoke
+    assert 'while (( SECONDS < probe_deadline )); do' in smoke
+    assert 'kubectl --request-timeout=10s -n "$NAMESPACE" get pod "$SMOKE_POD"' in smoke
+    assert 'kubectl --request-timeout=30s -n "$NAMESPACE" apply -f -' in smoke
+    assert 'LLM gateway smoke pod could not be created' in smoke
+    assert '--rm -i' not in smoke
+
+    # Diagnostics must run before the EXIT cleanup removes the pod, including
+    # the Pending/ImagePullBackOff case that caused the original one-minute
+    # kubectl run timeout to erase the evidence.
+    assert 'trap cleanup_smoke_pod EXIT' in smoke
+    assert 'kubectl --request-timeout=30s -n "$NAMESPACE" describe pod "$SMOKE_POD" || true' in smoke
+    assert 'kubectl --request-timeout=30s -n "$NAMESPACE" logs "$SMOKE_POD" --all-containers=true || true' in smoke
+    assert (
+        'kubectl --request-timeout=30s -n "$NAMESPACE" get events --field-selector "involvedObject.name=$SMOKE_POD"'
+        in smoke
+    )
+    assert 'LLM gateway smoke pod did not start within' in smoke
+    assert 'LLM gateway smoke probe did not complete within' in smoke
+
+
+def test_combined_gateway_smoke_rendered_script_handles_pod_phases_and_preserves_env_literals():
+    action = yaml.safe_load(DEPLOY_BACKEND_STACK_ACTION.read_text(encoding='utf-8'))
+    assert isinstance(action, dict)
+    smoke_step = next(step for step in action['runs']['steps'] if step.get('name') == 'Smoke LLM Gateway')
+    smoke = re.sub(r'\$\{\{[^}]+\}\}', 'placeholder', str(smoke_step['run']))
+
+    fake_kubectl = '''#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["FAKE_CALLS"]).open("a", encoding="utf-8") as handle:
+    handle.write(" ".join(args) + "\\n")
+if "apply" in args:
+    Path(os.environ["FAKE_MANIFEST"]).write_text(sys.stdin.read(), encoding="utf-8")
+elif "get" in args and "pod" in args:
+    print(os.environ["FAKE_PHASE"])
+'''
+
+    def run_case(phase: str, expected_code: int, *, startup_budget: int | None = None) -> tuple[str, str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            kubectl = root / 'kubectl'
+            kubectl.write_text(fake_kubectl, encoding='utf-8')
+            kubectl.chmod(0o755)
+            rendered = smoke
+            if startup_budget is not None:
+                rendered = rendered.replace(
+                    'SMOKE_STARTUP_BUDGET_SECONDS=300',
+                    f'SMOKE_STARTUP_BUDGET_SECONDS={startup_budget}',
+                )
+            env = {
+                **os.environ,
+                'PATH': f'{root}{os.pathsep}{os.environ["PATH"]}',
+                'GITHUB_RUN_ID': '42',
+                'GITHUB_RUN_ATTEMPT': '1',
+                'FAKE_PHASE': phase,
+                'FAKE_MANIFEST': str(root / 'manifest.yaml'),
+                'FAKE_CALLS': str(root / 'calls.txt'),
+            }
+            result = subprocess.run(
+                ['bash', '-euo', 'pipefail', '-c', rendered],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+            assert result.returncode == expected_code, result.stderr
+            return (root / 'manifest.yaml').read_text(encoding='utf-8'), (root / 'calls.txt').read_text(
+                encoding='utf-8'
+            )
+
+    manifest, succeeded_calls = run_case('Succeeded', 0)
+    assert r'--url \"$SMOKE_URL\" --token \"$SMOKE_TOKEN\"' in manifest
+    assert '--request-timeout=10s' in succeeded_calls
+    assert 'describe pod' in succeeded_calls
+    assert 'logs' in succeeded_calls
+    assert 'get events' in succeeded_calls
+    assert 'delete pod' in succeeded_calls
+
+    _, failed_calls = run_case('Failed', 1)
+    assert 'describe pod' in failed_calls
+    assert 'logs' in failed_calls
+    assert 'get events' in failed_calls
+    assert 'delete pod' in failed_calls
+
+    _, pending_calls = run_case('Pending', 1, startup_budget=1)
+    assert 'describe pod' in pending_calls
+    assert 'logs' in pending_calls
+    assert 'get events' in pending_calls
+    assert 'delete pod' in pending_calls
 
 
 def test_backend_deploy_requires_serving_and_cloud_run_vpc_gates_before_gateway_promotion():


### PR DESCRIPTION
## Problem
The auto development LLM gateway smoke used `kubectl run --rm -i`, inheriting kubectl's one minute pod startup timeout. A cold pull of the approximately 800 MB gateway image could exceed that budget, and `--rm` deleted the pod before Pending/ImagePullBackOff diagnostics were collected.

## Change
Create the smoke pod with secret references, wait up to 300 seconds for scheduling and image startup, then allow a separate 180 second smoke completion budget. Keep the pod until status, describe output, events, and logs have been emitted on every failure before the exit cleanup removes it.

## Validation
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_llm_gateway_deploy_contract.py --disable-warnings --maxfail=1` (16 passed)
- composite action YAML parse
- `git diff --check`
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

