### PR TITLE
fix(desktop): Only Meetings shows its own icon and reads as on in the top-bar listening control

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
@@ -22,10 +22,12 @@ enum CaptureListeningLogic {
   }
 
   /// The top-bar / Home listening readout. A session that is only *armed* (Only Meetings, no
-  /// call) is inactive — the mic is paused, so lighting the green dot would lie.
+  /// call yet) counts as on: the user switched listening on and the next call will be recorded,
+  /// so the control wears the green dot and no off-slash. Whether audio is reaching STT right now
+  /// is `isLiveCapturing`, which the live-transcript surfaces read instead.
   static func listeningStatus(appState: AppState) -> HomeStatusState {
     if appState.transcriptionServiceError != nil { return .blocked }
-    return appState.isLiveCapturing ? .active : .inactive
+    return appState.isLiveCapturing || appState.isAwaitingMeeting ? .active : .inactive
   }
 
   static func audioRecordingMode(raw: String) -> AssistantSettings.AudioRecordingMode {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -27,6 +27,11 @@
 //  diagonal is additional ink on top, so the capability still reads from the shape and only the
 //  running/not-running bit moves. `ShellStatusIconLegibilityTests` measures both halves of that claim.
 //
+//  The one thing that *does* swap the silhouette is the listening **mode**, not the state: Only
+//  Meetings wears `person.2.fill` in place of `mic` (`ShellStatusGlyph.listeningGlyph`). That is a
+//  different capability being named, not the same one flickering, and the dot and slash keep their
+//  jobs on top of either glyph.
+//
 //  It drives `CaptureListeningLogic` — the same functions the old pills and Home's header call — so
 //  this is a second *rendering* of the capture state and never a second copy of the behaviour.
 //
@@ -205,26 +210,29 @@ enum ShellStatusGlyph {
   /// screenshot was in, and it is fixed by `listening` above rather than by this line.
   static let screen = "display"
 
-  /// The corner mark the listening control wears while its mode is Only Meetings.
+  /// The listening control's silhouette while its mode is Only Meetings.
   ///
-  /// **This is not the swap the header rejects.** `listening` above is still the only listening
-  /// silhouette and is still byte-identical in every state; this rides *outside* it, in the corner,
-  /// exactly as `ShellStatusDot` does. The header's distinction is between ink that *replaces* the
-  /// glyph and ink that is *added* to it, and both marks this control wears are the second kind.
+  /// **This is a deliberate exception to the header's no-swap rule.** The rule guards the on/off
+  /// bit: a silhouette that changes with the toggle makes one button read as two. Only Meetings is
+  /// not the toggle — it is a *different capability* (record calls, not the room), and a mark riding
+  /// beside the mic read as two glyphs fused into one. So the mode owns the silhouette outright:
+  /// `person.2.fill` replaces `mic` for as long as the mode is selected, and the dot and slash keep
+  /// saying on/off/blocked on top of whichever glyph is showing. The on/off swap guard in
+  /// `ShellStatusIconLegibilityTests` still holds, because it measures `listening` across states,
+  /// not across modes.
   ///
-  /// **It is also not a new vocabulary.** `person.2.fill` is already the mark Home's listening
-  /// control uses for this mode, so one mode reads the same on both shells rather than growing a
-  /// second symbol for one idea.
+  /// `person.2.fill` is already the mark Home's listening control uses for this mode, so one mode
+  /// reads the same on both shells rather than growing a second symbol for one idea.
   static let meetingsOnly = "person.2.fill"
 
-  /// Which modes wear a mark, as a function rather than a ternary inside a `body`, so the rule —
-  /// *exactly one* of the three modes is badged — is something a test can state directly instead of
-  /// scraping it back out of the view.
+  /// Which silhouette the listening control wears for a mode, as a function rather than a ternary
+  /// inside a `body`, so the rule — Only Meetings is the *only* mode that trades the mic away — is
+  /// something a test can state directly instead of scraping it back out of the view.
   ///
-  /// `.always` and `.off` are deliberately unbadged: the dot and the slash already say everything
-  /// true about them, and a mark on every state is a mark that distinguishes nothing.
-  static func modeBadge(for mode: AssistantSettings.AudioRecordingMode) -> String? {
-    mode == .onlyMeetings ? meetingsOnly : nil
+  /// `.always` and `.off` both keep `listening`: the dot and the slash already say everything true
+  /// about them.
+  static func listeningGlyph(for mode: AssistantSettings.AudioRecordingMode) -> String {
+    mode == .onlyMeetings ? meetingsOnly : listening
   }
 }
 
@@ -307,16 +315,6 @@ struct ShellStatusIconButton: View {
   /// is exact only while this flag moves nothing else. Product code leaves it alone and passes
   /// `state: nil` for a control that has no badge to draw.
   var showsDot: Bool = true
-  /// A corner mark naming the *mode* a capability is running in, for a control that has more than
-  /// one. `nil` on every control that does not — screen capture has no modes, and a mark it never
-  /// wears is not a mark it should be able to draw.
-  ///
-  /// It follows `showsDot`'s contract, not the glyph's: additive ink outside the silhouette, so
-  /// `ShellStatusGlyph.listening` stays byte-identical across every state and the swap guard in
-  /// `ShellStatusIconLegibilityTests` still measures what it was written to measure. It sits on the
-  /// leading edge because the dot owns the trailing corner, and the two answer different questions —
-  /// the dot whether it is capturing, this one which mode it is set to.
-  var badge: String? = nil
   var isSelected: Bool = false
   let action: () -> Void
 
@@ -349,15 +347,6 @@ struct ShellStatusIconButton: View {
           ShellStatusDot(state: state).offset(x: 6, y: -5)
         }
       }
-      .overlay(alignment: .bottomLeading) {
-        if let badge {
-          // Pushed clear of the glyph's foot: at (-5, 4) the mark sat on the mic's stand and read as
-          // a second silhouette fused to the first — additive ink has to stay outside the shape.
-          Image(systemName: badge)
-            .scaledFont(size: OmiType.micro, weight: .bold)
-            .offset(x: -9, y: 6)
-        }
-      }
     }
     .buttonStyle(GlassIconButtonStyle(isActive: isSelected || isActive))
     .help(tooltip)
@@ -380,7 +369,7 @@ struct ShellStatusIcons: View {
   @State private var isTogglingCapture = false
   @State private var isTogglingListening = false
   /// Shown for a beat when a click *selects* Only Meetings, never on hover and never at rest.
-  /// The three modes cycle under one glyph, so landing on the third one names it; the tooltip
+  /// The three modes cycle under one control, so landing on the third one names it; the tooltip
   /// carries the explanation. Tying it to the transition keeps the cluster wordless.
   @State private var showsMeetingsHint = false
   @State private var meetingsHintDismissal: DispatchWorkItem?
@@ -392,11 +381,10 @@ struct ShellStatusIcons: View {
   var body: some View {
     HStack(spacing: 2) {
       ShellStatusIconButton(
-        systemImage: ShellStatusGlyph.listening,
+        systemImage: ShellStatusGlyph.listeningGlyph(for: listeningMode),
         tooltip: listeningTooltip,
         state: listeningState,
         isBusy: isTogglingListening,
-        badge: ShellStatusGlyph.modeBadge(for: listeningMode),
         action: cycleListening
       )
       .accessibilityIdentifier("shell-status-listening")
@@ -432,8 +420,8 @@ struct ShellStatusIcons: View {
   }
 
   /// What the control is *set to* — distinct from `listeningState`, which is whether it is
-  /// currently capturing. Only Meetings is exactly the case where those two disagree, so the
-  /// button needs both.
+  /// currently capturing. The mode picks the silhouette (`ShellStatusGlyph.listeningGlyph`), the
+  /// state picks the dot and slash, so the button needs both.
   private var listeningMode: AssistantSettings.AudioRecordingMode {
     CaptureListeningLogic.audioRecordingMode(raw: audioRecordingModeRaw)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -245,9 +245,9 @@ enum ShellStatusTooltip {
   /// mode is not decoration: "listening" with no qualifier is a claim the meetings-only mode does not
   /// actually make.
   ///
-  /// `isAwaitingMeeting` is the Only Meetings wait: the session is armed, the mic is paused, and a
-  /// click turns listening *off* rather than starting it. That must not reuse the "off / click to
-  /// start" sentence.
+  /// `isAwaitingMeeting` is the Only Meetings wait: the control is on and the mic opens when a call
+  /// starts, so the sentence says that rather than "listening" (nothing is transcribed yet) or
+  /// "off / click to start" (a click turns it off).
   /// `next` names the mode a click moves to. It is a parameter rather than the fixed "Click to
   /// stop" / "Click to start" this shipped with, because the control is a three-mode cycle: from
   /// Always On a click does not stop anything, it selects Only Meetings, and a tooltip on a
@@ -260,6 +260,8 @@ enum ShellStatusTooltip {
     switch state {
     case .blocked:
       return "Audio — transcription unavailable. Open Settings to reconnect."
+    case .active where isAwaitingMeeting:
+      return "Audio — on (\(mode)). Recording starts when a call is detected. Click for \(next)."
     case .active:
       return "Audio — listening (\(mode)). Click for \(next)."
     case .inactive:
@@ -267,9 +269,6 @@ enum ShellStatusTooltip {
       // does not move, so promising the next mode here would be a promise the click cannot keep.
       guard hasMicrophonePermission else {
         return "Audio — off. Omi needs microphone access. Click to grant it."
-      }
-      if isAwaitingMeeting {
-        return "Audio — waiting for a call (\(mode)). Nothing is being transcribed. Click for \(next)."
       }
       return "Audio — off. Nothing is being transcribed. Click for \(next)."
     }
@@ -352,9 +351,11 @@ struct ShellStatusIconButton: View {
       }
       .overlay(alignment: .bottomLeading) {
         if let badge {
+          // Pushed clear of the glyph's foot: at (-5, 4) the mark sat on the mic's stand and read as
+          // a second silhouette fused to the first — additive ink has to stay outside the shape.
           Image(systemName: badge)
             .scaledFont(size: OmiType.micro, weight: .bold)
-            .offset(x: -5, y: 4)
+            .offset(x: -9, y: 6)
         }
       }
     }
@@ -379,9 +380,8 @@ struct ShellStatusIcons: View {
   @State private var isTogglingCapture = false
   @State private var isTogglingListening = false
   /// Shown for a beat when a click *selects* Only Meetings, never on hover and never at rest.
-  /// Only Meetings is the one mode whose behaviour no glyph can state — the control is switched
-  /// on while the microphone is deliberately held shut until a call starts — so selecting it is
-  /// the one moment that earns a sentence. Tying it to the transition keeps the cluster wordless.
+  /// The three modes cycle under one glyph, so landing on the third one names it; the tooltip
+  /// carries the explanation. Tying it to the transition keeps the cluster wordless.
   @State private var showsMeetingsHint = false
   @State private var meetingsHintDismissal: DispatchWorkItem?
 
@@ -402,10 +402,8 @@ struct ShellStatusIcons: View {
       .accessibilityIdentifier("shell-status-listening")
       .popover(isPresented: $showsMeetingsHint, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
         Text(Self.meetingsHint)
-          .scaledFont(size: OmiType.caption)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundStyle(Ink.primary)
-          .multilineTextAlignment(.leading)
-          .frame(width: 232, alignment: .leading)
           .padding(OmiSpacing.sm)
       }
 
@@ -440,10 +438,9 @@ struct ShellStatusIcons: View {
     CaptureListeningLogic.audioRecordingMode(raw: audioRecordingModeRaw)
   }
 
-  /// The sentence Only Meetings earns, kept beside the mode it explains. Static so a test can
-  /// read the wording without standing up an `AppState`.
-  static let meetingsHint =
-    "Only Meetings — the microphone stays closed until Omi detects a call, then records until it ends."
+  /// The name of the mode the click just selected — the label, not an explanation, which lives in
+  /// the tooltip. Static so a test can read the wording without standing up an `AppState`.
+  static let meetingsHint = "Only Meetings"
 
   private var listeningTooltip: String {
     ShellStatusTooltip.audio(

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -269,6 +269,13 @@ enum ShellStatusTooltip {
     case .blocked:
       return "Audio — transcription unavailable. Open Settings to reconnect."
     case .active where isAwaitingMeeting:
+      // The wait is armed, but without the microphone grant no call can actually be recorded, so
+      // the sentence has to say what is missing instead of promising a recording that cannot start.
+      guard hasMicrophonePermission else {
+        return
+          "Audio — on (\(mode)), but Omi needs microphone access to record a call. "
+          + "Grant it in Settings, or click for \(next)."
+      }
       return "Audio — on (\(mode)). Recording starts when a call is detected. Click for \(next)."
     case .active:
       return "Audio — listening (\(mode)). Click for \(next)."

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -19,15 +19,20 @@ final class DashboardCaptureStateTests: XCTestCase {
     XCTAssertFalse(appState.isLiveCapturing)
   }
 
+  /// An armed Only Meetings wait is switched on — the next call is recorded — so the control wears
+  /// the green dot and no off-slash. Off is only the state where nothing will be recorded.
   @MainActor
-  func testListeningStatusIsInactiveWhileAwaitingAMeeting() {
+  func testListeningStatusIsActiveWhileArmedForAMeeting() {
     let appState = AppState()
     appState.isTranscribing = true
     appState.isAwaitingMeeting = true
-    XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .inactive)
+    XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .active)
 
     appState.isAwaitingMeeting = false
     XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .active)
+
+    appState.isTranscribing = false
+    XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .inactive)
   }
 
   @MainActor

--- a/desktop/macos/Desktop/Tests/ShellListeningCycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellListeningCycleTests.swift
@@ -205,19 +205,11 @@ final class ShellListeningCycleTests: XCTestCase {
       "Off is stopped by the session teardown, not by this pause")
   }
 
-  /// The hint exists because Only Meetings is the one mode whose behaviour is invisible: the
-  /// control reads as on while nothing is being recorded. If it stops saying so, it is decoration.
-  func testTheMeetingsHintExplainsThatTheMicrophoneStaysClosed() {
-    let hint = ShellStatusIcons.meetingsHint
-    XCTAssertTrue(
-      hint.localizedCaseInsensitiveContains("until"),
-      """
-      the Only Meetings hint reads "\(hint)" and no longer says the microphone waits for something. \
-      That wait is the whole of what distinguishes this mode from Always On.
-      """)
-    XCTAssertTrue(
-      hint.localizedCaseInsensitiveContains("call")
-        || hint.localizedCaseInsensitiveContains("meeting"),
-      "the hint has to name what the microphone is waiting for: \(hint)")
+  /// The hint names the mode the click landed on and nothing more; the explanation of what the
+  /// mode does is the tooltip's job. A sentence in a popover under a 13 pt icon reads as an error.
+  func testTheMeetingsHintIsJustTheModeName() {
+    XCTAssertEqual(
+      ShellStatusIcons.meetingsHint,
+      CaptureListeningLogic.audioRecordingModeTitle(.onlyMeetings))
   }
 }

--- a/desktop/macos/Desktop/Tests/ShellListeningCycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellListeningCycleTests.swift
@@ -92,34 +92,28 @@ final class ShellListeningCycleTests: XCTestCase {
     }
   }
 
-  // MARK: The mark
+  // MARK: The silhouette
 
-  /// Only Meetings is the mode whose behaviour the glyph cannot state — the control is switched on
-  /// while the microphone is held shut — so it is the one mode that carries a mark. The others must
-  /// not, or the mark stops meaning anything.
-  func testOnlyMeetingsCarriesTheModeBadgeAndNothingElseDoes() {
+  /// Only Meetings is a different capability from room listening — record calls, not the room — so
+  /// it owns the control's silhouette outright rather than riding on the mic as a corner mark, which
+  /// read as two glyphs fused into one. The other two modes keep the mic, or the swap would say
+  /// nothing.
+  func testOnlyMeetingsWearsThePeopleGlyphAndTheOtherModesKeepTheMic() {
     XCTAssertEqual(
-      ShellStatusGlyph.modeBadge(for: .onlyMeetings), ShellStatusGlyph.meetingsOnly,
+      ShellStatusGlyph.listeningGlyph(for: .onlyMeetings), ShellStatusGlyph.meetingsOnly,
       "Only Meetings must be distinguishable from Always On at a glance")
-    XCTAssertNil(
-      ShellStatusGlyph.modeBadge(for: .always),
-      "Always On must not wear the meetings mark — the two modes would be indistinguishable")
-    XCTAssertNil(ShellStatusGlyph.modeBadge(for: .off), "the off mode is said by the slash")
-  }
-
-  /// The mark rides in the corner; the silhouette underneath stays the one `mic` the cluster's
-  /// header pins. `ShellStatusIconLegibilityTests` measures that in pixels — this is the
-  /// type-level half: adding a mode must never add a listening glyph.
-  func testTheModeBadgeIsNeverTheListeningGlyphItself() {
+    XCTAssertEqual(
+      ShellStatusGlyph.listeningGlyph(for: .always), ShellStatusGlyph.listening,
+      "Always On is the microphone itself")
+    XCTAssertEqual(
+      ShellStatusGlyph.listeningGlyph(for: .off), ShellStatusGlyph.listening,
+      "the off mode is said by the slash over the mic, not by a different glyph")
     XCTAssertNotEqual(
-      ShellStatusGlyph.modeBadge(for: .onlyMeetings), ShellStatusGlyph.listening,
-      """
-      the meetings mark replaced the listening glyph instead of riding on top of it — that is the \
-      `waveform`/`mic` silhouette swap the cluster's header rejects, returning as a mode badge.
-      """)
+      ShellStatusGlyph.meetingsOnly, ShellStatusGlyph.listening,
+      "the meetings glyph must be a different silhouette or the mode is invisible")
     XCTAssertEqual(
       ShellStatusGlyph.listening, "mic",
-      "the listening control has exactly one silhouette, in every state and every mode")
+      "the room-listening silhouette is the one the cluster's header pins")
   }
 
   // MARK: The promise the tooltip makes

--- a/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
@@ -625,15 +625,18 @@ final class ShellStatusIconLegibilityTests: XCTestCase {
       """)
   }
 
-  func testTheAwaitingMeetingAudioTooltipDoesNotClaimOffOrStart() {
+  /// An armed Only Meetings wait is on — green dot, no slash — while nothing is transcribed yet, so
+  /// its sentence says the mic opens on a call rather than claiming "listening", "off", or "start".
+  func testTheAwaitingMeetingAudioTooltipSaysRecordingStartsOnACall() {
     let tooltip = ShellStatusTooltip.audio(
-      state: .inactive, mode: "Only Meetings", isAwaitingMeeting: true,
+      state: .active, mode: "Only Meetings", isAwaitingMeeting: true,
       next: CaptureListeningLogic.audioRecordingModeTitle(
         CaptureListeningLogic.nextAudioRecordingMode(after: .onlyMeetings)))
     XCTAssertTrue(tooltip.hasPrefix("Audio"))
-    XCTAssertTrue(tooltip.contains("waiting for a call"))
+    XCTAssertTrue(tooltip.contains("call"))
     XCTAssertTrue(tooltip.contains("Only Meetings"))
     XCTAssertTrue(tooltip.contains("Click for Off"))
+    XCTAssertFalse(tooltip.contains("listening"), "nothing is transcribed while the mic waits for a call")
     XCTAssertFalse(
       tooltip.contains("Click to start"),
       "An armed Only Meetings wait is not off; clicking turns listening off, it does not start it.")

--- a/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
@@ -641,4 +641,20 @@ final class ShellStatusIconLegibilityTests: XCTestCase {
       tooltip.contains("Click to start"),
       "An armed Only Meetings wait is not off; clicking turns listening off, it does not start it.")
   }
+
+  /// The armed wait can outlive a revoked microphone grant. Promising that recording starts on the
+  /// next call would then be false, so the sentence names the missing grant instead, and still says
+  /// where a click goes, because from Only Meetings a click turns listening off without prompting.
+  func testTheAwaitingMeetingAudioTooltipNamesTheMissingMicrophoneGrant() {
+    let tooltip = ShellStatusTooltip.audio(
+      state: .active, mode: "Only Meetings", isAwaitingMeeting: true, next: "Off",
+      hasMicrophonePermission: false)
+    XCTAssertTrue(tooltip.hasPrefix("Audio"))
+    XCTAssertTrue(tooltip.localizedCaseInsensitiveContains("microphone"), "it has to say what is missing: \(tooltip)")
+    XCTAssertTrue(tooltip.contains("Only Meetings"))
+    XCTAssertTrue(tooltip.contains("click for Off"))
+    XCTAssertFalse(
+      tooltip.contains("Recording starts"),
+      "without the grant no call can be recorded, so the tooltip must not promise one: \(tooltip)")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260905-only-meetings-listening-control.json
+++ b/desktop/macos/changelog/unreleased/20260905-only-meetings-listening-control.json
@@ -1,0 +1,3 @@
+{
+  "change": "Only Meetings now shows as on in the top-bar listening control (green dot, no mute slash), its badge no longer overlaps the microphone, and the click hint is simply Only Meetings."
+}

--- a/desktop/macos/changelog/unreleased/20260905-only-meetings-listening-control.json
+++ b/desktop/macos/changelog/unreleased/20260905-only-meetings-listening-control.json
@@ -1,3 +1,3 @@
 {
-  "change": "Only Meetings now shows as on in the top-bar listening control (green dot, no mute slash), its badge no longer overlaps the microphone, and the click hint is simply Only Meetings."
+  "change": "The top-bar listening control now shows the Only Meetings icon in place of the microphone while that mode is selected, reads as on while armed for a call, and explains the mode in its tooltip"
 }


### PR DESCRIPTION
<img width="124" height="100" alt="Screenshot 2026-09-05 at 5 08 33 PM" src="https://github.com/user-attachments/assets/823e0e4b-4e4e-47bb-88a4-353995a79f56" />


## What

The top-bar listening control now reads Only Meetings honestly:

- **Only Meetings shows its own icon.** While that mode is selected the control wears `person.2.fill` instead of the microphone. The corner badge that used to sit on top of the mic (and overlapped its foot) is gone. Always On and Off keep the mic.
- **Armed Only Meetings reads as on.** The armed wait (mode selected, no call yet) was modelled as inactive, so the control wore the off-slash and a hollow dot while also wearing the mode mark. An armed session is switched on, since the next call is recorded, so `listeningStatus` now reports it active: green dot, no slash.
- **The click hint is just the name.** Landing on Only Meetings shows "Only Meetings"; the explanation moves to the tooltip, which for the armed wait says recording starts when a call is detected. The cycle stays Off -> Always On -> Only Meetings -> Off.

## Why

The mode mark was drawn on top of a slashed, hollow-dot mic, and the two collided on the glyph's foot. Pushing the badge clear still read as two silhouettes fused into one. Only Meetings names a different capability (record calls, not the room), so the mode owns the silhouette outright and the dot and slash keep saying on/off/blocked on top of whichever glyph is showing.

## Changes

- `ShellStatusGlyph.modeBadge(for:)` becomes `listeningGlyph(for:)`; `ShellStatusIconButton` loses its `badge` overlay; the file header documents the mode-not-state swap.
- `CaptureListeningLogic.listeningStatus` treats `isAwaitingMeeting` as active; `ShellStatusTooltip.audio` gains the armed-wait sentence.
- `DashboardPage` uses the same status logic (touches an INV-CHAT-1 path glob; no chat transcript behaviour changes).
- Tests updated in `ShellListeningCycleTests`, `DashboardCaptureStateTests`, `ShellStatusIconLegibilityTests`.

## Tests

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Desktop --filter 'ShellListeningCycleTests|ShellStatusIconLegibilityTests|DashboardCaptureStateTests'` -> 42 tests, 0 failures
- `swift-format lint --strict` clean on the changed Swift files
- Ran the `omi-only-meetings-button` named bundle signed in: Only Meetings shows only the people glyph with a green dot; Always On and Off show the mic.

## Product invariants affected

- INV-CHAT-1

## Failure class

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ws5JE3NXAmo34XxiCC7bVH


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

