### PR TITLE
Chat: the recap gets its own card, the announcement stops journaling a bell card

### DIFF
--- a/.github/failure-classes/FC-chrome-announcement-journaled-as-turn.json
+++ b/.github/failure-classes/FC-chrome-announcement-journaled-as-turn.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-chrome-announcement-journaled-as-turn",
+  "violated_contract": "A presentation-only announcement whose content already owns a dedicated transcript surface must not enter the chat journal. The daily recap announcement routed through generic notification delivery with the default assistant identity, whose derived kind (.functional) journals: the recap became a bell-card turn in the transcript — a truncated, stat-less duplicate of the dedicated ChatDailyRecapRow day boundary the thread already renders, against INV-CHAT-1 (the recap is chrome, not a turn).",
+  "canonical_prevention": "Every producer that must never journal carries a dedicated ProactiveNotificationKind whose isJournaled is false and passes its own assistantId through delivery, so the floating bar's kind derivation lands on it. The journaling gate stays single (persistNotificationMessageIfNeeded consulting kind.isJournaled), and a producer-identity test pins each never-journaled producer's mapping.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift",
+    "desktop/macos/Desktop/Tests/ProactiveNotificationKindTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/MainWindow/Dashboard/**",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -15,6 +15,12 @@ enum ProactiveNotificationKind: String, Equatable, CaseIterable {
   case trial
   /// First-run permission help. Never journaled, for the same reason.
   case onboarding
+  /// The daily recap's once-a-day announcement. Never journaled: the recap's
+  /// transcript presence is the dedicated `ChatDailyRecapRow` day boundary, and
+  /// INV-CHAT-1 makes the recap chrome rather than a turn — a journaled bell
+  /// card would be a second, degraded copy (title truncated, no day stats) of
+  /// a row the transcript already renders.
+  case dailyRecap = "daily_recap"
   case suggestion
   case insight
   case task
@@ -52,6 +58,7 @@ enum ProactiveNotificationKind: String, Equatable, CaseIterable {
     case "integration_connect": return .integration
     case "trial": return .trial
     case "onboarding": return .onboarding
+    case "daily_recap": return .dailyRecap
     default: return .functional
     }
   }
@@ -60,7 +67,7 @@ enum ProactiveNotificationKind: String, Equatable, CaseIterable {
   /// journal. See `FloatingControlBarManager.persistNotificationMessageIfNeeded`.
   var isJournaled: Bool {
     switch self {
-    case .trial, .onboarding: return false
+    case .trial, .onboarding, .dailyRecap: return false
     case .general, .functional, .suggestion, .insight, .task, .memory, .goal, .meetingNotes,
       .resurface, .integration:
       return true

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
@@ -97,7 +97,7 @@ enum ProactiveNotificationCopy {
       return ["memory", "memory saved"]
     case .integration:
       return ["integration"]
-    case .general, .functional, .trial, .onboarding:
+    case .general, .functional, .trial, .onboarding, .dailyRecap:
       return ["notification"]
     }
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectDisplayDuration.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/Interject/InterjectDisplayDuration.swift
@@ -19,7 +19,8 @@ enum InterjectDisplayDuration {
       return 4
     case .insight, .suggestion:
       return 5
-    case .general, .functional, .trial, .onboarding, .memory, .goal, .meetingNotes, .integration:
+    case .general, .functional, .trial, .onboarding, .dailyRecap, .memory, .goal, .meetingNotes,
+      .integration:
       return 5
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -479,6 +479,11 @@ struct ProactiveNotificationBadge: Equatable {
       // Never journaled, so never rendered as a transcript row. Kept exhaustive
       // so a future decision to journal them has to state its badge here.
       (label, systemImage) = ("Omi", "bell")
+    case .dailyRecap:
+      // Never journaled either — the recap's transcript presence is the
+      // dedicated `ChatDailyRecapRow` day boundary, not a bell card. Kept
+      // exhaustive for the same reason.
+      (label, systemImage) = ("Daily Recap", "calendar")
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailyRecapRow.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailyRecapRow.swift
@@ -12,10 +12,10 @@ import SwiftUI
 /// **Below the messages in hierarchy, on purpose.** Left-aligned text one step smaller than the
 /// bubble's, a soft fill with no border, and a trailing chevron — a marker in the thread, not
 /// another card. Centered bordered prose reads as an answer; the day boundary is the quieter
-/// thing. A doorway, not the experience: day label, one-line headline, at most two lines of
-/// overview, and the day's stats as a strip of micro chips (the same numbers the Activity day
-/// card shows, at bubble-row weight) — the full record and its actions live on `DailyRecapPage`,
-/// which clicking opens through the typed recap route.
+/// thing. A doorway, not the experience: day label, the day's emoji beside a one-line headline,
+/// at most three lines of overview, and the day's stats as a strip of micro chips (the same
+/// numbers the Activity day card shows, at bubble-row weight) — the full record and its actions
+/// live on `DailyRecapPage`, which clicking opens through the typed recap route.
 struct ChatDailyRecapRow: View {
   let record: DailySummaryRecord
 
@@ -45,16 +45,22 @@ struct ChatDailyRecapRow: View {
             .scaledFont(size: OmiType.micro, weight: .semibold)
             .foregroundStyle(Ink.secondary)
         }
-        Text(nonEmpty(record.headline) ?? "Your day in review")
-          .scaledFont(size: OmiType.caption, weight: .medium)
-          .foregroundStyle(Ink.primary)
-          .lineLimit(1)
-          .truncationMode(.tail)
+        // The page's header shape, at row weight: the day's emoji beside the
+        // title, so the card reads as *the* recap rather than another notice.
+        HStack(spacing: OmiSpacing.xs) {
+          Text(nonEmpty(record.dayEmoji) ?? "📅")
+            .scaledFont(size: OmiType.subheading)
+          Text(nonEmpty(record.headline) ?? "Your day in review")
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundStyle(Ink.primary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
         if let overview = nonEmpty(record.overview) {
           Text(overview)
             .scaledFont(size: OmiType.caption)
             .foregroundStyle(Ink.secondary)
-            .lineLimit(2)
+            .lineLimit(3)
             .fixedSize(horizontal: false, vertical: true)
             .multilineTextAlignment(.leading)
         }
@@ -107,12 +113,10 @@ struct ChatDailyRecapRow: View {
     }
   }
 
-  /// "Yesterday · 🚀" — the day the recap is about, not the day it was written.
+  /// "Yesterday" — the day the recap is about, not the day it was written. The
+  /// day's emoji sits beside the title above, the way the page's header does.
   private var dayLabel: String {
-    let emoji = nonEmpty(record.dayEmoji) ?? "📅"
-    let day =
-      ChatDailySummaryPresentation.dateLabel(for: record.date, now: now()) ?? "Your day"
-    return "\(day) · \(emoji)"
+    ChatDailySummaryPresentation.dateLabel(for: record.date, now: now()) ?? "Your day"
   }
 
   private func nonEmpty(_ value: String?) -> String? {
@@ -124,15 +128,17 @@ struct ChatDailyRecapRow: View {
 /// Where the recap row goes, decided once and tested without a view.
 ///
 /// The row anchors **above the first message on or after the recap's day** — it is a day boundary
-/// in the thread, so it must sit where that day begins. Two shapes of thread render nothing at
-/// all, because either would draw the marker at a place the transcript cannot back up:
+/// in the thread, so it must sit where that day begins. Two shapes of thread place it
+/// differently, and one renders nothing at all:
 ///
-/// - **No message in the loaded window is on or after the recap's day.** The boundary is below
-///   what is loaded (or the thread is empty); a marker at the live edge would claim a day the
-///   visible history does not contain.
+/// - **No message in the loaded window is on or after the recap's day.** The recap is newer than
+///   everything loaded, so it is the newest thing in the thread: the marker takes the live edge,
+///   above the last row. (The row carries its own day label, so it claims nothing about the
+///   messages it sits below.)
 /// - **The boundary is at the very top of the loaded window while older messages exist above
 ///   it.** The day may begin further up; anchoring at the first loaded row would put the marker
-///   above messages from the same day whenever more history loads.
+///   above messages from the same day whenever more history loads, so it waits.
+/// - **An empty thread** renders nothing — the empty state owns that surface.
 enum ChatDailyRecapRowPlacement {
   static func anchorMessageID(
     in messages: [ChatMessage],
@@ -146,7 +152,7 @@ enum ChatDailyRecapRowPlacement {
     let dayStart = calendar.startOfDay(for: day)
     guard
       let index = messages.firstIndex(where: { calendar.startOfDay(for: $0.createdAt) >= dayStart })
-    else { return nil }
+    else { return messages.last?.id }
     if index == 0, hasOlderMessagesAbove { return nil }
     return messages[index].id
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
@@ -131,6 +131,13 @@ final class ChatDailySummaryCoordinator: ObservableObject {
     AnalyticsManager.shared.trackDailySummary(.cardShown)
   }
 
+  /// The assistant identity the recap announcement presents under, so the floating bar's kind
+  /// derivation (`ProactiveNotificationKind.from(assistantId:)`) lands on `.dailyRecap` —
+  /// presentation-only. The announcement must not journal a transcript turn: the recap is already
+  /// in the thread as the dedicated `ChatDailyRecapRow` day boundary, and a journaled bell card
+  /// rendered a truncated, stat-less copy of it (INV-CHAT-1 — the recap is chrome, not a turn).
+  static let assistantID = "daily_recap"
+
   private static let defaultCardSink: CardSink = { ownerID, title, body in
     // Fenced to the owner the summary was fetched for, not whoever is current now.
     guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: ownerID) else {
@@ -140,6 +147,7 @@ final class ChatDailySummaryCoordinator: ObservableObject {
       ownerID: snapshot.ownerID,
       title: title,
       message: body,
+      assistantId: ChatDailySummaryCoordinator.assistantID,
       // The summary is a statement about a day that already happened; the frequency budget exists
       // to throttle interruptions the user did not ask for, and this one is at most one per day.
       respectFrequency: false,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -1056,9 +1056,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     case .insight, .resurface, .goal: return insightEnabled
     case .memory: return memoryEnabled
     case .integration: return integrationEnabled
-    // Functional system notices and the two never-journaled product cards sit
-    // outside the five-category taxonomy and are ungated by it.
-    case .general, .functional, .trial, .onboarding: return true
+    // Functional system notices, the never-journaled product cards, and the
+    // recap announcement sit outside the five-category taxonomy and are
+    // ungated by it.
+    case .general, .functional, .trial, .onboarding, .dailyRecap: return true
     }
   }
 

--- a/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
@@ -397,9 +397,9 @@ final class ChatDailySummaryTests: XCTestCase {
 
   /// The recap lives in history now: a day-boundary row anchored above the
   /// first message on or after the recap's day. `ChatDailyRecapRowPlacement`
-  /// decides, without a view, where that boundary is and when a thread
-  /// deliberately shows none — a marker the transcript cannot back up would be
-  /// a lie about where the day began.
+  /// decides, without a view, where that boundary is, when it waits for older
+  /// history to load, and when it takes the live edge — a marker the transcript
+  /// cannot back up would be a lie about where the day began.
   func testRecapRowPlacement() throws {
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
@@ -431,10 +431,21 @@ final class ChatDailySummaryTests: XCTestCase {
     XCTAssertNil(
       ChatDailyRecapRowPlacement.anchorMessageID(
         in: thread, recapDate: "2026-08-31", hasOlderMessagesAbove: true, calendar: calendar))
-    // A recap newer than everything loaded has no boundary in the window.
+    // A recap newer than everything loaded is the newest thing in the thread:
+    // it takes the live edge, below the last row.
+    XCTAssertEqual(
+      ChatDailyRecapRowPlacement.anchorMessageID(
+        in: thread, recapDate: "2026-09-03", hasOlderMessagesAbove: false, calendar: calendar),
+      thread[2].id)
+    XCTAssertEqual(
+      ChatDailyRecapRowPlacement.anchorMessageID(
+        in: thread, recapDate: "2026-09-03", hasOlderMessagesAbove: true, calendar: calendar),
+      thread[2].id,
+      "the live edge does not depend on how much older history is still hidden")
+    // An empty thread renders nothing rather than inventing a row.
     XCTAssertNil(
       ChatDailyRecapRowPlacement.anchorMessageID(
-        in: thread, recapDate: "2026-09-03", hasOlderMessagesAbove: false, calendar: calendar))
+        in: [], recapDate: "2026-09-03", hasOlderMessagesAbove: false, calendar: calendar))
     // A missing or malformed date renders nothing rather than anchoring somewhere.
     XCTAssertNil(
       ChatDailyRecapRowPlacement.anchorMessageID(

--- a/desktop/macos/Desktop/Tests/ProactiveNotificationKindTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveNotificationKindTests.swift
@@ -15,7 +15,7 @@ final class ProactiveNotificationKindTests: XCTestCase {
   /// `.general` is not reachable from any of them — it is decode-only.
   private static let producerAssistantIDs = [
     "suggestion", "insight", "task", "memory-extraction", "goals", "meeting-notes",
-    "integration_connect", "context-director", "trial", "onboarding",
+    "integration_connect", "context-director", "trial", "onboarding", "daily_recap",
     "notch_receipt", "notch_end", "reach_error", "unknown-future-assistant",
   ]
 
@@ -63,14 +63,30 @@ final class ProactiveNotificationKindTests: XCTestCase {
       "the bare form stays reachable for round-tripping history, never for minting")
   }
 
-  /// Trial messaging and onboarding permission help are cards, not observations.
-  /// They present and dismiss; they must never become chat rows.
+  /// Trial messaging, onboarding permission help, and the daily recap's
+  /// announcement are cards, not observations. They present and dismiss; they
+  /// must never become chat rows.
   func testProductCopyCardsAreExcludedFromJournaling() {
     XCTAssertFalse(ProactiveNotificationKind.trial.isJournaled)
     XCTAssertFalse(ProactiveNotificationKind.onboarding.isJournaled)
-    for kind in ProactiveNotificationKind.allCases where kind != .trial && kind != .onboarding {
+    XCTAssertFalse(ProactiveNotificationKind.dailyRecap.isJournaled)
+    for kind in ProactiveNotificationKind.allCases
+    where kind != .trial && kind != .onboarding && kind != .dailyRecap {
       XCTAssertTrue(kind.isJournaled, "\(kind.rawValue) is something Omi observed")
     }
+  }
+
+  /// The recap announcement must present under the recap identity, never the
+  /// default assistant: the default derives `.functional`, which journals a
+  /// bell card into the transcript — a truncated, stat-less duplicate of the
+  /// dedicated `ChatDailyRecapRow` day boundary the thread already renders.
+  func testTheRecapAnnouncementPresentsUnjournaledUnderItsOwnIdentity() {
+    @MainActor func announcementKind() -> ProactiveNotificationKind {
+      ProactiveNotificationKind.from(assistantId: ChatDailySummaryCoordinator.assistantID)
+    }
+    let kind = MainActor.assumeIsolated(announcementKind)
+    XCTAssertEqual(kind, .dailyRecap)
+    XCTAssertFalse(ProactiveNotificationKind.dailyRecap.isJournaled)
   }
 
   /// The five category toggles gate the five proactive categories and nothing
@@ -91,7 +107,7 @@ final class ProactiveNotificationKindTests: XCTestCase {
     ] {
       XCTAssertFalse(allows(gated), "\(gated.rawValue) must honour its category toggle")
     }
-    for ungated: ProactiveNotificationKind in [.general, .functional, .trial, .onboarding] {
+    for ungated: ProactiveNotificationKind in [.general, .functional, .trial, .onboarding, .dailyRecap] {
       XCTAssertTrue(allows(ungated), "\(ungated.rawValue) sits outside the five-category taxonomy")
     }
   }

--- a/desktop/macos/changelog/unreleased/20260905-chat-recap-dedicated-card.json
+++ b/desktop/macos/changelog/unreleased/20260905-chat-recap-dedicated-card.json
@@ -1,0 +1,3 @@
+{
+  "change": "The daily recap in Chat history is now its own card — day, emoji, title, overview, and the day's stats — and the once-a-day announcement no longer adds a generic bell notification on top of it"
+}


### PR DESCRIPTION
## Summary

The daily recap reached Chat history twice, and the worse copy won the reader's eye.

`ChatDailySummaryCoordinator`'s once-a-day announcement routed through generic notification delivery **without an assistant id**, so the floating bar's kind derivation landed on `.functional` — a journaled kind. Every new recap therefore wrote a bell card into the transcript: "Omi" eyebrow, emoji + headline, and the overview truncated at 140 characters. No stats, no day label, no doorway to the record — a degraded duplicate of the dedicated `ChatDailyRecapRow` day boundary the same transcript already renders, and a violation of the coordinator's own INV-CHAT-1 stance ("nothing here writes a turn, a journal entry, or a synthetic message").

- **The announcement is presentation-only now.** New `ProactiveNotificationKind.dailyRecap` (`isJournaled == false`), and the sink passes `assistantId: ChatDailySummaryCoordinator.assistantID` (`"daily_recap"`) so the derivation lands on it. The notch card, the seen-once bookkeeping, and the analytics are unchanged. Declared as a new failure class, `FC-chrome-announcement-journaled-as-turn`, with the kind gate + producer-identity test as its guard artifacts.
- **The dedicated row carries the page's header shape** (what the reader asked for): the day's emoji beside the title — previously the emoji hid in the eyebrow — and the overview gets a third line, at bubble-row weight. Stat chips were already there.
- **The row renders reliably.** Its placement declined to draw when the recap's day contained no loaded message, so a quiet thread lost its recap entirely once the bell card stopped carrying it. A recap newer than everything loaded is the newest thing in the thread and now takes the live edge (above the last row); the top-of-window wait and the empty-thread cases are unchanged and tested.

## Testing

- `ProactiveNotificationKindTests`: new producer id, never-journaled set, ungated set, and a new pin — the recap announcement's assistant id derives `.dailyRecap`, never `.functional`.
- `ChatDailySummaryTests.testRecapRowPlacement`: live-edge anchoring (with and without hidden older history), empty thread renders nothing; existing boundary/wait cases unchanged.
- `xcrun swift build -c debug` clean; swift-format 602.0.0 clean; verified in the running `omi-recap-generation` bundle.

Failure-Class: new

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift | 1535 -> 1536 | one case (.dailyRecap) joins the category-gating switch's ungated arm; no split warranted for a single line


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

