### PR TITLE
test: add isolated JIT QA seed and drain proof

### DIFF
--- a/backend/docs/runbooks/jit-qa-seed-and-verify.md
+++ b/backend/docs/runbooks/jit-qa-seed-and-verify.md
@@ -7,12 +7,27 @@ execution. The only account it may touch is
 database `jit-qa`. It refuses a different project, database, UID, emulator, or
 customer Firebase credential selector.
 
-The deployment/database factory must create the QA database and the account's
-`users/{uid}/memory_state/apply_control` document first. The operator does not
-create or repair apply-control state. The initial writer mode must be
-`compatibility`; all rows and evidence are namespaced by the supplied run ID.
-Existing documents with a foreign marker are a hard failure, and rerunning the
-same seed is a read-only no-op for rows already owned by that run.
+The deployment/database factory creates the named Firestore database. Before
+seeding, run the explicit create-only bootstrap against that named database:
+
+```bash
+python3 backend/scripts/jit_qa_seed_and_verify.py bootstrap
+```
+
+Bootstrap fails unless the named database is truly empty, creates only the
+fixed QA UID's minimal `users/{uid}` profile and `testers/{uid}` entitlement
+marker, and calls `ensure_canonical_apply_control_state` to create the real
+compatibility apply-control fence. It never creates a migration completion or
+ledger cutover receipt; those remain owned by the drain job's canonical
+`publish_ledger_migration_cutover` path. A durable
+`jit_qa_bootstrap/{uid}` marker makes a retry idempotent while refusing any
+unowned or malformed document. The default database and every other UID remain
+out of scope.
+
+The initial writer mode must be `compatibility`; all rows and evidence are
+namespaced by the supplied run ID. Existing documents with a foreign marker
+are a hard failure, and rerunning the same seed is a read-only no-op for rows
+already owned by that run.
 
 ## Prepare and inspect
 
@@ -22,6 +37,8 @@ running the script. No model call or Cloud Run execution is made by these
 commands.
 
 ```bash
+python3 backend/scripts/jit_qa_seed_and_verify.py bootstrap
+
 python3 backend/scripts/jit_qa_seed_and_verify.py \
   --run-id qa-proof-20260905 prepare
 
@@ -100,3 +117,20 @@ The operator's drain proof is a separate data-plane receipt. A reviewed cloud
 resource receipt proves the endpoint/dependency tuple; it does not prove the
 101-row drain. Both must be retained together, with the exact Cloud Run
 execution names joined to the three summary files.
+
+## Emulator proof boundary
+
+For local correctness, run the real Firestore emulator proof under
+`firebase emulators:exec`:
+
+```bash
+firebase emulators:exec --only firestore --project demo-omi-jit-qa \
+  'PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify_emulator_test.py'
+```
+
+That test exercises bootstrap, 101-row seed, the actual migration helper's
+100+1 progress, canonical publication, rollback, and roll-forward against a
+real emulator. It injects only the rollout decision and labels that boundary
+in its output. The named-cloud command still rejects emulators and requires
+the deployed job's real rollout/admission path; an emulator pass is not a
+cloud readiness result.

--- a/backend/docs/runbooks/jit-qa-seed-and-verify.md
+++ b/backend/docs/runbooks/jit-qa-seed-and-verify.md
@@ -1,0 +1,102 @@
+# Isolated JIT QA seed and ledger-drain proof
+
+`backend/scripts/jit_qa_seed_and_verify.py` is the operator for the named JIT
+QA data plane. It is intentionally separate from deployment and model
+execution. The only account it may touch is
+`vi7SA9ckQCe4ccobWNxlbdcNdC23` in project `based-hardware-dev`, Firestore
+database `jit-qa`. It refuses a different project, database, UID, emulator, or
+customer Firebase credential selector.
+
+The deployment/database factory must create the QA database and the account's
+`users/{uid}/memory_state/apply_control` document first. The operator does not
+create or repair apply-control state. The initial writer mode must be
+`compatibility`; all rows and evidence are namespaced by the supplied run ID.
+Existing documents with a foreign marker are a hard failure, and rerunning the
+same seed is a read-only no-op for rows already owned by that run.
+
+## Prepare and inspect
+
+Use the existing dev-only credential loader or the workflow's workload
+identity. Verify the shell is pointed at the development project before
+running the script. No model call or Cloud Run execution is made by these
+commands.
+
+```bash
+python3 backend/scripts/jit_qa_seed_and_verify.py \
+  --run-id qa-proof-20260905 prepare
+
+python3 backend/scripts/jit_qa_seed_and_verify.py \
+  --run-id qa-proof-20260905 inspect
+```
+
+`prepare` creates 101 canonical `memory_items` rows and their synthetic
+evidence documents. The rows intentionally omit `ledger_schema_version`; they
+are the same legacy-shaped canonical fixture used by the bounded drain
+emulator proof. The printed result contains counts and the target identity,
+never row content. `inspect` reads only metadata and reports the count of
+legacy versus ledger rows, migration completion/projection presence, the
+content-free metadata digest, and whether the global drain cursor exists.
+
+## Execute and verify the two pages
+
+The reviewed QA workflow owns Cloud Run execution. Run its explicit drain
+execution twice, preserving the content-free summary for each execution. The
+first summary must report 100 migrated rows and one remaining user; the second
+must report one migrated row and one cutover user. A third allowlisted retry
+must be a stable no-op. The workflow's execution summaries can be wrapped as
+`{"execution": "...", "summary": {...}}` or supplied as the summary object
+itself.
+
+```bash
+python3 backend/scripts/jit_qa_seed_and_verify.py \
+  --run-id qa-proof-20260905 verify \
+  --first-summary /path/to/drain-1-summary.json \
+  --second-summary /path/to/drain-2-summary.json \
+  --retry-summary /path/to/drain-retry-summary.json
+```
+
+Verification requires the fixed allowlisted identity, no errors, exact
+`100 + 1` progress, 101 retained rows and evidence documents, a fenced ledger
+completion and 101-row prompt projection, and no global cursor write. It does
+not accept an injected rollout authorizer or an emulator result as cloud
+evidence.
+
+## Rollback and rollforward
+
+Rollback is an explicit control-plane operation and requires a separate
+confirmation. It does not rewrite the 101 canonical rows or evidence. After
+the rollback receipt is captured, run one more reviewed QA drain execution;
+the rollforward should migrate zero rows, cut over once, and restore the
+ledger completion. Re-run `inspect` to confirm the metadata digest is unchanged
+and all 101 rows remain present.
+
+```bash
+python3 backend/scripts/jit_qa_seed_and_verify.py \
+  --run-id qa-proof-20260905 rollback \
+  --confirmation ROLLBACK_QA
+```
+
+This command is intentionally not part of deployment and should only be run
+after the first `verify` pass has been reviewed. The operator never deletes
+fixture rows, evidence, or customer data.
+
+## Receipt contract
+
+The deployment producer and this consumer use the same cloud receipt contract:
+
+* `schema_version`: `omi.jit.qa.cloud.v1`
+* `project` and `data_plane_project`: `based-hardware-dev`
+* `firestore_database_id`: `jit-qa`
+* `auth_project`: `based-hardware`
+* services: `backend-jit-qa`, `desktop-backend-jit-qa`,
+  `llm-gateway-jit-qa`
+* `exact_python_url`, `exact_desktop_url`, `exact_gateway_url`
+* full 40-character `full_source_sha`
+* ready revision and immutable image digest for Python and desktop services
+* non-empty dependency vector naming the isolated Firestore, Redis, gateway,
+  Firebase-auth verification, storage, Pub/Sub, and Scheduler bindings
+
+The operator's drain proof is a separate data-plane receipt. A reviewed cloud
+resource receipt proves the endpoint/dependency tuple; it does not prove the
+101-row drain. Both must be retained together, with the exact Cloud Run
+execution names joined to the three summary files.

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -221,7 +221,9 @@ def _assert_named_database_empty(db_client: Any) -> None:
         if collection_id not in BOOTSTRAP_COLLECTIONS:
             raise JITQAVerificationError(f"bootstrap found an unsupported top-level collection: {collection_id!r}")
         limited = getattr(collection, "limit", None)
-        stream = getattr(limited(2) if callable(limited) else collection, "stream", None)
+        if not callable(limited):
+            raise JITQAVerificationError("bootstrap cannot bound the named Firestore database inventory")
+        stream = getattr(limited(2), "stream", None)
         if not callable(stream):
             raise JITQAVerificationError("bootstrap cannot prove the named Firestore database is empty")
         try:
@@ -373,8 +375,11 @@ def _assert_fixture_exclusive(db_client: Any, *, run_id: str) -> None:
         raise JITQAVerificationError("QA Firestore client cannot prove fixture exclusivity")
     collection = collection_factory(f"users/{QA_UID}/memory_items")
     selector = getattr(collection, "select", None)
-    if callable(selector):
-        collection = selector(["memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row"])
+    if not callable(selector):
+        raise JITQAVerificationError("QA Firestore client cannot project fixture ownership metadata")
+    collection = selector(
+        ["memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row", "promotion", "ledger_schema_version"]
+    )
     limiter = getattr(collection, "limit", None)
     if not callable(limiter):
         raise JITQAVerificationError("QA Firestore client cannot bound fixture exclusivity inventory")
@@ -390,10 +395,11 @@ def _assert_fixture_exclusive(db_client: Any, *, run_id: str) -> None:
             raise JITQAVerificationError("QA fixture exclusivity inventory exceeded its hard bound")
         snapshot_id = str(getattr(snapshot, "id", ""))
         payload = _as_dict(snapshot)
+        expected_index = int(snapshot_id.rsplit("-", 1)[-1]) if snapshot_id in expected_ids else -1
         if snapshot_id not in expected_ids or not _owned_fields_match(
             payload,
             run_id=run_id,
-            index=int(payload.get("jit_qa_row", -1)) if str(payload.get("jit_qa_row", "")).isdigit() else -1,
+            index=expected_index,
         ):
             # Stop at the first foreign row.  The query is deliberately capped
             # at 101 + 1 so a malicious/accidental large collection cannot turn
@@ -445,10 +451,18 @@ def _fixture_item(
         ledger_sequence=0,
         item_revision=1,
         account_generation=account_generation,
+        promotion={
+            "jit_qa_fixture": FIXTURE_MARKER,
+            "jit_qa_run_id": run_id,
+            "jit_qa_row": index,
+        },
         predicate="resides_in" if index == 0 else "likes",
     )
-    # These are the exact fields used to prove ownership without reading the
-    # synthetic content back.  They are ignored by MemoryItem validation.
+    # Keep the marker in a typed model field as well as the legacy top-level
+    # projection.  Canonical migration rewrites a MemoryItem through
+    # model_dump(), which intentionally drops unknown top-level fields; the
+    # promotion marker therefore survives the migration and keeps the
+    # post-cutover exclusivity proof content-free.
     payload = _stored_model(item)
     payload.update(
         {
@@ -471,10 +485,20 @@ def _item_payload(item: MemoryItem) -> dict[str, Any]:
 
 
 def _owned_fields_match(payload: Mapping[str, Any], *, run_id: str, index: int) -> bool:
-    return (
+    top_level_marker = (
         payload.get("jit_qa_fixture") == FIXTURE_MARKER
         and payload.get("jit_qa_run_id") == run_id
         and payload.get("jit_qa_row") == index
+    )
+    promotion = payload.get("promotion")
+    promoted_marker = (
+        isinstance(promotion, Mapping)
+        and promotion.get("jit_qa_fixture") == FIXTURE_MARKER
+        and promotion.get("jit_qa_run_id") == run_id
+        and promotion.get("jit_qa_row") == index
+    )
+    return (
+        (top_level_marker or promoted_marker)
         and payload.get("uid") == QA_UID
         and payload.get("memory_id") == f"jitqa-{run_id}-legacy-{index:03d}"
     )
@@ -529,7 +553,15 @@ def seed_fixture(db_client: Any, *, run_id: str) -> dict[str, int | str]:
         memory_ref = db_client.document(_memory_path(run_id, index))
         existing = _get_selected(
             memory_ref,
-            ("memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row", "ledger_schema_version"),
+            (
+                "memory_id",
+                "uid",
+                "jit_qa_fixture",
+                "jit_qa_run_id",
+                "jit_qa_row",
+                "promotion",
+                "ledger_schema_version",
+            ),
         )
         if existing:
             if not _owned_fields_match(existing, run_id=run_id, index=index):
@@ -545,8 +577,44 @@ def seed_fixture(db_client: Any, *, run_id: str) -> dict[str, int | str]:
         }:
             raise JITQAVerificationError(f"refusing to overwrite non-owned QA evidence {index:03d}")
         if not evidence:
-            evidence_ref.set(expected_evidence)
-        memory_ref.set(expected)
+            create_evidence = getattr(evidence_ref, "create", None)
+            if not callable(create_evidence):
+                raise JITQAVerificationError("QA fixture requires create-only Firestore writes for evidence")
+            try:
+                create_evidence(expected_evidence)
+            except Exception as exc:
+                raced_evidence = _get_selected(
+                    evidence_ref, ("evidence_id", "source_id", "source_state", "source_type")
+                )
+                if raced_evidence != {
+                    key: expected_evidence.get(key)
+                    for key in ("evidence_id", "source_id", "source_state", "source_type")
+                }:
+                    raise JITQAVerificationError(
+                        f"QA fixture evidence creation raced with an unowned document {index:03d}"
+                    ) from exc
+        create_memory = getattr(memory_ref, "create", None)
+        if not callable(create_memory):
+            raise JITQAVerificationError("QA fixture requires create-only Firestore writes for memory rows")
+        try:
+            create_memory(expected)
+        except Exception as exc:
+            raced_memory = _get_selected(
+                memory_ref,
+                (
+                    "memory_id",
+                    "uid",
+                    "jit_qa_fixture",
+                    "jit_qa_run_id",
+                    "jit_qa_row",
+                    "promotion",
+                    "ledger_schema_version",
+                ),
+            )
+            if not _owned_fields_match(raced_memory, run_id=run_id, index=index):
+                raise JITQAVerificationError(
+                    f"QA fixture memory creation raced with an unowned document {index:03d}"
+                ) from exc
         created_rows += 1
 
     return {
@@ -613,6 +681,7 @@ def inspect_fixture(db_client: Any, *, run_id: str, allow_ledger: bool = True) -
                 "jit_qa_fixture",
                 "jit_qa_run_id",
                 "jit_qa_row",
+                "promotion",
                 "ledger_schema_version",
                 "status",
                 "write_reason",

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -3,9 +3,11 @@
 
 This operator is deliberately narrower than the deployment workflow.  It owns
 only a deterministic, synthetic fixture in the named ``jit-qa`` Firestore
-database.  It never discovers or edits another account, never creates the
-apply-control document, and never calls a model.  The Cloud Run workflow owns
-job execution; this command consumes its content-free execution summaries.
+database.  The explicit ``bootstrap`` command is create-only and may only
+initialize a truly empty named database for the fixed QA identity.  It never
+discovers or edits another account, never creates a production control plane,
+and never calls a model.  The Cloud Run workflow owns job execution; this
+command consumes its content-free execution summaries.
 
 The fixture contains 101 canonical rows that are intentionally missing the
 ledger schema marker.  The production drain's mutation budget is 100 rows per
@@ -37,10 +39,12 @@ if str(BACKEND_DIR) not in sys.path:
 
 from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState  # noqa: E402
 from models.product_memory import MemoryItem, MemoryItemStatus, MemoryLayer, ProcessingState  # noqa: E402
+from models.users import PlanType, Subscription, SubscriptionStatus  # noqa: E402
 from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION  # noqa: E402
 from utils.memory.knowledge_ledger_migration import (  # noqa: E402
     rollback_ledger_writer_to_compatibility,
 )
+from utils.memory.memory_system import ensure_canonical_apply_control_state  # noqa: E402
 
 PROJECT_ID = "based-hardware-dev"
 DATABASE_ID = "jit-qa"
@@ -48,8 +52,19 @@ REGION = "us-central1"
 QA_UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
 LEDGER_DRAIN_JOB = "knowledge-ledger-drain-qa-job"
 FIXTURE_MARKER = "omi.jit.qa.seed-and-verify.v1"
+BOOTSTRAP_MARKER = "omi.jit.qa.bootstrap.v1"
+BOOTSTRAP_PATH = f"jit_qa_bootstrap/{QA_UID}"
+TESTER_PATH = f"testers/{QA_UID}"
+QA_TIME_ZONE = "America/New_York"
+# The isolated QA database has no Stripe authority.  This is a named, synthetic
+# entitlement used only by the QA service's fixed UID allowlist; it is never
+# copied to customer data or used as production billing evidence.
+QA_ENTITLEMENT_PLAN = PlanType.operator.value
+QA_ENTITLEMENT_PERIOD_END = 4102444800  # 2100-01-01T00:00:00Z
 ROW_COUNT = 101
 MUTATION_PAGE_SIZE = 100
+EXCLUSIVITY_SCAN_LIMIT = ROW_COUNT + 1
+BOOTSTRAP_COLLECTIONS = frozenset({"jit_qa_bootstrap", "users", "testers", "canonical_memory_maintenance_registry"})
 LEDGER_DRAIN_CURSOR_PATH = "knowledge_ledger_migration_control/inventory_cursor"
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
 SUMMARY_KEYS = (
@@ -132,6 +147,206 @@ def _projection_path() -> str:
     return f"users/{QA_UID}/memory_control/knowledge_ledger_prompt_projection"
 
 
+def _bootstrap_marker_payload(*, status: str) -> dict[str, Any]:
+    return {
+        "schema_version": BOOTSTRAP_MARKER,
+        "status": status,
+        "project": PROJECT_ID,
+        "database": DATABASE_ID,
+        "uid": QA_UID,
+        "time_zone": QA_TIME_ZONE,
+        "entitlement_plan": QA_ENTITLEMENT_PLAN,
+        "test_account": True,
+    }
+
+
+def _qa_subscription_payload() -> dict[str, Any]:
+    """Return the typed subscription projection required by desktop admission.
+
+    This is intentionally built through the shipped ``Subscription`` model.  A
+    QA database has no Stripe webhook, so the period is a fixed synthetic
+    horizon and is scoped by the explicit QA marker below.
+    """
+
+    return Subscription(
+        plan=PlanType.operator,
+        status=SubscriptionStatus.active,
+        current_period_end=QA_ENTITLEMENT_PERIOD_END,
+    ).model_dump(mode="json")
+
+
+def _qa_profile_payload() -> dict[str, Any]:
+    return {
+        "uid": QA_UID,
+        "time_zone": QA_TIME_ZONE,
+        "subscription": _qa_subscription_payload(),
+        "test_account": True,
+        "jit_qa_bootstrap_marker": BOOTSTRAP_MARKER,
+        "jit_qa_project": PROJECT_ID,
+        "jit_qa_database": DATABASE_ID,
+    }
+
+
+def _qa_tester_payload() -> dict[str, Any]:
+    # ``database.apps.is_tester_db`` treats existence of this canonical tester
+    # document as the test-account entitlement.  Keep the apps array explicit
+    # for readers that use the tester document's normal shape.
+    return {
+        "uid": QA_UID,
+        "apps": [],
+        "test_account": True,
+        "jit_qa_bootstrap_marker": BOOTSTRAP_MARKER,
+        "jit_qa_project": PROJECT_ID,
+        "jit_qa_database": DATABASE_ID,
+    }
+
+
+def _assert_named_database_empty(db_client: Any) -> None:
+    """Prove the named database is empty before creating the QA account.
+
+    ``collections()`` is a metadata-only inventory.  Each present top-level
+    collection is then queried with a two-document bound so a non-empty or
+    unsupported collection fails closed without reading customer content.
+    """
+
+    collections_factory = getattr(db_client, "collections", None)
+    if not callable(collections_factory):
+        raise JITQAVerificationError("bootstrap requires a Firestore client that can inventory collections")
+    try:
+        collections = list(collections_factory())
+    except Exception as exc:
+        raise JITQAVerificationError("bootstrap could not inventory the named Firestore database") from exc
+    for collection in collections:
+        collection_id = str(getattr(collection, "id", ""))
+        if collection_id not in BOOTSTRAP_COLLECTIONS:
+            raise JITQAVerificationError(f"bootstrap found an unsupported top-level collection: {collection_id!r}")
+        limited = getattr(collection, "limit", None)
+        stream = getattr(limited(2) if callable(limited) else collection, "stream", None)
+        if not callable(stream):
+            raise JITQAVerificationError("bootstrap cannot prove the named Firestore database is empty")
+        try:
+            first_two = list(stream())
+        except Exception as exc:
+            raise JITQAVerificationError("bootstrap could not inspect the named Firestore database") from exc
+        if first_two:
+            raise JITQAVerificationError(
+                f"bootstrap requires a truly empty named database; collection {collection_id!r} already has documents"
+            )
+
+
+def _assert_owned_fields(
+    db_client: Any,
+    path: str,
+    expected: Mapping[str, Any],
+    *,
+    label: str,
+) -> bool:
+    """Return whether a document exists with all owned fields unchanged."""
+
+    payload = _as_dict(db_client.document(path).get())
+    if not payload:
+        return False
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise JITQAVerificationError(f"refusing to overwrite unowned or malformed QA {label}")
+    return True
+
+
+def _create_or_verify_owned_document(
+    db_client: Any,
+    path: str,
+    payload: Mapping[str, Any],
+    *,
+    label: str,
+) -> str:
+    """Create a profile/tester document, never overwrite an existing document."""
+
+    ref = db_client.document(path)
+    snapshot = ref.get()
+    if getattr(snapshot, "exists", False):
+        existing = _as_dict(snapshot)
+        for key, value in payload.items():
+            if existing.get(key) != value:
+                raise JITQAVerificationError(f"refusing to overwrite unowned or malformed QA {label}")
+        return "existing"
+    create = getattr(ref, "create", None)
+    if not callable(create):
+        raise JITQAVerificationError(f"bootstrap requires create-only Firestore writes for QA {label}")
+    try:
+        create(dict(payload))
+    except Exception as exc:
+        # A race is safe only if the winner wrote the exact owned projection.
+        if _assert_owned_fields(db_client, path, payload, label=label):
+            return "existing"
+        raise JITQAVerificationError(f"QA {label} creation did not produce the owned document") from exc
+    return "created"
+
+
+def bootstrap_qa_account(db_client: Any) -> dict[str, Any]:
+    """Create the fixed QA identity and canonical apply state in an empty DB.
+
+    This is the only command allowed to prepare an empty ``jit-qa`` database.
+    It writes a durable ownership marker first, then creates only missing
+    profile/tester documents and invokes the shipped canonical apply-state
+    helper.  It never fabricates a ledger completion or cutover receipt; the
+    drain job remains the sole cutover authority.
+    """
+
+    validate_environment()
+    validate_target()
+    marker_ref = db_client.document(BOOTSTRAP_PATH)
+    marker_snapshot = marker_ref.get()
+    marker = _as_dict(marker_snapshot)
+    if not marker:
+        _assert_named_database_empty(db_client)
+        create = getattr(marker_ref, "create", None)
+        if not callable(create):
+            raise JITQAVerificationError("bootstrap requires create-only Firestore writes for its ownership marker")
+        try:
+            create(_bootstrap_marker_payload(status="in_progress"))
+        except Exception as exc:
+            marker = _as_dict(marker_ref.get())
+            if marker != _bootstrap_marker_payload(status="in_progress"):
+                raise JITQAVerificationError("bootstrap ownership marker raced with an unowned document") from exc
+    else:
+        expected_marker = _bootstrap_marker_payload(status=str(marker.get("status", "")))
+        if marker != expected_marker or marker.get("status") not in {"in_progress", "complete"}:
+            raise JITQAVerificationError("QA bootstrap marker is missing, malformed, or owned by another run")
+
+    profile_result = _create_or_verify_owned_document(
+        db_client,
+        f"users/{QA_UID}",
+        _qa_profile_payload(),
+        label="user profile",
+    )
+    tester_result = _create_or_verify_owned_document(db_client, TESTER_PATH, _qa_tester_payload(), label="tester")
+
+    # This helper atomically creates the real canonical apply-control state and
+    # its maintenance registry entry.  No raw MemoryControlState admission is
+    # fabricated here.
+    control = ensure_canonical_apply_control_state(QA_UID, db_client=db_client)
+    if control.uid != QA_UID or control.writer_mode.value != "compatibility":
+        raise JITQAVerificationError("canonical QA apply-control helper returned an unexpected writer state")
+
+    complete_marker = _bootstrap_marker_payload(status="complete")
+    marker_ref.set(complete_marker)
+    return {
+        "result": "PASS",
+        "status": "complete",
+        "project": PROJECT_ID,
+        "database": DATABASE_ID,
+        "uid": QA_UID,
+        "time_zone": QA_TIME_ZONE,
+        "entitlement_plan": QA_ENTITLEMENT_PLAN,
+        "profile": profile_result,
+        "tester": tester_result,
+        "apply_control_path": _control_path(),
+        "apply_control_writer_mode": control.writer_mode.value,
+        "maintenance_registry": f"canonical_memory_maintenance_registry/{QA_UID}",
+        "cutover_authority": "knowledge-ledger-drain-qa-job via publish_ledger_migration_cutover",
+    }
+
+
 def _as_dict(snapshot: Any) -> dict[str, Any]:
     if not getattr(snapshot, "exists", False):
         return {}
@@ -155,19 +370,24 @@ def _assert_fixture_exclusive(db_client: Any, *, run_id: str) -> None:
 
     collection_factory = getattr(db_client, "collection", None)
     if not callable(collection_factory):
-        # Lightweight unit fakes use point reads only.  The real Firestore
-        # client always exposes collection().
-        return
+        raise JITQAVerificationError("QA Firestore client cannot prove fixture exclusivity")
     collection = collection_factory(f"users/{QA_UID}/memory_items")
     selector = getattr(collection, "select", None)
     if callable(selector):
         collection = selector(["memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row"])
+    limiter = getattr(collection, "limit", None)
+    if not callable(limiter):
+        raise JITQAVerificationError("QA Firestore client cannot bound fixture exclusivity inventory")
+    collection = limiter(EXCLUSIVITY_SCAN_LIMIT)
     stream = getattr(collection, "stream", None)
     if not callable(stream):
         raise JITQAVerificationError("QA Firestore client cannot prove fixture exclusivity")
     expected_ids = {f"jitqa-{run_id}-legacy-{index:03d}" for index in range(ROW_COUNT)}
-    foreign_ids: list[str] = []
+    scanned = 0
     for snapshot in stream():
+        scanned += 1
+        if scanned > EXCLUSIVITY_SCAN_LIMIT:
+            raise JITQAVerificationError("QA fixture exclusivity inventory exceeded its hard bound")
         snapshot_id = str(getattr(snapshot, "id", ""))
         payload = _as_dict(snapshot)
         if snapshot_id not in expected_ids or not _owned_fields_match(
@@ -175,11 +395,12 @@ def _assert_fixture_exclusive(db_client: Any, *, run_id: str) -> None:
             run_id=run_id,
             index=int(payload.get("jit_qa_row", -1)) if str(payload.get("jit_qa_row", "")).isdigit() else -1,
         ):
-            foreign_ids.append(snapshot_id or "<missing-id>")
-    if foreign_ids:
-        raise JITQAVerificationError(
-            "QA account contains pre-existing or foreign memory rows; refusing to migrate shared state"
-        )
+            # Stop at the first foreign row.  The query is deliberately capped
+            # at 101 + 1 so a malicious/accidental large collection cannot turn
+            # this proof into an unbounded inventory.
+            raise JITQAVerificationError(
+                "QA account contains a non-owned QA row or foreign memory row; refusing to migrate shared state"
+            )
 
 
 def _stored_model(model: Any) -> dict[str, Any]:
@@ -639,8 +860,9 @@ def _load_args_summary(path: Path) -> Mapping[str, Any]:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--run-id", required=True, help="lowercase synthetic fixture namespace")
+    parser.add_argument("--run-id", help="lowercase synthetic fixture namespace")
     sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("bootstrap", help="create the fixed QA profile in a truly empty named database")
     sub.add_parser("prepare", help="preflight and create missing owned synthetic rows")
     sub.add_parser("inspect", help="read content-free fixture metadata")
     verify = sub.add_parser("verify", help="verify first, second, and stable retry drain summaries")
@@ -654,10 +876,15 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
-    validate_run_id(args.run_id)
+    if args.command != "bootstrap" and not args.run_id:
+        raise JITQAVerificationError("--run-id is required for prepare, inspect, verify, and rollback")
+    if args.run_id:
+        validate_run_id(args.run_id)
     validate_environment()
     db_client = build_firestore_client()
-    if args.command == "prepare":
+    if args.command == "bootstrap":
+        print(json.dumps(bootstrap_qa_account(db_client), sort_keys=True))
+    elif args.command == "prepare":
         print(json.dumps(seed_fixture(db_client, run_id=args.run_id), sort_keys=True))
     elif args.command == "inspect":
         print(json.dumps(inspect_fixture(db_client, run_id=args.run_id).as_dict(), sort_keys=True))

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Seed and verify the bounded JIT QA ledger-drain proof.
+
+This operator is deliberately narrower than the deployment workflow.  It owns
+only a deterministic, synthetic fixture in the named ``jit-qa`` Firestore
+database.  It never discovers or edits another account, never creates the
+apply-control document, and never calls a model.  The Cloud Run workflow owns
+job execution; this command consumes its content-free execution summaries.
+
+The fixture contains 101 canonical rows that are intentionally missing the
+ledger schema marker.  The production drain's mutation budget is 100 rows per
+run, so two executions prove durable ``100 + 1`` progress.  A later retry,
+rollback, and rollforward prove that the canonical rows and evidence remain
+present.  The fixture rows are synthetic and namespaced by ``run_id``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from google.cloud import firestore
+
+# Keep script invocation from the repository root and direct backend invocation
+# equally usable without changing the installed environment.
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from models.memory_evidence import ArtifactPreservationState, MemoryEvidence, SourceState  # noqa: E402
+from models.product_memory import MemoryItem, MemoryItemStatus, MemoryLayer, ProcessingState  # noqa: E402
+from utils.memory.knowledge_ledger import LEDGER_SCHEMA_VERSION  # noqa: E402
+from utils.memory.knowledge_ledger_migration import (  # noqa: E402
+    rollback_ledger_writer_to_compatibility,
+)
+
+PROJECT_ID = "based-hardware-dev"
+DATABASE_ID = "jit-qa"
+REGION = "us-central1"
+QA_UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
+LEDGER_DRAIN_JOB = "knowledge-ledger-drain-qa-job"
+FIXTURE_MARKER = "omi.jit.qa.seed-and-verify.v1"
+ROW_COUNT = 101
+MUTATION_PAGE_SIZE = 100
+LEDGER_DRAIN_CURSOR_PATH = "knowledge_ledger_migration_control/inventory_cursor"
+RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
+SUMMARY_KEYS = (
+    "inventoried_users",
+    "scanned_documents",
+    "attempted_users",
+    "allowlist_blocked_users",
+    "rollout_blocked_users",
+    "authorization_revoked_users",
+    "remaining_users",
+    "cutover_users",
+    "migrated_rows",
+    "errors",
+)
+
+
+class JITQAVerificationError(RuntimeError):
+    """A QA operator precondition or proof assertion failed."""
+
+
+def validate_target(*, project: str = PROJECT_ID, database: str = DATABASE_ID, uid: str = QA_UID) -> None:
+    """Reject every project, database, or identity outside the named QA plane."""
+
+    if project != PROJECT_ID:
+        raise JITQAVerificationError(f"QA project must be {PROJECT_ID}")
+    if database != DATABASE_ID:
+        raise JITQAVerificationError(f"QA Firestore database must be {DATABASE_ID}")
+    if uid != QA_UID:
+        raise JITQAVerificationError("QA UID must be the fixed isolated test identity")
+
+
+def validate_environment(environ: Mapping[str, str] | None = None) -> None:
+    """Fail closed when process selectors point at a different data plane."""
+
+    env = os.environ if environ is None else environ
+    for name in ("GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"):
+        value = env.get(name, "").strip()
+        if value and value != PROJECT_ID:
+            raise JITQAVerificationError(f"{name} must be {PROJECT_ID}")
+    database = env.get("FIRESTORE_DATABASE_ID", "").strip()
+    if database and database != DATABASE_ID:
+        raise JITQAVerificationError("FIRESTORE_DATABASE_ID must be jit-qa")
+    if env.get("FIRESTORE_EMULATOR_HOST", "").strip():
+        raise JITQAVerificationError("the QA proof must use named Cloud Firestore, not an emulator")
+    if env.get("SERVICE_ACCOUNT_JSON", "").strip() or env.get("FIREBASE_AUTH_CREDENTIALS_PATH", "").strip():
+        raise JITQAVerificationError("customer Firebase credential selectors are forbidden")
+
+
+def validate_run_id(run_id: str) -> str:
+    if not RUN_ID_RE.fullmatch(run_id):
+        raise JITQAVerificationError("run_id must be lowercase, namespaced, and contain only [a-z0-9_-]")
+    return run_id
+
+
+def build_firestore_client() -> Any:
+    """Construct an explicit named-database client; never inherit a default DB."""
+
+    validate_environment()
+    validate_target()
+    return firestore.Client(project=PROJECT_ID, database=DATABASE_ID)
+
+
+def _memory_path(run_id: str, index: int) -> str:
+    return f"users/{QA_UID}/memory_items/jitqa-{run_id}-legacy-{index:03d}"
+
+
+def _evidence_path(run_id: str, index: int) -> str:
+    return f"users/{QA_UID}/memory_evidence/jitqa-{run_id}-evidence-{index:03d}"
+
+
+def _control_path() -> str:
+    return f"users/{QA_UID}/memory_state/apply_control"
+
+
+def _completion_path() -> str:
+    return f"users/{QA_UID}/memory_control/knowledge_ledger_migration"
+
+
+def _projection_path() -> str:
+    return f"users/{QA_UID}/memory_control/knowledge_ledger_prompt_projection"
+
+
+def _as_dict(snapshot: Any) -> dict[str, Any]:
+    if not getattr(snapshot, "exists", False):
+        return {}
+    payload = snapshot.to_dict()
+    return dict(payload) if isinstance(payload, Mapping) else {}
+
+
+def _get_selected(ref: Any, fields: Sequence[str]) -> dict[str, Any]:
+    selector = getattr(ref, "select", None)
+    snapshot = selector(list(fields)).get() if callable(selector) else ref.get()
+    return _as_dict(snapshot)
+
+
+def _assert_fixture_exclusive(db_client: Any, *, run_id: str) -> None:
+    """Ensure the allowlisted QA account contains only this proof fixture.
+
+    The production drain scans the whole allowlisted account, so a pre-existing
+    row would consume the 100-row budget and make the proof ambiguous.  The
+    query projects ownership metadata only; it never fetches customer content.
+    """
+
+    collection_factory = getattr(db_client, "collection", None)
+    if not callable(collection_factory):
+        # Lightweight unit fakes use point reads only.  The real Firestore
+        # client always exposes collection().
+        return
+    collection = collection_factory(f"users/{QA_UID}/memory_items")
+    selector = getattr(collection, "select", None)
+    if callable(selector):
+        collection = selector(["memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row"])
+    stream = getattr(collection, "stream", None)
+    if not callable(stream):
+        raise JITQAVerificationError("QA Firestore client cannot prove fixture exclusivity")
+    expected_ids = {f"jitqa-{run_id}-legacy-{index:03d}" for index in range(ROW_COUNT)}
+    foreign_ids: list[str] = []
+    for snapshot in stream():
+        snapshot_id = str(getattr(snapshot, "id", ""))
+        payload = _as_dict(snapshot)
+        if snapshot_id not in expected_ids or not _owned_fields_match(
+            payload,
+            run_id=run_id,
+            index=int(payload.get("jit_qa_row", -1)) if str(payload.get("jit_qa_row", "")).isdigit() else -1,
+        ):
+            foreign_ids.append(snapshot_id or "<missing-id>")
+    if foreign_ids:
+        raise JITQAVerificationError(
+            "QA account contains pre-existing or foreign memory rows; refusing to migrate shared state"
+        )
+
+
+def _stored_model(model: Any) -> dict[str, Any]:
+    return model.model_dump(mode="json")
+
+
+def _fixture_evidence(run_id: str, index: int) -> MemoryEvidence:
+    return MemoryEvidence(
+        evidence_id=f"jitqa-{run_id}-evidence-{index:03d}",
+        source_type="conversation",
+        source_id=f"jitqa-{run_id}-synthetic-source-{index:03d}",
+        source_version="jit-qa-v1",
+        artifact_preservation=ArtifactPreservationState.preserved,
+        source_state=SourceState.active,
+    )
+
+
+def _fixture_item(
+    run_id: str,
+    index: int,
+    *,
+    account_generation: int,
+    head_commit_id: str,
+) -> MemoryItem:
+    evidence = _fixture_evidence(run_id, index)
+    item = MemoryItem(
+        memory_id=f"jitqa-{run_id}-legacy-{index:03d}",
+        uid=QA_UID,
+        version=1,
+        tier=MemoryLayer.long_term,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content=f"Synthetic JIT QA ledger proof row {index:03d} ({run_id})",
+        evidence=[evidence],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility="private",
+        user_asserted=index == 0,
+        captured_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        ledger_commit_id=head_commit_id,
+        ledger_sequence=0,
+        item_revision=1,
+        account_generation=account_generation,
+        predicate="resides_in" if index == 0 else "likes",
+    )
+    # These are the exact fields used to prove ownership without reading the
+    # synthetic content back.  They are ignored by MemoryItem validation.
+    payload = _stored_model(item)
+    payload.update(
+        {
+            "jit_qa_fixture": FIXTURE_MARKER,
+            "jit_qa_run_id": run_id,
+            "jit_qa_row": index,
+        }
+    )
+    # Return the model plus marker payload through a private helper below; the
+    # model remains useful to tests that verify the canonical legacy shape.
+    object.__setattr__(item, "_jit_qa_payload", payload)
+    return item
+
+
+def _item_payload(item: MemoryItem) -> dict[str, Any]:
+    payload = getattr(item, "_jit_qa_payload", None)
+    if not isinstance(payload, dict):
+        raise JITQAVerificationError("internal fixture payload lost its ownership marker")
+    return dict(payload)
+
+
+def _owned_fields_match(payload: Mapping[str, Any], *, run_id: str, index: int) -> bool:
+    return (
+        payload.get("jit_qa_fixture") == FIXTURE_MARKER
+        and payload.get("jit_qa_run_id") == run_id
+        and payload.get("jit_qa_row") == index
+        and payload.get("uid") == QA_UID
+        and payload.get("memory_id") == f"jitqa-{run_id}-legacy-{index:03d}"
+    )
+
+
+def _assert_apply_control(db_client: Any, *, allow_ledger: bool = False) -> dict[str, Any]:
+    payload = _get_selected(
+        db_client.document(_control_path()),
+        (
+            "uid",
+            "writer_mode",
+            "writer_epoch",
+            "head_commit_id",
+            "account_generation",
+            "source_generation",
+            "commit_sequence",
+        ),
+    )
+    if not payload:
+        raise JITQAVerificationError("QA apply-control state is missing; use the deployment/database factory first")
+    if payload.get("uid") != QA_UID:
+        raise JITQAVerificationError("QA apply-control UID does not match the fixed identity")
+    mode = payload.get("writer_mode")
+    allowed = {"compatibility", "ledger"} if allow_ledger else {"compatibility"}
+    if mode not in allowed:
+        raise JITQAVerificationError(f"QA apply-control writer_mode must be one of {sorted(allowed)}")
+    if not isinstance(payload.get("account_generation"), int) or not isinstance(payload.get("head_commit_id"), str):
+        raise JITQAVerificationError("QA apply-control state is missing the canonical generation fence")
+    return payload
+
+
+def seed_fixture(db_client: Any, *, run_id: str) -> dict[str, int | str]:
+    """Create only missing, owned synthetic rows and evidence documents."""
+
+    validate_target()
+    run_id = validate_run_id(run_id)
+    control = _assert_apply_control(db_client)
+    if control.get("writer_mode") != "compatibility":
+        raise JITQAVerificationError("seed requires compatibility writer mode")
+    _assert_fixture_exclusive(db_client, run_id=run_id)
+
+    created_rows = 0
+    existing_rows = 0
+    for index in range(ROW_COUNT):
+        item = _fixture_item(
+            run_id,
+            index,
+            account_generation=int(control["account_generation"]),
+            head_commit_id=str(control["head_commit_id"]),
+        )
+        expected = _item_payload(item)
+        memory_ref = db_client.document(_memory_path(run_id, index))
+        existing = _get_selected(
+            memory_ref,
+            ("memory_id", "uid", "jit_qa_fixture", "jit_qa_run_id", "jit_qa_row", "ledger_schema_version"),
+        )
+        if existing:
+            if not _owned_fields_match(existing, run_id=run_id, index=index):
+                raise JITQAVerificationError(f"refusing to overwrite non-owned QA row {index:03d}")
+            existing_rows += 1
+            continue
+
+        evidence_ref = db_client.document(_evidence_path(run_id, index))
+        evidence = _get_selected(evidence_ref, ("evidence_id", "source_id", "source_state", "source_type"))
+        expected_evidence = _stored_model(_fixture_evidence(run_id, index))
+        if evidence and evidence != {
+            key: expected_evidence.get(key) for key in ("evidence_id", "source_id", "source_state", "source_type")
+        }:
+            raise JITQAVerificationError(f"refusing to overwrite non-owned QA evidence {index:03d}")
+        if not evidence:
+            evidence_ref.set(expected_evidence)
+        memory_ref.set(expected)
+        created_rows += 1
+
+    return {
+        "run_id": run_id,
+        "created_rows": created_rows,
+        "existing_rows": existing_rows,
+        "row_count": ROW_COUNT,
+        "project": PROJECT_ID,
+        "database": DATABASE_ID,
+        "uid": QA_UID,
+    }
+
+
+@dataclass(frozen=True)
+class FixtureState:
+    run_id: str
+    retained_rows: int
+    retained_evidence: int
+    legacy_rows: int
+    ledger_rows: int
+    missing_rows: tuple[int, ...]
+    writer_mode: str
+    completion_present: bool
+    projection_scanned_rows: int | None
+    cursor_present: bool
+    metadata_digest: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "retained_rows": self.retained_rows,
+            "retained_evidence": self.retained_evidence,
+            "legacy_rows": self.legacy_rows,
+            "ledger_rows": self.ledger_rows,
+            "missing_rows": list(self.missing_rows),
+            "writer_mode": self.writer_mode,
+            "completion_present": self.completion_present,
+            "projection_scanned_rows": self.projection_scanned_rows,
+            "cursor_present": self.cursor_present,
+            "metadata_digest": self.metadata_digest,
+        }
+
+
+def inspect_fixture(db_client: Any, *, run_id: str, allow_ledger: bool = True) -> FixtureState:
+    """Read only the named fixture's metadata and content-free proof documents."""
+
+    validate_target()
+    run_id = validate_run_id(run_id)
+    control = _assert_apply_control(db_client, allow_ledger=allow_ledger)
+    _assert_fixture_exclusive(db_client, run_id=run_id)
+    retained_rows = 0
+    retained_evidence = 0
+    legacy_rows = 0
+    ledger_rows = 0
+    missing_rows: list[int] = []
+    digest_rows: list[dict[str, Any]] = []
+
+    for index in range(ROW_COUNT):
+        item_payload = _get_selected(
+            db_client.document(_memory_path(run_id, index)),
+            (
+                "memory_id",
+                "uid",
+                "jit_qa_fixture",
+                "jit_qa_run_id",
+                "jit_qa_row",
+                "ledger_schema_version",
+                "status",
+                "write_reason",
+                "slot",
+                "item_revision",
+                "ledger_sequence",
+                "content_hash",
+            ),
+        )
+        if not item_payload:
+            missing_rows.append(index)
+            continue
+        if not _owned_fields_match(item_payload, run_id=run_id, index=index):
+            raise JITQAVerificationError(f"fixture row {index:03d} is missing or has a foreign owner marker")
+        retained_rows += 1
+        schema = item_payload.get("ledger_schema_version")
+        if schema == LEDGER_SCHEMA_VERSION:
+            ledger_rows += 1
+        else:
+            legacy_rows += 1
+        digest_rows.append(
+            {
+                "id": item_payload.get("memory_id"),
+                "uid": item_payload.get("uid"),
+                "schema": schema,
+                "status": item_payload.get("status"),
+                "write_reason": item_payload.get("write_reason"),
+                "slot": item_payload.get("slot"),
+                "revision": item_payload.get("item_revision"),
+                "sequence": item_payload.get("ledger_sequence"),
+                "content_hash": item_payload.get("content_hash"),
+            }
+        )
+        evidence_payload = _get_selected(
+            db_client.document(_evidence_path(run_id, index)),
+            ("evidence_id", "source_id", "source_state", "source_type"),
+        )
+        if evidence_payload:
+            retained_evidence += 1
+
+    completion = _get_selected(
+        db_client.document(_completion_path()),
+        ("schema_version", "status", "blocking_row_count", "source_head_commit_id", "writer_epoch"),
+    )
+    projection = _get_selected(
+        db_client.document(_projection_path()),
+        (
+            "schema_version",
+            "status",
+            "uid",
+            "source_head_commit_id",
+            "writer_epoch",
+            "legacy_row_count",
+            "blocking_row_count",
+            "scanned_row_count",
+        ),
+    )
+    # A rollback intentionally leaves the old receipt documents in place while
+    # the compatibility writer makes them non-authoritative. Validate their
+    # fence only when ledger mode is active; the row/evidence digest is the
+    # rollback preservation proof.
+    if completion and control.get("writer_mode") == "ledger":
+        if (
+            completion.get("schema_version") != "knowledge_ledger.v1"
+            or completion.get("status") != "complete"
+            or completion.get("blocking_row_count") != 0
+            or completion.get("source_head_commit_id") != control.get("head_commit_id")
+            or completion.get("writer_epoch") != control.get("writer_epoch")
+        ):
+            raise JITQAVerificationError("ledger completion is malformed or stale against apply-control")
+    if projection and control.get("writer_mode") == "ledger":
+        if (
+            projection.get("schema_version") != "knowledge_ledger_prompt_projection.v1"
+            or projection.get("status") != "complete"
+            or projection.get("uid") != QA_UID
+            or projection.get("source_head_commit_id") != control.get("head_commit_id")
+            or projection.get("writer_epoch") != control.get("writer_epoch")
+            or projection.get("legacy_row_count") != 0
+            or projection.get("blocking_row_count") != 0
+        ):
+            raise JITQAVerificationError("ledger prompt projection is malformed or stale against apply-control")
+    cursor = _get_selected(db_client.document(LEDGER_DRAIN_CURSOR_PATH), ("schema_version", "generation", "last_path"))
+    canonical = json.dumps(digest_rows, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()
+    return FixtureState(
+        run_id=run_id,
+        retained_rows=retained_rows,
+        retained_evidence=retained_evidence,
+        legacy_rows=legacy_rows,
+        ledger_rows=ledger_rows,
+        missing_rows=tuple(missing_rows),
+        writer_mode=str(control.get("writer_mode")),
+        completion_present=bool(completion),
+        projection_scanned_rows=(
+            int(projection["scanned_row_count"]) if isinstance(projection.get("scanned_row_count"), int) else None
+        ),
+        cursor_present=bool(cursor),
+        metadata_digest=digest,
+    )
+
+
+def _summary_payload(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+    candidate = raw.get("summary") if isinstance(raw.get("summary"), Mapping) else raw
+    if not isinstance(candidate, Mapping):
+        raise JITQAVerificationError("drain summary must contain an object")
+    missing = [key for key in SUMMARY_KEYS if key not in candidate]
+    if missing:
+        raise JITQAVerificationError(f"drain summary is missing fields: {missing}")
+    if not isinstance(candidate.get("errors"), list):
+        raise JITQAVerificationError("drain summary errors must be a list")
+    return candidate
+
+
+def load_summary(path: Path) -> Mapping[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise JITQAVerificationError(f"could not read drain summary {path}") from exc
+    if not isinstance(raw, Mapping):
+        raise JITQAVerificationError("drain summary file must contain a JSON object")
+    return _summary_payload(raw)
+
+
+def _assert_summary(summary: Mapping[str, Any], expected: Mapping[str, Any], *, phase: str) -> None:
+    if summary.get("errors"):
+        raise JITQAVerificationError(f"{phase} drain reported errors")
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise JITQAVerificationError(f"{phase} drain {key}={summary.get(key)!r}; expected {value!r}")
+
+
+def verify_bounded_progress(
+    db_client: Any,
+    *,
+    run_id: str,
+    first_summary: Mapping[str, Any],
+    second_summary: Mapping[str, Any],
+    retry_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Verify the two page summaries and the durable post-cutover state."""
+
+    _assert_summary(
+        first_summary,
+        {
+            "inventoried_users": 1,
+            "scanned_documents": 1,
+            "attempted_users": 1,
+            "allowlist_blocked_users": 0,
+            "rollout_blocked_users": 0,
+            "authorization_revoked_users": 0,
+            "remaining_users": 1,
+            "cutover_users": 0,
+            "migrated_rows": 100,
+        },
+        phase="first",
+    )
+    _assert_summary(
+        second_summary,
+        {
+            "inventoried_users": 1,
+            "scanned_documents": 1,
+            "attempted_users": 1,
+            "allowlist_blocked_users": 0,
+            "rollout_blocked_users": 0,
+            "authorization_revoked_users": 0,
+            "remaining_users": 0,
+            "cutover_users": 1,
+            "migrated_rows": 1,
+        },
+        phase="second",
+    )
+    _assert_summary(
+        retry_summary,
+        {
+            "inventoried_users": 0,
+            "scanned_documents": 1,
+            "attempted_users": 0,
+            "allowlist_blocked_users": 0,
+            "rollout_blocked_users": 0,
+            "authorization_revoked_users": 0,
+            "remaining_users": 0,
+            "cutover_users": 0,
+            "migrated_rows": 0,
+        },
+        phase="retry",
+    )
+    state = inspect_fixture(db_client, run_id=run_id, allow_ledger=True)
+    if state.retained_rows != ROW_COUNT or state.retained_evidence != ROW_COUNT:
+        raise JITQAVerificationError("bounded drain did not retain all 101 owned rows and evidence documents")
+    if state.legacy_rows != 0 or state.ledger_rows != ROW_COUNT:
+        raise JITQAVerificationError("bounded drain did not complete all 101 ledger rows")
+    if state.writer_mode != "ledger" or not state.completion_present:
+        raise JITQAVerificationError("bounded drain did not publish the fenced completion")
+    if state.projection_scanned_rows != ROW_COUNT:
+        raise JITQAVerificationError("prompt projection did not scan all 101 rows")
+    if state.cursor_present:
+        raise JITQAVerificationError("allowlisted QA proof unexpectedly wrote the global drain cursor")
+    return {
+        "result": "PASS",
+        "run_id": run_id,
+        "retained_rows": ROW_COUNT,
+        "bounded_pages": [100, 1],
+        "stable_retry": "no-op",
+        "rollback": "pending",
+        "rollforward": "pending",
+        "metadata_digest": state.metadata_digest,
+        "authority_boundary": "real QA job summaries; no injected admission",
+    }
+
+
+def rollback_fixture(db_client: Any, *, run_id: str, confirmation: str) -> dict[str, Any]:
+    """Exercise the explicit control-plane rollback after a successful proof.
+
+    This is a separate, opt-in operation.  It does not rewrite rows, evidence,
+    or content.  The CLI requires the literal ``ROLLBACK_QA`` confirmation.
+    """
+
+    if confirmation != "ROLLBACK_QA":
+        raise JITQAVerificationError("rollback requires --confirmation ROLLBACK_QA")
+    before = inspect_fixture(db_client, run_id=run_id, allow_ledger=True)
+    if before.retained_rows != ROW_COUNT or before.ledger_rows != ROW_COUNT or before.writer_mode != "ledger":
+        raise JITQAVerificationError("rollback requires the completed 101-row ledger proof")
+    control = rollback_ledger_writer_to_compatibility(
+        QA_UID,
+        db_client=db_client,
+        rollback_authorizer=lambda: True,
+    )
+    after = inspect_fixture(db_client, run_id=run_id, allow_ledger=False)
+    if after.writer_mode != "compatibility" or after.metadata_digest != before.metadata_digest:
+        raise JITQAVerificationError("rollback changed row state or did not return compatibility mode")
+    return {
+        "result": "PASS",
+        "run_id": run_id,
+        "writer_mode": str(getattr(control.writer_mode, "value", control.writer_mode)),
+        "retained_rows": after.retained_rows,
+        "retained_evidence": after.retained_evidence,
+        "metadata_digest": after.metadata_digest,
+        "completion_authority": "hidden while compatibility mode is active",
+    }
+
+
+def _load_args_summary(path: Path) -> Mapping[str, Any]:
+    return load_summary(path)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True, help="lowercase synthetic fixture namespace")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("prepare", help="preflight and create missing owned synthetic rows")
+    sub.add_parser("inspect", help="read content-free fixture metadata")
+    verify = sub.add_parser("verify", help="verify first, second, and stable retry drain summaries")
+    verify.add_argument("--first-summary", type=Path, required=True)
+    verify.add_argument("--second-summary", type=Path, required=True)
+    verify.add_argument("--retry-summary", type=Path, required=True)
+    rollback = sub.add_parser("rollback", help="explicitly rollback the writer control plane after proof")
+    rollback.add_argument("--confirmation", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    validate_run_id(args.run_id)
+    validate_environment()
+    db_client = build_firestore_client()
+    if args.command == "prepare":
+        print(json.dumps(seed_fixture(db_client, run_id=args.run_id), sort_keys=True))
+    elif args.command == "inspect":
+        print(json.dumps(inspect_fixture(db_client, run_id=args.run_id).as_dict(), sort_keys=True))
+    elif args.command == "verify":
+        result = verify_bounded_progress(
+            db_client,
+            run_id=args.run_id,
+            first_summary=_load_args_summary(args.first_summary),
+            second_summary=_load_args_summary(args.second_summary),
+            retry_summary=_load_args_summary(args.retry_summary),
+        )
+        print(json.dumps(result, sort_keys=True))
+    elif args.command == "rollback":
+        result = rollback_fixture(db_client, run_id=args.run_id, confirmation=args.confirmation)
+        print(json.dumps(result, sort_keys=True))
+    else:  # pragma: no cover - argparse enforces command choices.
+        raise JITQAVerificationError(f"unknown command {args.command}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except JITQAVerificationError as exc:
+        print(f"JIT QA operator refused: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -64,7 +64,6 @@ QA_ENTITLEMENT_PERIOD_END = 4102444800  # 2100-01-01T00:00:00Z
 ROW_COUNT = 101
 MUTATION_PAGE_SIZE = 100
 EXCLUSIVITY_SCAN_LIMIT = ROW_COUNT + 1
-BOOTSTRAP_COLLECTIONS = frozenset({"jit_qa_bootstrap", "users", "testers", "canonical_memory_maintenance_registry"})
 LEDGER_DRAIN_CURSOR_PATH = "knowledge_ledger_migration_control/inventory_cursor"
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
 SUMMARY_KEYS = (
@@ -204,9 +203,10 @@ def _qa_tester_payload() -> dict[str, Any]:
 def _assert_named_database_empty(db_client: Any) -> None:
     """Prove the named database is empty before creating the QA account.
 
-    ``collections()`` is a metadata-only inventory.  Each present top-level
-    collection is then queried with a two-document bound so a non-empty or
-    unsupported collection fails closed without reading customer content.
+    ``collections()`` is a metadata-only inventory.  Firestore does not retain
+    empty collections, so any collection returned by this inventory means the
+    first-bootstrap precondition is false.  We stop before reading or writing a
+    document; the named database must be genuinely empty.
     """
 
     collections_factory = getattr(db_client, "collections", None)
@@ -216,24 +216,11 @@ def _assert_named_database_empty(db_client: Any) -> None:
         collections = list(collections_factory())
     except Exception as exc:
         raise JITQAVerificationError("bootstrap could not inventory the named Firestore database") from exc
-    for collection in collections:
-        collection_id = str(getattr(collection, "id", ""))
-        if collection_id not in BOOTSTRAP_COLLECTIONS:
-            raise JITQAVerificationError(f"bootstrap found an unsupported top-level collection: {collection_id!r}")
-        limited = getattr(collection, "limit", None)
-        if not callable(limited):
-            raise JITQAVerificationError("bootstrap cannot bound the named Firestore database inventory")
-        stream = getattr(limited(2), "stream", None)
-        if not callable(stream):
-            raise JITQAVerificationError("bootstrap cannot prove the named Firestore database is empty")
-        try:
-            first_two = list(stream())
-        except Exception as exc:
-            raise JITQAVerificationError("bootstrap could not inspect the named Firestore database") from exc
-        if first_two:
-            raise JITQAVerificationError(
-                f"bootstrap requires a truly empty named database; collection {collection_id!r} already has documents"
-            )
+    if collections:
+        collection_id = str(getattr(collections[0], "id", ""))
+        raise JITQAVerificationError(
+            "bootstrap requires a truly empty named database; " f"found collection {collection_id!r}"
+        )
 
 
 def _assert_owned_fields(
@@ -424,6 +411,27 @@ def _fixture_evidence(run_id: str, index: int) -> MemoryEvidence:
     )
 
 
+EVIDENCE_OWNERSHIP_FIELDS = (
+    "evidence_id",
+    "source_id",
+    "source_version",
+    "artifact_preservation",
+    "source_state",
+    "source_type",
+)
+
+
+def _expected_evidence_fields(run_id: str, index: int) -> dict[str, Any]:
+    expected = _stored_model(_fixture_evidence(run_id, index))
+    return {key: expected.get(key) for key in EVIDENCE_OWNERSHIP_FIELDS}
+
+
+def _projected_evidence_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize fake and Firestore projection responses to owned fields."""
+
+    return {key: payload[key] for key in EVIDENCE_OWNERSHIP_FIELDS if key in payload}
+
+
 def _fixture_item(
     run_id: str,
     index: int,
@@ -570,11 +578,10 @@ def seed_fixture(db_client: Any, *, run_id: str) -> dict[str, int | str]:
             continue
 
         evidence_ref = db_client.document(_evidence_path(run_id, index))
-        evidence = _get_selected(evidence_ref, ("evidence_id", "source_id", "source_state", "source_type"))
+        evidence = _get_selected(evidence_ref, EVIDENCE_OWNERSHIP_FIELDS)
         expected_evidence = _stored_model(_fixture_evidence(run_id, index))
-        if evidence and evidence != {
-            key: expected_evidence.get(key) for key in ("evidence_id", "source_id", "source_state", "source_type")
-        }:
+        expected_evidence_ownership = _expected_evidence_fields(run_id, index)
+        if evidence and _projected_evidence_fields(evidence) != expected_evidence_ownership:
             raise JITQAVerificationError(f"refusing to overwrite non-owned QA evidence {index:03d}")
         if not evidence:
             create_evidence = getattr(evidence_ref, "create", None)
@@ -583,13 +590,8 @@ def seed_fixture(db_client: Any, *, run_id: str) -> dict[str, int | str]:
             try:
                 create_evidence(expected_evidence)
             except Exception as exc:
-                raced_evidence = _get_selected(
-                    evidence_ref, ("evidence_id", "source_id", "source_state", "source_type")
-                )
-                if raced_evidence != {
-                    key: expected_evidence.get(key)
-                    for key in ("evidence_id", "source_id", "source_state", "source_type")
-                }:
+                raced_evidence = _get_selected(evidence_ref, EVIDENCE_OWNERSHIP_FIELDS)
+                if _projected_evidence_fields(raced_evidence) != expected_evidence_ownership:
                     raise JITQAVerificationError(
                         f"QA fixture evidence creation raced with an unowned document {index:03d}"
                     ) from exc
@@ -717,10 +719,13 @@ def inspect_fixture(db_client: Any, *, run_id: str, allow_ledger: bool = True) -
         )
         evidence_payload = _get_selected(
             db_client.document(_evidence_path(run_id, index)),
-            ("evidence_id", "source_id", "source_state", "source_type"),
+            EVIDENCE_OWNERSHIP_FIELDS,
         )
-        if evidence_payload:
-            retained_evidence += 1
+        if not evidence_payload:
+            raise JITQAVerificationError(f"fixture evidence {index:03d} is missing")
+        if _projected_evidence_fields(evidence_payload) != _expected_evidence_fields(run_id, index):
+            raise JITQAVerificationError(f"fixture evidence {index:03d} is foreign or malformed")
+        retained_evidence += 1
 
     completion = _get_selected(
         db_client.document(_completion_path()),

--- a/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
+++ b/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
@@ -24,6 +24,10 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_jit_qa_emulator_key_32_bytes")  # pragma: allowlist secret
+# Canonical migration is fenced by the deployment intake mode.  This local
+# proof opts into write mode only inside the emulator process; cloud operators
+# still read the real deployment environment and admission decision.
+os.environ.setdefault("MEMORY_MODE", "write")
 
 from models.memory_apply import WriterMode  # noqa: E402
 from scripts import jit_qa_seed_and_verify as operator  # noqa: E402

--- a/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
+++ b/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Real Firestore-emulator proof for the isolated JIT QA operator.
+
+This is deliberately labelled unit proof: rollout admission is injected so the
+test never calls a production flag service.  It exercises the same operator,
+canonical apply helper, migration sweep, cutover publication, and rollback
+against a real Firestore emulator.  The named-cloud operator still requires
+real rollout admission and never accepts this injected result as cloud proof.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from google.cloud import firestore
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_jit_qa_emulator_key_32_bytes")  # pragma: allowlist secret
+
+from models.memory_apply import WriterMode  # noqa: E402
+from scripts import jit_qa_seed_and_verify as operator  # noqa: E402
+from utils.memory import knowledge_ledger_drain as drain  # noqa: E402
+
+PROJECT_ID = "demo-omi-jit-qa-seed-verify"
+NOW = datetime(2026, 9, 5, 12, tzinfo=timezone.utc)
+
+
+async def _permit_injected_rollout(*_args: Any, **_kwargs: Any) -> Any:
+    return SimpleNamespace(permits_work=True)
+
+
+def _summary_payload(summary: Any) -> dict[str, Any]:
+    return {
+        "inventoried_users": summary.inventoried_users,
+        "scanned_documents": summary.scanned_documents,
+        "attempted_users": summary.attempted_users,
+        "allowlist_blocked_users": summary.allowlist_blocked_users,
+        "rollout_blocked_users": summary.rollout_blocked_users,
+        "authorization_revoked_users": summary.authorization_revoked_users,
+        "remaining_users": summary.remaining_users,
+        "cutover_users": summary.cutover_users,
+        "migrated_rows": summary.migrated_rows,
+        "errors": list(summary.errors),
+    }
+
+
+def main() -> int:
+    if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
+        raise RuntimeError("FIRESTORE_EMULATOR_HOST is required; run through firebase emulators:exec")
+    client: Any = firestore.Client(project=PROJECT_ID)
+    # The operator's production entrypoint rejects emulators.  This test calls
+    # the explicit bootstrap function under a labelled local override so cloud
+    # mode remains fail-closed and real-admission-only.
+    operator.validate_environment = lambda: None
+    operator.validate_target()
+    drain.resolve_jit_rollout = _permit_injected_rollout
+
+    bootstrapped = operator.bootstrap_qa_account(client)
+    if bootstrapped["apply_control_writer_mode"] != WriterMode.compatibility.value:
+        raise AssertionError("bootstrap did not create canonical compatibility control")
+    seeded = operator.seed_fixture(client, run_id="emulator-proof-20260905")
+    if seeded["created_rows"] != operator.ROW_COUNT:
+        raise AssertionError(f"unexpected emulator seed result: {seeded}")
+
+    first = asyncio.run(
+        drain.run_knowledge_ledger_drain(
+            db_client=client,
+            now=NOW,
+            uid_allowlist=[operator.QA_UID],
+        )
+    )
+    second = asyncio.run(
+        drain.run_knowledge_ledger_drain(
+            db_client=client,
+            now=NOW,
+            uid_allowlist=[operator.QA_UID],
+        )
+    )
+    first_payload = _summary_payload(first)
+    second_payload = _summary_payload(second)
+    if first.migrated_rows != 100 or first.remaining_users != 1 or first.cutover_users != 0:
+        raise AssertionError(f"emulator first page did not prove 100 + 1 progress: {first_payload}")
+    if second.migrated_rows != 1 or second.remaining_users != 0 or second.cutover_users != 1:
+        raise AssertionError(f"emulator second page did not publish cutover: {second_payload}")
+
+    before = operator.inspect_fixture(client, run_id="emulator-proof-20260905")
+    if before.writer_mode != WriterMode.ledger.value or before.retained_rows != operator.ROW_COUNT:
+        raise AssertionError("emulator ledger proof is not authoritative or lost rows")
+    rollback = operator.rollback_fixture(
+        client,
+        run_id="emulator-proof-20260905",
+        confirmation="ROLLBACK_QA",
+    )
+    after = operator.inspect_fixture(client, run_id="emulator-proof-20260905", allow_ledger=False)
+    if rollback["retained_rows"] != operator.ROW_COUNT or after.metadata_digest != before.metadata_digest:
+        raise AssertionError("emulator rollback changed the retained fixture")
+
+    rollforward = asyncio.run(
+        drain.run_knowledge_ledger_drain(
+            db_client=client,
+            now=NOW,
+            uid_allowlist=[operator.QA_UID],
+        )
+    )
+    if rollforward.migrated_rows != 0 or rollforward.cutover_users != 1 or rollforward.errors:
+        raise AssertionError(f"emulator roll-forward was not a stable no-op: {_summary_payload(rollforward)}")
+    final = operator.inspect_fixture(client, run_id="emulator-proof-20260905")
+    if final.writer_mode != WriterMode.ledger.value or final.retained_rows != operator.ROW_COUNT:
+        raise AssertionError("emulator roll-forward did not restore ledger authority")
+
+    print(
+        "PASS: labelled JIT QA Firestore emulator proof "
+        f"prepare=101 drain=[{first.migrated_rows},{second.migrated_rows}] "
+        f"rollback=preserved rollforward={rollforward.migrated_rows} "
+        "authority_boundary=injected-rollout-unit-proof-only"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
+++ b/backend/scripts/jit_qa_seed_and_verify_emulator_test.py
@@ -33,12 +33,23 @@ from models.memory_apply import WriterMode  # noqa: E402
 from scripts import jit_qa_seed_and_verify as operator  # noqa: E402
 from utils.memory import knowledge_ledger_drain as drain  # noqa: E402
 
-PROJECT_ID = "demo-omi-jit-qa-seed-verify"
+PROJECT_ID = "demo-omi-jit-qa"
+DATABASE_ID = "jit-qa"
 NOW = datetime(2026, 9, 5, 12, tzinfo=timezone.utc)
 
 
 async def _permit_injected_rollout(*_args: Any, **_kwargs: Any) -> Any:
     return SimpleNamespace(permits_work=True)
+
+
+def _validate_emulator_host(value: str) -> None:
+    host, separator, port = value.rpartition(":")
+    if not separator or host not in {"127.0.0.1", "localhost", "::1"} or not port.isdigit():
+        raise RuntimeError("FIRESTORE_EMULATOR_HOST must be a loopback host with a numeric port")
+
+
+def _build_emulator_client() -> Any:
+    return firestore.Client(project=PROJECT_ID, database=DATABASE_ID)
 
 
 def _summary_payload(summary: Any) -> dict[str, Any]:
@@ -57,9 +68,11 @@ def _summary_payload(summary: Any) -> dict[str, Any]:
 
 
 def main() -> int:
-    if not os.environ.get("FIRESTORE_EMULATOR_HOST"):
+    emulator_host = os.environ.get("FIRESTORE_EMULATOR_HOST", "").strip()
+    if not emulator_host:
         raise RuntimeError("FIRESTORE_EMULATOR_HOST is required; run through firebase emulators:exec")
-    client: Any = firestore.Client(project=PROJECT_ID)
+    _validate_emulator_host(emulator_host)
+    client: Any = _build_emulator_client()
     # The operator's production entrypoint rejects emulators.  This test calls
     # the explicit bootstrap function under a labelled local override so cloud
     # mode remains fail-closed and real-admission-only.

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+# The migration import is intentionally top-level in the operator, matching
+# backend import rules. Unit tests provide only the minimum synthetic key; no
+# network or Firestore credential is used.
+os.environ.setdefault("ENCRYPTION_SECRET", "x" * 32)
+
+from scripts import jit_qa_seed_and_verify as operator
+
+
+class _Snapshot:
+    def __init__(self, payload: dict | None):
+        self.exists = payload is not None
+        self._payload = dict(payload or {})
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _Ref:
+    def __init__(self, db: "_DB", path: str):
+        self.db = db
+        self.path = path
+
+    def select(self, _fields):
+        return self
+
+    def get(self):
+        return _Snapshot(self.db.docs.get(self.path))
+
+    def set(self, payload, merge=False):
+        if merge and self.path in self.db.docs:
+            self.db.docs[self.path].update(payload)
+        else:
+            self.db.docs[self.path] = dict(payload)
+
+
+class _DB:
+    def __init__(self):
+        self.docs = {
+            f"users/{operator.QA_UID}/memory_state/apply_control": {
+                "uid": operator.QA_UID,
+                "writer_mode": "compatibility",
+                "writer_epoch": 1,
+                "head_commit_id": "qa-head",
+                "account_generation": 1,
+                "source_generation": 1,
+                "commit_sequence": 0,
+            }
+        }
+
+    def document(self, path):
+        return _Ref(self, path)
+
+
+def _summary(**overrides):
+    value = {
+        "inventoried_users": 1,
+        "scanned_documents": 1,
+        "attempted_users": 1,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 0,
+        "cutover_users": 1,
+        "migrated_rows": 1,
+        "errors": [],
+    }
+    value.update(overrides)
+    return value
+
+
+def test_target_and_environment_are_fail_closed(monkeypatch):
+    with pytest.raises(operator.JITQAVerificationError, match="based-hardware-dev"):
+        operator.validate_target(project="based-hardware")
+    with pytest.raises(operator.JITQAVerificationError, match="jit-qa"):
+        operator.validate_target(database="(default)")
+    with pytest.raises(operator.JITQAVerificationError, match="fixed isolated"):
+        operator.validate_target(uid="other-user")
+
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    with pytest.raises(operator.JITQAVerificationError, match="GOOGLE_CLOUD_PROJECT"):
+        operator.validate_environment()
+
+
+def test_seed_is_idempotent_and_writes_only_owned_rows():
+    db = _DB()
+    first = operator.seed_fixture(db, run_id="proof-20260905")
+    assert first["created_rows"] == operator.ROW_COUNT
+    assert first["existing_rows"] == 0
+    assert len(db.docs) == 1 + (operator.ROW_COUNT * 2)
+
+    second = operator.seed_fixture(db, run_id="proof-20260905")
+    assert second["created_rows"] == 0
+    assert second["existing_rows"] == operator.ROW_COUNT
+    assert len(db.docs) == 1 + (operator.ROW_COUNT * 2)
+
+    state = operator.inspect_fixture(db, run_id="proof-20260905")
+    assert state.retained_rows == operator.ROW_COUNT
+    assert state.retained_evidence == operator.ROW_COUNT
+    assert state.legacy_rows == operator.ROW_COUNT
+    assert state.ledger_rows == 0
+    assert state.missing_rows == ()
+    assert state.writer_mode == "compatibility"
+    assert not state.cursor_present
+
+
+def test_seed_refuses_foreign_document_without_overwriting_it():
+    db = _DB()
+    path = operator._memory_path("proof-20260905", 0)
+    db.docs[path] = {
+        "memory_id": "customer-row",
+        "uid": "customer-uid",
+        "jit_qa_fixture": "someone-else",
+    }
+    with pytest.raises(operator.JITQAVerificationError, match="non-owned QA row"):
+        operator.seed_fixture(db, run_id="proof-20260905")
+    assert db.docs[path]["uid"] == "customer-uid"
+    assert operator._evidence_path("proof-20260905", 0) not in db.docs
+
+
+def test_summary_parser_accepts_workflow_envelope_and_rejects_missing_fields(tmp_path: Path):
+    path = tmp_path / "drain.json"
+    path.write_text(json.dumps({"execution": "knowledge-ledger-drain-qa-job-1", "summary": _summary()}))
+    parsed = operator.load_summary(path)
+    assert parsed["migrated_rows"] == 1
+
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"summary": {"errors": []}}))
+    with pytest.raises(operator.JITQAVerificationError, match="missing fields"):
+        operator.load_summary(bad)
+
+
+def test_verify_requires_exact_bounded_page_shape():
+    db = _DB()
+    operator.seed_fixture(db, run_id="proof-20260905")
+    run_id = "proof-20260905"
+    for index in range(operator.ROW_COUNT):
+        payload = db.docs[operator._memory_path(run_id, index)]
+        payload.update(
+            {
+                "ledger_schema_version": operator.LEDGER_SCHEMA_VERSION,
+                "write_reason": "legacy_migration",
+                "status": "active",
+                "item_revision": 2,
+                "ledger_sequence": index + 1,
+                "content_hash": f"hash-{index}",
+            }
+        )
+    db.docs[operator._control_path()]["writer_mode"] = "ledger"
+    db.docs[operator._completion_path()] = {
+        "schema_version": "knowledge_ledger.v1",
+        "status": "complete",
+        "blocking_row_count": 0,
+        "source_head_commit_id": "qa-head",
+        "writer_epoch": 1,
+    }
+    db.docs[operator._projection_path()] = {
+        "schema_version": "knowledge_ledger_prompt_projection.v1",
+        "status": "complete",
+        "uid": operator.QA_UID,
+        "source_head_commit_id": "qa-head",
+        "writer_epoch": 1,
+        "legacy_row_count": 0,
+        "blocking_row_count": 0,
+        "scanned_row_count": operator.ROW_COUNT,
+    }
+
+    result = operator.verify_bounded_progress(
+        db,
+        run_id=run_id,
+        first_summary=_summary(remaining_users=1, cutover_users=0, migrated_rows=100),
+        second_summary=_summary(migrated_rows=1),
+        retry_summary=_summary(
+            inventoried_users=0,
+            scanned_documents=1,
+            attempted_users=0,
+            cutover_users=0,
+            migrated_rows=0,
+        ),
+    )
+    assert result["result"] == "PASS"
+    assert result["bounded_pages"] == [100, 1]
+    assert result["retained_rows"] == operator.ROW_COUNT
+
+    bad = _summary(remaining_users=1, cutover_users=0, migrated_rows=99)
+    with pytest.raises(operator.JITQAVerificationError, match="first drain migrated_rows"):
+        operator.verify_bounded_progress(
+            db,
+            run_id=run_id,
+            first_summary=bad,
+            second_summary=_summary(migrated_rows=1),
+            retry_summary=_summary(
+                inventoried_users=0,
+                scanned_documents=1,
+                attempted_users=0,
+                cutover_users=0,
+                migrated_rows=0,
+            ),
+        )

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -134,6 +134,21 @@ def test_target_and_environment_are_fail_closed(monkeypatch):
         operator.validate_environment()
 
 
+def test_firestore_client_selects_named_qa_database(monkeypatch):
+    calls = {}
+
+    class FakeFirestoreClient:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("FIRESTORE_DATABASE_ID", raising=False)
+    monkeypatch.setattr(operator.firestore, "Client", FakeFirestoreClient)
+    operator.build_firestore_client()
+    assert calls == {"project": "based-hardware-dev", "database": "jit-qa"}
+
+
 def test_seed_is_idempotent_and_writes_only_owned_rows():
     db = _DB()
     first = operator.seed_fixture(db, run_id="proof-20260905")
@@ -195,7 +210,7 @@ def test_fixture_exclusivity_fails_closed_without_metadata_projection():
         operator._assert_fixture_exclusive(NoProjectionDB(), run_id="proof-20260905")
 
 
-def test_bootstrap_empty_inventory_fails_closed_without_bound():
+def test_bootstrap_empty_inventory_rejects_any_present_collection():
     class UnboundedCollection:
         id = "users"
 
@@ -203,8 +218,25 @@ def test_bootstrap_empty_inventory_fails_closed_without_bound():
         def collections(self):
             return [UnboundedCollection()]
 
-    with pytest.raises(operator.JITQAVerificationError, match="bound the named Firestore database"):
+    with pytest.raises(operator.JITQAVerificationError, match="truly empty"):
         operator._assert_named_database_empty(UnboundedDB())
+
+
+def test_bootstrap_empty_inventory_accepts_no_collections():
+    class EmptyDB:
+        def collections(self):
+            return []
+
+    operator._assert_named_database_empty(EmptyDB())
+
+
+def test_evidence_ownership_requires_full_source_metadata():
+    db = _DB()
+    operator.seed_fixture(db, run_id="proof-20260905")
+    evidence = db.docs[operator._evidence_path("proof-20260905", 0)]
+    evidence.pop("source_version")
+    with pytest.raises(operator.JITQAVerificationError, match="foreign or malformed"):
+        operator.inspect_fixture(db, run_id="proof-20260905")
 
 
 def test_bootstrap_is_create_only_and_idempotent(monkeypatch):

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -179,6 +179,34 @@ def test_fixture_exclusivity_fails_closed_without_a_queryable_collection():
         operator._assert_fixture_exclusive(PointOnlyDB(), run_id="proof-20260905")
 
 
+def test_fixture_exclusivity_fails_closed_without_metadata_projection():
+    class NoProjectionCollection:
+        def limit(self, _value):
+            return self
+
+        def stream(self):
+            return []
+
+    class NoProjectionDB:
+        def collection(self, _path):
+            return NoProjectionCollection()
+
+    with pytest.raises(operator.JITQAVerificationError, match="project fixture ownership metadata"):
+        operator._assert_fixture_exclusive(NoProjectionDB(), run_id="proof-20260905")
+
+
+def test_bootstrap_empty_inventory_fails_closed_without_bound():
+    class UnboundedCollection:
+        id = "users"
+
+    class UnboundedDB:
+        def collections(self):
+            return [UnboundedCollection()]
+
+    with pytest.raises(operator.JITQAVerificationError, match="bound the named Firestore database"):
+        operator._assert_named_database_empty(UnboundedDB())
+
+
 def test_bootstrap_is_create_only_and_idempotent(monkeypatch):
     db = _DB(include_control=False)
 

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,9 +16,10 @@ from scripts import jit_qa_seed_and_verify as operator
 
 
 class _Snapshot:
-    def __init__(self, payload: dict | None):
+    def __init__(self, payload: dict | None, *, document_id: str = ""):
         self.exists = payload is not None
         self._payload = dict(payload or {})
+        self.id = document_id
 
     def to_dict(self):
         return dict(self._payload)
@@ -32,7 +34,7 @@ class _Ref:
         return self
 
     def get(self):
-        return _Snapshot(self.db.docs.get(self.path))
+        return _Snapshot(self.db.docs.get(self.path), document_id=self.path.rsplit("/", 1)[-1])
 
     def set(self, payload, merge=False):
         if merge and self.path in self.db.docs:
@@ -40,23 +42,66 @@ class _Ref:
         else:
             self.db.docs[self.path] = dict(payload)
 
+    def create(self, payload):
+        if self.path in self.db.docs:
+            raise RuntimeError("already exists")
+        self.db.docs[self.path] = dict(payload)
+
+
+class _Collection:
+    def __init__(self, db: "_DB", path: str):
+        self.db = db
+        self.path = path.strip("/")
+        self._limit = None
+
+    @property
+    def id(self):
+        return self.path.rsplit("/", 1)[-1]
+
+    def select(self, _fields):
+        return self
+
+    def limit(self, value):
+        self._limit = value
+        return self
+
+    def stream(self):
+        prefix_parts = self.path.split("/")
+        rows = []
+        for path, payload in self.db.docs.items():
+            parts = path.split("/")
+            if len(parts) == len(prefix_parts) + 1 and parts[: len(prefix_parts)] == prefix_parts:
+                rows.append(_Snapshot(payload, document_id=parts[-1]))
+        return rows[: self._limit]
+
 
 class _DB:
-    def __init__(self):
-        self.docs = {
-            f"users/{operator.QA_UID}/memory_state/apply_control": {
-                "uid": operator.QA_UID,
-                "writer_mode": "compatibility",
-                "writer_epoch": 1,
-                "head_commit_id": "qa-head",
-                "account_generation": 1,
-                "source_generation": 1,
-                "commit_sequence": 0,
+    def __init__(self, *, include_control=True):
+        self.docs = (
+            {
+                f"users/{operator.QA_UID}/memory_state/apply_control": {
+                    "uid": operator.QA_UID,
+                    "writer_mode": "compatibility",
+                    "writer_epoch": 1,
+                    "head_commit_id": "qa-head",
+                    "account_generation": 1,
+                    "source_generation": 1,
+                    "commit_sequence": 0,
+                }
             }
-        }
+            if include_control
+            else {}
+        )
 
     def document(self, path):
         return _Ref(self, path)
+
+    def collection(self, path):
+        return _Collection(self, path)
+
+    def collections(self):
+        ids = {path.split("/", 1)[0] for path in self.docs}
+        return [_Collection(self, collection_id) for collection_id in sorted(ids)]
 
 
 def _summary(**overrides):
@@ -123,6 +168,65 @@ def test_seed_refuses_foreign_document_without_overwriting_it():
         operator.seed_fixture(db, run_id="proof-20260905")
     assert db.docs[path]["uid"] == "customer-uid"
     assert operator._evidence_path("proof-20260905", 0) not in db.docs
+
+
+def test_fixture_exclusivity_fails_closed_without_a_queryable_collection():
+    class PointOnlyDB:
+        def document(self, path):
+            return _Ref(_DB(), path)
+
+    with pytest.raises(operator.JITQAVerificationError, match="cannot prove fixture exclusivity"):
+        operator._assert_fixture_exclusive(PointOnlyDB(), run_id="proof-20260905")
+
+
+def test_bootstrap_is_create_only_and_idempotent(monkeypatch):
+    db = _DB(include_control=False)
+
+    def ensure_control(uid, *, db_client):
+        assert uid == operator.QA_UID
+        control_ref = db_client.document(operator._control_path())
+        if not control_ref.get().exists:
+            control_ref.create(
+                {
+                    "uid": uid,
+                    "writer_mode": "compatibility",
+                    "writer_epoch": 0,
+                    "head_commit_id": "head0",
+                    "account_generation": 1,
+                    "source_generation": 1,
+                    "commit_sequence": 0,
+                }
+            )
+        registry_ref = db_client.document(f"canonical_memory_maintenance_registry/{uid}")
+        if not registry_ref.get().exists:
+            registry_ref.create({"uid": uid, "schema_version": 1})
+        return SimpleNamespace(uid=uid, writer_mode=SimpleNamespace(value="compatibility"))
+
+    monkeypatch.setattr(operator, "ensure_canonical_apply_control_state", ensure_control)
+    monkeypatch.setattr(operator, "validate_environment", lambda: None)
+
+    first = operator.bootstrap_qa_account(db)
+    assert first["profile"] == "created"
+    assert first["tester"] == "created"
+    assert db.docs[f"users/{operator.QA_UID}"]["time_zone"] == operator.QA_TIME_ZONE
+    assert db.docs[f"users/{operator.QA_UID}"]["subscription"]["plan"] == operator.QA_ENTITLEMENT_PLAN
+    assert db.docs[operator.TESTER_PATH]["test_account"] is True
+    assert db.docs[operator.BOOTSTRAP_PATH]["status"] == "complete"
+
+    before = {path: dict(payload) for path, payload in db.docs.items()}
+    second = operator.bootstrap_qa_account(db)
+    assert second["profile"] == "existing"
+    assert second["tester"] == "existing"
+    assert db.docs == before
+
+
+def test_bootstrap_refuses_unowned_document_before_any_write(monkeypatch):
+    db = _DB(include_control=False)
+    db.docs["users/another-uid"] = {"uid": "another-uid"}
+    monkeypatch.setattr(operator, "validate_environment", lambda: None)
+    with pytest.raises(operator.JITQAVerificationError, match="truly empty"):
+        operator.bootstrap_qa_account(db)
+    assert operator.BOOTSTRAP_PATH not in db.docs
 
 
 def test_summary_parser_accepts_workflow_envelope_and_rejects_missing_fields(tmp_path: Path):


### PR DESCRIPTION
## What changed and why

Adds a guarded operator and emulator proof for the isolated JIT QA seed path. Bootstrap is create-only and fail-closed for the fixed `based-hardware-dev` / `jit-qa` / `vi7SA9ckQCe4ccobWNxlbdcNdC23` tuple; seed writes are race-safe, and full evidence ownership metadata is checked before content-free post-cutover checks. Bootstrap now rejects any present collection because Firestore does not retain empty collections. The emulator proof requires a numeric loopback host and uses the named `jit-qa` client.

## Product invariants affected

none

## How it was verified

- Real Firestore emulator run with Firebase CLI 15.22 and Java 21 on `127.0.0.1:19893`: `prepare=101`, drain pages `[100,1]`, rollback preserved all rows, and rollforward was a stable no-op (`0`).
- The emulator run used an explicitly injected rollout decision and demo project `demo-omi-jit-qa`; it is labelled unit proof and does not establish cloud admission, deployment readiness, or production behavior.
- Non-loopback emulator hosts are rejected; the emulator port was confirmed closed after `firebase emulators:exec` completed.

Receipt: `/Volumes/Ephemeral/scratch/omi-jit-beta-20260905/review/jit-qa-seed-emulator-receipt-fcb82eeefd.json`

## Tests

- `PYTHONPATH=backend /Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/pytest -q backend/tests/unit/test_jit_qa_seed_and_verify.py` — 13 passed.
- `PYTHONPATH=backend /Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python -m py_compile backend/scripts/jit_qa_seed_and_verify.py backend/scripts/jit_qa_seed_and_verify_emulator_test.py`
- `make preflight` — 26 checks passed.
- `git diff --check`

## Failure class (fixes)

Failure-Class: none
