### PR TITLE
Keep today’s crash-rate bucket when the clock advances

### DIFF
--- a/.github/failure-classes/FC-independent-clock-reads-in-one-window.json
+++ b/.github/failure-classes/FC-independent-clock-reads-in-one-window.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-independent-clock-reads-in-one-window",
+  "violated_contract": "A date-series window must include its upper calendar bucket even when the clock advances while constructing the bounds.",
+  "canonical_prevention": "Capture one clock instant and derive both window bounds from it; exercise a clock that advances between successive reads.",
+  "canonical_prevention_artifact": [
+    "web/admin/lib/__tests__/stats-staleness-honesty.test.ts"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "web/admin/**"
+  ],
+  "status": "open"
+}

--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -34,7 +34,11 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 90);
 
-    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
+    if (
+      cache &&
+      cache.days === days &&
+      Date.now() - cache.timestamp < CACHE_TTL
+    ) {
       return NextResponse.json({ data: cache.data, days });
     }
 
@@ -80,7 +84,8 @@ export async function GET(request: NextRequest) {
       const last = data[data.length - 1];
       last.crashes = Number(rollCrashes);
       last.users = Number(rollUsers);
-      last.crashFreeRate = Math.round((1 - Number(rollCrashes) / Number(rollUsers)) * 1000) / 10;
+      last.crashFreeRate =
+        Math.round((1 - Number(rollCrashes) / Number(rollUsers)) * 1000) / 10;
     }
     cache = { data, days, timestamp: Date.now() };
     return NextResponse.json({ data, days });
@@ -99,14 +104,17 @@ export function buildDateSeries(
   dauMap: Record<string, number>
 ): CrashRatePoint[] {
   const toDate = new Date();
-  const fromDate = new Date();
+  const fromDate = new Date(toDate);
   fromDate.setUTCDate(fromDate.getUTCDate() - days);
 
   // UTC getters, because PostHog buckets these rows with `toDate(timestamp)`,
   // which is UTC. Local-time keys shifted every bucket by a day on any runtime
   // west of Greenwich, so the joined counts landed on the wrong dates.
   const formatDate = (d: Date) =>
-    `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+    `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(
+      2,
+      "0"
+    )}-${String(d.getUTCDate()).padStart(2, "0")}`;
 
   const data: CrashRatePoint[] = [];
   const current = new Date(fromDate);
@@ -114,7 +122,8 @@ export function buildDateSeries(
     const dateStr = formatDate(current);
     const crashes = crashMap[dateStr] ?? 0;
     const users = dauMap[dateStr] ?? 0;
-    const crashFreeRate = users > 0 ? Math.round((1 - crashes / users) * 1000) / 10 : 100;
+    const crashFreeRate =
+      users > 0 ? Math.round((1 - crashes / users) * 1000) / 10 : 100;
     data.push({ date: dateStr, crashes, users, crashFreeRate });
     current.setUTCDate(current.getUTCDate() + 1);
   }

--- a/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
+++ b/web/admin/lib/__tests__/stats-staleness-honesty.test.ts
@@ -86,6 +86,40 @@ describe("withFreshness", () => {
 });
 
 describe("crash-rate date keys", () => {
+  it("keeps today's bucket when successive clock reads advance", () => {
+    const RealDate = Date;
+    const instant = RealDate.parse("2026-09-05T23:22:00.000Z");
+    let reads = 0;
+    class AdvancingDate extends RealDate {
+      constructor(value?: string | number | Date) {
+        super(
+          value === undefined
+            ? instant + reads++
+            : value instanceof RealDate
+            ? value.getTime()
+            : value
+        );
+      }
+    }
+    vi.stubGlobal("Date", AdvancingDate);
+    try {
+      const series = buildDateSeries(
+        3,
+        { "2026-09-05": 5 },
+        { "2026-09-05": 100 }
+      );
+      expect(series).toHaveLength(4);
+      expect(series.at(-1)).toEqual({
+        date: "2026-09-05",
+        crashes: 5,
+        users: 100,
+        crashFreeRate: 95,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("builds UTC date keys so they join with PostHog's toDate() buckets", () => {
     const series = buildDateSeries(2, {}, {});
     const expected = new Date().toISOString().slice(0, 10);


### PR DESCRIPTION
The crash-rate date series could omit today's counts when its second clock read was even one millisecond later than its first. Derive the start from the same captured instant as the end so the final UTC bucket is always included.

A deterministic advancing-clock regression fails on the old code and passes with the fix. All 10 focused tests and the admin TypeScript check pass. This was exposed by web CI for #12817.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

