### PR TITLE
feat(backend): index conversations into Typesense from lifecycle writes

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -77,6 +77,9 @@ HOSTED_PUSHER_API_URL=
 TYPESENSE_HOST=
 TYPESENSE_HOST_PORT=
 TYPESENSE_API_KEY=
+# Optional kill switch for first-party conversation index writes (utils/conversations/typesense_index.py).
+# Unset = on whenever TYPESENSE_HOST/TYPESENSE_API_KEY are configured; set to 0/false/off/no to disable.
+# TYPESENSE_CONVERSATION_INDEX_WRITES=
 
 STRIPE_API_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -18,7 +18,6 @@ from models.conversation_enums import ConversationStatus, PostProcessingModel, P
 from models.conversation_photo import ConversationPhoto
 from models.transcript_segment import TranscriptSegment
 from utils import encryption
-from utils.conversations import typesense_index as conversation_typesense_index
 from utils.conversations.transcript_hash import (
     canonicalize_transcript_segments_for_storage,
     transcript_sha256_for_binding,
@@ -419,6 +418,36 @@ def iter_all_conversation_photos(uid: str):
             yield conversation_id, doc.to_dict()
 
 
+def _sync_conversation_search_index(uid: str, conversation_id: str) -> None:
+    """Converge the Typesense projection after a durable write (fail-open).
+
+    The import stays inside the hook on purpose: several test harnesses load
+    this module against stubbed ``utils`` packages without a real
+    ``utils.conversations`` path, and a module-top import of the projection
+    breaks them (PR #12819 round one).
+    """
+    try:
+        from utils.conversations.typesense_index import sync_conversation_index_after_write
+
+        sync_conversation_index_after_write(uid, conversation_id)
+    except Exception as exc:
+        logger.warning(
+            "conversation Typesense sync hook failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc
+        )
+
+
+def _delete_conversation_search_index(uid: str, conversation_id: str) -> None:
+    """Remove one conversation from Typesense after a durable delete (fail-open)."""
+    try:
+        from utils.conversations.typesense_index import delete_conversation_index_doc
+
+        delete_conversation_index_doc(uid, conversation_id)
+    except Exception as exc:
+        logger.warning(
+            "conversation Typesense delete hook failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc
+        )
+
+
 # *****************************
 # ********** CRUD *************
 # *****************************
@@ -479,7 +508,7 @@ def upsert_conversation_with_lifecycle(uid: str, conversation_data: dict):
         transaction.set(conversation_ref, write_data)
 
     _write_processing_result(transaction)
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
+    _sync_conversation_search_index(uid, conversation_data['id'])
 
 
 @set_data_protection_level(data_arg_name='conversation_data')
@@ -553,11 +582,11 @@ def persist_processing_result_with_lifecycle(
 
     persisted = _persist(transaction)
     if persisted:
-        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
+        _sync_conversation_search_index(uid, conversation_data['id'])
     else:
         # A processor result for a conversation whose owner is already gone:
         # converge the search index to absence too.
-        conversation_typesense_index.delete_conversation_index_doc(uid, conversation_data['id'])
+        _delete_conversation_search_index(uid, conversation_data['id'])
     return persisted
 
 
@@ -581,8 +610,11 @@ def create_conversation_if_absent_with_lifecycle(uid: str, conversation_data: di
     try:
         conversation_ref.create(conversation_data)
     except (AlreadyExists, Conflict):
+        # The conversation exists but may be new to the search index (writer
+        # lag, backfill gap); the read-back sync converges it either way.
+        _sync_conversation_search_index(uid, conversation_data['id'])
         return False
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
+    _sync_conversation_search_index(uid, conversation_data['id'])
     return True
 
 
@@ -955,7 +987,7 @@ def update_conversation(uid: str, conversation_id: str, update_data: dict) -> bo
         # the audio budget) instead of logging an ERROR and retrying forever.
         return False
     if _SEARCH_INDEXED_FIELD_ROOTS.intersection(str(key).split('.', 1)[0] for key in update_data):
-        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+        _sync_conversation_search_index(uid, conversation_id)
     return True
 
 
@@ -1093,7 +1125,7 @@ def update_conversation_title(uid: str, conversation_id: str, title: str):
         return
 
     conversation_ref.update({'structured.title': title, 'user_title': title})
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+    _sync_conversation_search_index(uid, conversation_id)
 
 
 def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional[str], content: str) -> str:
@@ -1116,7 +1148,7 @@ def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional
 
     if app_id is None:
         conversation_ref.update({'structured.overview': content})
-        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+        _sync_conversation_search_index(uid, conversation_id)
         return 'ok'
 
     raw = doc_snapshot.to_dict() or {}
@@ -1244,7 +1276,7 @@ def delete_conversation(uid, conversation_id):
     for sub in conversation_ref.collections():
         delete_collection_recursive(sub, client=db)
     conversation_ref.delete()
-    conversation_typesense_index.delete_conversation_index_doc(uid, conversation_id)
+    _delete_conversation_search_index(uid, conversation_id)
 
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
@@ -1541,14 +1573,14 @@ def set_conversation_as_discarded(uid: str, conversation_id: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'discarded': True})
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+    _sync_conversation_search_index(uid, conversation_id)
 
 
 def restore_conversation_from_discarded(uid: str, conversation_id: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'discarded': False})
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+    _sync_conversation_search_index(uid, conversation_id)
 
 
 # *********************************
@@ -1683,7 +1715,7 @@ def update_conversation_finished_at(uid: str, conversation_id: str, finished_at:
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'finished_at': finished_at})
-    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
+    _sync_conversation_search_index(uid, conversation_id)
 
 
 def _invalidate_client_processing(payload: Dict[str, Any]) -> None:

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -18,6 +18,7 @@ from models.conversation_enums import ConversationStatus, PostProcessingModel, P
 from models.conversation_photo import ConversationPhoto
 from models.transcript_segment import TranscriptSegment
 from utils import encryption
+from utils.conversations import typesense_index as conversation_typesense_index
 from utils.conversations.transcript_hash import (
     canonicalize_transcript_segments_for_storage,
     transcript_sha256_for_binding,
@@ -47,6 +48,11 @@ logger = logging.getLogger(__name__)
 conversations_collection = 'conversations'
 
 _LIFECYCLE_FIELDS = frozenset({'status', 'discarded'})
+# Top-level fields behind the Typesense conversation projection (see
+# utils/conversations/typesense_index.py). A generic update re-syncs the index
+# only when it touches one of these roots — segment/photo/app-result writes
+# never reach Typesense, so they must not pay for it.
+_SEARCH_INDEXED_FIELD_ROOTS = frozenset({'structured', 'created_at', 'started_at', 'finished_at', 'geolocation'})
 _PUBLIC_TRANSCRIPT_MAX_STORED_BYTES = 256 * 1024
 _PUBLIC_TRANSCRIPT_MAX_DECODED_BYTES = 512 * 1024
 _PUBLIC_TRANSCRIPT_MAX_SEGMENTS = 4096
@@ -473,6 +479,7 @@ def upsert_conversation_with_lifecycle(uid: str, conversation_data: dict):
         transaction.set(conversation_ref, write_data)
 
     _write_processing_result(transaction)
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
 
 
 @set_data_protection_level(data_arg_name='conversation_data')
@@ -544,7 +551,14 @@ def persist_processing_result_with_lifecycle(
         transaction.set(conversation_ref, write_data, merge=True)
         return True
 
-    return _persist(transaction)
+    persisted = _persist(transaction)
+    if persisted:
+        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
+    else:
+        # A processor result for a conversation whose owner is already gone:
+        # converge the search index to absence too.
+        conversation_typesense_index.delete_conversation_index_doc(uid, conversation_data['id'])
+    return persisted
 
 
 @set_data_protection_level(data_arg_name='conversation_data')
@@ -566,9 +580,10 @@ def create_conversation_if_absent_with_lifecycle(uid: str, conversation_data: di
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_data['id'])
     try:
         conversation_ref.create(conversation_data)
-        return True
     except (AlreadyExists, Conflict):
         return False
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_data['id'])
+    return True
 
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
@@ -939,6 +954,8 @@ def update_conversation(uid: str, conversation_id: str, update_data: dict) -> bo
         # audio sync take their designed gone-owner path (stop syncing, release
         # the audio budget) instead of logging an ERROR and retrying forever.
         return False
+    if _SEARCH_INDEXED_FIELD_ROOTS.intersection(str(key).split('.', 1)[0] for key in update_data):
+        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
     return True
 
 
@@ -1076,6 +1093,7 @@ def update_conversation_title(uid: str, conversation_id: str, title: str):
         return
 
     conversation_ref.update({'structured.title': title, 'user_title': title})
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
 
 
 def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional[str], content: str) -> str:
@@ -1098,6 +1116,7 @@ def update_conversation_summary(uid: str, conversation_id: str, app_id: Optional
 
     if app_id is None:
         conversation_ref.update({'structured.overview': content})
+        conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
         return 'ok'
 
     raw = doc_snapshot.to_dict() or {}
@@ -1225,6 +1244,7 @@ def delete_conversation(uid, conversation_id):
     for sub in conversation_ref.collections():
         delete_collection_recursive(sub, client=db)
     conversation_ref.delete()
+    conversation_typesense_index.delete_conversation_index_doc(uid, conversation_id)
 
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
@@ -1521,12 +1541,14 @@ def set_conversation_as_discarded(uid: str, conversation_id: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'discarded': True})
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
 
 
 def restore_conversation_from_discarded(uid: str, conversation_id: str):
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'discarded': False})
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
 
 
 # *********************************
@@ -1661,6 +1683,7 @@ def update_conversation_finished_at(uid: str, conversation_id: str, finished_at:
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
     conversation_ref.update({'finished_at': finished_at})
+    conversation_typesense_index.sync_conversation_index_after_write(uid, conversation_id)
 
 
 def _invalidate_client_processing(payload: Dict[str, Any]) -> None:

--- a/backend/services/conversation_finalization.py
+++ b/backend/services/conversation_finalization.py
@@ -443,6 +443,20 @@ def final_attempt_failed(
             # Dead-lettering is authoritative; a best-effort metric lookup must
             # never change its terminal outcome.
             logger.exception('listen finalization terminal metric lookup failed job=%s', job_id)
+        # Dead-lettering flips the bound conversation to discarded inside its
+        # own transaction, bypassing the update hooks; converge the search
+        # projection. Fail-open: never change the terminal outcome.
+        try:
+            job = jobs_db.get_finalization_job(job_id, firestore_client=firestore_client)
+            if job:
+                uid = job.get('uid')
+                conversation_id = job.get('conversation_id')
+                if isinstance(uid, str) and uid and isinstance(conversation_id, str) and conversation_id:
+                    from utils.conversations.typesense_index import sync_conversation_index_after_write
+
+                    sync_conversation_index_after_write(uid, conversation_id)
+        except Exception:
+            logger.warning('listen finalization dead-letter index sync failed job=%s', job_id)
     return marked
 
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -44,6 +44,7 @@ from utils.retrieval.frame_request_storage import (
     delete_all_frame_request_pixels_for_user,
     delete_frame_request_pixels_for_user,
 )
+from utils.conversations.typesense_index import purge_user_conversation_index
 from utils.twilio_service import delete_user_caller_ids_strict as delete_user_caller_ids
 from utils.integration_telemetry import emit_posthog_event
 from services.users.agent_vm_account_cleanup import delete_agent_vm_for_account
@@ -61,6 +62,7 @@ class PurgeResult(TypedDict):
     best_effort_failures: list[PurgeFailure]
     vectors_deleted: int
     recordings_deleted: int
+    conversation_typesense_docs_deleted: int
 
 
 ACCOUNT_DELETION_WIPE_COMPLETED = 'Account Deletion Wipe Completed'
@@ -100,6 +102,7 @@ def purge_derived_user_data(uid: str) -> PurgeResult:
         'best_effort_failures': [],
         'vectors_deleted': 0,
         'recordings_deleted': 0,
+        'conversation_typesense_docs_deleted': 0,
     }
 
     def record_failure(
@@ -222,6 +225,16 @@ def purge_derived_user_data(uid: str) -> PurgeResult:
     except Exception as e:
         record_failure('required_failures', 'canonical_derived_data', e)
         logger.error(f'delete_account purge canonical vectors failed for {uid}: {sanitize(str(e))}')
+
+    try:
+        # The search index is derived PII: leaving conversation documents
+        # readable after account deletion is a privacy failure, so this purge
+        # is required, like the vector purges. It is filter-based (userId),
+        # so a failed attempt stays retryable even after the Firestore wipe.
+        result['conversation_typesense_docs_deleted'] = purge_user_conversation_index(uid, raise_on_failure=True)
+    except Exception as e:
+        record_failure('required_failures', 'conversation_typesense_index', e)
+        logger.error(f'delete_account purge conversation typesense index failed for {uid}: {sanitize(str(e))}')
 
     return result
 

--- a/backend/services/users/account_deletion.py
+++ b/backend/services/users/account_deletion.py
@@ -44,7 +44,6 @@ from utils.retrieval.frame_request_storage import (
     delete_all_frame_request_pixels_for_user,
     delete_frame_request_pixels_for_user,
 )
-from utils.conversations.typesense_index import purge_user_conversation_index
 from utils.twilio_service import delete_user_caller_ids_strict as delete_user_caller_ids
 from utils.integration_telemetry import emit_posthog_event
 from services.users.agent_vm_account_cleanup import delete_agent_vm_for_account
@@ -62,7 +61,6 @@ class PurgeResult(TypedDict):
     best_effort_failures: list[PurgeFailure]
     vectors_deleted: int
     recordings_deleted: int
-    conversation_typesense_docs_deleted: int
 
 
 ACCOUNT_DELETION_WIPE_COMPLETED = 'Account Deletion Wipe Completed'
@@ -102,7 +100,6 @@ def purge_derived_user_data(uid: str) -> PurgeResult:
         'best_effort_failures': [],
         'vectors_deleted': 0,
         'recordings_deleted': 0,
-        'conversation_typesense_docs_deleted': 0,
     }
 
     def record_failure(
@@ -226,16 +223,6 @@ def purge_derived_user_data(uid: str) -> PurgeResult:
         record_failure('required_failures', 'canonical_derived_data', e)
         logger.error(f'delete_account purge canonical vectors failed for {uid}: {sanitize(str(e))}')
 
-    try:
-        # The search index is derived PII: leaving conversation documents
-        # readable after account deletion is a privacy failure, so this purge
-        # is required, like the vector purges. It is filter-based (userId),
-        # so a failed attempt stays retryable even after the Firestore wipe.
-        result['conversation_typesense_docs_deleted'] = purge_user_conversation_index(uid, raise_on_failure=True)
-    except Exception as e:
-        record_failure('required_failures', 'conversation_typesense_index', e)
-        logger.error(f'delete_account purge conversation typesense index failed for {uid}: {sanitize(str(e))}')
-
     return result
 
 
@@ -358,6 +345,21 @@ def background_wipe_user_data(uid: str, retry_count: int = 0, terminal: bool = F
         wipe_result = users_db.delete_user_data(uid)
         if wipe_result.get('status') != 'ok':
             raise RuntimeError('authoritative Firestore user-data wipe did not complete')
+        # Best-effort Typesense conversation purge AFTER the wipe: while the
+        # Firebase extension still owns production indexing, account deletion
+        # must not fail closed on Typesense. The purge is userId-filter-based,
+        # so it stays executable (and retryable) even with the user document
+        # gone; a failure here never changes the wipe outcome.
+        current_operation = 'conversation_typesense_purge'
+        try:
+            from utils.conversations.typesense_index import purge_user_conversation_index
+
+            purge_user_conversation_index(uid)
+        except Exception as purge_err:
+            logger.error(
+                f'delete_account post-wipe conversation typesense purge failed for {uid}: '
+                f'{sanitize(str(purge_err))}'
+            )
         current_operation = 'memory_maintenance_registry'
         _delete_memory_maintenance_registry(uid)
         logger.info('delete_account background wipe complete')

--- a/backend/testing/e2e/conftest.py
+++ b/backend/testing/e2e/conftest.py
@@ -83,6 +83,11 @@ def _set_e2e_env():
     os.environ["TYPESENSE_HOST"] = "localhost"
     os.environ["TYPESENSE_HOST_PORT"] = "8108"
     os.environ["TYPESENSE_API_KEY"] = "fake-typesense-key"
+    # The hermetic harness runs no Typesense server: an enabled first-party
+    # conversation index writer would block ~5s per durable conversation write
+    # on refused localhost:8108 retries and blow the e2e timing budget. The
+    # projection is covered by tests/unit/test_conversation_typesense_index.py.
+    os.environ["TYPESENSE_CONVERSATION_INDEX_WRITES"] = "0"
     os.environ["BUCKET_SPEECH_PROFILES"] = "speech-profiles"
     os.environ["BUCKET_POSTPROCESSING"] = "postprocessing"
     os.environ["BUCKET_PRIVATE_CLOUD_SYNC"] = "omi-private-cloud-sync"

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -1446,6 +1446,11 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         'purge_canonical_derived_user_data',
         MagicMock(return_value={'vector_ids': ['canonical-1', 'canonical-2']}),
     )
+    monkeypatch.setattr(
+        account_deletion,
+        'purge_user_conversation_index',
+        lambda uid, raise_on_failure=False: calls.append(('purge_typesense', uid)) or 4,
+    )
     monkeypatch.setattr(account_deletion, 'get_conversation_photos', lambda uid, conversation_id: [])
     monkeypatch.setattr(
         account_deletion.frame_requests_db, 'list_all_frame_request_storage_ids', lambda uid: ['request-object']
@@ -1478,12 +1483,14 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         ('delete_screen_vectors', 'uid1', ['s1']),
         ('recordings', 'uid1'),
         ('get_conversations', 'uid1'),
+        ('purge_typesense', 'uid1'),
     ]
     assert result == {
         'required_failures': [],
         'best_effort_failures': [],
         'vectors_deleted': 8,
         'recordings_deleted': 3,
+        'conversation_typesense_docs_deleted': 4,
     }
     delete_frame_pixels.assert_called_once_with('uid1', ['request-object', 'orphan-object', 'deferred-object'])
 
@@ -1506,6 +1513,9 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     monkeypatch.setattr(
         account_deletion, 'purge_canonical_derived_user_data', MagicMock(side_effect=Exception('canonical down'))
     )
+    monkeypatch.setattr(
+        account_deletion, 'purge_user_conversation_index', MagicMock(side_effect=Exception('typesense down'))
+    )
 
     result = account_deletion.purge_derived_user_data('uid1')
 
@@ -1527,6 +1537,7 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
         'conversation_recordings',
         'frame_request_pixels',
         'canonical_derived_data',
+        'conversation_typesense_index',
     ]
     assert result['best_effort_failures'] == []
 

--- a/backend/tests/services/users/test_account_deletion.py
+++ b/backend/tests/services/users/test_account_deletion.py
@@ -3,7 +3,7 @@ import importlib.machinery
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1334,6 +1334,49 @@ def test_background_wipe_proceeds_when_subscription_is_already_canceled(monkeypa
     account_deletion.users_db.mark_user_deletion_wipe_failed.assert_not_called()
 
 
+def test_background_wipe_purges_conversation_typesense_index_after_firestore_wipe(monkeypatch):
+    """The post-wipe Typesense conversation purge is best-effort: it runs after
+    delete_user_data and can never change the wipe outcome while the Firebase
+    extension still owns production indexing."""
+    _stub_wipe_steps_after_billing(monkeypatch)
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'get_user_subscription',
+        MagicMock(return_value=SimpleNamespace(stripe_subscription_id='sub_123')),
+    )
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.stripe_utils, 'is_subscription_terminal', MagicMock(return_value=True))
+
+    from utils.conversations import typesense_index
+
+    purge = MagicMock(return_value=7)
+    with patch.object(typesense_index, 'purge_user_conversation_index', purge):
+        assert account_deletion.background_wipe_user_data('uid1') is True
+
+    purge.assert_called_once_with('uid1')
+    account_deletion.users_db.delete_user_data.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_not_called()
+
+
+def test_background_wipe_survives_conversation_typesense_purge_failure(monkeypatch):
+    _stub_wipe_steps_after_billing(monkeypatch)
+    monkeypatch.setattr(
+        account_deletion.users_db,
+        'get_user_subscription',
+        MagicMock(return_value=SimpleNamespace(stripe_subscription_id='sub_123')),
+    )
+    monkeypatch.setattr(account_deletion.stripe_utils, 'cancel_subscription', MagicMock(return_value=None))
+    monkeypatch.setattr(account_deletion.stripe_utils, 'is_subscription_terminal', MagicMock(return_value=True))
+
+    from utils.conversations import typesense_index
+
+    with patch.object(typesense_index, 'purge_user_conversation_index', MagicMock(side_effect=Exception('down'))):
+        assert account_deletion.background_wipe_user_data('uid1') is True
+
+    account_deletion.users_db.delete_user_data.assert_called_once_with('uid1')
+    account_deletion.users_db.mark_user_deletion_wipe_failed.assert_not_called()
+
+
 def test_background_wipe_still_fails_when_subscription_is_not_terminal(monkeypatch):
     """A cancel that failed while the subscription can still bill stays a hard failure."""
     _stub_wipe_steps_after_billing(monkeypatch)
@@ -1446,11 +1489,6 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         'purge_canonical_derived_user_data',
         MagicMock(return_value={'vector_ids': ['canonical-1', 'canonical-2']}),
     )
-    monkeypatch.setattr(
-        account_deletion,
-        'purge_user_conversation_index',
-        lambda uid, raise_on_failure=False: calls.append(('purge_typesense', uid)) or 4,
-    )
     monkeypatch.setattr(account_deletion, 'get_conversation_photos', lambda uid, conversation_id: [])
     monkeypatch.setattr(
         account_deletion.frame_requests_db, 'list_all_frame_request_storage_ids', lambda uid: ['request-object']
@@ -1483,14 +1521,12 @@ def test_purge_derived_user_data_isolates_backends_and_reloads_conversation_ids(
         ('delete_screen_vectors', 'uid1', ['s1']),
         ('recordings', 'uid1'),
         ('get_conversations', 'uid1'),
-        ('purge_typesense', 'uid1'),
     ]
     assert result == {
         'required_failures': [],
         'best_effort_failures': [],
         'vectors_deleted': 8,
         'recordings_deleted': 3,
-        'conversation_typesense_docs_deleted': 4,
     }
     delete_frame_pixels.assert_called_once_with('uid1', ['request-object', 'orphan-object', 'deferred-object'])
 
@@ -1513,9 +1549,6 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
     monkeypatch.setattr(
         account_deletion, 'purge_canonical_derived_user_data', MagicMock(side_effect=Exception('canonical down'))
     )
-    monkeypatch.setattr(
-        account_deletion, 'purge_user_conversation_index', MagicMock(side_effect=Exception('typesense down'))
-    )
 
     result = account_deletion.purge_derived_user_data('uid1')
 
@@ -1537,7 +1570,6 @@ def test_purge_derived_user_data_continues_after_each_failure(monkeypatch):
         'conversation_recordings',
         'frame_request_pixels',
         'canonical_derived_data',
-        'conversation_typesense_index',
     ]
     assert result['best_effort_failures'] == []
 

--- a/backend/tests/unit/test_conversation_typesense_index.py
+++ b/backend/tests/unit/test_conversation_typesense_index.py
@@ -1,0 +1,452 @@
+"""First-party conversation Typesense projection — payload, gating, fail-open.
+
+Covers the contract from SCA-452:
+- upsert payload shape matches the `conversations` collection schema the
+  Firebase extension created and `utils.conversations.search` queries;
+- ``transcript_segments`` / speaker fields can never reach Typesense;
+- e2ee accounts are skipped by deleting any previously indexed document;
+- Typesense being down never raises out of the conversation write paths;
+- account-deletion purge is filter-based and fail-closed when required.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+os.environ.setdefault("TYPESENSE_HOST", "localhost")
+os.environ.setdefault("TYPESENSE_HOST_PORT", "8108")
+os.environ.setdefault("TYPESENSE_API_KEY", "test-key-not-real")
+
+from utils.conversations import typesense_index
+from utils.conversations.typesense_index import (
+    build_conversation_index_document,
+    conversation_index_writes_enabled,
+    delete_conversation_index_doc,
+    purge_user_conversation_index,
+    sync_conversation_index_after_write,
+)
+from database import conversations as conversations_db
+
+UID = "uid-conv-typesense"
+CONVERSATION_ID = "conv-1"
+
+ALLOWED_FIELDS = frozenset(
+    {"id", "userId", "created_at", "discarded", "started_at", "finished_at", "structured", "geolocation"}
+)
+
+
+def _conversation_data() -> dict:
+    return {
+        "id": CONVERSATION_ID,
+        "created_at": datetime(2026, 9, 5, 12, 0, 0, tzinfo=timezone.utc),
+        "started_at": datetime(2026, 9, 5, 11, 58, 30, tzinfo=timezone.utc),
+        "finished_at": datetime(2026, 9, 5, 12, 4, 0, tzinfo=timezone.utc),
+        "discarded": False,
+        "structured": {"title": "Standup", "overview": "Daily sync", "events": [], "action_items": []},
+        "geolocation": {"latitude": 37.7749, "longitude": -122.4194, "google_place_id": "place-x"},
+        # Fields that must never reach Typesense.
+        "transcript_segments": [
+            {"text": "hello", "is_user": True, "person_id": "speaker-1"},
+            {"text": "world", "is_user": False, "person_id": "speaker-2"},
+        ],
+        "photos": [{"base64": "zzz"}],
+        "apps_results": [{"app_id": "a1", "content": "app output"}],
+    }
+
+
+def _fake_typesense() -> tuple[MagicMock, dict]:
+    docs_store: dict = {}
+    typesense_client = MagicMock()
+
+    def _upsert(doc):
+        docs_store[doc["id"]] = doc
+        return doc
+
+    def _delete_filter(params):
+        filter_by = params.get("filter_by", "")
+        quoted = [value for value in filter_by.split("`") if value and ":" not in value and "[" not in value]
+        user_id = quoted[0] if quoted else None
+        to_delete = [doc_id for doc_id, doc in docs_store.items() if doc.get("userId") == user_id]
+        for doc_id in to_delete:
+            docs_store.pop(doc_id, None)
+        return {"num_deleted": len(to_delete)}
+
+    documents = MagicMock()
+    documents.upsert.side_effect = _upsert
+    documents.delete.side_effect = _delete_filter
+    documents.__getitem__.side_effect = lambda doc_id: MagicMock(delete=lambda: docs_store.pop(doc_id, None))
+
+    collection = MagicMock()
+    collection.documents = documents
+    typesense_client.collections.__getitem__.return_value = collection
+    return typesense_client, docs_store
+
+
+def _policy_db(level: str = "enhanced") -> MagicMock:
+    user_doc = MagicMock(exists=True, to_dict=lambda: {"data_protection_level": level})
+    db_client = MagicMock()
+    db_client.document.return_value = MagicMock(get=lambda: user_doc)
+    return db_client
+
+
+def _firestore_with_doc(doc: dict | None) -> MagicMock:
+    snapshot = MagicMock()
+    snapshot.exists = doc is not None
+    snapshot.to_dict = lambda: dict(doc) if doc is not None else None
+    client = MagicMock()
+    client.collection.return_value.document.return_value.collection.return_value.document.return_value.get.return_value = (
+        snapshot
+    )
+    return client
+
+
+@pytest.fixture
+def index_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TYPESENSE_HOST", "localhost")
+    monkeypatch.setenv("TYPESENSE_API_KEY", "test-key-not-real")
+    monkeypatch.delenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, raising=False)
+
+
+@pytest.fixture
+def mock_typesense():
+    typesense_client, docs_store = _fake_typesense()
+    with (
+        patch.object(typesense_index, "_typesense_client", return_value=typesense_client),
+        patch.object(typesense_index, "default_db_client", _policy_db()),
+    ):
+        yield typesense_client, docs_store
+
+
+class TestDocumentShape:
+    def test_payload_carries_exactly_the_schema_fields(self):
+        document = build_conversation_index_document(UID, _conversation_data())
+
+        assert document is not None
+        assert set(document) == ALLOWED_FIELDS
+        assert document["id"] == CONVERSATION_ID
+        assert document["userId"] == UID
+        assert document["created_at"] == 1788609600  # 2026-09-05T12:00:00Z in unix seconds
+        assert document["started_at"] == 1788609510
+        assert document["finished_at"] == 1788609840
+        assert document["discarded"] is False
+        assert document["structured"]["title"] == "Standup"
+        assert document["geolocation"] == [37.7749, -122.4194]
+
+    def test_transcript_segments_and_speaker_fields_never_leave(self):
+        document = build_conversation_index_document(UID, _conversation_data())
+
+        dumped = str(document)
+        assert "transcript_segments" not in dumped
+        assert "speaker-1" not in dumped
+        assert "speaker-2" not in dumped
+        assert "is_user" not in dumped
+        assert "zzz" not in dumped
+
+    def test_epoch_numbers_pass_through(self):
+        document = build_conversation_index_document(
+            UID,
+            {
+                "id": "c2",
+                "created_at": 1788609600,
+                "started_at": 1788609510.25,
+                "discarded": True,
+            },
+        )
+
+        assert document is not None
+        assert document["created_at"] == 1788609600
+        assert document["started_at"] == 1788609510
+        assert document["discarded"] is True
+
+    def test_naive_datetime_is_treated_as_utc(self):
+        document = build_conversation_index_document(UID, {"id": "c3", "created_at": datetime(2026, 9, 5, 12, 0, 0)})
+
+        assert document is not None
+        assert document["created_at"] == 1788609600
+
+    def test_unparseable_geolocation_is_omitted_not_fatal(self):
+        document = build_conversation_index_document(
+            UID,
+            {
+                "id": "c4",
+                "created_at": 1788609600,
+                "geolocation": {"latitude": "north", "longitude": None},
+            },
+        )
+
+        assert document is not None
+        assert "geolocation" not in document
+
+    def test_geopoint_object_maps_to_typesense_point(self):
+        geopoint = MagicMock(latitude=52.52, longitude=13.405)
+
+        document = build_conversation_index_document(
+            UID, {"id": "c5", "created_at": 1788609600, "geolocation": geopoint}
+        )
+
+        assert document is not None
+        assert document["geolocation"] == [52.52, 13.405]
+
+    def test_missing_created_at_is_unindexable(self):
+        assert build_conversation_index_document(UID, {"id": "c6"}) is None
+        assert build_conversation_index_document(UID, {"id": "", "created_at": 1788609600}) is None
+
+
+class TestWriteFlag:
+    def test_default_on_when_typesense_env_present(self, index_env, monkeypatch):
+        assert conversation_index_writes_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "no", "OFF"])
+    def test_kill_switch_disables(self, index_env, monkeypatch, value):
+        monkeypatch.setenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, value)
+        assert conversation_index_writes_enabled() is False
+
+    def test_missing_typesense_env_disables(self, monkeypatch):
+        monkeypatch.delenv("TYPESENSE_HOST", raising=False)
+        monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
+        assert conversation_index_writes_enabled() is False
+
+
+class TestSync:
+    def test_sync_upserts_projected_document(self, index_env, mock_typesense):
+        typesense_client, docs_store = mock_typesense
+        firestore = _firestore_with_doc(_conversation_data())
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
+
+        assert set(docs_store) == {CONVERSATION_ID}
+        assert set(docs_store[CONVERSATION_ID]) == ALLOWED_FIELDS
+        typesense_client.collections.__getitem__.assert_called_with("conversations")
+
+    def test_sync_skips_when_disabled(self, index_env, monkeypatch, mock_typesense):
+        typesense_client, _ = mock_typesense
+        monkeypatch.setenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, "0")
+        firestore = _firestore_with_doc(_conversation_data())
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is False
+
+        typesense_client.collections.__getitem__.return_value.documents.upsert.assert_not_called()
+
+    def test_e2ee_user_deletes_instead_of_upserting(self, index_env, mock_typesense):
+        typesense_client, docs_store = mock_typesense
+        docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
+        firestore = _firestore_with_doc(_conversation_data())
+
+        with patch.object(typesense_index, "default_db_client", _policy_db(level="e2ee")):
+            assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
+
+        assert docs_store == {}
+        typesense_client.collections.__getitem__.return_value.documents.upsert.assert_not_called()
+
+    def test_missing_firestore_doc_converges_to_delete(self, index_env, mock_typesense):
+        _, docs_store = mock_typesense
+        docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
+        firestore = _firestore_with_doc(None)
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
+
+        assert docs_store == {}
+
+    def test_typesense_down_does_not_raise(self, index_env, mock_typesense):
+        typesense_client, _ = mock_typesense
+        typesense_client.collections.__getitem__.return_value.documents.upsert.side_effect = Exception(
+            "connection refused"
+        )
+        firestore = _firestore_with_doc(_conversation_data())
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is False
+
+    def test_projection_read_failure_does_not_raise(self, index_env, mock_typesense):
+        firestore = _firestore_with_doc(_conversation_data())
+        firestore.collection.return_value.document.return_value.collection.return_value.document.return_value.get.side_effect = Exception(
+            "firestore unavailable"
+        )
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is False
+
+    def test_internal_never_raise_contract(self, index_env, mock_typesense):
+        firestore = _firestore_with_doc(_conversation_data())
+
+        with patch.object(
+            typesense_index,
+            "_sync_conversation_index_after_write",
+            side_effect=Exception("unexpected bug"),
+        ):
+            assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is False
+
+
+class TestDelete:
+    def test_delete_removes_by_conversation_id(self, mock_typesense):
+        _, docs_store = mock_typesense
+        docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
+
+        assert delete_conversation_index_doc(UID, CONVERSATION_ID) is True
+        assert docs_store == {}
+
+    def test_object_not_found_is_success(self, mock_typesense):
+        typesense_client, _ = mock_typesense
+
+        class ObjectNotFound(Exception):
+            pass
+
+        ObjectNotFound.__module__ = "typesense.exceptions"
+        failing_doc = MagicMock()
+        failing_doc.delete.side_effect = ObjectNotFound("not found")
+        typesense_client.collections.__getitem__.return_value.documents.__getitem__.side_effect = (
+            lambda doc_id: failing_doc
+        )
+
+        assert delete_conversation_index_doc(UID, "missing-conv") is True
+
+    def test_typesense_down_does_not_raise_on_delete(self, mock_typesense):
+        typesense_client, _ = mock_typesense
+        failing_doc = MagicMock()
+        failing_doc.delete.side_effect = Exception("timeout")
+        typesense_client.collections.__getitem__.return_value.documents.__getitem__.side_effect = (
+            lambda doc_id: failing_doc
+        )
+
+        assert delete_conversation_index_doc(UID, CONVERSATION_ID) is False
+
+    def test_unconfigured_typesense_is_a_silent_noop(self, monkeypatch):
+        monkeypatch.delenv("TYPESENSE_HOST", raising=False)
+        monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
+
+        with patch.object(typesense_index, "_typesense_client", side_effect=AssertionError("client constructed")):
+            assert delete_conversation_index_doc(UID, CONVERSATION_ID) is False
+
+
+class TestPurge:
+    def test_purge_deletes_all_user_documents(self, mock_typesense):
+        _, docs_store = mock_typesense
+        docs_store.update(
+            {
+                "c1": {"id": "c1", "userId": UID},
+                "c2": {"id": "c2", "userId": UID},
+                "other": {"id": "other", "userId": "someone-else"},
+            }
+        )
+
+        assert purge_user_conversation_index(UID) == 2
+        assert set(docs_store) == {"other"}
+
+    def test_purge_raises_when_required(self, mock_typesense):
+        typesense_client, _ = mock_typesense
+        typesense_client.collections.__getitem__.return_value.documents.delete.side_effect = Exception("typesense down")
+
+        with pytest.raises(Exception, match="typesense down"):
+            purge_user_conversation_index(UID, raise_on_failure=True)
+
+    def test_purge_is_silent_noop_when_unconfigured(self, monkeypatch):
+        monkeypatch.delenv("TYPESENSE_HOST", raising=False)
+        monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
+
+        assert purge_user_conversation_index(UID) == 0
+
+
+class TestConversationWriteWiring:
+    """The durable write paths must converge the index and must never leak a
+    Typesense failure into the caller (SCA-452 fail-open requirement)."""
+
+    @pytest.fixture
+    def conversations_db(self, monkeypatch: pytest.MonkeyPatch):
+        # conversations_db is imported at module scope on purpose: binding the
+        # real module object at collection time keeps this suite independent of
+        # import-order games other test modules play with sys.modules.
+        index = MagicMock()
+        monkeypatch.setattr(conversations_db, "conversation_typesense_index", index)
+
+        conversation_ref = MagicMock()
+        conversation_ref.get.return_value = MagicMock(
+            exists=True, to_dict=lambda: {"data_protection_level": "standard"}
+        )
+        conversation_ref.collections.return_value = []
+        db = MagicMock()
+        db.collection.return_value.document.return_value.collection.return_value.document.return_value = (
+            conversation_ref
+        )
+        monkeypatch.setattr(conversations_db, "db", db)
+        return conversations_db, index, conversation_ref
+
+    def test_discard_marks_and_syncs(self, conversations_db):
+        module, index, _ = conversations_db
+
+        module.set_conversation_as_discarded(UID, CONVERSATION_ID)
+
+        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_restore_marks_and_syncs(self, conversations_db):
+        module, index, _ = conversations_db
+
+        module.restore_conversation_from_discarded(UID, CONVERSATION_ID)
+
+        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_title_edit_syncs(self, conversations_db):
+        module, index, _ = conversations_db
+
+        module.update_conversation_title(UID, CONVERSATION_ID, "Renamed")
+
+        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_delete_removes_from_index(self, conversations_db):
+        module, index, _ = conversations_db
+
+        module.delete_conversation(UID, CONVERSATION_ID)
+
+        index.delete_conversation_index_doc.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_structured_update_syncs(self, conversations_db):
+        module, index, _ = conversations_db
+
+        assert module.update_conversation(UID, CONVERSATION_ID, {"structured.title": "New"}) is True
+
+        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_non_search_update_does_not_sync(self, conversations_db):
+        module, index, _ = conversations_db
+
+        assert module.update_conversation(UID, CONVERSATION_ID, {"starred": True}) is True
+
+        index.sync_conversation_index_after_write.assert_not_called()
+
+    def test_typesense_outage_does_not_raise_out_of_write_paths(self, monkeypatch: pytest.MonkeyPatch):
+        """The real fail-open path: every Typesense call fails, and neither the
+        discard update nor the delete may raise or skip its Firestore write."""
+
+        conversation_ref = MagicMock()
+        conversation_ref.get.return_value = MagicMock(
+            exists=True, to_dict=lambda: {"data_protection_level": "standard"}
+        )
+        conversation_ref.collections.return_value = []
+        db = MagicMock()
+        db.collection.return_value.document.return_value.collection.return_value.document.return_value = (
+            conversation_ref
+        )
+        monkeypatch.setattr(conversations_db, "db", db)
+        monkeypatch.setenv("TYPESENSE_HOST", "localhost")
+        monkeypatch.setenv("TYPESENSE_API_KEY", "test-key-not-real")
+        monkeypatch.delenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, raising=False)
+
+        broken_client = MagicMock()
+        broken_client.collections.__getitem__.return_value.documents.upsert.side_effect = Exception("typesense down")
+        broken_client.collections.__getitem__.return_value.documents.__getitem__.side_effect = Exception(
+            "typesense down"
+        )
+        monkeypatch.setattr(typesense_index, "_typesense_client", lambda: broken_client)
+        monkeypatch.setattr(typesense_index, "default_db_client", _policy_db())
+
+        conversations_db.set_conversation_as_discarded(UID, CONVERSATION_ID)
+        conversations_db.delete_conversation(UID, CONVERSATION_ID)
+
+        # The Firestore writes themselves still landed.
+        assert conversation_ref.update.called
+        assert conversation_ref.delete.called

--- a/backend/tests/unit/test_conversation_typesense_index.py
+++ b/backend/tests/unit/test_conversation_typesense_index.py
@@ -1,30 +1,38 @@
 """First-party conversation Typesense projection — payload, gating, fail-open.
 
-Covers the contract from SCA-452:
+Covers the contract from SCA-452 (round 2):
 - upsert payload shape matches the `conversations` collection schema the
   Firebase extension created and `utils.conversations.search` queries;
 - ``transcript_segments`` / speaker fields can never reach Typesense;
-- e2ee accounts are skipped by deleting any previously indexed document;
-- Typesense being down never raises out of the conversation write paths;
-- account-deletion purge is filter-based and fail-closed when required.
+- e2ee accounts are skipped by deleting any previously indexed document —
+  and the kill switch disables upserts, never these privacy deletes;
+- the Firestore document path is the index key (a stale stored ``id`` loses);
+- a required purge fails loudly when Typesense is unconfigured;
+- Typesense being down never raises out of any conversation write path;
+- every durable write/delete choke point converges the index, including the
+  AlreadyExists branch, the absent-owner processor result, failed-finalization
+  discard, dead-letter bypasses, and empty-recording deletion.
 """
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import os
+
 os.environ.setdefault(
     "ENCRYPTION_SECRET",
     "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
 )
-os.environ.setdefault("TYPESENSE_HOST", "localhost")
-os.environ.setdefault("TYPESENSE_HOST_PORT", "8108")
-os.environ.setdefault("TYPESENSE_API_KEY", "test-key-not-real")
+# No module-scope TYPESENSE env on purpose: it leaks process-wide and flips
+# other suites' account-deletion wipes into real Typesense network attempts
+# (round-2 regression). Each test sets the env it needs via `index_env`.
 
+from database import conversations as conversations_db
+from utils.conversations import lifecycle as conversations_lifecycle
 from utils.conversations import typesense_index
 from utils.conversations.typesense_index import (
     build_conversation_index_document,
@@ -33,7 +41,6 @@ from utils.conversations.typesense_index import (
     purge_user_conversation_index,
     sync_conversation_index_after_write,
 )
-from database import conversations as conversations_db
 
 UID = "uid-conv-typesense"
 CONVERSATION_ID = "conv-1"
@@ -108,6 +115,15 @@ def _firestore_with_doc(doc: dict | None) -> MagicMock:
     return client
 
 
+class _Snapshot:
+    def __init__(self, data):
+        self.exists = data is not None
+        self._data = data
+
+    def to_dict(self):
+        return self._data
+
+
 @pytest.fixture
 def index_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("TYPESENSE_HOST", "localhost")
@@ -116,13 +132,46 @@ def index_env(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def mock_typesense():
+def mock_typesense(index_env):
     typesense_client, docs_store = _fake_typesense()
     with (
         patch.object(typesense_index, "_typesense_client", return_value=typesense_client),
-        patch.object(typesense_index, "default_db_client", _policy_db()),
+        patch.object(typesense_index, "_resolve_default_db_client", return_value=_policy_db()),
     ):
         yield typesense_client, docs_store
+
+
+class _Ref:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+        self.written = None
+
+    def get(self, transaction=None, field_paths=None):
+        return self._snapshot
+
+    def update(self, data=None, **kwargs):
+        self.written = data
+
+    def create(self, data):
+        if self.written == "EXISTS":
+            from google.api_core.exceptions import AlreadyExists
+
+            raise AlreadyExists("conflict")
+        self.written = data
+
+    def delete(self):
+        self.written = "DELETED"
+
+    def collections(self):
+        return []
+
+
+class _Transaction:
+    def set(self, ref, data, merge=False):
+        ref.written = data
+
+    def update(self, ref, data):
+        ref.written = data
 
 
 class TestDocumentShape:
@@ -226,7 +275,31 @@ class TestSync:
         assert set(docs_store[CONVERSATION_ID]) == ALLOWED_FIELDS
         typesense_client.collections.__getitem__.assert_called_with("conversations")
 
-    def test_sync_skips_when_disabled(self, index_env, monkeypatch, mock_typesense):
+    def test_firestore_path_is_the_index_key_not_a_stale_stored_id(self, index_env, mock_typesense):
+        _, docs_store = mock_typesense
+        stale = _conversation_data()
+        stale["id"] = "wrong-stale-id"
+        firestore = _firestore_with_doc(stale)
+
+        assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
+
+        assert set(docs_store) == {CONVERSATION_ID}
+        assert docs_store[CONVERSATION_ID]["id"] == CONVERSATION_ID
+
+    def test_unconfigured_typesense_skips_without_any_io(self, monkeypatch):
+        """No shared Typesense env means no index exists: skip before any
+        Firestore policy read or Typesense client construction (hermetic
+        harnesses depend on this being zero-I/O)."""
+        monkeypatch.delenv("TYPESENSE_HOST", raising=False)
+        monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
+
+        with (
+            patch.object(typesense_index, "_resolve_default_db_client", side_effect=AssertionError("policy read")),
+            patch.object(typesense_index, "_typesense_client", side_effect=AssertionError("client")),
+        ):
+            assert sync_conversation_index_after_write(UID, CONVERSATION_ID) is False
+
+    def test_sync_skips_upserts_when_disabled(self, index_env, monkeypatch, mock_typesense):
         typesense_client, _ = mock_typesense
         monkeypatch.setenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, "0")
         firestore = _firestore_with_doc(_conversation_data())
@@ -235,12 +308,25 @@ class TestSync:
 
         typesense_client.collections.__getitem__.return_value.documents.upsert.assert_not_called()
 
+    def test_kill_switch_still_runs_e2ee_delete(self, index_env, monkeypatch, mock_typesense):
+        """Disabling upserts must not disable privacy cleanup (cubic P1)."""
+        typesense_client, docs_store = mock_typesense
+        monkeypatch.setenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, "0")
+        docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
+        firestore = _firestore_with_doc(_conversation_data())
+
+        with patch.object(typesense_index, "_resolve_default_db_client", return_value=_policy_db(level="e2ee")):
+            assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
+
+        assert docs_store == {}
+        typesense_client.collections.__getitem__.return_value.documents.upsert.assert_not_called()
+
     def test_e2ee_user_deletes_instead_of_upserting(self, index_env, mock_typesense):
         typesense_client, docs_store = mock_typesense
         docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
         firestore = _firestore_with_doc(_conversation_data())
 
-        with patch.object(typesense_index, "default_db_client", _policy_db(level="e2ee")):
+        with patch.object(typesense_index, "_resolve_default_db_client", return_value=_policy_db(level="e2ee")):
             assert sync_conversation_index_after_write(UID, CONVERSATION_ID, firestore_client=firestore) is True
 
         assert docs_store == {}
@@ -285,6 +371,14 @@ class TestSync:
 
 class TestDelete:
     def test_delete_removes_by_conversation_id(self, mock_typesense):
+        _, docs_store = mock_typesense
+        docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
+
+        assert delete_conversation_index_doc(UID, CONVERSATION_ID) is True
+        assert docs_store == {}
+
+    def test_delete_ignores_the_kill_switch(self, mock_typesense, monkeypatch):
+        monkeypatch.setenv(typesense_index.CONVERSATION_INDEX_WRITES_ENV, "0")
         _, docs_store = mock_typesense
         docs_store[CONVERSATION_ID] = {"id": CONVERSATION_ID, "userId": UID}
 
@@ -345,6 +439,14 @@ class TestPurge:
         with pytest.raises(Exception, match="typesense down"):
             purge_user_conversation_index(UID, raise_on_failure=True)
 
+    def test_required_purge_raises_when_typesense_unconfigured(self, monkeypatch):
+        """A required purge must not report silent success (cubic P1)."""
+        monkeypatch.delenv("TYPESENSE_HOST", raising=False)
+        monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="not configured"):
+            purge_user_conversation_index(UID, raise_on_failure=True)
+
     def test_purge_is_silent_noop_when_unconfigured(self, monkeypatch):
         monkeypatch.delenv("TYPESENSE_HOST", raising=False)
         monkeypatch.delenv("TYPESENSE_API_KEY", raising=False)
@@ -353,80 +455,208 @@ class TestPurge:
 
 
 class TestConversationWriteWiring:
-    """The durable write paths must converge the index and must never leak a
+    """Every durable write path must converge the index and must never leak a
     Typesense failure into the caller (SCA-452 fail-open requirement)."""
 
     @pytest.fixture
-    def conversations_db(self, monkeypatch: pytest.MonkeyPatch):
+    def wired(self, monkeypatch: pytest.MonkeyPatch):
+        """Patch the hook seam: the DB layer lazy-imports these functions from
+        ``utils.conversations.typesense_index`` at call time, so patching the
+        module attributes intercepts every hook."""
         # conversations_db is imported at module scope on purpose: binding the
         # real module object at collection time keeps this suite independent of
         # import-order games other test modules play with sys.modules.
-        index = MagicMock()
-        monkeypatch.setattr(conversations_db, "conversation_typesense_index", index)
+        sync = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(typesense_index, "sync_conversation_index_after_write", sync)
+        monkeypatch.setattr(typesense_index, "delete_conversation_index_doc", delete)
 
-        conversation_ref = MagicMock()
-        conversation_ref.get.return_value = MagicMock(
-            exists=True, to_dict=lambda: {"data_protection_level": "standard"}
-        )
-        conversation_ref.collections.return_value = []
+        conversation_ref = _Ref(_Snapshot({"data_protection_level": "standard"}))
         db = MagicMock()
         db.collection.return_value.document.return_value.collection.return_value.document.return_value = (
             conversation_ref
         )
+        db.transaction.return_value = _Transaction()
         monkeypatch.setattr(conversations_db, "db", db)
-        return conversations_db, index, conversation_ref
+        monkeypatch.setattr(conversations_db.firestore, "transactional", lambda fn: fn)
+        return sync, delete, conversation_ref
 
-    def test_discard_marks_and_syncs(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_discard_marks_and_syncs(self, wired):
+        sync, _, _ = wired
 
-        module.set_conversation_as_discarded(UID, CONVERSATION_ID)
+        conversations_db.set_conversation_as_discarded(UID, CONVERSATION_ID)
 
-        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
 
-    def test_restore_marks_and_syncs(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_restore_marks_and_syncs(self, wired):
+        sync, _, _ = wired
 
-        module.restore_conversation_from_discarded(UID, CONVERSATION_ID)
+        conversations_db.restore_conversation_from_discarded(UID, CONVERSATION_ID)
 
-        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
 
-    def test_title_edit_syncs(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_title_edit_syncs(self, wired):
+        sync, _, _ = wired
 
-        module.update_conversation_title(UID, CONVERSATION_ID, "Renamed")
+        conversations_db.update_conversation_title(UID, CONVERSATION_ID, "Renamed")
 
-        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
 
-    def test_delete_removes_from_index(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_summary_overview_edit_syncs(self, wired):
+        sync, _, _ = wired
 
-        module.delete_conversation(UID, CONVERSATION_ID)
+        assert conversations_db.update_conversation_summary(UID, CONVERSATION_ID, None, "New overview") == "ok"
 
-        index.delete_conversation_index_doc.assert_called_once_with(UID, CONVERSATION_ID)
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
 
-    def test_structured_update_syncs(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_summary_app_result_edit_does_not_sync(self, wired):
+        sync, _, _ = wired
 
-        assert module.update_conversation(UID, CONVERSATION_ID, {"structured.title": "New"}) is True
+        result = conversations_db.update_conversation_summary(UID, CONVERSATION_ID, "missing-app", "content")
 
-        index.sync_conversation_index_after_write.assert_called_once_with(UID, CONVERSATION_ID)
+        assert result == "app_result_not_found"
+        sync.assert_not_called()
 
-    def test_non_search_update_does_not_sync(self, conversations_db):
-        module, index, _ = conversations_db
+    def test_finished_at_update_syncs(self, wired):
+        sync, _, _ = wired
 
-        assert module.update_conversation(UID, CONVERSATION_ID, {"starred": True}) is True
+        conversations_db.update_conversation_finished_at(
+            UID, CONVERSATION_ID, datetime(2026, 9, 5, 12, 5, 0, tzinfo=timezone.utc)
+        )
 
-        index.sync_conversation_index_after_write.assert_not_called()
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
 
+    def test_delete_removes_from_index(self, wired):
+        _, delete, _ = wired
+
+        conversations_db.delete_conversation(UID, CONVERSATION_ID)
+
+        delete.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_structured_update_syncs(self, wired):
+        sync, _, _ = wired
+
+        assert conversations_db.update_conversation(UID, CONVERSATION_ID, {"structured.title": "New"}) is True
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_non_search_update_does_not_sync(self, wired):
+        sync, _, _ = wired
+
+        assert conversations_db.update_conversation(UID, CONVERSATION_ID, {"starred": True}) is True
+
+        sync.assert_not_called()
+
+    def test_upsert_with_lifecycle_syncs(self, wired):
+        sync, _, _ = wired
+
+        conversations_db.upsert_conversation_with_lifecycle(UID, {"id": CONVERSATION_ID, "status": "in_progress"})
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_create_if_absent_syncs_on_create(self, wired):
+        sync, _, _ = wired
+
+        assert conversations_db.create_conversation_if_absent_with_lifecycle(UID, {"id": CONVERSATION_ID}) is True
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_create_if_absent_syncs_on_already_exists(self, wired):
+        sync, _, ref = wired
+        ref.written = "EXISTS"  # _Ref.create raises AlreadyExists
+
+        assert conversations_db.create_conversation_if_absent_with_lifecycle(UID, {"id": CONVERSATION_ID}) is False
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_persist_processing_result_syncs_for_present_owner(self, wired):
+        sync, _, _ = wired
+
+        assert conversations_db.persist_processing_result_with_lifecycle(UID, {"id": CONVERSATION_ID}) is True
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_persist_processing_result_deletes_for_absent_owner(self, wired):
+        sync, delete, ref = wired
+        ref._snapshot = _Snapshot(None)
+
+        assert conversations_db.persist_processing_result_with_lifecycle(UID, {"id": CONVERSATION_ID}) is False
+
+        sync.assert_not_called()
+        delete.assert_called_once_with(UID, CONVERSATION_ID)
+
+
+class TestLifecycleWiring:
+    """Paths that mutate conversations outside the conversations_db hooks."""
+
+    @pytest.fixture
+    def wired_lifecycle(self, monkeypatch: pytest.MonkeyPatch):
+        sync = MagicMock()
+        delete = MagicMock()
+        monkeypatch.setattr(typesense_index, "sync_conversation_index_after_write", sync)
+        monkeypatch.setattr(typesense_index, "delete_conversation_index_doc", delete)
+        return sync, delete
+
+    def test_fail_and_discard_processing_syncs_when_claimed(self, wired_lifecycle, monkeypatch):
+        sync, _ = wired_lifecycle
+        monkeypatch.setattr(
+            conversations_lifecycle.conversations_db, "claim_conversation_status", MagicMock(return_value=True)
+        )
+
+        assert conversations_lifecycle.fail_and_discard_processing(UID, CONVERSATION_ID) is True
+
+        sync.assert_called_once_with(UID, CONVERSATION_ID)
+
+    def test_fail_and_discard_processing_skips_sync_when_fence_rejects(self, wired_lifecycle, monkeypatch):
+        sync, _ = wired_lifecycle
+        monkeypatch.setattr(
+            conversations_lifecycle.conversations_db, "claim_conversation_status", MagicMock(return_value=False)
+        )
+
+        assert conversations_lifecycle.fail_and_discard_processing(UID, CONVERSATION_ID) is False
+
+        sync.assert_not_called()
+
+    def test_delete_empty_recording_conversation_deletes_index_before_photo_cleanup(self, wired_lifecycle, monkeypatch):
+        _, delete = wired_lifecycle
+        order: list[str] = []
+        delete.side_effect = lambda uid, cid: order.append("index_delete")
+        monkeypatch.setattr(
+            conversations_lifecycle.recording_sessions_db,
+            "tombstone_and_delete_empty_conversation",
+            MagicMock(return_value=True),
+        )
+        photos = MagicMock(side_effect=lambda *a: order.append("photos"))
+        monkeypatch.setattr(conversations_lifecycle.conversations_db, "delete_conversation_photos", photos)
+        monkeypatch.setattr(
+            conversations_lifecycle,
+            "_discard_unreferenced_audio",
+            MagicMock(side_effect=lambda *a: order.append("audio")),
+        )
+
+        assert conversations_lifecycle.delete_empty_recording_conversation(UID, CONVERSATION_ID, "session-1") is True
+
+        delete.assert_called_once_with(UID, CONVERSATION_ID)
+        assert order == ["index_delete", "photos", "audio"]
+
+    def test_delete_empty_recording_conversation_noop_when_not_deleted(self, wired_lifecycle, monkeypatch):
+        _, delete = wired_lifecycle
+        monkeypatch.setattr(
+            conversations_lifecycle.recording_sessions_db,
+            "tombstone_and_delete_empty_conversation",
+            MagicMock(return_value=False),
+        )
+
+        assert conversations_lifecycle.delete_empty_recording_conversation(UID, CONVERSATION_ID, "session-1") is False
+
+        delete.assert_not_called()
+
+
+class TestFailOpenWiring:
     def test_typesense_outage_does_not_raise_out_of_write_paths(self, monkeypatch: pytest.MonkeyPatch):
         """The real fail-open path: every Typesense call fails, and neither the
         discard update nor the delete may raise or skip its Firestore write."""
-
-        conversation_ref = MagicMock()
-        conversation_ref.get.return_value = MagicMock(
-            exists=True, to_dict=lambda: {"data_protection_level": "standard"}
-        )
-        conversation_ref.collections.return_value = []
+        conversation_ref = _Ref(_Snapshot({"data_protection_level": "standard"}))
         db = MagicMock()
         db.collection.return_value.document.return_value.collection.return_value.document.return_value = (
             conversation_ref
@@ -442,11 +672,36 @@ class TestConversationWriteWiring:
             "typesense down"
         )
         monkeypatch.setattr(typesense_index, "_typesense_client", lambda: broken_client)
-        monkeypatch.setattr(typesense_index, "default_db_client", _policy_db())
+        monkeypatch.setattr(typesense_index, "_resolve_default_db_client", lambda: _policy_db())
 
         conversations_db.set_conversation_as_discarded(UID, CONVERSATION_ID)
         conversations_db.delete_conversation(UID, CONVERSATION_ID)
 
         # The Firestore writes themselves still landed.
-        assert conversation_ref.update.called
-        assert conversation_ref.delete.called
+        assert conversation_ref.written == "DELETED"
+
+    def test_lazy_import_failure_does_not_raise_out_of_write_paths(self, monkeypatch: pytest.MonkeyPatch):
+        """The round-one CI regression: a harness where utils.conversations is
+        unavailable must not break the durable write paths."""
+        import builtins
+
+        conversation_ref = _Ref(_Snapshot({"data_protection_level": "standard"}))
+        db = MagicMock()
+        db.collection.return_value.document.return_value.collection.return_value.document.return_value = (
+            conversation_ref
+        )
+        monkeypatch.setattr(conversations_db, "db", db)
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "utils.conversations.typesense_index":
+                raise ImportError("cannot import name 'typesense_index' from 'utils.conversations'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+        conversations_db.set_conversation_as_discarded(UID, CONVERSATION_ID)
+        conversations_db.delete_conversation(UID, CONVERSATION_ID)
+
+        assert conversation_ref.written == "DELETED"

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -62,6 +62,8 @@ def users_service():
         "utils.retrieval": _pkg("utils.retrieval"),
         "utils.retrieval.frame_request_storage": AutoMockModule("utils.retrieval.frame_request_storage"),
         "utils.twilio_service": AutoMockModule("utils.twilio_service"),
+        "utils.conversations": _pkg("utils.conversations"),
+        "utils.conversations.typesense_index": AutoMockModule("utils.conversations.typesense_index"),
     }
     with stub_modules(fakes):
         module = load_module_fresh(

--- a/backend/tests/unit/test_delete_account_purge_storage.py
+++ b/backend/tests/unit/test_delete_account_purge_storage.py
@@ -62,8 +62,6 @@ def users_service():
         "utils.retrieval": _pkg("utils.retrieval"),
         "utils.retrieval.frame_request_storage": AutoMockModule("utils.retrieval.frame_request_storage"),
         "utils.twilio_service": AutoMockModule("utils.twilio_service"),
-        "utils.conversations": _pkg("utils.conversations"),
-        "utils.conversations.typesense_index": AutoMockModule("utils.conversations.typesense_index"),
     }
     with stub_modules(fakes):
         module = load_module_fresh(

--- a/backend/utils/conversations/ARCHITECTURE.md
+++ b/backend/utils/conversations/ARCHITECTURE.md
@@ -28,6 +28,13 @@ and background processing.
 - `meeting_receipt.py` is the sole writer of the final meeting verdict. It
   records reason and measured inputs on the finalization job, projects the
   verdict to the conversation, and attaches the deterministic Chat intent.
+- `typesense_index.py` owns the first-party Typesense projection of the
+  durable conversation store. It is called fail-open from the conversation
+  write/delete choke points (`database/conversations.py` durable mutations,
+  `lifecycle.delete_empty_recording_conversation`, and the account-deletion
+  purge), never from routers. Dual-writes on top of the still-installed
+  Firebase extension `firestore-typesense-conversations`; the extension is
+  removed only after this writer has baked (see the module runbook note).
 - The old orphaned WAV retranscription util (`postprocess_conversation.py`) was
   removed: the historical Flutter upload (`memoryPostProcessing`) and
   `POST /v1/memories/{id}/post-processing` router were removed and nothing

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -34,7 +34,6 @@ from utils.conversations.finalization_decision import (
 )
 from utils.observability.fallback import record_fallback
 from utils.other.storage import delete_conversation_audio_files
-from utils.conversations.typesense_index import delete_conversation_index_doc
 from utils.journey_metrics_contract import bounded_client_kind
 from utils.observability.journeys import record_client_journey_accepted, record_journey_accepted
 
@@ -354,13 +353,23 @@ def fail_and_discard_processing(uid: str, conversation_id: str) -> bool:
     processing. The compare-and-swap fences a stale worker from hiding a newer
     or already-completed generation.
     """
-    return conversations_db.claim_conversation_status(
+    claimed = conversations_db.claim_conversation_status(
         uid,
         conversation_id,
         ConversationStatus.processing,
         ConversationStatus.failed,
         extra_updates={'discarded': True},
     )
+    if claimed:
+        # This path flips `discarded` outside update_conversation /
+        # set_conversation_as_discarded, so their index hooks never run.
+        try:
+            from utils.conversations.typesense_index import sync_conversation_index_after_write
+
+            sync_conversation_index_after_write(uid, conversation_id)
+        except Exception:
+            logger.warning('failed-finalization Typesense sync failed uid=%s conversation_id=%s', uid, conversation_id)
+    return claimed
 
 
 def reacquire_deferred_processing(uid: str, conversation_id: str) -> bool:
@@ -571,14 +580,21 @@ def delete_empty_recording_conversation(
         deleted_conversation=deleted_conversation,
     )
     if deleted:
+        # Remove the search projection before photo/audio cleanup: a later
+        # cleanup failure must not leave the deleted conversation indexed.
+        # This path deletes the Firestore row in its own transaction inside
+        # recording_sessions_db, so conversations_db.delete_conversation's
+        # index cleanup never runs.
+        try:
+            from utils.conversations.typesense_index import delete_conversation_index_doc
+
+            delete_conversation_index_doc(uid, conversation_id)
+        except Exception:
+            logger.warning('empty-recording Typesense delete failed uid=%s conversation_id=%s', uid, conversation_id)
         # Parent deletion is transactionally fenced with content writes; photos
         # are a subcollection and need their physical cleanup afterwards.
         conversations_db.delete_conversation_photos(uid, conversation_id)
         _discard_unreferenced_audio(uid, conversation_id, deleted_conversation)
-        # This path deletes the Firestore row in its own transaction inside
-        # recording_sessions_db, so conversations_db.delete_conversation's
-        # index cleanup never runs; converge the search index here instead.
-        delete_conversation_index_doc(uid, conversation_id)
     return deleted
 
 

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -34,6 +34,7 @@ from utils.conversations.finalization_decision import (
 )
 from utils.observability.fallback import record_fallback
 from utils.other.storage import delete_conversation_audio_files
+from utils.conversations.typesense_index import delete_conversation_index_doc
 from utils.journey_metrics_contract import bounded_client_kind
 from utils.observability.journeys import record_client_journey_accepted, record_journey_accepted
 
@@ -574,6 +575,10 @@ def delete_empty_recording_conversation(
         # are a subcollection and need their physical cleanup afterwards.
         conversations_db.delete_conversation_photos(uid, conversation_id)
         _discard_unreferenced_audio(uid, conversation_id, deleted_conversation)
+        # This path deletes the Firestore row in its own transaction inside
+        # recording_sessions_db, so conversations_db.delete_conversation's
+        # index cleanup never runs; converge the search index here instead.
+        delete_conversation_index_doc(uid, conversation_id)
     return deleted
 
 

--- a/backend/utils/conversations/typesense_index.py
+++ b/backend/utils/conversations/typesense_index.py
@@ -1,0 +1,352 @@
+"""First-party Typesense projection of the durable conversation store.
+
+Prod conversation search (`utils.conversations.search`) reads the Typesense
+``conversations`` collection. Writes to that collection historically came only
+from the Firebase extension ``typesense/firestore-typesense-search`` (instance
+``firestore-typesense-conversations``, Cloud Run
+``ext-firestore-typesense-conversations-indexonwrite``), which is not part of
+this monorepo. This module mirrors that pipe: every durable conversation
+write/delete now dual-writes the same projection from the backend, the same
+posture the memory keyword index (`utils.memory.atom_keyword_index`) already
+has for memories.
+
+Runbook: the Firebase extension is deliberately still installed and still
+indexing. This code dual-writes on top of it — documents are keyed by
+conversation id and upserted idempotently, so the two writers converge on the
+same content. Do NOT uninstall or disable ``firestore-typesense-conversations``
+here; removal is a follow-up ops step taken only after this first-party writer
+has baked in prod and its coverage has been verified against the extension's
+documents.
+
+Field contract — must match what search already queries and what the extension
+indexed: ``id, userId, created_at, started_at, finished_at, discarded,
+structured, geolocation``. ``transcript_segments`` and per-segment speaker
+fields are NOT part of the Typesense schema (Typesense rejects them with 400),
+so the projection is a strict allow-list: fields not named above can never
+reach Typesense through this module.
+
+E2EE accounts are skipped the same way the atom keyword index skips them, and
+a skip deletes any document previously indexed for that conversation so a
+policy change cannot leave plaintext readable.
+
+Everything here is fail-open: a Typesense or Firestore read error is logged,
+counted, and swallowed. Search indexing must never fail a durable
+conversation write.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, cast
+
+from prometheus_client import Counter
+
+from database._client import data_plane_db as default_db_client
+from database._client import get_firestore_client
+
+logger = logging.getLogger(__name__)
+
+# The Typesense collection `utils.conversations.search` reads. Hardcoded on
+# purpose: an env override here would silently split reads from writes.
+CONVERSATION_TYPESENSE_COLLECTION = "conversations"
+
+# Optional kill switch. Unset (or any value other than the disabled set) means
+# "on whenever the shared Typesense env (TYPESENSE_HOST / TYPESENSE_API_KEY
+# already used by search) is configured", so dual-write starts in every
+# environment that can already search — no new secret is required.
+CONVERSATION_INDEX_WRITES_ENV = "TYPESENSE_CONVERSATION_INDEX_WRITES"
+_DISABLED_VALUES = frozenset({"0", "false", "off", "no"})
+
+# Firestore fields the projection carries. `userId` is derived from the document
+# path (as the extension derived it), not stored on the conversation document.
+_INDEXED_FIRESTORE_FIELDS = (
+    "id",
+    "structured",
+    "created_at",
+    "discarded",
+    "started_at",
+    "finished_at",
+    "geolocation",
+)
+
+CONVERSATION_TYPESENSE_INDEX_EVENTS = Counter(
+    "omi_conversation_typesense_index_events_total",
+    "First-party conversation Typesense projection outcomes by bounded event; never labeled by UID",
+    ["event"],
+)
+
+
+def _count(event: str) -> None:
+    CONVERSATION_TYPESENSE_INDEX_EVENTS.labels(event=event).inc()
+
+
+def _payload_or_empty(value: object) -> Dict[str, Any]:
+    return cast(Dict[str, Any], value) if isinstance(value, dict) else {}
+
+
+def _typesense_filter_literal(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("`", "\\`")
+    return f"`{escaped}`"
+
+
+def _typesense_client() -> Any:
+    # Local import mirrors utils.memory.atom_keyword_index: the shared lazy
+    # client seam in utils.conversations.search, which tests replace.
+    from utils.conversations.search import client
+
+    return client
+
+
+def _is_object_not_found(exc: BaseException) -> bool:
+    try:
+        from typesense.exceptions import ObjectNotFound
+    except ImportError:
+        object_not_found_type: Optional[type] = None
+    else:
+        object_not_found_type = ObjectNotFound
+    if object_not_found_type is not None and isinstance(exc, object_not_found_type):
+        return True
+    # Lightweight runtimes and tests provide only a top-level `typesense`
+    # placeholder without the exceptions module.
+    return type(exc).__module__.endswith("exceptions") and type(exc).__name__ == "ObjectNotFound"
+
+
+def typesense_configured() -> bool:
+    """Return True when the shared Typesense env vars are present."""
+    return bool(os.getenv("TYPESENSE_HOST") and os.getenv("TYPESENSE_API_KEY"))
+
+
+def conversation_index_writes_enabled() -> bool:
+    """Return whether first-party conversation index writes should run.
+
+    Default on whenever the shared Typesense env is configured (the same env
+    search already requires), so dual-write begins in every environment that
+    can already serve conversation search. ``TYPESENSE_CONVERSATION_INDEX_WRITES``
+    is an explicit kill switch for that default.
+    """
+    if not typesense_configured():
+        return False
+    override = os.getenv(CONVERSATION_INDEX_WRITES_ENV)
+    if override is None or not override.strip():
+        return True
+    return override.strip().lower() not in _DISABLED_VALUES
+
+
+def user_allows_conversation_index(uid: str, *, db_client: Any = None) -> bool:
+    """Return whether the account may use the conversation keyword projection.
+
+    Indexing remains opt-out for E2EE accounts, matching the atom keyword index
+    posture. There is no UID entitlement/cohort branch.
+    """
+    if not uid or not uid.strip():
+        return False
+    client = db_client if db_client is not None else default_db_client
+    user_doc: Any = client.document(f"users/{uid}").get()
+    user_data = _payload_or_empty(user_doc.to_dict() if getattr(user_doc, "exists", False) else {})
+    return user_data.get("data_protection_level", "enhanced") != "e2ee"
+
+
+def _epoch_seconds(value: object) -> Optional[int]:
+    """Coerce a stored timestamp to unix seconds; None when not derivable."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, datetime):
+        moment = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return int(moment.timestamp())
+    if isinstance(value, (int, float)):
+        return int(value)
+    return None
+
+
+def _geolocation_point(value: object) -> Optional[list[float]]:
+    """Coerce a stored geolocation to the Typesense ``[lat, lng]`` shape."""
+    latitude: object = getattr(value, "latitude", None)
+    longitude: object = getattr(value, "longitude", None)
+    if latitude is None and longitude is None and isinstance(value, dict):
+        latitude = value.get("latitude")
+        longitude = value.get("longitude")
+    if isinstance(latitude, bool) or isinstance(longitude, bool):
+        return None
+    if isinstance(latitude, (int, float)) and isinstance(longitude, (int, float)):
+        return [float(latitude), float(longitude)]
+    return None
+
+
+def build_conversation_index_document(uid: str, conversation_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build the Typesense document for one conversation, or None when unindexable.
+
+    Strict allow-list: only the fields the ``conversations`` collection schema
+    declares ever leave this function. ``transcript_segments``, speaker fields,
+    photos, and app results cannot be indexed because they are never read.
+    """
+    conversation_id = str(conversation_data.get("id") or "").strip()
+    created_at = _epoch_seconds(conversation_data.get("created_at"))
+    if not conversation_id or created_at is None:
+        # `created_at` is the collection's default sorting field; a document
+        # without it cannot serve the search sort contract.
+        return None
+    document: Dict[str, Any] = {
+        "id": conversation_id,
+        "userId": uid,
+        "created_at": created_at,
+        "discarded": bool(conversation_data.get("discarded", False)),
+    }
+    started_at = _epoch_seconds(conversation_data.get("started_at"))
+    if started_at is not None:
+        document["started_at"] = started_at
+    finished_at = _epoch_seconds(conversation_data.get("finished_at"))
+    if finished_at is not None:
+        document["finished_at"] = finished_at
+    structured = conversation_data.get("structured")
+    if isinstance(structured, dict) and structured:
+        document["structured"] = structured
+    geolocation = _geolocation_point(conversation_data.get("geolocation"))
+    if geolocation is not None:
+        document["geolocation"] = geolocation
+    return document
+
+
+def _fetch_index_projection(
+    uid: str, conversation_id: str, *, firestore_client: Any = None
+) -> Optional[Dict[str, Any]]:
+    """Read only the indexed fields of one conversation document.
+
+    The extension re-synced the whole Firestore document on every write; this
+    is the bounded equivalent. Returns None when the document is gone, which
+    routes the caller to an index delete (write-after-delete self-healing).
+    """
+    client = firestore_client if firestore_client is not None else get_firestore_client()
+    snapshot = (
+        client.collection("users")
+        .document(uid)
+        .collection(CONVERSATION_TYPESENSE_COLLECTION)
+        .document(conversation_id)
+        .get(field_paths=list(_INDEXED_FIRESTORE_FIELDS))
+    )
+    if not getattr(snapshot, "exists", False):
+        return None
+    data = _payload_or_empty(snapshot.to_dict())
+    data.setdefault("id", conversation_id)
+    return data
+
+
+def delete_conversation_index_doc(uid: str, conversation_id: str) -> bool:
+    """Remove one conversation from the index; ObjectNotFound counts as done.
+
+    Deliberately not gated on the write flag or the user policy: deletes are
+    privacy hygiene and must keep flowing when dual-writes are disabled.
+    """
+    if not uid or not conversation_id:
+        return False
+    if not typesense_configured():
+        return False
+    try:
+        _typesense_client().collections[CONVERSATION_TYPESENSE_COLLECTION].documents[conversation_id].delete()
+        _count("deleted")
+        return True
+    except Exception as exc:
+        if _is_object_not_found(exc):
+            _count("deleted")
+            return True
+        _count("error")
+        logger.warning("conversation Typesense delete failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
+        return False
+
+
+def _sync_conversation_index_after_write(
+    uid: str,
+    conversation_id: str,
+    *,
+    firestore_client: Any = None,
+    db_client: Any = None,
+) -> bool:
+    if not conversation_index_writes_enabled():
+        _count("skipped_disabled")
+        return False
+    if not user_allows_conversation_index(uid, db_client=db_client):
+        # A policy change can revoke eligibility after this conversation was
+        # indexed (by this writer or by the extension). Exact deletion is
+        # therefore required; a no-op would leave the prior document readable.
+        _count("skipped_e2ee")
+        return delete_conversation_index_doc(uid, conversation_id)
+    try:
+        data = _fetch_index_projection(uid, conversation_id, firestore_client=firestore_client)
+    except Exception as exc:
+        _count("error")
+        logger.warning(
+            "conversation Typesense projection read failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc
+        )
+        return False
+    if data is None:
+        # The Firestore document is gone (deleted since the write that queued
+        # this sync); converge the index to absence instead of upserting stale
+        # content — the race the extension's delete trigger otherwise covered.
+        return delete_conversation_index_doc(uid, conversation_id)
+    document = build_conversation_index_document(uid, data)
+    if document is None:
+        _count("skipped_invalid")
+        logger.warning(
+            "conversation Typesense projection dropped unindexable document uid=%s conversation_id=%s",
+            uid,
+            conversation_id,
+        )
+        return False
+    try:
+        _typesense_client().collections[CONVERSATION_TYPESENSE_COLLECTION].documents.upsert(document)
+        _count("upserted")
+        return True
+    except Exception as exc:
+        _count("error")
+        logger.warning("conversation Typesense upsert failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
+        return False
+
+
+def sync_conversation_index_after_write(
+    uid: str,
+    conversation_id: str,
+    *,
+    firestore_client: Any = None,
+    db_client: Any = None,
+) -> bool:
+    """Converge the index to the durable state of one conversation after a write.
+
+    Fail-open by contract: this function never raises, so a Typesense outage
+    degrades search freshness, never the Firestore write that called it.
+    """
+    try:
+        return _sync_conversation_index_after_write(
+            uid, conversation_id, firestore_client=firestore_client, db_client=db_client
+        )
+    except Exception as exc:
+        _count("error")
+        logger.warning("conversation Typesense sync failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
+        return False
+
+
+def purge_user_conversation_index(uid: str, *, raise_on_failure: bool = False) -> int:
+    """Delete every indexed conversation for a user. Returns the deleted count.
+
+    Used by the account-deletion wipe. Filter-based, so it stays executable
+    even after the Firestore user document is gone.
+    """
+    if not uid:
+        return 0
+    if not typesense_configured():
+        return 0
+    try:
+        result = _payload_or_empty(
+            _typesense_client()
+            .collections[CONVERSATION_TYPESENSE_COLLECTION]
+            .documents.delete({"filter_by": f"userId:={_typesense_filter_literal(uid)}"})
+        )
+        deleted = int(result.get("num_deleted") or 0)
+        _count("purged")
+        return deleted
+    except Exception as exc:
+        _count("error")
+        logger.warning("purge_user_conversation_index failed uid=%s: %s", uid, exc)
+        if raise_on_failure:
+            raise
+        return 0

--- a/backend/utils/conversations/typesense_index.py
+++ b/backend/utils/conversations/typesense_index.py
@@ -32,6 +32,11 @@ policy change cannot leave plaintext readable.
 Everything here is fail-open: a Typesense or Firestore read error is logged,
 counted, and swallowed. Search indexing must never fail a durable
 conversation write.
+
+No per-conversation revision CAS or sync mutex guards these writes: the
+Firebase extension still owns production indexing and already races every
+first-party write, and Typesense upserts are idempotent per document id.
+Serialization is a follow-up for when the extension is removed.
 """
 
 from __future__ import annotations
@@ -43,10 +48,38 @@ from typing import Any, Dict, Optional, cast
 
 from prometheus_client import Counter
 
-from database._client import data_plane_db as default_db_client
-from database._client import get_firestore_client
-
 logger = logging.getLogger(__name__)
+
+
+def _resolve_default_db_client() -> Any:
+    # Lazy: `database._client` pulls google-cloud-firestore (~0.6s first-import
+    # CPU) that stub-loading test harnesses and Typesense-unconfigured runtimes
+    # must not pay. Tests patch this resolver to inject their policy client.
+    from database._client import data_plane_db as client
+
+    return client
+
+
+def _resolve_firestore_client() -> Any:
+    from database._client import get_firestore_client as client
+
+    return client
+
+
+def _record_fallback_helper(component: str, *, from_mode: str, to_mode: str, reason: str) -> None:
+    # Lazy: `utils.observability.fallback` pulls fastapi via utils.metrics
+    # (~1s first-import CPU) — error paths only.
+    from utils.observability.fallback import record_fallback
+
+    record_fallback(
+        component=component,
+        from_mode=from_mode,
+        to_mode=to_mode,
+        reason=reason,
+        outcome="degraded",
+        log=logger,
+    )
+
 
 # The Typesense collection `utils.conversations.search` reads. Hardcoded on
 # purpose: an env override here would silently split reads from writes.
@@ -80,6 +113,28 @@ CONVERSATION_TYPESENSE_INDEX_EVENTS = Counter(
 
 def _count(event: str) -> None:
     CONVERSATION_TYPESENSE_INDEX_EVENTS.labels(event=event).inc()
+
+
+_TRANSIENT_ERROR_MARKERS = (
+    "timed out",
+    "timeout",
+    "connection refused",
+    "connection reset",
+    "temporarily unavailable",
+    "service unavailable",
+)
+
+
+def _record_index_fallback(exc: BaseException) -> None:
+    """Fail-open telemetry per the shared fallback contract (`.github/agent-docs/fallback-telemetry.md`)."""
+    message = str(exc).lower()
+    reason = "timeout" if any(marker in message for marker in _TRANSIENT_ERROR_MARKERS) else "other"
+    _record_fallback_helper(
+        component="other",
+        from_mode="conversation_index_dual_write",
+        to_mode="fail_open",
+        reason=reason,
+    )
 
 
 def _payload_or_empty(value: object) -> Dict[str, Any]:
@@ -142,7 +197,7 @@ def user_allows_conversation_index(uid: str, *, db_client: Any = None) -> bool:
     """
     if not uid or not uid.strip():
         return False
-    client = db_client if db_client is not None else default_db_client
+    client = db_client if db_client is not None else _resolve_default_db_client()
     user_doc: Any = client.document(f"users/{uid}").get()
     user_data = _payload_or_empty(user_doc.to_dict() if getattr(user_doc, "exists", False) else {})
     return user_data.get("data_protection_level", "enhanced") != "e2ee"
@@ -217,7 +272,7 @@ def _fetch_index_projection(
     is the bounded equivalent. Returns None when the document is gone, which
     routes the caller to an index delete (write-after-delete self-healing).
     """
-    client = firestore_client if firestore_client is not None else get_firestore_client()
+    client = firestore_client if firestore_client is not None else _resolve_firestore_client()
     snapshot = (
         client.collection("users")
         .document(uid)
@@ -228,7 +283,7 @@ def _fetch_index_projection(
     if not getattr(snapshot, "exists", False):
         return None
     data = _payload_or_empty(snapshot.to_dict())
-    data.setdefault("id", conversation_id)
+    data["id"] = conversation_id
     return data
 
 
@@ -251,6 +306,7 @@ def delete_conversation_index_doc(uid: str, conversation_id: str) -> bool:
             _count("deleted")
             return True
         _count("error")
+        _record_index_fallback(exc)
         logger.warning("conversation Typesense delete failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
         return False
 
@@ -262,19 +318,28 @@ def _sync_conversation_index_after_write(
     firestore_client: Any = None,
     db_client: Any = None,
 ) -> bool:
-    if not conversation_index_writes_enabled():
-        _count("skipped_disabled")
+    if not typesense_configured():
+        # No shared Typesense env means no index can exist in this environment
+        # (the extension indexes the same env): skip before any Firestore or
+        # Typesense I/O. This is distinct from the kill switch below, which
+        # keeps privacy deletes flowing against an existing index.
+        _count("skipped_unconfigured")
         return False
     if not user_allows_conversation_index(uid, db_client=db_client):
         # A policy change can revoke eligibility after this conversation was
         # indexed (by this writer or by the extension). Exact deletion is
-        # therefore required; a no-op would leave the prior document readable.
+        # therefore required even when upserts are disabled: the kill switch
+        # stops indexing, not privacy cleanup.
         _count("skipped_e2ee")
         return delete_conversation_index_doc(uid, conversation_id)
+    if not conversation_index_writes_enabled():
+        _count("skipped_disabled")
+        return False
     try:
         data = _fetch_index_projection(uid, conversation_id, firestore_client=firestore_client)
     except Exception as exc:
         _count("error")
+        _record_index_fallback(exc)
         logger.warning(
             "conversation Typesense projection read failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc
         )
@@ -299,6 +364,7 @@ def _sync_conversation_index_after_write(
         return True
     except Exception as exc:
         _count("error")
+        _record_index_fallback(exc)
         logger.warning("conversation Typesense upsert failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
         return False
 
@@ -321,6 +387,7 @@ def sync_conversation_index_after_write(
         )
     except Exception as exc:
         _count("error")
+        _record_index_fallback(exc)
         logger.warning("conversation Typesense sync failed uid=%s conversation_id=%s: %s", uid, conversation_id, exc)
         return False
 
@@ -334,6 +401,10 @@ def purge_user_conversation_index(uid: str, *, raise_on_failure: bool = False) -
     if not uid:
         return 0
     if not typesense_configured():
+        # A required purge must not report silent success when it never
+        # reached the index; only best-effort callers accept the quiet 0.
+        if raise_on_failure:
+            raise RuntimeError("Typesense env is not configured; conversation index purge cannot be verified")
         return 0
     try:
         result = _payload_or_empty(
@@ -346,6 +417,7 @@ def purge_user_conversation_index(uid: str, *, raise_on_failure: bool = False) -
         return deleted
     except Exception as exc:
         _count("error")
+        _record_index_fallback(exc)
         logger.warning("purge_user_conversation_index failed uid=%s: %s", uid, exc)
         if raise_on_failure:
             raise


### PR DESCRIPTION
## Summary

Prod conversation search reads Typesense (`backend/utils/conversations/search.py`), but writes to the `conversations` collection come only from the Firebase extension `typesense/firestore-typesense-search` (instance `firestore-typesense-conversations`, Cloud Run `ext-firestore-typesense-conversations-indexonwrite`). That pipe lives outside the monorepo, its function image is wiped after 3 days, and Eventarc retries bill when it scales to zero — the 2026-09-05 emergency rebuild had to set `minInstances=1` as a stop-gap.

This PR makes the Omi backend own conversation index writes as a **fail-open search-index mirror** (not a new privacy fence), the same posture memories already have (`utils/memory/atom_keyword_index.py`):

- New `backend/utils/conversations/typesense_index.py`: strict allow-list projection (`id, userId, created_at, started_at, finished_at, discarded, structured, geolocation`) matching what search already queries and what the extension indexed. `transcript_segments`/speaker fields can never reach Typesense (they 400). E2EE accounts are skipped by deleting any previously indexed doc — and the kill switch disables upserts, never these privacy deletes. Fail-open everywhere: Typesense/read errors are logged, counted (`omi_conversation_typesense_index_events_total`), and reported through the shared `record_fallback` helper (`omi_fallback_total`); nothing raises into the write path. The Firestore document path is the index key (a stale stored `id` never wins), and a missing doc converges the index to absence (write-after-delete self-healing).
- Wired at the durable write choke points via **lazy in-function imports** (module-top imports of `utils.conversations.typesense_index` broke stub-loading test harnesses — round-one CI): `upsert_conversation_with_lifecycle`, `create_conversation_if_absent_with_lifecycle` (including the AlreadyExists branch), `persist_processing_result_with_lifecycle` (absent owner → index delete), `update_conversation` (only when the update touches a search-relevant field root), title/overview/finished_at updates, discard/restore, `delete_conversation`, `lifecycle.delete_empty_recording_conversation` (index delete runs before photo/audio cleanup), `lifecycle.fail_and_discard_processing`, and the finalization dead-letter terminal (`services/conversation_finalization.final_attempt_failed`).
- Account deletion: the Typesense purge is **best-effort, after the Firestore wipe** — account deletion must not fail closed on Typesense while the Firebase extension still owns production indexing. The purge stays userId-filter-based, so it remains executable and retryable post-wipe. `purge_user_conversation_index(..., raise_on_failure=True)` fails loudly when Typesense is unconfigured (for the future required posture); no caller uses it yet.
- Rollout: on by default wherever `TYPESENSE_HOST`/`TYPESENSE_API_KEY` — the env search already requires — are configured; kill switch `TYPESENSE_CONVERSATION_INDEX_WRITES=0|false|off|no` (documented in `backend/.env.template`). The hermetic e2e harness sets the kill switch because it runs no Typesense server: an enabled writer would block ~5s per durable conversation write on refused `localhost:8108` retries and blow the e2e timing budget.
- No per-conversation revision CAS or sync mutex, deliberately: the Firebase extension still owns production indexing and already races every first-party write, and Typesense upserts are idempotent per document id. Serialization is a documented follow-up for when the extension is removed. Note the same applies to a Typesense outage: with the shared client's retry behavior a failed call can cost seconds before failing open — the kill switch is the emergency lever, matching the atom keyword index's synchronous posture.

## Not in this PR

- The Firebase extension `firestore-typesense-conversations` stays installed and keeps indexing. Documents are keyed by conversation id and upserted idempotently, so the two writers converge. Uninstalling the extension (and dropping its `minInstances`) is a follow-up runbook step, taken only after this first-party writer has baked in prod and its coverage has been verified against the extension's documents; the runbook note lives in the `typesense_index.py` module docstring.
- No Cloud Run min-instance, Firebase extension, or GCP changes; no write fence around account deletion (accepted as out of scope per review).

Failure-Class: none

(New indexing path, not a registered failure-class fix.)

Line-Count-Exception: backend/database/conversations.py | 2324 -> 2379 | One-line fail-open lazy-import index-sync hooks at the durable write choke points; the projection logic lives in utils/conversations/typesense_index.py.

## Product invariants affected

- INV-MEM-3

`backend/services/users/account_deletion.py` matched the invariant's path globs. This PR does not touch memory reads, canonical hydration, historical suppression, or intake pause handling; on the deletion surface it replaces a required Typesense purge with a best-effort post-wipe purge, keeping account deletion independent of Typesense while the Firebase extension owns indexing (INV-MEM-3 is not a Typesense invariant until the extension is gone — reviewer direction).

## Test plan

Focused runs (worktree venv, `.venv/bin/python -m pytest`):

- `tests/unit/test_conversation_typesense_index.py` — 52 passed. Payload contract (exact allow-list, epoch coercion, `[lat, lng]` geolocation incl. GeoPoint, path-key overriding a stale stored id), forbidden fields never leaving, kill switch (upserts off while e2ee deletes still run, deletes ignore the switch), e2ee skip → delete, write-after-delete self-healing, Typesense-down fail-open (module level, out of wired write paths, and on a simulated lazy-import failure — the round-one CI regression), ObjectNotFound swallow, required purge raising when unconfigured, and wiring of every hooked path incl. upsert/create-if-absent (created + AlreadyExists), persist (present → sync, absent → delete), summary overview vs apps_results, finished_at, fail-and-discard (claimed + fenced), and empty-recording deletion ordering (index delete before photo/audio cleanup).
- `tests/unit/test_conversation_revision_contract.py test_conversation_discard_revival.py test_delete_conversation_cascade.py test_listen_fallback_removal.py test_empty_conversation_audio_cleanup.py test_free_tier_entrypoint_matrix.py test_listen_phone_call_instrumentation.py test_process_conversation_free_tier_branch.py test_conversation_hybrid_search.py test_conversation_search_speaker_filter.py test_conversation_search_pagination_clamp.py test_search_conversations_utc_timestamps.py` — 361 passed.
- `tests/services/users/test_account_deletion.py tests/unit/test_delete_account_purge_storage.py tests/unit/test_account_deletion_single_executor.py tests/routers/test_users.py tests/unit/test_conversation_typesense_index.py` — 169 passed (canonical services-before-unit order; incl. new tests that the post-wipe purge runs after `delete_user_data` and that its failure never changes the wipe outcome). `tests/services/users/test_account_deletion.py` has a pre-existing order sensitivity when a unit file importing `database.conversations` is collected before it — reproducible on `origin/main` with untouched files.
- Dead-letter/finalization suites (`test_conversation_lifecycle_contract.py`, `test_byok_abandonment_reconciliation.py`, `test_durable_queue.py`, `test_transcript_canonicalization.py`, `test_backend_runtime_env_validator.py`) — 163 + 43 passed.
- Round-one CI reproduction: `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh` with `test_conversation_archive_filter_contract.py` + `test_delete_account_stripe_cancel.py` failed on the round-one head and passes now (4 passed).
- Hermetic e2e (`E2E_PYTEST_TIMEOUT=120s bash testing/e2e/run.sh -q --tb=short`): the round-one head fails locally (same F-then-timeout shape as CI); with the round-two tree every e2e test passes (166s wall locally vs CI's 120s budget — CI hardware/caches have historically fit; user CPU is ~44s and the writer adds near-zero work under the kill switch).
- Gates: `scripts/pr-preflight` and `make preflight` (11 checks) PASS, `check_module_stub_pollution.py` 0 violations, `scan_import_time_side_effects.py` 0 violations, `scan_async_blockers.py --dirs routers utils` 0 findings, `make runtime-image-source-closure` 14 images PASS; pre-push bounded lane runs on push.

CI note: the changed-file selector maps `backend/database/conversations.py` to the full backend unit suite; the full local run exceeded a 1-hour wall budget on this machine (~1077 files), so CI carries it.

Closes nothing (no matching upstream issue found).
