### PR TITLE
Add bounded manual operations for the isolated JIT QA plane

### DIFF
--- a/.github/workflows/jit_qa_cloud_run.yml
+++ b/.github/workflows/jit_qa_cloud_run.yml
@@ -162,6 +162,22 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v3
+      - name: Ensure named development Redis API is enabled before provisioning
+        run: |
+          set -euo pipefail
+          service="redis.googleapis.com"
+          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
+            --project "$QA_PROJECT" --format='value(state)' 2>/dev/null || true)"
+          if [[ "$state" != "ENABLED" ]]; then
+            timeout --foreground --kill-after=5s 60s gcloud services enable "$service" \
+              --project "$QA_PROJECT" --quiet
+          fi
+          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
+            --project "$QA_PROJECT" --format='value(state)')"
+          [[ "$state" == "ENABLED" ]] || {
+            echo "ERROR: $service is not enabled in $QA_PROJECT (state=$state)." >&2
+            exit 1
+          }
       - name: Preflight required development secret metadata before resource mutation
         run: |
           set -euo pipefail

--- a/.github/workflows/jit_qa_cloud_run.yml
+++ b/.github/workflows/jit_qa_cloud_run.yml
@@ -166,16 +166,16 @@ jobs:
         run: |
           set -euo pipefail
           service="redis.googleapis.com"
-          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
-            --project "$QA_PROJECT" --format='value(state)' 2>/dev/null || true)"
-          if [[ "$state" != "ENABLED" ]]; then
+          enabled_service="$(timeout --foreground --kill-after=5s 60s gcloud services list --enabled \
+            --project "$QA_PROJECT" --filter="config.name=${service}" --format='value(config.name)' --limit=1)"
+          if [[ "$enabled_service" != "$service" ]]; then
             timeout --foreground --kill-after=5s 60s gcloud services enable "$service" \
               --project "$QA_PROJECT" --quiet
           fi
-          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
-            --project "$QA_PROJECT" --format='value(state)')"
-          [[ "$state" == "ENABLED" ]] || {
-            echo "ERROR: $service is not enabled in $QA_PROJECT (state=$state)." >&2
+          enabled_service="$(timeout --foreground --kill-after=5s 60s gcloud services list --enabled \
+            --project "$QA_PROJECT" --filter="config.name=${service}" --format='value(config.name)' --limit=1)"
+          [[ "$enabled_service" == "$service" ]] || {
+            echo "ERROR: $service is not enabled in $QA_PROJECT." >&2
             exit 1
           }
       - name: Preflight required development secret metadata before resource mutation

--- a/.github/workflows/jit_qa_manual_operator.yml
+++ b/.github/workflows/jit_qa_manual_operator.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - bootstrap
+          - ensure-infrastructure-api
           - prepare
           - inspect
           - drain-verify
@@ -23,7 +24,7 @@ on:
         required: false
         type: string
       confirmation:
-        description: Use PREPARE_QA, DRAIN_VERIFY_QA, ROLLFORWARD_QA, or ROLLBACK_QA for mutating operations
+        description: Use ENABLE_QA_API, PREPARE_QA, DRAIN_VERIFY_QA, ROLLFORWARD_QA, or ROLLBACK_QA for mutating operations
         required: false
         type: string
 
@@ -79,7 +80,7 @@ jobs:
             echo "ERROR: source_sha must not be the all-zero SHA." >&2
             exit 1
           fi
-          if [[ "$OPERATION" != bootstrap && ! "$RUN_ID" =~ ^[a-z0-9][a-z0-9_-]{0,47}$ ]]; then
+          if [[ "$OPERATION" != bootstrap && "$OPERATION" != ensure-infrastructure-api && ! "$RUN_ID" =~ ^[a-z0-9][a-z0-9_-]{0,47}$ ]]; then
             echo "ERROR: run_id is required and must match [a-z0-9][a-z0-9_-]{0,47}." >&2
             exit 1
           fi
@@ -88,7 +89,7 @@ jobs:
             exit 1
           fi
           case "$OPERATION:$CONFIRMATION" in
-            bootstrap:PREPARE_QA|prepare:PREPARE_QA|inspect:|drain-verify:DRAIN_VERIFY_QA|rollforward:ROLLFORWARD_QA|rollback:ROLLBACK_QA) ;;
+            bootstrap:PREPARE_QA|ensure-infrastructure-api:ENABLE_QA_API|prepare:PREPARE_QA|inspect:|drain-verify:DRAIN_VERIFY_QA|rollforward:ROLLFORWARD_QA|rollback:ROLLBACK_QA) ;;
             *)
               echo "ERROR: confirmation does not match the selected QA operation." >&2
               exit 1
@@ -167,12 +168,49 @@ jobs:
           PYTHONPATH=. .venv/bin/python scripts/jit_qa_seed_and_verify.py --help >/dev/null
 
       - name: Authenticate to the development project
+        id: auth
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
+
+      - name: Verify action-provided development ADC
+        env:
+          ACTION_CREDENTIALS_PATH: ${{ steps.auth.outputs.credentials_file_path }}
+        run: |
+          set -euo pipefail
+          [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || {
+            echo "ERROR: google-github-actions/auth did not provide GOOGLE_APPLICATION_CREDENTIALS." >&2
+            exit 1
+          }
+          [[ -n "$ACTION_CREDENTIALS_PATH" ]] || {
+            echo "ERROR: google-github-actions/auth did not expose credentials_file_path." >&2
+            exit 1
+          }
+          [[ "$GOOGLE_APPLICATION_CREDENTIALS" == "$ACTION_CREDENTIALS_PATH" ]] || {
+            echo "ERROR: ADC path does not match the credentials file produced by the auth action." >&2
+            exit 1
+          }
+          [[ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]] || {
+            echo "ERROR: action-provided ADC file is missing." >&2
+            exit 1
+          }
+          "$QA_PYTHON" - <<'PY'
+          import google.auth
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+          credentials, project = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+          if credentials is None:
+              raise SystemExit("auth action did not resolve ADC credentials")
+          if project and project != os.environ["QA_PROJECT"]:
+              raise SystemExit(f"auth action resolved unexpected project: {project}")
+          if not path.is_file():
+              raise SystemExit("resolved ADC path is not a regular file")
+          PY
 
       - name: Verify active development project
         env:
@@ -189,6 +227,50 @@ jobs:
             exit 1
           }
           timeout --foreground --kill-after=5s 60s gcloud projects describe "$QA_PROJECT" --format='value(projectId)' | grep -Fx "$QA_PROJECT" >/dev/null
+
+      - name: Ensure named development Redis API is enabled
+        if: ${{ inputs.operation == 'ensure-infrastructure-api' }}
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          service="redis.googleapis.com"
+          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
+            --project "$QA_PROJECT" --format='value(state)' 2>/dev/null || true)"
+          mutation="false"
+          if [[ "$state" != "ENABLED" ]]; then
+            timeout --foreground --kill-after=5s 60s gcloud services enable "$service" \
+              --project "$QA_PROJECT" --quiet
+            mutation="true"
+          fi
+          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
+            --project "$QA_PROJECT" --format='value(state)')"
+          [[ "$state" == "ENABLED" ]] || {
+            echo "ERROR: $service is not enabled in $QA_PROJECT (state=$state)." >&2
+            exit 1
+          }
+          "$QA_PYTHON" - "$SOURCE_SHA" "$RUN_ID" "$state" "$mutation" \
+            "$RUNNER_TEMP/jit-qa-operator/source.json" \
+            > "$RUNNER_TEMP/jit-qa-operator/artifacts/operator-receipt.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          source = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
+          print(json.dumps({
+              "schema_version": "omi.jit.qa.infrastructure-api.v1",
+              "status": "PASS",
+              "operation": "ensure-infrastructure-api",
+              "source_sha": sys.argv[1],
+              "run_id": sys.argv[2],
+              "project": "based-hardware-dev",
+              "service": "redis.googleapis.com",
+              "state": sys.argv[3],
+              "api_mutation": sys.argv[4] == "true",
+              "source": source,
+          }, sort_keys=True))
+          PY
 
       - name: Verify the deployed immutable QA drain job
         if: ${{ inputs.operation == 'drain-verify' || inputs.operation == 'rollforward' || inputs.operation == 'rollback' }}
@@ -225,7 +307,7 @@ jobs:
           KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST: ${{ env.QA_UID }}
         run: |
           set -euo pipefail
-          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS FIREBASE_AUTH_CREDENTIALS_PATH
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
           operator_dir="$RUNNER_TEMP/jit-qa-operator"
           case "$OPERATION" in
             bootstrap)
@@ -288,7 +370,7 @@ jobs:
           KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST: ${{ env.QA_UID }}
         run: |
           set -euo pipefail
-          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS FIREBASE_AUTH_CREDENTIALS_PATH
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
           operator_dir="$RUNNER_TEMP/jit-qa-operator"
           gcloud_bounded() {
             timeout --foreground --kill-after=5s 60s gcloud "$@"

--- a/.github/workflows/jit_qa_manual_operator.yml
+++ b/.github/workflows/jit_qa_manual_operator.yml
@@ -13,8 +13,9 @@ on:
           - inspect
           - drain-verify
           - rollback
+          - rollforward
       source_sha:
-        description: Exact current main SHA with first-attempt Release Eligibility proof
+        description: Immutable deployed QA source SHA with first-attempt Release Eligibility proof
         required: true
         type: string
       run_id:
@@ -22,7 +23,7 @@ on:
         required: false
         type: string
       confirmation:
-        description: Use PREPARE_QA, DRAIN_VERIFY_QA, or ROLLBACK_QA for mutating operations
+        description: Use PREPARE_QA, DRAIN_VERIFY_QA, ROLLFORWARD_QA, or ROLLBACK_QA for mutating operations
         required: false
         type: string
 
@@ -33,6 +34,7 @@ env:
   QA_UID: vi7SA9ckQCe4ccobWNxlbdcNdC23
   QA_DRAIN_JOB: knowledge-ledger-drain-qa-job
   QA_RUNTIME_SERVICE_ACCOUNT: jit-qa-runtime@based-hardware-dev.iam.gserviceaccount.com
+  QA_PYTHON: backend/.venv/bin/python
 
 concurrency:
   group: jit-qa-manual-operator-development
@@ -48,6 +50,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout the current main source
         uses: actions/checkout@v7
@@ -85,7 +88,7 @@ jobs:
             exit 1
           fi
           case "$OPERATION:$CONFIRMATION" in
-            bootstrap:PREPARE_QA|prepare:PREPARE_QA|inspect:|drain-verify:DRAIN_VERIFY_QA|rollback:ROLLBACK_QA) ;;
+            bootstrap:PREPARE_QA|prepare:PREPARE_QA|inspect:|drain-verify:DRAIN_VERIFY_QA|rollforward:ROLLFORWARD_QA|rollback:ROLLBACK_QA) ;;
             *)
               echo "ERROR: confirmation does not match the selected QA operation." >&2
               exit 1
@@ -93,8 +96,12 @@ jobs:
           esac
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           main_sha="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
-          [[ "$SOURCE_SHA" == "$main_sha" ]] || {
-            echo "ERROR: main advanced or source_sha is stale; refusing the operation." >&2
+          git cat-file -e "$SOURCE_SHA^{commit}" || {
+            echo "ERROR: source_sha is not present in the checked-out repository." >&2
+            exit 1
+          }
+          git merge-base --is-ancestor "$SOURCE_SHA" "$main_sha" || {
+            echo "ERROR: deployed source_sha is not an ancestor of current main." >&2
             exit 1
           }
           proof_path="$RUNNER_TEMP/release-eligibility-${SOURCE_SHA}.json"
@@ -106,21 +113,58 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --workflow-runs "$proof_path" \
             --require-first-attempt
-          git checkout --detach "$SOURCE_SHA"
-          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
-          install -d -m 700 "$RUNNER_TEMP/jit-qa-operator"
-          python3 - "$SOURCE_SHA" "$main_sha" "$OPERATION" "$RUN_ID" <<'PY' > "$RUNNER_TEMP/jit-qa-operator/source.json"
+          git checkout --detach "$main_sha"
+          operator_checkout_sha="$(git rev-parse HEAD)"
+          [[ "$operator_checkout_sha" == "$main_sha" ]]
+          install -d -m 700 "$RUNNER_TEMP/jit-qa-operator/artifacts"
+          python3 - "$SOURCE_SHA" "$main_sha" "$operator_checkout_sha" "$OPERATION" "$RUN_ID" <<'PY' > "$RUNNER_TEMP/jit-qa-operator/source.json"
           import json
           import sys
 
           print(json.dumps({
               "schema_version": "omi.jit.qa.operator.source.v1",
-              "source_sha": sys.argv[1],
-              "main_sha": sys.argv[2],
-              "operation": sys.argv[3],
-              "run_id": sys.argv[4],
+              "deployed_source_sha": sys.argv[1],
+              "current_main_sha": sys.argv[2],
+              "operator_checkout_sha": sys.argv[3],
+              "operation": sys.argv[4],
+              "run_id": sys.argv[5],
+              "deployed_source_is_ancestor": True,
           }, sort_keys=True))
           PY
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up pinned uv
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          version: "0.11.13"
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      - name: Install pinned backend runtime and verify operator imports
+        working-directory: backend
+        env:
+          OMI_ENV_STAGE: dev
+          GOOGLE_CLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          GCLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          OMI_FIRESTORE_DATA_PLANE_PROJECT: ${{ env.QA_PROJECT }}
+          FIRESTORE_DATABASE_ID: ${{ env.QA_DATABASE }}
+          FIREBASE_AUTH_PROJECT_ID: based-hardware
+          MEMORY_ENABLED: "on"
+          OMI_JIT_QA_AUTH_ONLY: "true"
+          OMI_JIT_QA_UID_ALLOWLIST: ${{ env.QA_UID }}
+          KNOWLEDGE_LEDGER_DRAIN_ENABLED: "false"
+          KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST: ${{ env.QA_UID }}
+        run: |
+          set -euo pipefail
+          uv venv .venv
+          uv pip sync pylock.runtime.toml --python .venv/bin/python
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          .venv/bin/python scripts/jit_qa_manual_operator.py --help >/dev/null
+          PYTHONPATH=. .venv/bin/python scripts/jit_qa_seed_and_verify.py --help >/dev/null
 
       - name: Authenticate to the development project
         uses: google-github-actions/auth@v3
@@ -138,25 +182,25 @@ jobs:
           CONFIRMATION: ${{ inputs.confirmation }}
         run: |
           set -euo pipefail
-          gcloud config set project "$QA_PROJECT" >/dev/null
-          actual_project="$(gcloud config get-value project 2>/dev/null)"
+          timeout --foreground --kill-after=5s 60s gcloud config set project "$QA_PROJECT" >/dev/null
+          actual_project="$(timeout --foreground --kill-after=5s 60s gcloud config get-value project 2>/dev/null)"
           [[ "$actual_project" == "$QA_PROJECT" ]] || {
             echo "ERROR: gcloud resolved project $actual_project, expected $QA_PROJECT." >&2
             exit 1
           }
-          gcloud projects describe "$QA_PROJECT" --format='value(projectId)' | grep -Fx "$QA_PROJECT" >/dev/null
+          timeout --foreground --kill-after=5s 60s gcloud projects describe "$QA_PROJECT" --format='value(projectId)' | grep -Fx "$QA_PROJECT" >/dev/null
 
       - name: Verify the deployed immutable QA drain job
-        if: ${{ inputs.operation == 'drain-verify' || inputs.operation == 'rollback' }}
+        if: ${{ inputs.operation == 'drain-verify' || inputs.operation == 'rollforward' || inputs.operation == 'rollback' }}
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          gcloud run jobs describe "$QA_DRAIN_JOB" \
+          timeout --foreground --kill-after=5s 60s gcloud run jobs describe "$QA_DRAIN_JOB" \
             --project "$QA_PROJECT" \
             --region "$QA_REGION" \
             --format=json > "$RUNNER_TEMP/jit-qa-operator/job.json"
-          python3 backend/scripts/jit_qa_manual_operator.py validate-job \
+          "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-job \
             --source-sha "$SOURCE_SHA" \
             --resource-json "$RUNNER_TEMP/jit-qa-operator/job.json" \
             > "$RUNNER_TEMP/jit-qa-operator/job-contract.json"
@@ -167,39 +211,49 @@ jobs:
           OPERATION: ${{ inputs.operation }}
           RUN_ID: ${{ inputs.run_id }}
           CONFIRMATION: ${{ inputs.confirmation }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
           GOOGLE_CLOUD_PROJECT: ${{ env.QA_PROJECT }}
           GCLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          OMI_ENV_STAGE: dev
+          OMI_FIRESTORE_DATA_PLANE_PROJECT: ${{ env.QA_PROJECT }}
           FIRESTORE_DATABASE_ID: ${{ env.QA_DATABASE }}
+          FIREBASE_AUTH_PROJECT_ID: based-hardware
+          MEMORY_ENABLED: "on"
+          OMI_JIT_QA_AUTH_ONLY: "true"
+          OMI_JIT_QA_UID_ALLOWLIST: ${{ env.QA_UID }}
+          KNOWLEDGE_LEDGER_DRAIN_ENABLED: "false"
+          KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST: ${{ env.QA_UID }}
         run: |
           set -euo pipefail
-          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS FIREBASE_AUTH_CREDENTIALS_PATH
           operator_dir="$RUNNER_TEMP/jit-qa-operator"
           case "$OPERATION" in
             bootstrap)
-              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py bootstrap \
+              PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py bootstrap \
                 > "$operator_dir/operation.json"
               ;;
             prepare)
-              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+              PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py \
                 --run-id "$RUN_ID" prepare > "$operator_dir/operation.json"
               ;;
             inspect)
-              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+              PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py \
                 --run-id "$RUN_ID" inspect > "$operator_dir/operation.json"
               ;;
             rollback)
-              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+              PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py \
                 --run-id "$RUN_ID" rollback --confirmation "$CONFIRMATION" \
                 > "$operator_dir/operation.json"
               ;;
           esac
-          python3 - "$OPERATION" "$RUN_ID" "$SOURCE_SHA" "$operator_dir/operation.json" <<'PY' \
-            > "$operator_dir/operator-receipt.json"
+          "$QA_PYTHON" - "$OPERATION" "$RUN_ID" "$SOURCE_SHA" "$operator_dir/operation.json" "$operator_dir/source.json" <<'PY' \
+            > "$operator_dir/artifacts/operator-receipt.json"
           import json
           import sys
           from pathlib import Path
 
           payload = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+          source = json.loads(Path(sys.argv[5]).read_text(encoding="utf-8"))
           print(json.dumps({
               "schema_version": "omi.jit.qa.manual.operator.v1",
               "status": "PASS",
@@ -209,22 +263,36 @@ jobs:
               "project": "based-hardware-dev",
               "database": "jit-qa",
               "uid": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+              "source": source,
               "result": payload,
           }, sort_keys=True))
           PY
+          rm -f "$operator_dir/operation.json"
 
       - name: Execute three bounded drain pages and verify durable proof
-        if: ${{ inputs.operation == 'drain-verify' }}
+        if: ${{ inputs.operation == 'drain-verify' || inputs.operation == 'rollforward' }}
         env:
+          OPERATION: ${{ inputs.operation }}
           SOURCE_SHA: ${{ inputs.source_sha }}
           RUN_ID: ${{ inputs.run_id }}
           GOOGLE_CLOUD_PROJECT: ${{ env.QA_PROJECT }}
           GCLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          OMI_ENV_STAGE: dev
+          OMI_FIRESTORE_DATA_PLANE_PROJECT: ${{ env.QA_PROJECT }}
           FIRESTORE_DATABASE_ID: ${{ env.QA_DATABASE }}
+          FIREBASE_AUTH_PROJECT_ID: based-hardware
+          MEMORY_ENABLED: "on"
+          OMI_JIT_QA_AUTH_ONLY: "true"
+          OMI_JIT_QA_UID_ALLOWLIST: ${{ env.QA_UID }}
+          KNOWLEDGE_LEDGER_DRAIN_ENABLED: "false"
+          KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST: ${{ env.QA_UID }}
         run: |
           set -euo pipefail
-          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS FIREBASE_AUTH_CREDENTIALS_PATH
           operator_dir="$RUNNER_TEMP/jit-qa-operator"
+          gcloud_bounded() {
+            timeout --foreground --kill-after=5s 60s gcloud "$@"
+          }
 
           run_drain() {
             local phase="$1"
@@ -233,21 +301,21 @@ jobs:
             local state_file="$operator_dir/${phase}.state.json"
             local logs_file="$operator_dir/${phase}.logs.json"
             local summary_file="$operator_dir/${phase}.summary.json"
-            gcloud run jobs execute "$QA_DRAIN_JOB" \
+            gcloud_bounded run jobs execute "$QA_DRAIN_JOB" \
               --project "$QA_PROJECT" \
               --region "$QA_REGION" \
               --update-env-vars "KNOWLEDGE_LEDGER_DRAIN_ENABLED=true,KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST=${QA_UID}" \
               --format=json > "$launch_file"
             local execution
-            execution="$(python3 backend/scripts/jit_qa_manual_operator.py execution-name \
+            execution="$("$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py execution-name \
               --execution-json "$launch_file")"
             local state=running
             for _ in $(seq 1 130); do
-              gcloud run jobs executions describe "$execution" \
+              gcloud_bounded run jobs executions describe "$execution" \
                 --project "$QA_PROJECT" \
                 --region "$QA_REGION" \
                 --format=json > "$state_file"
-              state="$(python3 backend/scripts/jit_qa_manual_operator.py execution-state \
+              state="$("$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py execution-state \
                 --execution-json "$state_file")"
               if [[ "$state" == succeeded || "$state" == failed ]]; then
                 break
@@ -260,71 +328,96 @@ jobs:
             }
             printf '%s\n' "$execution" > "$execution_file"
             filter="resource.type=\"cloud_run_job\" AND resource.labels.job_name=\"${QA_DRAIN_JOB}\" AND labels.\"run.googleapis.com/execution_name\"=\"${execution}\""
-            gcloud logging read "$filter" \
-              --project "$QA_PROJECT" \
-              --freshness=1h \
-              --limit=100 \
-              --format=json > "$logs_file"
-            python3 backend/scripts/jit_qa_manual_operator.py summary \
-              --logs-json "$logs_file" > "$summary_file"
+            local summary_ready=0
+            for _ in $(seq 1 12); do
+              if gcloud_bounded logging read "$filter" \
+                --project "$QA_PROJECT" \
+                --freshness=1h \
+                --limit=100 \
+                --format=json > "$logs_file"; then
+                if "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py summary \
+                  --logs-json "$logs_file" > "$summary_file" && \
+                  "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-summary \
+                  --summary-json "$summary_file" --phase "$phase" > "$summary_file.validated"; then
+                  mv "$summary_file.validated" "$summary_file"
+                  summary_ready=1
+                  break
+                fi
+              fi
+              sleep 5
+            done
+            [[ "$summary_ready" == 1 ]] || {
+              echo "ERROR: content-free QA drain logs did not become visible or valid for $execution." >&2
+              exit 1
+            }
             rm -f "$launch_file" "$state_file" "$logs_file"
             # A run override must not leave the persistent job gate open.
-            gcloud run jobs describe "$QA_DRAIN_JOB" \
+            gcloud_bounded run jobs describe "$QA_DRAIN_JOB" \
               --project "$QA_PROJECT" \
               --region "$QA_REGION" \
               --format=json > "$operator_dir/job.json"
-            python3 backend/scripts/jit_qa_manual_operator.py validate-job \
+            "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-job \
               --source-sha "$SOURCE_SHA" \
               --resource-json "$operator_dir/job.json" \
               > "$operator_dir/job-contract.json"
           }
 
-          run_drain first
-          run_drain second
-          run_drain retry
+          if [[ "$OPERATION" == rollforward ]]; then
+            run_drain rollforward
+            PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py \
+              --run-id "$RUN_ID" inspect > "$operator_dir/seed-verify.json"
+          else
+            run_drain first
+            run_drain second
+            run_drain retry
+            PYTHONPATH=backend "$QA_PYTHON" backend/scripts/jit_qa_seed_and_verify.py \
+              --run-id "$RUN_ID" verify \
+              --first-summary "$operator_dir/first.summary.json" \
+              --second-summary "$operator_dir/second.summary.json" \
+              --retry-summary "$operator_dir/retry.summary.json" \
+              > "$operator_dir/seed-verify.json"
+          fi
 
-          PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
-            --run-id "$RUN_ID" verify \
-            --first-summary "$operator_dir/first.summary.json" \
-            --second-summary "$operator_dir/second.summary.json" \
-            --retry-summary "$operator_dir/retry.summary.json" \
-            > "$operator_dir/seed-verify.json"
-
-          token="$(gcloud auth print-access-token)"
+          token="$(gcloud_bounded auth print-access-token)"
           base="https://firestore.googleapis.com/v1/projects/${QA_PROJECT}/databases/${QA_DATABASE}/documents/users/${QA_UID}"
           for path in memory_state/apply_control memory_control/knowledge_ledger_migration memory_control/knowledge_ledger_prompt_projection; do
-            curl --fail-with-body --silent --show-error \
+            timeout --foreground --kill-after=5s 30s curl --fail-with-body --silent --show-error \
+              --connect-timeout 10 --max-time 25 \
               -H "Authorization: Bearer ${token}" \
               "${base}/${path}" > "$operator_dir/${path##*/}.json"
           done
-          python3 backend/scripts/jit_qa_manual_operator.py durable \
+          "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py durable \
             --control-json "$operator_dir/apply_control.json" \
             --completion-json "$operator_dir/knowledge_ledger_migration.json" \
             --projection-json "$operator_dir/knowledge_ledger_prompt_projection.json" \
             > "$operator_dir/durable-proof.json"
-          python3 - "$SOURCE_SHA" "$RUN_ID" "$operator_dir" <<'PY' > "$operator_dir/operator-receipt.json"
+          "$QA_PYTHON" - "$SOURCE_SHA" "$RUN_ID" "$operator_dir" "$OPERATION" <<'PY' > "$operator_dir/artifacts/operator-receipt.json"
           import json
           import sys
           from pathlib import Path
 
           root = Path(sys.argv[3])
+          operation = sys.argv[4]
+          source = json.loads((root / "source.json").read_text(encoding="utf-8"))
+          phases = ("rollforward",) if operation == "rollforward" else ("first", "second", "retry")
           execution_names = {
               phase: (root / f"{phase}.execution.json").read_text(encoding="utf-8").strip()
-              for phase in ("first", "second", "retry")
+              for phase in phases
           }
           summaries = {
               phase: json.loads((root / f"{phase}.summary.json").read_text(encoding="utf-8"))
-              for phase in ("first", "second", "retry")
+              for phase in phases
           }
           receipt = {
               "schema_version": "omi.jit.qa.manual.operator.v1",
               "status": "PASS",
-              "operation": "drain-verify",
+              "operation": operation,
               "source_sha": sys.argv[1],
               "run_id": sys.argv[2],
               "project": "based-hardware-dev",
               "database": "jit-qa",
               "uid": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+              "source": source,
               "job": "knowledge-ledger-drain-qa-job",
               "job_contract": json.loads((root / "job-contract.json").read_text(encoding="utf-8")),
               "executions": execution_names,
@@ -336,11 +429,12 @@ jobs:
           }
           print(json.dumps(receipt, sort_keys=True))
           PY
+          rm -f "$operator_dir"/*.json "$operator_dir"/*.logs.json "$operator_dir"/*.state.json "$operator_dir"/*.launch.json
 
       - name: Upload content-free operator receipt
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: jit-qa-manual-operator-${{ github.run_id }}
-          path: ${{ runner.temp }}/jit-qa-operator
+          path: ${{ runner.temp }}/jit-qa-operator/artifacts
           if-no-files-found: warn

--- a/.github/workflows/jit_qa_manual_operator.yml
+++ b/.github/workflows/jit_qa_manual_operator.yml
@@ -302,7 +302,7 @@ jobs:
             --format=json > "$RUNNER_TEMP/jit-qa-operator/job.json"
           "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-job \
             --source-sha "$SOURCE_SHA" \
-            --expected-image "$QA_DRAIN_IMAGE" \
+            --expected-image "$resolved_image" \
             --resource-json "$RUNNER_TEMP/jit-qa-operator/job.json" \
             > "$RUNNER_TEMP/jit-qa-operator/job-contract.json"
 

--- a/.github/workflows/jit_qa_manual_operator.yml
+++ b/.github/workflows/jit_qa_manual_operator.yml
@@ -198,11 +198,20 @@ jobs:
             exit 1
           }
           "$QA_PYTHON" - <<'PY'
+          import json
           import google.auth
           import os
           from pathlib import Path
 
           path = Path(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          if payload.get("type") != "service_account":
+              raise SystemExit("development auth action must provide a service-account credential")
+          if payload.get("project_id") != os.environ["QA_PROJECT"]:
+              raise SystemExit("development auth action credential is not scoped to the QA project")
+          client_email = payload.get("client_email")
+          if not isinstance(client_email, str) or not client_email.endswith("@based-hardware-dev.iam.gserviceaccount.com"):
+              raise SystemExit("development auth action credential has an unexpected service-account identity")
           credentials, project = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
           if credentials is None:
               raise SystemExit("auth action did not resolve ADC credentials")
@@ -236,21 +245,21 @@ jobs:
         run: |
           set -euo pipefail
           service="redis.googleapis.com"
-          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
-            --project "$QA_PROJECT" --format='value(state)' 2>/dev/null || true)"
+          enabled_service="$(timeout --foreground --kill-after=5s 60s gcloud services list --enabled \
+            --project "$QA_PROJECT" --filter="config.name=${service}" --format='value(config.name)' --limit=1)"
           mutation="false"
-          if [[ "$state" != "ENABLED" ]]; then
+          if [[ "$enabled_service" != "$service" ]]; then
             timeout --foreground --kill-after=5s 60s gcloud services enable "$service" \
               --project "$QA_PROJECT" --quiet
             mutation="true"
           fi
-          state="$(timeout --foreground --kill-after=5s 60s gcloud services describe "$service" \
-            --project "$QA_PROJECT" --format='value(state)')"
-          [[ "$state" == "ENABLED" ]] || {
-            echo "ERROR: $service is not enabled in $QA_PROJECT (state=$state)." >&2
+          enabled_service="$(timeout --foreground --kill-after=5s 60s gcloud services list --enabled \
+            --project "$QA_PROJECT" --filter="config.name=${service}" --format='value(config.name)' --limit=1)"
+          [[ "$enabled_service" == "$service" ]] || {
+            echo "ERROR: $service is not enabled in $QA_PROJECT." >&2
             exit 1
           }
-          "$QA_PYTHON" - "$SOURCE_SHA" "$RUN_ID" "$state" "$mutation" \
+          "$QA_PYTHON" - "$SOURCE_SHA" "$RUN_ID" "ENABLED" "$mutation" \
             "$RUNNER_TEMP/jit-qa-operator/source.json" \
             > "$RUNNER_TEMP/jit-qa-operator/artifacts/operator-receipt.json" <<'PY'
           import json
@@ -278,12 +287,22 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
+          image_tag="gcr.io/${QA_PROJECT}/knowledge-ledger-drain-qa-job:${SOURCE_SHA}"
+          image_digest="$(timeout --foreground --kill-after=5s 60s gcloud container images describe "$image_tag" \
+            --format='value(image_summary.digest)')"
+          [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "ERROR: admitted QA drain source tag did not resolve to an immutable digest." >&2
+            exit 1
+          }
+          resolved_image="gcr.io/${QA_PROJECT}/knowledge-ledger-drain-qa-job@${image_digest}"
+          echo "QA_DRAIN_IMAGE=$resolved_image" >> "$GITHUB_ENV"
           timeout --foreground --kill-after=5s 60s gcloud run jobs describe "$QA_DRAIN_JOB" \
             --project "$QA_PROJECT" \
             --region "$QA_REGION" \
             --format=json > "$RUNNER_TEMP/jit-qa-operator/job.json"
           "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-job \
             --source-sha "$SOURCE_SHA" \
+            --expected-image "$QA_DRAIN_IMAGE" \
             --resource-json "$RUNNER_TEMP/jit-qa-operator/job.json" \
             > "$RUNNER_TEMP/jit-qa-operator/job-contract.json"
 
@@ -440,6 +459,7 @@ jobs:
               --format=json > "$operator_dir/job.json"
             "$QA_PYTHON" backend/scripts/jit_qa_manual_operator.py validate-job \
               --source-sha "$SOURCE_SHA" \
+              --expected-image "$QA_DRAIN_IMAGE" \
               --resource-json "$operator_dir/job.json" \
               > "$operator_dir/job-contract.json"
           }

--- a/.github/workflows/jit_qa_manual_operator.yml
+++ b/.github/workflows/jit_qa_manual_operator.yml
@@ -1,0 +1,346 @@
+name: Operate isolated JIT QA data plane
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Named QA operation to run
+        required: true
+        type: choice
+        options:
+          - bootstrap
+          - prepare
+          - inspect
+          - drain-verify
+          - rollback
+      source_sha:
+        description: Exact current main SHA with first-attempt Release Eligibility proof
+        required: true
+        type: string
+      run_id:
+        description: Lowercase synthetic fixture namespace (for example qa-proof-20260905)
+        required: false
+        type: string
+      confirmation:
+        description: Use PREPARE_QA, DRAIN_VERIFY_QA, or ROLLBACK_QA for mutating operations
+        required: false
+        type: string
+
+env:
+  QA_PROJECT: based-hardware-dev
+  QA_REGION: us-central1
+  QA_DATABASE: jit-qa
+  QA_UID: vi7SA9ckQCe4ccobWNxlbdcNdC23
+  QA_DRAIN_JOB: knowledge-ledger-drain-qa-job
+  QA_RUNTIME_SERVICE_ACCOUNT: jit-qa-runtime@based-hardware-dev.iam.gserviceaccount.com
+
+concurrency:
+  group: jit-qa-manual-operator-development
+  cancel-in-progress: false
+
+jobs:
+  operate:
+    name: Run isolated JIT QA operator
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment: development
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the current main source
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Admit exact source and operation
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RUN_ID: ${{ inputs.run_id }}
+          OPERATION: ${{ inputs.operation }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "ERROR: this operator may only run from main." >&2
+            exit 1
+          }
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "ERROR: source_sha must be a full lowercase commit SHA." >&2
+            exit 1
+          }
+          if [[ "$SOURCE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            echo "ERROR: source_sha must not be the all-zero SHA." >&2
+            exit 1
+          fi
+          if [[ "$OPERATION" != bootstrap && ! "$RUN_ID" =~ ^[a-z0-9][a-z0-9_-]{0,47}$ ]]; then
+            echo "ERROR: run_id is required and must match [a-z0-9][a-z0-9_-]{0,47}." >&2
+            exit 1
+          fi
+          if [[ "$OPERATION" == bootstrap && -n "$RUN_ID" && ! "$RUN_ID" =~ ^[a-z0-9][a-z0-9_-]{0,47}$ ]]; then
+            echo "ERROR: an optional bootstrap run_id must match [a-z0-9][a-z0-9_-]{0,47}." >&2
+            exit 1
+          fi
+          case "$OPERATION:$CONFIRMATION" in
+            bootstrap:PREPARE_QA|prepare:PREPARE_QA|inspect:|drain-verify:DRAIN_VERIFY_QA|rollback:ROLLBACK_QA) ;;
+            *)
+              echo "ERROR: confirmation does not match the selected QA operation." >&2
+              exit 1
+              ;;
+          esac
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse --verify 'refs/remotes/origin/main^{commit}')"
+          [[ "$SOURCE_SHA" == "$main_sha" ]] || {
+            echo "ERROR: main advanced or source_sha is stale; refusing the operation." >&2
+            exit 1
+          }
+          proof_path="$RUNNER_TEMP/release-eligibility-${SOURCE_SHA}.json"
+          gh api -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/release-eligibility.yml/runs?event=push&branch=main&status=completed&head_sha=${SOURCE_SHA}&per_page=100" \
+            > "$proof_path"
+          python3 .github/scripts/verify_backend_release_admission.py \
+            --sha "$SOURCE_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow-runs "$proof_path" \
+            --require-first-attempt
+          git checkout --detach "$SOURCE_SHA"
+          [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]]
+          install -d -m 700 "$RUNNER_TEMP/jit-qa-operator"
+          python3 - "$SOURCE_SHA" "$main_sha" "$OPERATION" "$RUN_ID" <<'PY' > "$RUNNER_TEMP/jit-qa-operator/source.json"
+          import json
+          import sys
+
+          print(json.dumps({
+              "schema_version": "omi.jit.qa.operator.source.v1",
+              "source_sha": sys.argv[1],
+              "main_sha": sys.argv[2],
+              "operation": sys.argv[3],
+              "run_id": sys.argv[4],
+          }, sort_keys=True))
+          PY
+
+      - name: Authenticate to the development project
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Verify active development project
+        env:
+          OPERATION: ${{ inputs.operation }}
+          RUN_ID: ${{ inputs.run_id }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          gcloud config set project "$QA_PROJECT" >/dev/null
+          actual_project="$(gcloud config get-value project 2>/dev/null)"
+          [[ "$actual_project" == "$QA_PROJECT" ]] || {
+            echo "ERROR: gcloud resolved project $actual_project, expected $QA_PROJECT." >&2
+            exit 1
+          }
+          gcloud projects describe "$QA_PROJECT" --format='value(projectId)' | grep -Fx "$QA_PROJECT" >/dev/null
+
+      - name: Verify the deployed immutable QA drain job
+        if: ${{ inputs.operation == 'drain-verify' || inputs.operation == 'rollback' }}
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          gcloud run jobs describe "$QA_DRAIN_JOB" \
+            --project "$QA_PROJECT" \
+            --region "$QA_REGION" \
+            --format=json > "$RUNNER_TEMP/jit-qa-operator/job.json"
+          python3 backend/scripts/jit_qa_manual_operator.py validate-job \
+            --source-sha "$SOURCE_SHA" \
+            --resource-json "$RUNNER_TEMP/jit-qa-operator/job.json" \
+            > "$RUNNER_TEMP/jit-qa-operator/job-contract.json"
+
+      - name: Run read-only or seed operator action
+        if: ${{ inputs.operation == 'bootstrap' || inputs.operation == 'prepare' || inputs.operation == 'inspect' || inputs.operation == 'rollback' }}
+        env:
+          OPERATION: ${{ inputs.operation }}
+          RUN_ID: ${{ inputs.run_id }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          GOOGLE_CLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          GCLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          FIRESTORE_DATABASE_ID: ${{ env.QA_DATABASE }}
+        run: |
+          set -euo pipefail
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
+          operator_dir="$RUNNER_TEMP/jit-qa-operator"
+          case "$OPERATION" in
+            bootstrap)
+              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py bootstrap \
+                > "$operator_dir/operation.json"
+              ;;
+            prepare)
+              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+                --run-id "$RUN_ID" prepare > "$operator_dir/operation.json"
+              ;;
+            inspect)
+              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+                --run-id "$RUN_ID" inspect > "$operator_dir/operation.json"
+              ;;
+            rollback)
+              PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+                --run-id "$RUN_ID" rollback --confirmation "$CONFIRMATION" \
+                > "$operator_dir/operation.json"
+              ;;
+          esac
+          python3 - "$OPERATION" "$RUN_ID" "$SOURCE_SHA" "$operator_dir/operation.json" <<'PY' \
+            > "$operator_dir/operator-receipt.json"
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[4]).read_text(encoding="utf-8"))
+          print(json.dumps({
+              "schema_version": "omi.jit.qa.manual.operator.v1",
+              "status": "PASS",
+              "operation": sys.argv[1],
+              "run_id": sys.argv[2],
+              "source_sha": sys.argv[3],
+              "project": "based-hardware-dev",
+              "database": "jit-qa",
+              "uid": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+              "result": payload,
+          }, sort_keys=True))
+          PY
+
+      - name: Execute three bounded drain pages and verify durable proof
+        if: ${{ inputs.operation == 'drain-verify' }}
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          RUN_ID: ${{ inputs.run_id }}
+          GOOGLE_CLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          GCLOUD_PROJECT: ${{ env.QA_PROJECT }}
+          FIRESTORE_DATABASE_ID: ${{ env.QA_DATABASE }}
+        run: |
+          set -euo pipefail
+          unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH
+          operator_dir="$RUNNER_TEMP/jit-qa-operator"
+
+          run_drain() {
+            local phase="$1"
+            local launch_file="$operator_dir/${phase}.launch.json"
+            local execution_file="$operator_dir/${phase}.execution.json"
+            local state_file="$operator_dir/${phase}.state.json"
+            local logs_file="$operator_dir/${phase}.logs.json"
+            local summary_file="$operator_dir/${phase}.summary.json"
+            gcloud run jobs execute "$QA_DRAIN_JOB" \
+              --project "$QA_PROJECT" \
+              --region "$QA_REGION" \
+              --update-env-vars "KNOWLEDGE_LEDGER_DRAIN_ENABLED=true,KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST=${QA_UID}" \
+              --format=json > "$launch_file"
+            local execution
+            execution="$(python3 backend/scripts/jit_qa_manual_operator.py execution-name \
+              --execution-json "$launch_file")"
+            local state=running
+            for _ in $(seq 1 130); do
+              gcloud run jobs executions describe "$execution" \
+                --project "$QA_PROJECT" \
+                --region "$QA_REGION" \
+                --format=json > "$state_file"
+              state="$(python3 backend/scripts/jit_qa_manual_operator.py execution-state \
+                --execution-json "$state_file")"
+              if [[ "$state" == succeeded || "$state" == failed ]]; then
+                break
+              fi
+              sleep 10
+            done
+            [[ "$state" == succeeded ]] || {
+              echo "ERROR: QA drain execution $execution ended in state $state." >&2
+              exit 1
+            }
+            printf '%s\n' "$execution" > "$execution_file"
+            filter="resource.type=\"cloud_run_job\" AND resource.labels.job_name=\"${QA_DRAIN_JOB}\" AND labels.\"run.googleapis.com/execution_name\"=\"${execution}\""
+            gcloud logging read "$filter" \
+              --project "$QA_PROJECT" \
+              --freshness=1h \
+              --limit=100 \
+              --format=json > "$logs_file"
+            python3 backend/scripts/jit_qa_manual_operator.py summary \
+              --logs-json "$logs_file" > "$summary_file"
+            rm -f "$launch_file" "$state_file" "$logs_file"
+            # A run override must not leave the persistent job gate open.
+            gcloud run jobs describe "$QA_DRAIN_JOB" \
+              --project "$QA_PROJECT" \
+              --region "$QA_REGION" \
+              --format=json > "$operator_dir/job.json"
+            python3 backend/scripts/jit_qa_manual_operator.py validate-job \
+              --source-sha "$SOURCE_SHA" \
+              --resource-json "$operator_dir/job.json" \
+              > "$operator_dir/job-contract.json"
+          }
+
+          run_drain first
+          run_drain second
+          run_drain retry
+
+          PYTHONPATH=backend python3 backend/scripts/jit_qa_seed_and_verify.py \
+            --run-id "$RUN_ID" verify \
+            --first-summary "$operator_dir/first.summary.json" \
+            --second-summary "$operator_dir/second.summary.json" \
+            --retry-summary "$operator_dir/retry.summary.json" \
+            > "$operator_dir/seed-verify.json"
+
+          token="$(gcloud auth print-access-token)"
+          base="https://firestore.googleapis.com/v1/projects/${QA_PROJECT}/databases/${QA_DATABASE}/documents/users/${QA_UID}"
+          for path in memory_state/apply_control memory_control/knowledge_ledger_migration memory_control/knowledge_ledger_prompt_projection; do
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${token}" \
+              "${base}/${path}" > "$operator_dir/${path##*/}.json"
+          done
+          python3 backend/scripts/jit_qa_manual_operator.py durable \
+            --control-json "$operator_dir/apply_control.json" \
+            --completion-json "$operator_dir/knowledge_ledger_migration.json" \
+            --projection-json "$operator_dir/knowledge_ledger_prompt_projection.json" \
+            > "$operator_dir/durable-proof.json"
+          python3 - "$SOURCE_SHA" "$RUN_ID" "$operator_dir" <<'PY' > "$operator_dir/operator-receipt.json"
+          import json
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[3])
+          execution_names = {
+              phase: (root / f"{phase}.execution.json").read_text(encoding="utf-8").strip()
+              for phase in ("first", "second", "retry")
+          }
+          summaries = {
+              phase: json.loads((root / f"{phase}.summary.json").read_text(encoding="utf-8"))
+              for phase in ("first", "second", "retry")
+          }
+          receipt = {
+              "schema_version": "omi.jit.qa.manual.operator.v1",
+              "status": "PASS",
+              "operation": "drain-verify",
+              "source_sha": sys.argv[1],
+              "run_id": sys.argv[2],
+              "project": "based-hardware-dev",
+              "database": "jit-qa",
+              "uid": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+              "job": "knowledge-ledger-drain-qa-job",
+              "job_contract": json.loads((root / "job-contract.json").read_text(encoding="utf-8")),
+              "executions": execution_names,
+              "summaries": summaries,
+              "seed_verification": json.loads((root / "seed-verify.json").read_text(encoding="utf-8")),
+              "durable_proof": json.loads((root / "durable-proof.json").read_text(encoding="utf-8")),
+              "model_calls": False,
+              "scheduler_mutation": False,
+          }
+          print(json.dumps(receipt, sort_keys=True))
+          PY
+
+      - name: Upload content-free operator receipt
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: jit-qa-manual-operator-${{ github.run_id }}
+          path: ${{ runner.temp }}/jit-qa-operator
+          if-no-files-found: warn

--- a/backend/docs/runbooks/jit-qa-manual-operator.md
+++ b/backend/docs/runbooks/jit-qa-manual-operator.md
@@ -19,35 +19,43 @@ The fixed data-plane tuple is:
 | QA UID | `vi7SA9ckQCe4ccobWNxlbdcNdC23` |
 | Cloud Run region | `us-central1` |
 | drain job | `knowledge-ledger-drain-qa-job` |
+| Required service API | `redis.googleapis.com` |
 
 The workflow authenticates with the development GitHub environment's
-`GCP_CREDENTIALS`. It never prints or exports that credential. Before a drain
-or rollback, it reads the named job and rejects a different project, job name,
-runtime service account, source label, image tag, customer credential selector,
-Firestore database, or UID allowlist. The image must be a `gcr.io` development
-image pinned by a SHA-256 digest and its `source-sha` label must equal the
-admitted deployed source SHA. Before any credentialed operation, the runner
+`GCP_CREDENTIALS`. The auth action's generated `GOOGLE_APPLICATION_CREDENTIALS`
+file is retained for Firestore ADC resolution; the workflow checks that it is
+the action output and never prints its contents. Before a drain or rollback, it
+reads the named job and rejects a different project, job name, runtime service
+account, source label, image tag, customer credential selector, Firestore
+database, or UID allowlist. The image must be a `gcr.io` development image
+pinned by a SHA-256 digest and its `source-sha` label must equal the admitted
+deployed source SHA. Before any credentialed operation, the runner
 installs the pinned `backend/pylock.runtime.toml` environment and runs both
 operator and seed `--help` import checks under the complete QA data-plane
 environment.
 
 Run the actions in this order for a fresh named database:
 
-1. `bootstrap` with confirmation `PREPARE_QA`. This is create-only and fails
+1. If deployment stopped at Redis API provisioning, run
+   `ensure-infrastructure-api` with confirmation `ENABLE_QA_API`. It checks
+   `redis.googleapis.com` in `based-hardware-dev` and enables it only when the
+   service is not already enabled. This operation does not require a `run_id`
+   and does not mutate a Redis instance or any Firestore data.
+2. `bootstrap` with confirmation `PREPARE_QA`. This is create-only and fails
    before writing when any collection already exists.
-2. `prepare` with the chosen lowercase synthetic `run_id` and confirmation
+3. `prepare` with the chosen lowercase synthetic `run_id` and confirmation
    `PREPARE_QA`. This creates only the 101 owned synthetic rows and evidence
    through `backend/scripts/jit_qa_seed_and_verify.py`.
-3. `inspect` to capture the content-free pre-drain state.
-4. `drain-verify` with `DRAIN_VERIFY_QA`. This executes the existing job three
+4. `inspect` to capture the content-free pre-drain state.
+5. `drain-verify` with `DRAIN_VERIFY_QA`. This executes the existing job three
    times using Cloud Run execution overrides, waits for each exact execution,
    parses its aggregate log line, and runs the seed operator's real durable
    100 + 1 + stable-retry verification. The persistent job gate is checked
    again after every execution and must remain `false`.
-5. `rollback` with `ROLLBACK_QA` only after a reviewed successful proof. This
+6. `rollback` with `ROLLBACK_QA` only after a reviewed successful proof. This
    calls the canonical writer-transition rollback helper and checks that all
    synthetic rows/evidence remain present with the same metadata digest.
-6. `rollforward` with `ROLLFORWARD_QA` after rollback. This executes one
+7. `rollforward` with `ROLLFORWARD_QA` after rollback. This executes one
    bounded retry, requires zero migrated rows and one cutover, then verifies
    the canonical ledger fences are restored.
 

--- a/backend/docs/runbooks/jit-qa-manual-operator.md
+++ b/backend/docs/runbooks/jit-qa-manual-operator.md
@@ -1,0 +1,54 @@
+# Isolated JIT QA manual operator
+
+`.github/workflows/jit_qa_manual_operator.yml` is the operator entrypoint for
+the already deployed isolated QA plane. It does not deploy a service or job,
+create a Scheduler trigger, build an image, call a model, or change a global
+flag. Every dispatch must be from `main` and must name the exact current
+`main` commit with a successful first-attempt Release Eligibility run.
+
+The fixed data-plane tuple is:
+
+| Field | Value |
+| --- | --- |
+| GCP project | `based-hardware-dev` |
+| Firestore database | `jit-qa` |
+| Firebase Auth project | `based-hardware` |
+| QA UID | `vi7SA9ckQCe4ccobWNxlbdcNdC23` |
+| Cloud Run region | `us-central1` |
+| drain job | `knowledge-ledger-drain-qa-job` |
+
+The workflow authenticates with the development GitHub environment's
+`GCP_CREDENTIALS`. It never prints or exports that credential. Before a drain
+or rollback, it reads the named job and rejects a different project, job name,
+runtime service account, source label, image tag, customer credential selector,
+Firestore database, or UID allowlist. The image must be a `gcr.io` development
+image pinned by a SHA-256 digest and its `source-sha` label must equal the
+admitted commit.
+
+Run the actions in this order for a fresh named database:
+
+1. `bootstrap` with confirmation `PREPARE_QA`. This is create-only and fails
+   before writing when any collection already exists.
+2. `prepare` with the chosen lowercase synthetic `run_id` and confirmation
+   `PREPARE_QA`. This creates only the 101 owned synthetic rows and evidence
+   through `backend/scripts/jit_qa_seed_and_verify.py`.
+3. `inspect` to capture the content-free pre-drain state.
+4. `drain-verify` with `DRAIN_VERIFY_QA`. This executes the existing job three
+   times using Cloud Run execution overrides, waits for each exact execution,
+   parses its aggregate log line, and runs the seed operator's real durable
+   100 + 1 + stable-retry verification. The persistent job gate is checked
+   again after every execution and must remain `false`.
+5. `rollback` with `ROLLBACK_QA` only after a reviewed successful proof. This
+   calls the canonical writer-transition rollback helper and checks that all
+   synthetic rows/evidence remain present with the same metadata digest.
+
+The `drain-verify` receipt joins the exact execution names to the aggregate
+producer counters, the seed verifier result, and the Firestore completion and
+prompt-projection fences. It contains no row content or provider payload. A
+successful emulator proof is a code-contract result and cannot substitute for
+the named Cloud Run execution and its real rollout/admission path.
+
+The workflow artifacts are content-free and should be retained with the
+separate isolated-plane readiness receipt. If any precondition fails, preserve
+the failed artifact and fix the named QA resource or data-plane state before
+retrying; do not point the operator at the shared development job.

--- a/backend/docs/runbooks/jit-qa-manual-operator.md
+++ b/backend/docs/runbooks/jit-qa-manual-operator.md
@@ -3,8 +3,11 @@
 `.github/workflows/jit_qa_manual_operator.yml` is the operator entrypoint for
 the already deployed isolated QA plane. It does not deploy a service or job,
 create a Scheduler trigger, build an image, call a model, or change a global
-flag. Every dispatch must be from `main` and must name the exact current
-`main` commit with a successful first-attempt Release Eligibility run.
+flag. Every dispatch must be from `main` and must name the immutable deployed
+QA source SHA with a successful first-attempt Release Eligibility run. That
+SHA must be an ancestor of current `main`; the workflow records both the
+deployed source and the operator's current-main checkout so an unrelated main
+commit does not force a QA image rebuild.
 
 The fixed data-plane tuple is:
 
@@ -23,7 +26,10 @@ or rollback, it reads the named job and rejects a different project, job name,
 runtime service account, source label, image tag, customer credential selector,
 Firestore database, or UID allowlist. The image must be a `gcr.io` development
 image pinned by a SHA-256 digest and its `source-sha` label must equal the
-admitted commit.
+admitted deployed source SHA. Before any credentialed operation, the runner
+installs the pinned `backend/pylock.runtime.toml` environment and runs both
+operator and seed `--help` import checks under the complete QA data-plane
+environment.
 
 Run the actions in this order for a fresh named database:
 
@@ -41,6 +47,9 @@ Run the actions in this order for a fresh named database:
 5. `rollback` with `ROLLBACK_QA` only after a reviewed successful proof. This
    calls the canonical writer-transition rollback helper and checks that all
    synthetic rows/evidence remain present with the same metadata digest.
+6. `rollforward` with `ROLLFORWARD_QA` after rollback. This executes one
+   bounded retry, requires zero migrated rows and one cutover, then verifies
+   the canonical ledger fences are restored.
 
 The `drain-verify` receipt joins the exact execution names to the aggregate
 producer counters, the seed verifier result, and the Firestore completion and
@@ -48,7 +57,9 @@ prompt-projection fences. It contains no row content or provider payload. A
 successful emulator proof is a code-contract result and cannot substitute for
 the named Cloud Run execution and its real rollout/admission path.
 
-The workflow artifacts are content-free and should be retained with the
-separate isolated-plane readiness receipt. If any precondition fails, preserve
-the failed artifact and fix the named QA resource or data-plane state before
-retrying; do not point the operator at the shared development job.
+The uploaded workflow artifact is limited to the content-free operator receipt;
+raw Cloud Run descriptions, logs, Firestore documents, and temporary launch
+files remain outside the artifact staging directory. Retain the receipt with
+the separate isolated-plane readiness receipt. If any precondition fails,
+preserve the failed receipt and fix the named QA resource or data-plane state
+before retrying; do not point the operator at the shared development job.

--- a/backend/scripts/jit_qa_manual_operator.py
+++ b/backend/scripts/jit_qa_manual_operator.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Content-free helpers for the isolated JIT QA manual workflow.
+
+The workflow is the only caller that performs Cloud Run execution.  This
+module keeps its safety checks and execution parsing testable without cloud
+credentials.  It accepts only the named development job and emits aggregate
+counters; log messages and Firestore documents are never copied into a
+receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+PROJECT = "based-hardware-dev"
+REGION = "us-central1"
+DATABASE = "jit-qa"
+UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
+JOB = "knowledge-ledger-drain-qa-job"
+RUNTIME_SERVICE_ACCOUNT = "jit-qa-runtime@based-hardware-dev.iam.gserviceaccount.com"
+SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+IMAGE_RE = re.compile(r"^gcr\.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:[0-9a-f]{64}$")
+EXECUTION_RE = re.compile(r"^knowledge-ledger-drain-qa-job-[a-z0-9-]+$")
+SUMMARY_RE = re.compile(
+    r"knowledge_ledger_drain:\s+"
+    r"scanned=(?P<scanned>\d+)\s+"
+    r"inventoried=(?P<inventoried>\d+)\s+"
+    r"attempted=(?P<attempted>\d+)\s+"
+    r"allowlist_blocked=(?P<allowlist_blocked>\d+)\s+"
+    r"blocked=(?P<blocked>\d+)\s+"
+    r"revoked=(?P<revoked>\d+)\s+"
+    r"remaining=(?P<remaining>\d+)\s+"
+    r"cutover=(?P<cutover>\d+)\s+"
+    r"migrated_rows=(?P<migrated>\d+)\s+"
+    r"errors=(?P<errors>\d+)"
+)
+
+
+class OperatorError(ValueError):
+    """Raised when a cloud result crosses the fixed QA boundary."""
+
+
+def require_source_sha(value: str) -> str:
+    if not SOURCE_SHA_RE.fullmatch(value):
+        raise OperatorError("source SHA must be a full lowercase 40-character commit")
+    return value
+
+
+def _containers(resource: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """Read both Cloud Run v1 and v2 job response shapes."""
+
+    paths = (
+        ("spec", "template", "template", "spec", "containers"),
+        ("spec", "template", "template", "containers"),
+        ("spec", "template", "spec", "template", "spec", "containers"),
+        ("spec", "template", "spec", "template", "containers"),
+    )
+    for path in paths:
+        value: object = resource
+        for key in path:
+            value = value.get(key) if isinstance(value, Mapping) else None
+        if value is not None:
+            if isinstance(value, list) and len(value) == 1 and isinstance(value[0], Mapping):
+                return [value[0]]
+            raise OperatorError("QA drain job must have exactly one application container")
+    raise OperatorError("QA drain job has no supported container shape")
+
+
+def _env(container: Mapping[str, Any]) -> tuple[dict[str, str], set[str]]:
+    values: dict[str, str] = {}
+    secret_names: set[str] = set()
+    entries = container.get("env")
+    if not isinstance(entries, list):
+        raise OperatorError("QA drain job environment is missing")
+    for entry in entries:
+        if not isinstance(entry, Mapping) or not isinstance(entry.get("name"), str):
+            raise OperatorError("QA drain job environment entry is malformed")
+        name = str(entry["name"])
+        if name in values or name in secret_names:
+            raise OperatorError(f"QA drain job environment repeats {name}")
+        if "value" in entry:
+            if not isinstance(entry["value"], str):
+                raise OperatorError(f"QA drain job value for {name} is malformed")
+            values[name] = entry["value"]
+            continue
+        source = entry.get("valueSource", entry.get("valueFrom"))
+        if isinstance(source, Mapping):
+            reference = source.get("secretKeyRef")
+            if isinstance(reference, Mapping):
+                secret = reference.get("secret", reference.get("name"))
+                version = reference.get("version", reference.get("key"))
+                if secret == name and version == "latest":
+                    secret_names.add(name)
+                    continue
+        raise OperatorError(f"QA drain job environment binding for {name} is malformed")
+    return values, secret_names
+
+
+def _service_account(resource: Mapping[str, Any]) -> str | None:
+    for path in (
+        ("spec", "template", "spec", "template", "spec", "serviceAccount"),
+        ("spec", "template", "spec", "template", "spec", "serviceAccountName"),
+        ("spec", "template", "template", "serviceAccount"),
+        ("spec", "template", "template", "serviceAccountName"),
+        ("spec", "template", "spec", "serviceAccount"),
+        ("spec", "template", "spec", "serviceAccountName"),
+    ):
+        value: object = resource
+        for key in path:
+            value = value.get(key) if isinstance(value, Mapping) else None
+        if value is not None:
+            return str(value)
+    return None
+
+
+def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str) -> dict[str, str]:
+    """Validate the live job's identity, source label, digest, and QA fence."""
+
+    require_source_sha(source_sha)
+    metadata = resource.get("metadata")
+    if not isinstance(metadata, Mapping) or metadata.get("name") != JOB:
+        raise OperatorError("Cloud Run resource is not the isolated QA drain job")
+    labels = metadata.get("labels")
+    if not isinstance(labels, Mapping) or labels.get("jit-qa") != "true" or labels.get("source-sha") != source_sha:
+        raise OperatorError("QA drain job source admission label is missing or stale")
+    container = _containers(resource)[0]
+    image = container.get("image")
+    if not isinstance(image, str) or not IMAGE_RE.fullmatch(image):
+        raise OperatorError("QA drain job must serve the immutable development image digest")
+    if _service_account(resource) != RUNTIME_SERVICE_ACCOUNT:
+        raise OperatorError("QA drain job uses an unexpected runtime service account")
+    if container.get("envFrom"):
+        raise OperatorError("QA drain job may not inherit an environment bundle")
+    values, secrets = _env(container)
+    expected = {
+        "OMI_ENV_STAGE": "dev",
+        "GOOGLE_CLOUD_PROJECT": PROJECT,
+        "OMI_FIRESTORE_DATA_PLANE_PROJECT": PROJECT,
+        "FIRESTORE_DATABASE_ID": DATABASE,
+        "FIREBASE_AUTH_PROJECT_ID": "based-hardware",
+        "MEMORY_ENABLED": "on",
+        "KNOWLEDGE_LEDGER_DRAIN_ENABLED": "false",
+        "KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST": UID,
+        "OMI_JIT_QA_AUTH_ONLY": "true",
+        "OMI_JIT_QA_UID_ALLOWLIST": UID,
+    }
+    for name, expected_value in expected.items():
+        if values.get(name) != expected_value:
+            raise OperatorError(f"QA drain job environment {name} is not the fixed QA value")
+    if secrets != {"ENCRYPTION_SECRET", "POSTHOG_PROJECT_API_KEY"}:
+        raise OperatorError("QA drain job has an unexpected secret binding")
+    forbidden = {"SERVICE_ACCOUNT_JSON", "GOOGLE_APPLICATION_CREDENTIALS", "FIREBASE_AUTH_CREDENTIALS_PATH"}
+    if forbidden.intersection(values) or forbidden.intersection(secrets):
+        raise OperatorError("QA drain job contains a customer credential selector")
+    return {"job": JOB, "image": image, "source_sha": source_sha, "database": DATABASE, "uid": UID}
+
+
+def execution_name(payload: Mapping[str, Any]) -> str:
+    metadata = payload.get("metadata")
+    name = metadata.get("name") if isinstance(metadata, Mapping) else None
+    if not isinstance(name, str) or not EXECUTION_RE.fullmatch(name):
+        raise OperatorError("Cloud Run returned an unexpected QA drain execution name")
+    return name
+
+
+def execution_state(payload: Mapping[str, Any]) -> str:
+    status = payload.get("status")
+    conditions = status.get("conditions") if isinstance(status, Mapping) else None
+    if not isinstance(conditions, list):
+        return "running"
+    completed = next(
+        (item for item in conditions if isinstance(item, Mapping) and item.get("type") == "Completed"), None
+    )
+    if not isinstance(completed, Mapping) or completed.get("status") not in {"True", "False"}:
+        return "running"
+    return "succeeded" if completed.get("status") == "True" else "failed"
+
+
+def _strings(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        result: list[str] = []
+        for child in value.values():
+            result.extend(_strings(child))
+        return result
+    if isinstance(value, list):
+        result = []
+        for child in value:
+            result.extend(_strings(child))
+        return result
+    return []
+
+
+def summary_from_logs(payload: object) -> dict[str, Any]:
+    """Extract the aggregate line emitted by the real drain job.
+
+    The query is already scoped to one execution by the workflow.  We still
+    parse every returned string and require exactly one summary line, so a
+    missing or ambiguous log can never be mistaken for a successful page.
+    """
+
+    matches = []
+    for candidate in _strings(payload):
+        matches.extend(SUMMARY_RE.finditer(candidate))
+    if len(matches) != 1:
+        raise OperatorError(f"expected one content-free drain summary, found {len(matches)}")
+    match = matches[0]
+    values = {key: int(value) for key, value in match.groupdict().items()}
+    return {
+        "inventoried_users": values["inventoried"],
+        "scanned_documents": values["scanned"],
+        "attempted_users": values["attempted"],
+        "allowlist_blocked_users": values["allowlist_blocked"],
+        "rollout_blocked_users": values["blocked"],
+        "authorization_revoked_users": values["revoked"],
+        "remaining_users": values["remaining"],
+        "cutover_users": values["cutover"],
+        "migrated_rows": values["migrated"],
+        "errors": ["<redacted>"] * values["errors"],
+    }
+
+
+def _firestore_value(document: Mapping[str, Any], field: str) -> Any:
+    fields = document.get("fields")
+    entry = fields.get(field) if isinstance(fields, Mapping) else None
+    if not isinstance(entry, Mapping):
+        return None
+    if "stringValue" in entry:
+        return entry["stringValue"]
+    if "integerValue" in entry:
+        try:
+            return int(str(entry["integerValue"]))
+        except (TypeError, ValueError):
+            return None
+    if "booleanValue" in entry:
+        return entry["booleanValue"]
+    return None
+
+
+def validate_durable_state(
+    control: Mapping[str, Any],
+    completion: Mapping[str, Any],
+    projection: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate the named account's content-free post-drain fences."""
+
+    control_mode = _firestore_value(control, "writer_mode")
+    if control_mode != "ledger":
+        raise OperatorError("durable proof has no stable ledger writer")
+    if _firestore_value(completion, "status") != "complete" or _firestore_value(completion, "blocking_row_count") != 0:
+        raise OperatorError("durable ledger completion is incomplete")
+    if _firestore_value(control, "head_commit_id") != _firestore_value(completion, "source_head_commit_id"):
+        raise OperatorError("durable ledger completion head fence mismatches apply-control")
+    if _firestore_value(control, "writer_epoch") != _firestore_value(completion, "writer_epoch"):
+        raise OperatorError("durable ledger completion epoch fence mismatches apply-control")
+    if _firestore_value(projection, "status") != "complete" or _firestore_value(projection, "legacy_row_count") != 0:
+        raise OperatorError("durable prompt projection is incomplete")
+    scanned = _firestore_value(projection, "scanned_row_count")
+    if _firestore_value(projection, "blocking_row_count") != 0 or not isinstance(scanned, int) or scanned <= 0:
+        raise OperatorError("durable prompt projection has no completed nonempty scan")
+    return {
+        "writer_mode": control_mode,
+        "completion_status": "complete",
+        "projection_status": "complete",
+        "scanned_row_count": scanned,
+    }
+
+
+def _load(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OperatorError(f"could not read JSON from {path}") from exc
+
+
+def _load_mapping(path: Path) -> Mapping[str, Any]:
+    payload = _load(path)
+    if not isinstance(payload, Mapping):
+        raise OperatorError(f"{path} must contain a JSON object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    job = sub.add_parser("validate-job")
+    job.add_argument("--source-sha", required=True)
+    job.add_argument("--resource-json", type=Path, required=True)
+    name = sub.add_parser("execution-name")
+    name.add_argument("--execution-json", type=Path, required=True)
+    state = sub.add_parser("execution-state")
+    state.add_argument("--execution-json", type=Path, required=True)
+    logs = sub.add_parser("summary")
+    logs.add_argument("--logs-json", type=Path, required=True)
+    durable = sub.add_parser("durable")
+    durable.add_argument("--control-json", type=Path, required=True)
+    durable.add_argument("--completion-json", type=Path, required=True)
+    durable.add_argument("--projection-json", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate-job":
+            print(
+                json.dumps(
+                    validate_job_resource(_load_mapping(args.resource_json), source_sha=args.source_sha),
+                    sort_keys=True,
+                )
+            )
+        elif args.command == "execution-name":
+            print(execution_name(_load_mapping(args.execution_json)))
+        elif args.command == "execution-state":
+            print(execution_state(_load_mapping(args.execution_json)))
+        elif args.command == "summary":
+            print(json.dumps(summary_from_logs(_load(args.logs_json)), sort_keys=True))
+        else:
+            print(
+                json.dumps(
+                    validate_durable_state(
+                        _load_mapping(args.control_json),
+                        _load_mapping(args.completion_json),
+                        _load_mapping(args.projection_json),
+                    ),
+                    sort_keys=True,
+                )
+            )
+        return 0
+    except (OSError, json.JSONDecodeError, OperatorError) as exc:
+        print(f"JIT QA operator refused: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/jit_qa_manual_operator.py
+++ b/backend/scripts/jit_qa_manual_operator.py
@@ -17,14 +17,21 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping
 
-PROJECT = "based-hardware-dev"
-REGION = "us-central1"
-DATABASE = "jit-qa"
-UID = "vi7SA9ckQCe4ccobWNxlbdcNdC23"
-JOB = "knowledge-ledger-drain-qa-job"
-RUNTIME_SERVICE_ACCOUNT = "jit-qa-runtime@based-hardware-dev.iam.gserviceaccount.com"
+# The deployed-resource contract is owned by the QA deployment workflow.  Keep
+# this consumer on that same contract instead of maintaining a second copy of
+# its environment and Secret Manager bindings.
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+import jit_qa_cloud_run_contract as qa_contract  # noqa: E402
+
+PROJECT = qa_contract.PROJECT_ID
+REGION = qa_contract.REGION
+DATABASE = qa_contract.FIRESTORE_DATABASE_ID
+UID = qa_contract.QA_UID
+JOB = qa_contract.LEDGER_DRAIN_JOB
+RUNTIME_SERVICE_ACCOUNT = qa_contract.RUNTIME_SERVICE_ACCOUNT
 SOURCE_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-IMAGE_RE = re.compile(r"^gcr\.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:[0-9a-f]{64}$")
 EXECUTION_RE = re.compile(r"^knowledge-ledger-drain-qa-job-[a-z0-9-]+$")
 SUMMARY_RE = re.compile(
     r"knowledge_ledger_drain:\s+"
@@ -39,6 +46,52 @@ SUMMARY_RE = re.compile(
     r"migrated_rows=(?P<migrated>\d+)\s+"
     r"errors=(?P<errors>\d+)"
 )
+SUMMARY_EXPECTATIONS: dict[str, dict[str, int]] = {
+    "first": {
+        "inventoried_users": 1,
+        "scanned_documents": 1,
+        "attempted_users": 1,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 1,
+        "cutover_users": 0,
+        "migrated_rows": 100,
+    },
+    "second": {
+        "inventoried_users": 1,
+        "scanned_documents": 1,
+        "attempted_users": 1,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 0,
+        "cutover_users": 1,
+        "migrated_rows": 1,
+    },
+    "retry": {
+        "inventoried_users": 0,
+        "scanned_documents": 1,
+        "attempted_users": 0,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 0,
+        "cutover_users": 0,
+        "migrated_rows": 0,
+    },
+    "rollforward": {
+        "inventoried_users": 1,
+        "scanned_documents": 1,
+        "attempted_users": 1,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 0,
+        "cutover_users": 1,
+        "migrated_rows": 0,
+    },
+}
 
 
 class OperatorError(ValueError):
@@ -51,75 +104,8 @@ def require_source_sha(value: str) -> str:
     return value
 
 
-def _containers(resource: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    """Read both Cloud Run v1 and v2 job response shapes."""
-
-    paths = (
-        ("spec", "template", "template", "spec", "containers"),
-        ("spec", "template", "template", "containers"),
-        ("spec", "template", "spec", "template", "spec", "containers"),
-        ("spec", "template", "spec", "template", "containers"),
-    )
-    for path in paths:
-        value: object = resource
-        for key in path:
-            value = value.get(key) if isinstance(value, Mapping) else None
-        if value is not None:
-            if isinstance(value, list) and len(value) == 1 and isinstance(value[0], Mapping):
-                return [value[0]]
-            raise OperatorError("QA drain job must have exactly one application container")
-    raise OperatorError("QA drain job has no supported container shape")
-
-
-def _env(container: Mapping[str, Any]) -> tuple[dict[str, str], set[str]]:
-    values: dict[str, str] = {}
-    secret_names: set[str] = set()
-    entries = container.get("env")
-    if not isinstance(entries, list):
-        raise OperatorError("QA drain job environment is missing")
-    for entry in entries:
-        if not isinstance(entry, Mapping) or not isinstance(entry.get("name"), str):
-            raise OperatorError("QA drain job environment entry is malformed")
-        name = str(entry["name"])
-        if name in values or name in secret_names:
-            raise OperatorError(f"QA drain job environment repeats {name}")
-        if "value" in entry:
-            if not isinstance(entry["value"], str):
-                raise OperatorError(f"QA drain job value for {name} is malformed")
-            values[name] = entry["value"]
-            continue
-        source = entry.get("valueSource", entry.get("valueFrom"))
-        if isinstance(source, Mapping):
-            reference = source.get("secretKeyRef")
-            if isinstance(reference, Mapping):
-                secret = reference.get("secret", reference.get("name"))
-                version = reference.get("version", reference.get("key"))
-                if secret == name and version == "latest":
-                    secret_names.add(name)
-                    continue
-        raise OperatorError(f"QA drain job environment binding for {name} is malformed")
-    return values, secret_names
-
-
-def _service_account(resource: Mapping[str, Any]) -> str | None:
-    for path in (
-        ("spec", "template", "spec", "template", "spec", "serviceAccount"),
-        ("spec", "template", "spec", "template", "spec", "serviceAccountName"),
-        ("spec", "template", "template", "serviceAccount"),
-        ("spec", "template", "template", "serviceAccountName"),
-        ("spec", "template", "spec", "serviceAccount"),
-        ("spec", "template", "spec", "serviceAccountName"),
-    ):
-        value: object = resource
-        for key in path:
-            value = value.get(key) if isinstance(value, Mapping) else None
-        if value is not None:
-            return str(value)
-    return None
-
-
 def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str) -> dict[str, str]:
-    """Validate the live job's identity, source label, digest, and QA fence."""
+    """Validate the live job with the deployment workflow's shared contract."""
 
     require_source_sha(source_sha)
     metadata = resource.get("metadata")
@@ -128,35 +114,28 @@ def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str) -> di
     labels = metadata.get("labels")
     if not isinstance(labels, Mapping) or labels.get("jit-qa") != "true" or labels.get("source-sha") != source_sha:
         raise OperatorError("QA drain job source admission label is missing or stale")
-    container = _containers(resource)[0]
+    try:
+        container = qa_contract._containers(resource, kind="job")[0]
+    except qa_contract.JITQAContractError as exc:
+        raise OperatorError(str(exc)) from exc
     image = container.get("image")
-    if not isinstance(image, str) or not IMAGE_RE.fullmatch(image):
+    if not isinstance(image, str) or not re.fullmatch(
+        r"gcr\.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:[0-9a-f]{64}", image
+    ):
         raise OperatorError("QA drain job must serve the immutable development image digest")
-    if _service_account(resource) != RUNTIME_SERVICE_ACCOUNT:
-        raise OperatorError("QA drain job uses an unexpected runtime service account")
-    if container.get("envFrom"):
-        raise OperatorError("QA drain job may not inherit an environment bundle")
-    values, secrets = _env(container)
-    expected = {
-        "OMI_ENV_STAGE": "dev",
-        "GOOGLE_CLOUD_PROJECT": PROJECT,
-        "OMI_FIRESTORE_DATA_PLANE_PROJECT": PROJECT,
-        "FIRESTORE_DATABASE_ID": DATABASE,
-        "FIREBASE_AUTH_PROJECT_ID": "based-hardware",
-        "MEMORY_ENABLED": "on",
-        "KNOWLEDGE_LEDGER_DRAIN_ENABLED": "false",
-        "KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST": UID,
-        "OMI_JIT_QA_AUTH_ONLY": "true",
-        "OMI_JIT_QA_UID_ALLOWLIST": UID,
-    }
-    for name, expected_value in expected.items():
-        if values.get(name) != expected_value:
-            raise OperatorError(f"QA drain job environment {name} is not the fixed QA value")
-    if secrets != {"ENCRYPTION_SECRET", "POSTHOG_PROJECT_API_KEY"}:
-        raise OperatorError("QA drain job has an unexpected secret binding")
-    forbidden = {"SERVICE_ACCOUNT_JSON", "GOOGLE_APPLICATION_CREDENTIALS", "FIREBASE_AUTH_CREDENTIALS_PATH"}
-    if forbidden.intersection(values) or forbidden.intersection(secrets):
-        raise OperatorError("QA drain job contains a customer credential selector")
+    expected_environment, expected_secret_bindings = qa_contract.resource_environment("drain")
+    try:
+        qa_contract.validate_cloud_run_resource(
+            resource,
+            kind="job",
+            expected_image=image,
+            expected_environment=expected_environment,
+            expected_secret_bindings=expected_secret_bindings,
+            expected_name=JOB,
+            expected_service_account=RUNTIME_SERVICE_ACCOUNT,
+        )
+    except qa_contract.JITQAContractError as exc:
+        raise OperatorError(str(exc)) from exc
     return {"job": JOB, "image": image, "source_sha": source_sha, "database": DATABASE, "uid": UID}
 
 
@@ -226,6 +205,20 @@ def summary_from_logs(payload: object) -> dict[str, Any]:
     }
 
 
+def validate_summary(summary: Mapping[str, Any], *, phase: str) -> dict[str, Any]:
+    """Require the exact content-free counters for one bounded drain phase."""
+
+    expected = SUMMARY_EXPECTATIONS.get(phase)
+    if expected is None:
+        raise OperatorError(f"unknown drain phase {phase!r}")
+    if not isinstance(summary.get("errors"), list) or summary.get("errors"):
+        raise OperatorError(f"{phase} drain reported errors")
+    for key, value in expected.items():
+        if summary.get(key) != value:
+            raise OperatorError(f"{phase} drain {key}={summary.get(key)!r}; expected {value!r}")
+    return dict(summary)
+
+
 def _firestore_value(document: Mapping[str, Any], field: str) -> Any:
     fields = document.get("fields")
     entry = fields.get(field) if isinstance(fields, Mapping) else None
@@ -243,6 +236,20 @@ def _firestore_value(document: Mapping[str, Any], field: str) -> Any:
     return None
 
 
+def _required_string(document: Mapping[str, Any], field: str) -> str:
+    value = _firestore_value(document, field)
+    if not isinstance(value, str) or not value.strip():
+        raise OperatorError(f"durable proof is missing non-empty {field}")
+    return value
+
+
+def _required_int(document: Mapping[str, Any], field: str, *, minimum: int) -> int:
+    value = _firestore_value(document, field)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise OperatorError(f"durable proof has invalid {field}")
+    return value
+
+
 def validate_durable_state(
     control: Mapping[str, Any],
     completion: Mapping[str, Any],
@@ -250,24 +257,59 @@ def validate_durable_state(
 ) -> dict[str, Any]:
     """Validate the named account's content-free post-drain fences."""
 
-    control_mode = _firestore_value(control, "writer_mode")
+    if _required_string(control, "uid") != UID:
+        raise OperatorError("durable proof belongs to an unexpected QA identity")
+    control_mode = _required_string(control, "writer_mode")
     if control_mode != "ledger":
         raise OperatorError("durable proof has no stable ledger writer")
-    if _firestore_value(completion, "status") != "complete" or _firestore_value(completion, "blocking_row_count") != 0:
+    control_head = _required_string(control, "head_commit_id")
+    control_account_generation = _required_int(control, "account_generation", minimum=0)
+    control_source_generation = _required_int(control, "source_generation", minimum=0)
+    control_writer_epoch = _required_int(control, "writer_epoch", minimum=1)
+    if _required_string(completion, "schema_version") != "knowledge_ledger.v1":
+        raise OperatorError("durable ledger completion has an unexpected schema")
+    if (
+        _required_string(completion, "status") != "complete"
+        or _required_int(completion, "blocking_row_count", minimum=0) != 0
+    ):
         raise OperatorError("durable ledger completion is incomplete")
-    if _firestore_value(control, "head_commit_id") != _firestore_value(completion, "source_head_commit_id"):
+    completion_head = _required_string(completion, "source_head_commit_id")
+    completion_writer_epoch = _required_int(completion, "writer_epoch", minimum=1)
+    if control_head != completion_head:
         raise OperatorError("durable ledger completion head fence mismatches apply-control")
-    if _firestore_value(control, "writer_epoch") != _firestore_value(completion, "writer_epoch"):
+    if control_writer_epoch != completion_writer_epoch:
         raise OperatorError("durable ledger completion epoch fence mismatches apply-control")
-    if _firestore_value(projection, "status") != "complete" or _firestore_value(projection, "legacy_row_count") != 0:
+    if _required_string(projection, "schema_version") != "knowledge_ledger_prompt_projection.v1":
+        raise OperatorError("durable prompt projection has an unexpected schema")
+    if _required_string(projection, "status") != "complete" or _required_string(projection, "uid") != UID:
+        raise OperatorError("durable prompt projection is incomplete or foreign")
+    projection_head = _required_string(projection, "source_head_commit_id")
+    projection_account_generation = _required_int(projection, "account_generation", minimum=0)
+    projection_source_generation = _required_int(projection, "source_generation", minimum=0)
+    projection_writer_epoch = _required_int(projection, "writer_epoch", minimum=1)
+    if projection_head != control_head or projection_head != completion_head:
+        raise OperatorError("durable prompt projection head fence mismatches canonical state")
+    if projection_account_generation != control_account_generation:
+        raise OperatorError("durable prompt projection account generation mismatches apply-control")
+    if projection_source_generation != control_source_generation:
+        raise OperatorError("durable prompt projection source generation mismatches apply-control")
+    if projection_writer_epoch != control_writer_epoch or projection_writer_epoch != completion_writer_epoch:
+        raise OperatorError("durable prompt projection epoch fence mismatches canonical state")
+    if _required_int(projection, "legacy_row_count", minimum=0) != 0:
         raise OperatorError("durable prompt projection is incomplete")
-    scanned = _firestore_value(projection, "scanned_row_count")
-    if _firestore_value(projection, "blocking_row_count") != 0 or not isinstance(scanned, int) or scanned <= 0:
+    if _required_int(projection, "blocking_row_count", minimum=0) != 0:
+        raise OperatorError("durable prompt projection is incomplete")
+    scanned = _required_int(projection, "scanned_row_count", minimum=1)
+    if scanned <= 0:
         raise OperatorError("durable prompt projection has no completed nonempty scan")
     return {
         "writer_mode": control_mode,
         "completion_status": "complete",
         "projection_status": "complete",
+        "head_commit_id": control_head,
+        "account_generation": control_account_generation,
+        "source_generation": control_source_generation,
+        "writer_epoch": control_writer_epoch,
         "scanned_row_count": scanned,
     }
 
@@ -298,6 +340,9 @@ def main(argv: list[str] | None = None) -> int:
     state.add_argument("--execution-json", type=Path, required=True)
     logs = sub.add_parser("summary")
     logs.add_argument("--logs-json", type=Path, required=True)
+    validated = sub.add_parser("validate-summary")
+    validated.add_argument("--summary-json", type=Path, required=True)
+    validated.add_argument("--phase", choices=tuple(SUMMARY_EXPECTATIONS), required=True)
     durable = sub.add_parser("durable")
     durable.add_argument("--control-json", type=Path, required=True)
     durable.add_argument("--completion-json", type=Path, required=True)
@@ -317,6 +362,8 @@ def main(argv: list[str] | None = None) -> int:
             print(execution_state(_load_mapping(args.execution_json)))
         elif args.command == "summary":
             print(json.dumps(summary_from_logs(_load(args.logs_json)), sort_keys=True))
+        elif args.command == "validate-summary":
+            print(json.dumps(validate_summary(_load_mapping(args.summary_json), phase=args.phase), sort_keys=True))
         else:
             print(
                 json.dumps(

--- a/backend/scripts/jit_qa_manual_operator.py
+++ b/backend/scripts/jit_qa_manual_operator.py
@@ -104,7 +104,7 @@ def require_source_sha(value: str) -> str:
     return value
 
 
-def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str) -> dict[str, str]:
+def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str, expected_image: str) -> dict[str, str]:
     """Validate the live job with the deployment workflow's shared contract."""
 
     require_source_sha(source_sha)
@@ -123,6 +123,12 @@ def validate_job_resource(resource: Mapping[str, Any], *, source_sha: str) -> di
         r"gcr\.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:[0-9a-f]{64}", image
     ):
         raise OperatorError("QA drain job must serve the immutable development image digest")
+    if not re.fullmatch(
+        r"gcr\.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:[0-9a-f]{64}", expected_image
+    ):
+        raise OperatorError("resolved QA drain image is not an immutable development image digest")
+    if image != expected_image:
+        raise OperatorError("live QA drain image does not match the digest resolved from the admitted source tag")
     expected_environment, expected_secret_bindings = qa_contract.resource_environment("drain")
     try:
         qa_contract.validate_cloud_run_resource(
@@ -333,6 +339,7 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="command", required=True)
     job = sub.add_parser("validate-job")
     job.add_argument("--source-sha", required=True)
+    job.add_argument("--expected-image", required=True)
     job.add_argument("--resource-json", type=Path, required=True)
     name = sub.add_parser("execution-name")
     name.add_argument("--execution-json", type=Path, required=True)
@@ -352,7 +359,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "validate-job":
             print(
                 json.dumps(
-                    validate_job_resource(_load_mapping(args.resource_json), source_sha=args.source_sha),
+                    validate_job_resource(
+                        _load_mapping(args.resource_json),
+                        source_sha=args.source_sha,
+                        expected_image=args.expected_image,
+                    ),
                     sort_keys=True,
                 )
             )

--- a/backend/tests/unit/test_jit_qa_manual_operator.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator.py
@@ -69,7 +69,7 @@ def _firestore_document(**fields):
 
 
 def test_job_contract_requires_immutable_source_admitted_qa_resource():
-    result = OPERATOR.validate_job_resource(_resource(), source_sha=SOURCE_SHA)
+    result = OPERATOR.validate_job_resource(_resource(), source_sha=SOURCE_SHA, expected_image=IMAGE)
     assert result == {
         "job": OPERATOR.JOB,
         "image": IMAGE,
@@ -88,26 +88,33 @@ def test_job_contract_requires_immutable_source_admitted_qa_resource():
 )
 def test_job_contract_rejects_wrong_environment(changes, message):
     with pytest.raises(OPERATOR.OperatorError, match=message):
-        OPERATOR.validate_job_resource(_resource(**changes), source_sha=SOURCE_SHA)
+        OPERATOR.validate_job_resource(_resource(**changes), source_sha=SOURCE_SHA, expected_image=IMAGE)
 
 
 def test_job_contract_rejects_tagged_image_stale_source_and_customer_binding():
     resource = _resource()
     resource["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["image"] = IMAGE.replace("@sha256:", ":")
     with pytest.raises(OPERATOR.OperatorError, match="immutable"):
-        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA, expected_image=IMAGE)
 
     resource = _resource()
     resource["metadata"]["labels"]["source-sha"] = "c" * 40
     with pytest.raises(OPERATOR.OperatorError, match="source admission"):
-        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA, expected_image=IMAGE)
 
     resource = _resource()
     resource["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["env"].append(
         {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/customer/key.json"}
     )
     with pytest.raises(OPERATOR.OperatorError, match="forbidden credential"):
-        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA, expected_image=IMAGE)
+
+
+def test_job_contract_rejects_live_digest_that_does_not_match_admitted_source_tag():
+    with pytest.raises(OPERATOR.OperatorError, match="does not match"):
+        OPERATOR.validate_job_resource(
+            _resource(), source_sha=SOURCE_SHA, expected_image=IMAGE.replace("b" * 64, "c" * 64)
+        )
 
 
 def test_execution_name_and_state_are_fail_closed():

--- a/backend/tests/unit/test_jit_qa_manual_operator.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator.py
@@ -1,0 +1,168 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = BACKEND_ROOT / "scripts" / "jit_qa_manual_operator.py"
+
+
+def _load_operator():
+    spec = importlib.util.spec_from_file_location("jit_qa_manual_operator_for_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+OPERATOR = _load_operator()
+SOURCE_SHA = "a" * 40
+IMAGE = "gcr.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:" + "b" * 64
+
+
+def _resource(**changes):
+    values = {
+        "OMI_ENV_STAGE": "dev",
+        "GOOGLE_CLOUD_PROJECT": OPERATOR.PROJECT,
+        "OMI_FIRESTORE_DATA_PLANE_PROJECT": OPERATOR.PROJECT,
+        "FIRESTORE_DATABASE_ID": OPERATOR.DATABASE,
+        "FIREBASE_AUTH_PROJECT_ID": "based-hardware",
+        "MEMORY_ENABLED": "on",
+        "KNOWLEDGE_LEDGER_DRAIN_ENABLED": "false",
+        "KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST": OPERATOR.UID,
+        "OMI_JIT_QA_AUTH_ONLY": "true",
+        "OMI_JIT_QA_UID_ALLOWLIST": OPERATOR.UID,
+    }
+    values.update(changes)
+    env = [{"name": name, "value": value} for name, value in values.items()]
+    env.extend(
+        {"name": name, "valueSource": {"secretKeyRef": {"secret": name, "version": "latest"}}}
+        for name in ("ENCRYPTION_SECRET", "POSTHOG_PROJECT_API_KEY")
+    )
+    return {
+        "metadata": {"name": OPERATOR.JOB, "labels": {"jit-qa": "true", "source-sha": SOURCE_SHA}},
+        "spec": {
+            "template": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "serviceAccountName": OPERATOR.RUNTIME_SERVICE_ACCOUNT,
+                            "containers": [{"image": IMAGE, "env": env}],
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+
+def _firestore_document(**fields):
+    def typed(value):
+        if isinstance(value, bool):
+            return {"booleanValue": value}
+        if isinstance(value, int):
+            return {"integerValue": str(value)}
+        return {"stringValue": value}
+
+    return {"fields": {key: typed(value) for key, value in fields.items()}}
+
+
+def test_job_contract_requires_immutable_source_admitted_qa_resource():
+    result = OPERATOR.validate_job_resource(_resource(), source_sha=SOURCE_SHA)
+    assert result == {
+        "job": OPERATOR.JOB,
+        "image": IMAGE,
+        "source_sha": SOURCE_SHA,
+        "database": OPERATOR.DATABASE,
+        "uid": OPERATOR.UID,
+    }
+
+
+@pytest.mark.parametrize(
+    "changes, message",
+    [
+        ({"GOOGLE_CLOUD_PROJECT": "based-hardware"}, "fixed QA value"),
+        ({"KNOWLEDGE_LEDGER_DRAIN_ENABLED": "true"}, "fixed QA value"),
+    ],
+)
+def test_job_contract_rejects_wrong_environment(changes, message):
+    with pytest.raises(OPERATOR.OperatorError, match=message):
+        OPERATOR.validate_job_resource(_resource(**changes), source_sha=SOURCE_SHA)
+
+
+def test_job_contract_rejects_tagged_image_stale_source_and_customer_binding():
+    resource = _resource()
+    resource["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["image"] = IMAGE.replace("@sha256:", ":")
+    with pytest.raises(OPERATOR.OperatorError, match="immutable"):
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+
+    resource = _resource()
+    resource["metadata"]["labels"]["source-sha"] = "c" * 40
+    with pytest.raises(OPERATOR.OperatorError, match="source admission"):
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+
+    resource = _resource()
+    resource["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["env"].append(
+        {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/customer/key.json"}
+    )
+    with pytest.raises(OPERATOR.OperatorError, match="customer credential"):
+        OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
+
+
+def test_execution_name_and_state_are_fail_closed():
+    assert OPERATOR.execution_name({"metadata": {"name": OPERATOR.JOB + "-abc123"}}) == OPERATOR.JOB + "-abc123"
+    with pytest.raises(OPERATOR.OperatorError):
+        OPERATOR.execution_name({"metadata": {"name": "knowledge-ledger-drain-job-abc123"}})
+    assert OPERATOR.execution_state({}) == "running"
+    assert (
+        OPERATOR.execution_state({"status": {"conditions": [{"type": "Completed", "status": "True"}]}}) == "succeeded"
+    )
+    assert OPERATOR.execution_state({"status": {"conditions": [{"type": "Completed", "status": "False"}]}}) == "failed"
+
+
+def test_summary_parser_maps_content_free_cloud_log_line():
+    logs = {
+        "entries": [
+            {
+                "resource": {"type": "cloud_run_job"},
+                "jsonPayload": {
+                    "message": (
+                        "knowledge_ledger_drain: scanned=1 inventoried=1 attempted=1 allowlist_blocked=0 "
+                        "blocked=0 revoked=0 remaining=1 cutover=0 migrated_rows=100 errors=0"
+                    )
+                },
+            }
+        ]
+    }
+    assert OPERATOR.summary_from_logs(logs) == {
+        "inventoried_users": 1,
+        "scanned_documents": 1,
+        "attempted_users": 1,
+        "allowlist_blocked_users": 0,
+        "rollout_blocked_users": 0,
+        "authorization_revoked_users": 0,
+        "remaining_users": 1,
+        "cutover_users": 0,
+        "migrated_rows": 100,
+        "errors": [],
+    }
+    with pytest.raises(OPERATOR.OperatorError, match="found 0"):
+        OPERATOR.summary_from_logs({"entries": []})
+    list_payload = [logs["entries"][0]]
+    assert OPERATOR.summary_from_logs(list_payload)["migrated_rows"] == 100
+
+
+def test_durable_state_requires_matching_fences_and_nonempty_projection():
+    control = _firestore_document(writer_mode="ledger", head_commit_id="head", writer_epoch=2)
+    completion = _firestore_document(
+        status="complete", blocking_row_count=0, source_head_commit_id="head", writer_epoch=2
+    )
+    projection = _firestore_document(status="complete", legacy_row_count=0, blocking_row_count=0, scanned_row_count=101)
+    assert OPERATOR.validate_durable_state(control, completion, projection)["scanned_row_count"] == 101
+    with pytest.raises(OPERATOR.OperatorError, match="head fence"):
+        OPERATOR.validate_durable_state(
+            control,
+            _firestore_document(status="complete", blocking_row_count=0, source_head_commit_id="other", writer_epoch=2),
+            projection,
+        )

--- a/backend/tests/unit/test_jit_qa_manual_operator.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator.py
@@ -82,8 +82,8 @@ def test_job_contract_requires_immutable_source_admitted_qa_resource():
 @pytest.mark.parametrize(
     "changes, message",
     [
-        ({"GOOGLE_CLOUD_PROJECT": "based-hardware"}, "fixed QA value"),
-        ({"KNOWLEDGE_LEDGER_DRAIN_ENABLED": "true"}, "fixed QA value"),
+        ({"GOOGLE_CLOUD_PROJECT": "based-hardware"}, "unexpected value"),
+        ({"KNOWLEDGE_LEDGER_DRAIN_ENABLED": "true"}, "unexpected value"),
     ],
 )
 def test_job_contract_rejects_wrong_environment(changes, message):
@@ -106,7 +106,7 @@ def test_job_contract_rejects_tagged_image_stale_source_and_customer_binding():
     resource["spec"]["template"]["spec"]["template"]["spec"]["containers"][0]["env"].append(
         {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/customer/key.json"}
     )
-    with pytest.raises(OPERATOR.OperatorError, match="customer credential"):
+    with pytest.raises(OPERATOR.OperatorError, match="forbidden credential"):
         OPERATOR.validate_job_resource(resource, source_sha=SOURCE_SHA)
 
 
@@ -153,16 +153,80 @@ def test_summary_parser_maps_content_free_cloud_log_line():
     assert OPERATOR.summary_from_logs(list_payload)["migrated_rows"] == 100
 
 
-def test_durable_state_requires_matching_fences_and_nonempty_projection():
-    control = _firestore_document(writer_mode="ledger", head_commit_id="head", writer_epoch=2)
-    completion = _firestore_document(
-        status="complete", blocking_row_count=0, source_head_commit_id="head", writer_epoch=2
+def test_summary_validation_requires_phase_specific_rollforward_counters():
+    first = OPERATOR.summary_from_logs(
+        {
+            "message": (
+                "knowledge_ledger_drain: scanned=1 inventoried=1 attempted=1 allowlist_blocked=0 "
+                "blocked=0 revoked=0 remaining=1 cutover=0 migrated_rows=100 errors=0"
+            )
+        }
     )
-    projection = _firestore_document(status="complete", legacy_row_count=0, blocking_row_count=0, scanned_row_count=101)
+    assert OPERATOR.validate_summary(first, phase="first")["migrated_rows"] == 100
+    rollforward = dict(first)
+    rollforward.update(remaining_users=0, cutover_users=1, migrated_rows=0)
+    assert OPERATOR.validate_summary(rollforward, phase="rollforward")["cutover_users"] == 1
+    with pytest.raises(OPERATOR.OperatorError, match="rollforward drain"):
+        OPERATOR.validate_summary(first, phase="rollforward")
+
+
+def test_durable_state_requires_matching_fences_and_nonempty_projection():
+    control = _firestore_document(
+        uid=OPERATOR.UID,
+        writer_mode="ledger",
+        head_commit_id="head",
+        account_generation=3,
+        source_generation=4,
+        writer_epoch=2,
+    )
+    completion = _firestore_document(
+        schema_version="knowledge_ledger.v1",
+        status="complete",
+        blocking_row_count=0,
+        source_head_commit_id="head",
+        writer_epoch=2,
+    )
+    projection = _firestore_document(
+        schema_version="knowledge_ledger_prompt_projection.v1",
+        status="complete",
+        uid=OPERATOR.UID,
+        source_head_commit_id="head",
+        account_generation=3,
+        source_generation=4,
+        writer_epoch=2,
+        legacy_row_count=0,
+        blocking_row_count=0,
+        scanned_row_count=101,
+    )
     assert OPERATOR.validate_durable_state(control, completion, projection)["scanned_row_count"] == 101
     with pytest.raises(OPERATOR.OperatorError, match="head fence"):
         OPERATOR.validate_durable_state(
             control,
-            _firestore_document(status="complete", blocking_row_count=0, source_head_commit_id="other", writer_epoch=2),
+            _firestore_document(
+                schema_version="knowledge_ledger.v1",
+                status="complete",
+                blocking_row_count=0,
+                source_head_commit_id="other",
+                writer_epoch=2,
+            ),
             projection,
+        )
+    with pytest.raises(OPERATOR.OperatorError, match="missing non-empty head_commit_id"):
+        OPERATOR.validate_durable_state(
+            _firestore_document(
+                uid=OPERATOR.UID,
+                writer_mode="ledger",
+                head_commit_id="",
+                account_generation=3,
+                source_generation=4,
+                writer_epoch=2,
+            ),
+            completion,
+            projection,
+        )
+    with pytest.raises(OPERATOR.OperatorError, match="account generation"):
+        OPERATOR.validate_durable_state(
+            control,
+            completion,
+            {**projection, "fields": {**projection["fields"], "account_generation": {"integerValue": "9"}}},
         )

--- a/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".." / ".github" / "workflows" / "jit_qa_manual_operator.yml"
+QA_CLOUD_WORKFLOW = Path(__file__).resolve().parents[2] / ".." / ".github" / "workflows" / "jit_qa_cloud_run.yml"
 
 
 def _workflow_steps():
@@ -17,6 +18,11 @@ def _workflow_steps():
 
 def _step(name: str):
     return next(step for step in _workflow_steps() if step.get("name") == name)
+
+
+def _qa_cloud_steps():
+    document = yaml.safe_load(QA_CLOUD_WORKFLOW.read_text(encoding="utf-8"))
+    return document["jobs"]["provision"]["steps"]
 
 
 def test_manual_operator_is_main_only_and_qa_fenced():
@@ -34,7 +40,15 @@ def test_manual_operator_is_main_only_and_qa_fenced():
 
 def test_manual_operator_uses_existing_seed_contract_without_deploying_resources():
     text = WORKFLOW.read_text(encoding="utf-8")
-    for operation in ("bootstrap", "prepare", "inspect", "drain-verify", "rollback", "rollforward"):
+    for operation in (
+        "bootstrap",
+        "ensure-infrastructure-api",
+        "prepare",
+        "inspect",
+        "drain-verify",
+        "rollback",
+        "rollforward",
+    ):
         assert operation in text
     assert "jit_qa_seed_and_verify.py bootstrap" in text
     assert "jit_qa_seed_and_verify.py" in text
@@ -43,6 +57,8 @@ def test_manual_operator_uses_existing_seed_contract_without_deploying_resources
     assert "jit_qa_manual_operator.py validate-job" in text
     assert "DRAIN_VERIFY_QA" in text
     assert "ROLLBACK_QA" in text
+    assert "ENABLE_QA_API" in text
+    assert "redis.googleapis.com" in text
     assert "gcloud run deploy" not in text
     assert "gcloud run jobs deploy" not in text
     assert "gcloud scheduler" not in text
@@ -123,7 +139,105 @@ def test_mutating_seed_step_executes_with_source_sha_and_sanitized_artifact_only
     step = _step("Run read-only or seed operator action")
     assert "SOURCE_SHA" in step["env"]
     assert '"$operator_dir/artifacts/operator-receipt.json"' in step["run"]
-    assert 'unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS' in step["run"]
+    assert "unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH" in step["run"]
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in step["run"].split("unset", 1)[1].split("\n", 1)[0]
+
+
+def test_action_adc_is_retained_and_resolves_a_harmless_local_fixture_without_network(monkeypatch, tmp_path):
+    auth_step = _step("Authenticate to the development project")
+    assert auth_step["id"] == "auth"
+    adc_step = _step("Verify action-provided development ADC")
+    assert adc_step["env"]["ACTION_CREDENTIALS_PATH"] == "${{ steps.auth.outputs.credentials_file_path }}"
+    drain_step = _step("Execute three bounded drain pages and verify durable proof")
+    assert "unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON FIREBASE_AUTH_CREDENTIALS_PATH" in drain_step["run"]
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in drain_step["run"].split("unset", 1)[1].split("\n", 1)[0]
+
+    credentials_path = tmp_path / "authorized-user.json"
+    credentials_path.write_text(
+        json.dumps(
+            {
+                "type": "authorized_user",
+                "client_id": "local-fixture.apps.googleusercontent.com",
+                "client_secret": "local-fixture-secret",
+                "refresh_token": "local-fixture-refresh-token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_path))
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware-dev")
+    monkeypatch.delenv("SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.delenv("FIREBASE_AUTH_CREDENTIALS_PATH", raising=False)
+    from google.auth import default
+
+    credentials, project = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    assert credentials.__class__.__module__ == "google.oauth2.credentials"
+    assert project == "based-hardware-dev"
+
+
+def test_qa_provision_enables_only_the_fixed_development_redis_api_before_resource_creation():
+    steps = _qa_cloud_steps()
+    api_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Ensure named development Redis API is enabled before provisioning"
+    )
+    api_command = api_step["run"]
+    redis_step = next(step for step in steps if step.get("name") == "Create or verify the 1 GiB Basic Redis dependency")
+    assert 'service="redis.googleapis.com"' in api_command
+    assert '--project "$QA_PROJECT"' in api_command
+    assert "timeout --foreground --kill-after=5s 60s gcloud services enable" in api_command
+    assert steps.index(api_step) < steps.index(redis_step)
+    redis_command = redis_step["run"]
+    assert "gcloud redis instances create" in redis_command
+
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        state = root / "state"
+        state.write_text("DISABLED\n", encoding="utf-8")
+        calls = root / "calls"
+        (fake_bin / "gcloud").write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "printf '%s\\n' \"$*\" >> \"$CALLS\"\n"
+            "if [[ \"${1:-}\" == services && \"${2:-}\" == describe ]]; then cat \"$STATE\"; exit 0; fi\n"
+            "if [[ \"${1:-}\" == services && \"${2:-}\" == enable ]]; then printf 'ENABLED\\n' > \"$STATE\"; exit 0; fi\n"
+            "echo \"unexpected gcloud command: $*\" >&2\n"
+            "exit 2\n",
+            encoding="utf-8",
+        )
+        (fake_bin / "gcloud").chmod(0o755)
+        environment = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "QA_PROJECT": "based-hardware-dev",
+            "STATE": str(state),
+            "CALLS": str(calls),
+        }
+        result = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", api_command],
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert state.read_text(encoding="utf-8").strip() == "ENABLED"
+        assert any(
+            "services enable redis.googleapis.com" in line for line in calls.read_text(encoding="utf-8").splitlines()
+        )
+
+        calls.write_text("", encoding="utf-8")
+        result = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", api_command],
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert not any(
+            "services enable redis.googleapis.com" in line for line in calls.read_text(encoding="utf-8").splitlines()
+        )
 
 
 def test_seed_bash_step_runs_with_fake_cli_and_cannot_lose_source_sha():

--- a/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
@@ -246,6 +246,68 @@ def test_qa_provision_enables_only_the_fixed_development_redis_api_before_resour
         )
 
 
+def test_deployed_job_validation_uses_same_step_resolved_digest_before_github_env_propagation():
+    step = _step("Verify the deployed immutable QA drain job")
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        runner_temp = root / "runner-temp"
+        (runner_temp / "jit-qa-operator").mkdir(parents=True)
+        gcloud = fake_bin / "gcloud"
+        gcloud.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ \"${1:-}\" == container && \"${2:-}\" == images && \"${3:-}\" == describe ]]; then\n"
+            "  printf 'sha256:%064d\\n' 7\n"
+            "  exit 0\n"
+            "fi\n"
+            "if [[ \"${1:-}\" == run && \"${2:-}\" == jobs && \"${3:-}\" == describe ]]; then\n"
+            "  printf '{}\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            "echo \"unexpected gcloud command: $*\" >&2\n"
+            "exit 2\n",
+            encoding="utf-8",
+        )
+        gcloud.chmod(0o755)
+        fake_python = fake_bin / "python"
+        fake_python.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ \"${1:-}\" == backend/scripts/jit_qa_manual_operator.py ]]; then\n"
+            "  printf '%s\\n' \"$*\" > \"$PYTHON_CALL\"\n"
+            "  printf '{}\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            "echo \"unexpected python command: $*\" >&2\n"
+            "exit 2\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+        environment = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "RUNNER_TEMP": str(runner_temp),
+            "GITHUB_ENV": str(root / "github-env"),
+            "QA_PYTHON": str(fake_python),
+            "QA_PROJECT": "based-hardware-dev",
+            "QA_REGION": "us-central1",
+            "QA_DRAIN_JOB": "knowledge-ledger-drain-qa-job",
+            "SOURCE_SHA": "a" * 40,
+            "PYTHON_CALL": str(root / "python-call"),
+        }
+        result = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", step["run"]],
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        expected = "gcr.io/based-hardware-dev/knowledge-ledger-drain-qa-job@sha256:" + "0" * 63 + "7"
+        assert f"QA_DRAIN_IMAGE={expected}" in (root / "github-env").read_text(encoding="utf-8")
+        assert f"--expected-image {expected}" in (root / "python-call").read_text(encoding="utf-8")
+
+
 def test_seed_bash_step_runs_with_fake_cli_and_cannot_lose_source_sha():
     step = _step("Run read-only or seed operator action")
     with TemporaryDirectory() as temporary:

--- a/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".." / ".github" / "workflows" / "jit_qa_manual_operator.yml"
+
+
+def test_manual_operator_is_main_only_and_qa_fenced():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in text
+    assert "github.ref == 'refs/heads/main'" in text
+    assert "based-hardware-dev" in text
+    assert "QA_DATABASE: jit-qa" in text
+    assert "QA_UID: vi7SA9ckQCe4ccobWNxlbdcNdC23" in text
+    assert "QA_DRAIN_JOB: knowledge-ledger-drain-qa-job" in text
+    assert "source_sha" in text
+    assert "verify_backend_release_admission.py" in text
+    assert "actions/upload-artifact@v7" in text
+
+
+def test_manual_operator_uses_existing_seed_contract_without_deploying_resources():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    for operation in ("bootstrap", "prepare", "inspect", "drain-verify", "rollback"):
+        assert operation in text
+    assert "jit_qa_seed_and_verify.py bootstrap" in text
+    assert "jit_qa_seed_and_verify.py" in text
+    assert "--update-env-vars \"KNOWLEDGE_LEDGER_DRAIN_ENABLED=true" in text
+    assert "jobs executions describe" in text
+    assert "jit_qa_manual_operator.py validate-job" in text
+    assert "DRAIN_VERIFY_QA" in text
+    assert "ROLLBACK_QA" in text
+    assert "gcloud run deploy" not in text
+    assert "gcloud run jobs deploy" not in text
+    assert "gcloud scheduler" not in text
+    assert "docker build" not in text
+    assert "api.omi.me" not in text

--- a/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
@@ -55,6 +55,8 @@ def test_manual_operator_uses_existing_seed_contract_without_deploying_resources
     assert "--update-env-vars \"KNOWLEDGE_LEDGER_DRAIN_ENABLED=true" in text
     assert "jobs executions describe" in text
     assert "jit_qa_manual_operator.py validate-job" in text
+    assert "gcloud container images describe" in text
+    assert "--expected-image \"$QA_DRAIN_IMAGE\"" in text
     assert "DRAIN_VERIFY_QA" in text
     assert "ROLLBACK_QA" in text
     assert "ENABLE_QA_API" in text
@@ -186,6 +188,8 @@ def test_qa_provision_enables_only_the_fixed_development_redis_api_before_resour
     redis_step = next(step for step in steps if step.get("name") == "Create or verify the 1 GiB Basic Redis dependency")
     assert 'service="redis.googleapis.com"' in api_command
     assert '--project "$QA_PROJECT"' in api_command
+    assert "gcloud services list --enabled" in api_command
+    assert "--filter=\"config.name=${service}\"" in api_command
     assert "timeout --foreground --kill-after=5s 60s gcloud services enable" in api_command
     assert steps.index(api_step) < steps.index(redis_step)
     redis_command = redis_step["run"]
@@ -196,14 +200,16 @@ def test_qa_provision_enables_only_the_fixed_development_redis_api_before_resour
         fake_bin = root / "bin"
         fake_bin.mkdir()
         state = root / "state"
-        state.write_text("DISABLED\n", encoding="utf-8")
+        state.write_text("disabled\n", encoding="utf-8")
         calls = root / "calls"
         (fake_bin / "gcloud").write_text(
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
             "printf '%s\\n' \"$*\" >> \"$CALLS\"\n"
-            "if [[ \"${1:-}\" == services && \"${2:-}\" == describe ]]; then cat \"$STATE\"; exit 0; fi\n"
-            "if [[ \"${1:-}\" == services && \"${2:-}\" == enable ]]; then printf 'ENABLED\\n' > \"$STATE\"; exit 0; fi\n"
+            "if [[ \"${1:-}\" == services && \"${2:-}\" == list ]]; then\n"
+            "  [[ $(cat \"$STATE\") == enabled ]] && printf 'redis.googleapis.com\\n'; exit 0\n"
+            "fi\n"
+            "if [[ \"${1:-}\" == services && \"${2:-}\" == enable ]]; then printf 'enabled\\n' > \"$STATE\"; exit 0; fi\n"
             "echo \"unexpected gcloud command: $*\" >&2\n"
             "exit 2\n",
             encoding="utf-8",
@@ -222,7 +228,7 @@ def test_qa_provision_enables_only_the_fixed_development_redis_api_before_resour
             text=True,
         )
         assert result.returncode == 0, result.stderr
-        assert state.read_text(encoding="utf-8").strip() == "ENABLED"
+        assert state.read_text(encoding="utf-8").strip() == "enabled"
         assert any(
             "services enable redis.googleapis.com" in line for line in calls.read_text(encoding="utf-8").splitlines()
         )

--- a/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
+++ b/backend/tests/unit/test_jit_qa_manual_operator_workflow.py
@@ -1,6 +1,22 @@
+import os
+import json
+import subprocess
+from tempfile import TemporaryDirectory
+
 from pathlib import Path
 
+import yaml
+
 WORKFLOW = Path(__file__).resolve().parents[2] / ".." / ".github" / "workflows" / "jit_qa_manual_operator.yml"
+
+
+def _workflow_steps():
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return document["jobs"]["operate"]["steps"]
+
+
+def _step(name: str):
+    return next(step for step in _workflow_steps() if step.get("name") == name)
 
 
 def test_manual_operator_is_main_only_and_qa_fenced():
@@ -18,7 +34,7 @@ def test_manual_operator_is_main_only_and_qa_fenced():
 
 def test_manual_operator_uses_existing_seed_contract_without_deploying_resources():
     text = WORKFLOW.read_text(encoding="utf-8")
-    for operation in ("bootstrap", "prepare", "inspect", "drain-verify", "rollback"):
+    for operation in ("bootstrap", "prepare", "inspect", "drain-verify", "rollback", "rollforward"):
         assert operation in text
     assert "jit_qa_seed_and_verify.py bootstrap" in text
     assert "jit_qa_seed_and_verify.py" in text
@@ -32,3 +48,139 @@ def test_manual_operator_uses_existing_seed_contract_without_deploying_resources
     assert "gcloud scheduler" not in text
     assert "docker build" not in text
     assert "api.omi.me" not in text
+
+
+def test_every_workflow_shell_block_is_valid_bash():
+    for step in _workflow_steps():
+        command = step.get("run")
+        if command:
+            result = subprocess.run(
+                ["bash", "-n", "-o", "pipefail", "-c", command],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, f"{step['name']}: {result.stderr}"
+
+
+def test_dependency_setup_executes_pinned_runtime_help_smoke_with_qa_environment():
+    step = _step("Install pinned backend runtime and verify operator imports")
+    assert step["env"]["OMI_FIRESTORE_DATA_PLANE_PROJECT"] == "${{ env.QA_PROJECT }}"
+    assert step["env"]["FIREBASE_AUTH_PROJECT_ID"] == "based-hardware"
+    assert "pylock.runtime.toml" in step["run"]
+    assert "scripts/jit_qa_seed_and_verify.py --help" in step["run"]
+
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        (root / "backend" / "scripts").mkdir(parents=True)
+        (root / "backend" / "scripts" / "jit_qa_manual_operator.py").write_text("", encoding="utf-8")
+        (root / "backend" / "scripts" / "jit_qa_seed_and_verify.py").write_text("", encoding="utf-8")
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        (fake_bin / "uv").write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ ${1:-} == venv ]]; then mkdir -p \"$2/bin\"; fi\n"
+            "if [[ ${1:-} == venv ]]; then cat > \"$2/bin/python\" <<'PY'\n"
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "printf '%s\\n' \"$*\" >> \"$CALL_LOG\"\n"
+            "exit 0\n"
+            "PY\nchmod +x \"$2/bin/python\"; fi\n",
+            encoding="utf-8",
+        )
+        (fake_bin / "uv").chmod(0o755)
+        github_path = root / "github-path"
+        environment = {
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "GITHUB_PATH": str(github_path),
+            "CALL_LOG": str(root / "python-calls"),
+            "OMI_ENV_STAGE": "dev",
+            "GOOGLE_CLOUD_PROJECT": "based-hardware-dev",
+            "GCLOUD_PROJECT": "based-hardware-dev",
+            "OMI_FIRESTORE_DATA_PLANE_PROJECT": "based-hardware-dev",
+            "FIRESTORE_DATABASE_ID": "jit-qa",
+            "FIREBASE_AUTH_PROJECT_ID": "based-hardware",
+            "MEMORY_ENABLED": "on",
+            "OMI_JIT_QA_AUTH_ONLY": "true",
+            "OMI_JIT_QA_UID_ALLOWLIST": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+            "KNOWLEDGE_LEDGER_DRAIN_ENABLED": "false",
+            "KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+        }
+        result = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", step["run"]],
+            cwd=root / "backend",
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        calls = (root / "python-calls").read_text(encoding="utf-8").splitlines()
+        assert any("scripts/jit_qa_manual_operator.py --help" in call for call in calls)
+        assert any("scripts/jit_qa_seed_and_verify.py --help" in call for call in calls)
+
+
+def test_mutating_seed_step_executes_with_source_sha_and_sanitized_artifact_only():
+    step = _step("Run read-only or seed operator action")
+    assert "SOURCE_SHA" in step["env"]
+    assert '"$operator_dir/artifacts/operator-receipt.json"' in step["run"]
+    assert 'unset FIRESTORE_EMULATOR_HOST SERVICE_ACCOUNT_JSON GOOGLE_APPLICATION_CREDENTIALS' in step["run"]
+
+
+def test_seed_bash_step_runs_with_fake_cli_and_cannot_lose_source_sha():
+    step = _step("Run read-only or seed operator action")
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        runner_temp = root / "runner-temp"
+        operator_dir = runner_temp / "jit-qa-operator"
+        (operator_dir / "artifacts").mkdir(parents=True)
+        (operator_dir / "source.json").write_text(
+            '{"deployed_source_sha":"' + "a" * 40 + '","current_main_sha":"' + "b" * 40 + '"}',
+            encoding="utf-8",
+        )
+        fake_python = root / "fake-python"
+        fake_python.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ ${1:-} == backend/scripts/jit_qa_seed_and_verify.py ]]; then\n"
+            "  echo '{\"result\":\"PASS\"}'\n"
+            "  exit 0\n"
+            "fi\n"
+            "exec python3 \"$@\"\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+        environment = {
+            "PATH": os.environ["PATH"],
+            "RUNNER_TEMP": str(runner_temp),
+            "QA_PYTHON": str(fake_python),
+            "QA_PROJECT": "based-hardware-dev",
+            "QA_DATABASE": "jit-qa",
+            "QA_UID": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+            "OPERATION": "inspect",
+            "RUN_ID": "qa-proof-20260905",
+            "CONFIRMATION": "",
+            "SOURCE_SHA": "a" * 40,
+            "GOOGLE_CLOUD_PROJECT": "based-hardware-dev",
+            "GCLOUD_PROJECT": "based-hardware-dev",
+            "OMI_ENV_STAGE": "dev",
+            "OMI_FIRESTORE_DATA_PLANE_PROJECT": "based-hardware-dev",
+            "FIRESTORE_DATABASE_ID": "jit-qa",
+            "FIREBASE_AUTH_PROJECT_ID": "based-hardware",
+            "MEMORY_ENABLED": "on",
+            "OMI_JIT_QA_AUTH_ONLY": "true",
+            "OMI_JIT_QA_UID_ALLOWLIST": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+            "KNOWLEDGE_LEDGER_DRAIN_ENABLED": "false",
+            "KNOWLEDGE_LEDGER_DRAIN_UID_ALLOWLIST": "vi7SA9ckQCe4ccobWNxlbdcNdC23",
+        }
+        result = subprocess.run(
+            ["bash", "-euo", "pipefail", "-c", step["run"]],
+            cwd=root,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        receipt = json.loads((operator_dir / "artifacts" / "operator-receipt.json").read_text(encoding="utf-8"))
+        assert receipt["source_sha"] == "a" * 40
+        assert not (operator_dir / "operation.json").exists()
+        assert [path.name for path in (operator_dir / "artifacts").iterdir()] == ["operator-receipt.json"]


### PR DESCRIPTION
The isolated JIT QA plane needs a repeatable way to seed and verify its named development database, execute bounded migration pages, and exercise rollback without reopening persistent job gates. Add a main-only, manually dispatched operator using the development GitHub credential and fixed `based-hardware-dev` / `jit-qa` / QA UID boundaries.

Operations cover bootstrap, 101-row synthetic preparation, inspection, the 100+1 migration and zero-work retry, rollback, and rollforward. The operator admits a first-attempt Release Eligibility-proven deployed ancestor of main, records the operator checkout separately, resolves the source-tag image digest, and checks the live drain job against the shared deployment contract before mutation. Completion requires exact counters and matching durable writer, head, generation, and projection fences. It uploads only a content-free receipt.

The first isolated deployment stopped because Redis API was disabled. Add an explicit `ensure-infrastructure-api` operation plus the same idempotent provisioning prerequisite, limited to `redis.googleapis.com` in the development project. Preserve and validate the auth action's ADC file for the Firestore SDK. No scheduler is enabled; execution overrides leave the persistent drain gate closed.

Validation includes focused operator and workflow tests, real Bash step execution against harmless CLI boundaries, offline ADC resolution, the installed gcloud command surface, actionlint, and preflight. Tests reject mismatched job digests and incomplete durable proofs. Live cloud migration and app notification qualification remain subsequent acceptance work.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

