### PR TITLE
fix(desktop): typing with nothing focused goes to search (or chat) instead of playing the alert sound

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -710,12 +710,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   override var canBecomeKey: Bool { true }
   override var canBecomeMain: Bool { false }
 
+  /// Unhandled keys stop here. This panel has no window controller, so `super.keyDown` has no next
+  /// responder to pass to and answers with `noResponderFor(_:)` — the alert sound — every time the
+  /// user types while the input field is not first responder (hover menu open, response showing).
+  /// Escape is the one key the window itself acts on; everything else is deliberately absorbed.
   override func keyDown(with event: NSEvent) {
     if event.keyCode == 53 {  // Escape
       handleEscapeKey()
-      return
     }
-    super.keyDown(with: event)
   }
 
   func handleEscapeKey() {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -713,10 +713,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// Unhandled keys stop here. This panel has no window controller, so `super.keyDown` has no next
   /// responder to pass to and answers with `noResponderFor(_:)` — the alert sound — every time the
   /// user types while the input field is not first responder (hover menu open, response showing).
-  /// Escape is the one key the window itself acts on; everything else is deliberately absorbed.
+  /// Escape and Tab are the keys the window itself acts on (Tab so Full Keyboard Access can still
+  /// step into the panel's controls, which `NSWindow.keyDown` used to do); everything else is
+  /// deliberately absorbed.
   override func keyDown(with event: NSEvent) {
-    if event.keyCode == 53 {  // Escape
+    switch event.keyCode {
+    case 53:  // Escape
       handleEscapeKey()
+    case 48:  // Tab
+      if event.modifierFlags.contains(.shift) { selectPreviousKeyView(nil) } else { selectNextKeyView(nil) }
+    default:
+      break
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -93,6 +93,9 @@ struct ChatInputView: View {
   @Environment(\.fontScale) private var fontScale
   @State private var isDropTargeted = false
   @State private var hasMarkedText = false
+  /// Caret claim for stray typing — a counter, because a flag already `true` cannot re-claim a caret
+  /// AppKit has since given away (`OmiTextEditor.focusRequest`).
+  @State private var caretClaims = 0
 
   private var hasText: Bool {
     !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -173,8 +176,11 @@ struct ChatInputView: View {
                 textColor: Ink.nsPrimaryOnGlass,
                 textContainerInset: NSSize(width: inputPaddingH, height: inputPaddingV),
                 onSubmit: handleSubmit,
-                onMarkedTextChange: { hasMarkedText = $0 }
+                onMarkedTextChange: { hasMarkedText = $0 },
+                focusRequest: caretClaims
               )
+              // Typing with nothing focused means this composer, not the page's search bar behind it.
+              .straysTypingHere(priority: .primary) { caretClaims &+= 1 }
             }
             .frame(maxHeight: 200)
             .clipped()

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
@@ -31,6 +31,9 @@ struct QuerySearchBar: View {
         guard focus == nil else { return }
         reportFocus(focused)
       }
+      // Typing on the page with nothing focused starts a search here. The bar is not focused ahead
+      // of time — no caret, no stroke — until the first key arrives (`StrayTypingRouter`).
+      .straysTypingHere(focus ?? $internalFocus)
   }
 
   private func reportFocus(_ focused: Bool) {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -279,6 +279,9 @@ struct QueryShellHome: View {
       references: chatProvider.pendingComposerReferences,
       onReferenceRemoved: { chatProvider.removeComposerReference(id: $0) }
     )
+    // Chat is the one page with two fields on it. Typing here means talking to Omi, so the composer
+    // outranks the search bar above it; when the composer is unmounted (`.results`) the bar takes over.
+    .straysTypingHere(priority: .primary) { claimCaret() }
     // The footer unit (quota banner + composer) is measured where it is
     // composed, so the bar itself carries no height reporting of its own.
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -492,6 +492,7 @@ struct SettingsSidebar: View {
         .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.primary)
         .focused($isSearchFocused)
+        .straysTypingHere($isSearchFocused)
 
       if !searchQuery.isEmpty {
         Button {

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
@@ -205,6 +205,9 @@ struct ShellModalScrim: View {
             .contentShape(Rectangle())
             .onTapGesture { onTap?() }
             .background(InkGlassHitRegionReporter())
+            // Modality for the keyboard too: a stray key over the modal must not start a search in
+            // the bar behind it (`StrayTypingRouter`).
+            .straysTypingBlocked()
         }
 
         RoundedRectangle(cornerRadius: ShellModalScrimLayout.cornerRadius, style: .continuous)

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -297,6 +297,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // background-service startup so the probe has no product side effects.
     if AuthStorageCanary.runIfRequested() { return }
     if UserNotificationCallbackBridge.runSignedSmokeIfRequested() { return }
+    // A keystroke nothing handled must not fall off the end of the responder chain, where AppKit
+    // answers it with the alert sound. See `UnhandledKeystrokeSink`.
+    UnhandledKeystrokeSink.install(after: NSApp)
     // Running from the mounted DMG / a translocated mount breaks TCC permissions
     // and Sparkle updates — install to /Applications and relaunch before any
     // services start. Returns true when this process is being replaced.

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -297,9 +297,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // background-service startup so the probe has no product side effects.
     if AuthStorageCanary.runIfRequested() { return }
     if UserNotificationCallbackBridge.runSignedSmokeIfRequested() { return }
-    // A keystroke nothing handled must not fall off the end of the responder chain, where AppKit
+    // A keystroke nothing handled must not fall off the end of a responder chain, where AppKit
     // answers it with the alert sound. See `UnhandledKeystrokeSink`.
-    UnhandledKeystrokeSink.install(after: NSApp)
+    UnhandledKeystrokeSink.installEverywhere()
     // Running from the mounted DMG / a translocated mount breaks TCC permissions
     // and Sparkle updates — install to /Applications and relaunch before any
     // services start. Returns true when this process is being replaced.

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchBar.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchBar.swift
@@ -116,6 +116,7 @@ struct RewindSearchBar: View {
           .font(.system(size: RewindSearchMetrics.queryFontSize, weight: .semibold))
           .foregroundStyle(Ink.primary)
           .focused(focus)
+          .straysTypingHere(focus)
           .accessibilityLabel(Text(Self.searchActionName))
           .onChange(of: focus.wrappedValue) { _, focused in
             guard focused else { return }

--- a/desktop/macos/Desktop/Sources/Startup/StrayTypingRouter.swift
+++ b/desktop/macos/Desktop/Sources/Startup/StrayTypingRouter.swift
@@ -1,0 +1,341 @@
+//
+//  StrayTypingRouter.swift — a keystroke nobody was listening for lands in the field you meant.
+//
+//  `UnhandledKeystrokeSink` caps the responder chain so typing with no field focused is silent
+//  instead of a beep. Silence is the floor, not the product: on every page of the shell there is one
+//  obvious place a typed letter belongs — the search bar across the top of Tasks, Apps, Memories and
+//  Rewind, or the chat composer on Chat — and a person who starts typing on a page means that field.
+//  Making them click into it first, on a bar that is the only text field in sight, is a step the bar
+//  can take for them.
+//
+//  ## The shape of it
+//
+//  - A field that wants stray typing registers with the router while it is in a window
+//    (`straysTypingHere`). The registration is anchored by a zero-size AppKit view, the same way
+//    `EscapeKeyHandler` anchors Escape: it learns its window in `viewDidMoveToWindow`, so a key is
+//    only ever aimed at a field **in the window it was typed into**, and it leaves the registry when
+//    the view leaves the window or is freed — a closed window cannot leave a stale claim behind.
+//  - When several fields share a window, `priority` decides. Chat mounts a search bar and the
+//    composer together, and the composer wins, because Chat is the page where typing means "talk to
+//    Omi". A modal drawn *inside* the window (`ShellModalScrim`) registers as a blocker above both,
+//    so typing over a modal never lights up the bar behind it.
+//  - **Nothing is focused ahead of time.** The bar sits with no caret and no focus stroke until the
+//    first key arrives. That first key is what claims focus, so the field only ever lights up as the
+//    letter appears in it — the cursor shows up because you typed, not before.
+//  - The key that arrived is **re-sent** rather than appended to the text. SwiftUI applies the focus
+//    claim at the end of the run-loop turn, so the router steps out to the next turn, confirms the
+//    caret is now in an editable text view, parks it at the end of whatever is already there, and
+//    lets AppKit deliver the same event to the field. Dead keys, input methods and Option-modified
+//    characters all work because the field editor interprets the key itself; a string append would
+//    have lost every one of them.
+//  - **Every key typed while the caret is on its way is queued behind the first**, in order. A local
+//    event monitor holds them for the duration, so a fast second letter cannot slip straight into
+//    the newly focused field ahead of the first one and come out transposed, and a burst typed into
+//    a busy main thread is not thrown away after its first letter.
+//  - If the caret never arrives — the page changed underneath, the claim was refused — the queue is
+//    dropped silently, which is exactly what the sink did before this existed. A re-sent event that
+//    somehow makes it back to the sink is recognised by identity and dropped, so there is no loop.
+//
+//  ## What counts as typing
+//
+//  A printable character with no `⌘`/`⌃` on it. Arrows, function keys, Escape, Tab, Return and
+//  Delete are not typing, and neither is a bare Space — Tasks uses Space and Return as commands on
+//  the selected row, Rewind uses the arrows, and a search field that opens because you tapped Space
+//  is a field that opens when you did not mean it. `StrayTypingPolicy` is the whole rule, kept pure
+//  so a test can hold it.
+//
+//  Brand: nothing here draws (INV-UI-1). Focus is claimed through the field's own binding, so the
+//  field styles its own focused state exactly as it does when clicked.
+//
+
+import AppKit
+import SwiftUI
+
+// MARK: - Policy
+
+/// Which key events count as "typing" — the ones a field would want handed to it.
+enum StrayTypingPolicy {
+  /// A printable character, typed without `⌘` or `⌃`. See the file header for what is excluded and why.
+  static func isTyping(
+    characters: String?, charactersIgnoringModifiers: String?, modifierFlags: NSEvent.ModifierFlags
+  ) -> Bool {
+    let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
+    guard flags.isDisjoint(with: [.command, .control]) else { return false }
+    if let characters, !characters.isEmpty {
+      return characters.unicodeScalars.first.map(isPrintable) ?? false
+    }
+    // A dead key (`⌥e` before the `e` of `é`) arrives with empty `characters` and the base key in
+    // `charactersIgnoringModifiers`. The field editor knows how to compose it; the sink does not.
+    guard let base = charactersIgnoringModifiers?.unicodeScalars.first else { return false }
+    return isPrintable(base)
+  }
+
+  static func isTyping(_ event: NSEvent) -> Bool {
+    guard event.type == .keyDown else { return false }
+    return isTyping(
+      characters: event.characters, charactersIgnoringModifiers: event.charactersIgnoringModifiers,
+      modifierFlags: event.modifierFlags)
+  }
+
+  /// Whether a key that arrived in `window` may be re-aimed at a field in it. A sheet or any other
+  /// child window has its own controls; a stray key there must not light up a bar behind it.
+  /// (Modals drawn inside the window are handled by a blocking registration instead — see
+  /// `straysTypingBlocked`.)
+  @MainActor
+  static func windowAcceptsStrays(_ window: NSWindow?) -> Bool {
+    guard let window else { return true }  // Synthetic events carry no window.
+    return window.sheetParent == nil && window.parent == nil
+  }
+
+  private static func isPrintable(_ scalar: Unicode.Scalar) -> Bool {
+    if scalar.properties.isWhitespace { return false }
+    switch scalar.properties.generalCategory {
+    case .control, .format, .privateUse, .unassigned:
+      return false  // Function and arrow keys are private-use scalars (U+F700–U+F8FF).
+    default:
+      return true
+    }
+  }
+}
+
+// MARK: - Router
+
+/// Holds the fields currently willing to take stray typing and hands an unhandled key to the winner.
+@MainActor
+final class StrayTypingRouter {
+  static let shared = StrayTypingRouter()
+
+  /// Which registration wins when more than one shares a window. Chat mounts a search bar and the
+  /// composer together; the composer is `.primary`. A modal drawn inside the window is `.blocking`:
+  /// it wins, and it takes nothing — the key is swallowed rather than aimed at the bar behind it.
+  enum Priority: Comparable {
+    case secondary
+    case primary
+    case blocking
+  }
+
+  typealias Claim = @MainActor () -> Void
+  typealias Schedule = @MainActor (@escaping @MainActor () -> Void) -> Void
+  typealias CaretHolder = @MainActor (NSEvent) -> NSTextView?
+  typealias Deliver = @MainActor (NSEvent) -> Void
+  /// Installs a key-down monitor that sees every key before the responder chain does; the handler
+  /// returns `nil` to swallow a key. Returns the token `RemoveMonitor` takes.
+  typealias InstallMonitor = @MainActor (@escaping @MainActor (NSEvent) -> NSEvent?) -> Any?
+  typealias RemoveMonitor = @MainActor (Any) -> Void
+
+  private struct Registration {
+    let id: UUID
+    /// The window the field lives in. `nil` only for synthetic registrations (tests), which match
+    /// synthetic events (no window) and nothing else.
+    weak var window: NSWindow?
+    let hasWindow: Bool
+    let priority: Priority
+    let claim: Claim
+  }
+
+  /// The re-send is retried across this many run-loop turns for the focus claim to land.
+  static let deliveryAttempts = 3
+
+  /// Append-only between removals, so array order is registration order; among equal priorities the
+  /// most recently registered wins, which is the most recently mounted field.
+  private var registrations: [Registration] = []
+  /// The keys waiting for the caret, in the order they were typed. Empty when nothing is in flight.
+  private var pending: [NSEvent] = []
+  /// The window `pending` belongs to; keys held by the monitor are only those aimed at it.
+  private weak var pendingWindow: NSWindow?
+  private var monitorToken: Any?
+  /// The events being handed back to AppKit right now, so the sink recognises one that comes around again.
+  private var delivering: [NSEvent] = []
+
+  // Seams. Production wires AppKit; tests wire counters.
+  private let schedule: Schedule
+  private let caretHolder: CaretHolder
+  private let deliver: Deliver
+  private let installMonitor: InstallMonitor
+  private let removeMonitor: RemoveMonitor
+
+  init(
+    schedule: @escaping Schedule = { work in
+      DispatchQueue.main.async { MainActor.assumeIsolated { work() } }
+    },
+    caretHolder: @escaping CaretHolder = { event in
+      // Only a field that can take the letter. A selectable read-only text view (a transcript) can
+      // hold first responder too, and it would consume the re-sent key without showing it anywhere.
+      guard let textView = (event.window ?? NSApp.keyWindow)?.firstResponder as? NSTextView,
+        textView.isEditable
+      else { return nil }
+      return textView
+    },
+    deliver: @escaping Deliver = { event in (event.window ?? NSApp.keyWindow)?.sendEvent(event) },
+    installMonitor: @escaping InstallMonitor = { handler in
+      NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in handler(event) }
+    },
+    removeMonitor: @escaping RemoveMonitor = { NSEvent.removeMonitor($0) }
+  ) {
+    self.schedule = schedule
+    self.caretHolder = caretHolder
+    self.deliver = deliver
+    self.installMonitor = installMonitor
+    self.removeMonitor = removeMonitor
+  }
+
+  /// Offers a field in `window` for stray typing until `unregister`. `claim` must put the caret in
+  /// the field. A `.blocking` registration's claim is never run.
+  @discardableResult
+  func register(window: NSWindow?, priority: Priority, claim: @escaping Claim = {}) -> UUID {
+    let registration = Registration(
+      id: UUID(), window: window, hasWindow: window != nil, priority: priority, claim: claim)
+    registrations.append(registration)
+    return registration.id
+  }
+
+  func unregister(_ id: UUID) {
+    registrations.removeAll { $0.id == id }
+  }
+
+  private func target(for window: NSWindow?) -> Registration? {
+    let candidates = registrations.filter { registration in
+      if registration.hasWindow { return registration.window === window }
+      return window == nil
+    }
+    guard let top = candidates.map(\.priority).max() else { return nil }
+    return candidates.last { $0.priority == top }
+  }
+
+  /// Takes a key nothing else handled. `true` means a field claimed it and it will be re-sent once
+  /// the caret is there; `false` means it is not typing, or there is nowhere for it to go — the
+  /// caller swallows it either way.
+  func route(_ event: NSEvent) -> Bool {
+    if delivering.contains(where: { $0 === event }) { return false }
+    guard StrayTypingPolicy.isTyping(event), StrayTypingPolicy.windowAcceptsStrays(event.window)
+    else { return false }
+    if !pending.isEmpty {
+      // The monitor normally holds these; one that reached the chain anyway still belongs in order.
+      guard event.window === pendingWindow else { return false }
+      pending.append(event)
+      return true
+    }
+    guard let target = target(for: event.window), target.priority != .blocking else { return false }
+    target.claim()
+    pending = [event]
+    pendingWindow = event.window
+    holdFollowingKeys()
+    attemptDelivery(attemptsLeft: Self.deliveryAttempts)
+    return true
+  }
+
+  /// While the caret is on its way, every typing key aimed at the same window queues behind the first
+  /// instead of racing it into the field.
+  private func holdFollowingKeys() {
+    monitorToken = installMonitor { [weak self] event in
+      guard let self, !self.pending.isEmpty, event.window === self.pendingWindow,
+        StrayTypingPolicy.isTyping(event)
+      else { return event }
+      self.pending.append(event)
+      return nil
+    }
+  }
+
+  private func releaseFollowingKeys() {
+    if let monitorToken { removeMonitor(monitorToken) }
+    monitorToken = nil
+  }
+
+  private func attemptDelivery(attemptsLeft: Int) {
+    schedule { [weak self] in
+      guard let self, let first = self.pending.first else { return }
+      guard let textView = self.caretHolder(first) else {
+        if attemptsLeft > 1 {
+          self.attemptDelivery(attemptsLeft: attemptsLeft - 1)
+        } else {
+          self.releaseFollowingKeys()
+          self.pending.removeAll()
+        }
+        return
+      }
+      self.releaseFollowingKeys()
+      let queued = self.pending
+      self.pending.removeAll()
+      // Becoming first responder selects the field's whole text; a re-sent letter would replace a
+      // search you had already typed. Continue it instead.
+      let end = (textView.string as NSString).length
+      textView.setSelectedRange(NSRange(location: end, length: 0))
+      self.delivering = queued
+      for event in queued { self.deliver(event) }
+      self.delivering.removeAll()
+    }
+  }
+}
+
+// MARK: - SwiftUI seam
+
+extension View {
+  /// Typing with nothing focused lands in this control. Registered while the view is in a window; the
+  /// first stray key runs `claim`, which must put the caret in the control, and is then re-sent to it.
+  func straysTypingHere(
+    priority: StrayTypingRouter.Priority = .secondary, claim: @escaping StrayTypingRouter.Claim
+  ) -> some View {
+    background(StrayTypingAnchor(priority: priority, claim: claim))
+  }
+
+  /// `straysTypingHere` for a control focused through a `FocusState` binding.
+  func straysTypingHere(
+    _ focus: FocusState<Bool>.Binding, priority: StrayTypingRouter.Priority = .secondary
+  ) -> some View {
+    straysTypingHere(priority: priority) { focus.wrappedValue = true }
+  }
+
+  /// While this view is in a window, stray typing in that window goes nowhere. For modals drawn inside
+  /// the window, whose controls are the only ones a key should reach.
+  func straysTypingBlocked() -> some View {
+    background(StrayTypingAnchor(priority: .blocking, claim: {}))
+  }
+}
+
+/// A zero-size, untouchable view whose only job is to know which window it is in.
+private struct StrayTypingAnchor: NSViewRepresentable {
+  let priority: StrayTypingRouter.Priority
+  let claim: StrayTypingRouter.Claim
+
+  func makeNSView(context: Context) -> StrayTypingAnchorView {
+    let view = StrayTypingAnchorView()
+    view.priority = priority
+    view.claim = claim
+    return view
+  }
+
+  func updateNSView(_ nsView: StrayTypingAnchorView, context: Context) {
+    nsView.priority = priority
+    nsView.claim = claim
+  }
+}
+
+@MainActor
+final class StrayTypingAnchorView: NSView {
+  var priority: StrayTypingRouter.Priority = .secondary
+  var claim: StrayTypingRouter.Claim = {}
+  private var registration: UUID?
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    removeRegistration()
+    guard let window else { return }
+    registration = StrayTypingRouter.shared.register(window: window, priority: priority) { [weak self] in
+      self?.claim()
+    }
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? { nil }
+  override var acceptsFirstResponder: Bool { false }
+
+  private func removeRegistration() {
+    if let registration { StrayTypingRouter.shared.unregister(registration) }
+    registration = nil
+  }
+
+  deinit {
+    if let registration {
+      Task { @MainActor in StrayTypingRouter.shared.unregister(registration) }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
+++ b/desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+/// The last responder in the application's key-event chain, so an unhandled keystroke ends in
+/// silence instead of in `NSBeep()`.
+///
+/// Typing with no field focused — on Rewind, on Tasks, on the resting Home — sends the key event
+/// down the chain: view → window → window controller → `NSApp` → app delegate. When nothing takes
+/// it, the last responder's `noResponderFor(_:)` runs, and AppKit's implementation of that beeps for
+/// `keyDown`. Nothing else was wrong; the "pop" was purely that the chain had an open end.
+///
+/// SwiftUI owns the main window, its controller, and the delegate it installs ahead of ours, so the
+/// chain cannot be capped by subclassing any of them. Appending one responder after whatever is
+/// currently last is the documented seam: SwiftUI's `onKeyPress` handlers, menu key equivalents,
+/// and focused controls have all already declined by the time an event reaches here, so absorbing
+/// it takes nothing from them. (Windows with no controller end at themselves and cap their own
+/// chain — see `FloatingControlBarWindow.keyDown`.)
+final class UnhandledKeystrokeSink: NSResponder {
+  /// Swallow it. `super` would forward to a `nil` next responder and beep.
+  override func keyDown(with event: NSEvent) {}
+
+  /// `nextResponder` is an unretained reference, so the chain does not keep the sink alive; this does.
+  @MainActor private static var installed: UnhandledKeystrokeSink?
+
+  /// Appends a sink after the last responder reachable from `root`. Idempotent: a chain that already
+  /// ends in a sink is left alone.
+  @MainActor
+  static func install(after root: NSResponder) {
+    var last = root
+    while let next = last.nextResponder { last = next }
+    guard !(last is UnhandledKeystrokeSink) else { return }
+    let sink = UnhandledKeystrokeSink()
+    last.nextResponder = sink
+    installed = sink
+  }
+}

--- a/desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
+++ b/desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
@@ -1,7 +1,7 @@
 import AppKit
 
-/// The last responder in the application's key-event chain, so an unhandled keystroke ends in
-/// silence instead of in `NSBeep()`.
+/// The last responder in a key-event chain, so an unhandled keystroke ends in silence instead of in
+/// `NSBeep()`.
 ///
 /// Typing with no field focused — on Rewind, on Tasks, on the resting Home — sends the key event
 /// down the chain: view → window → window controller → `NSApp` → app delegate. When nothing takes
@@ -12,14 +12,33 @@ import AppKit
 /// chain cannot be capped by subclassing any of them. Appending one responder after whatever is
 /// currently last is the documented seam: SwiftUI's `onKeyPress` handlers, menu key equivalents,
 /// and focused controls have all already declined by the time an event reaches here, so absorbing
-/// it takes nothing from them. (Windows with no controller end at themselves and cap their own
-/// chain — see `FloatingControlBarWindow.keyDown`.)
+/// it takes nothing from them. Plain AppKit windows (Feedback, the prompt editors, the onboarding
+/// cinematic) do not drain into `NSApp` at all — their chain ends at the window or its controller —
+/// so `installEverywhere` also caps each window as it becomes key. (`FloatingControlBarWindow`
+/// additionally absorbs in its own `keyDown`, since it acts on Escape and Tab itself.)
+///
+/// Absorbing is the floor. A key that is *typing* is first offered to `StrayTypingRouter`, which
+/// puts it in the field the page means — the search bar, or Chat's composer — so the first letter
+/// you type on a page is the first letter of your search rather than a silent miss.
 final class UnhandledKeystrokeSink: NSResponder {
-  /// Swallow it. `super` would forward to a `nil` next responder and beep.
-  override func keyDown(with event: NSEvent) {}
+  private let router: StrayTypingRouter
 
-  /// `nextResponder` is an unretained reference, so the chain does not keep the sink alive; this does.
-  @MainActor private static var installed: UnhandledKeystrokeSink?
+  init(router: StrayTypingRouter = .shared) {
+    self.router = router
+    super.init()
+  }
+
+  required init?(coder: NSCoder) { nil }
+
+  /// Route it if it is typing; otherwise swallow it. `super` would forward to a `nil` next responder
+  /// and beep, so neither branch calls it.
+  override func keyDown(with event: NSEvent) {
+    _ = router.route(event)
+  }
+
+  /// `nextResponder` is an unretained reference, so the chain does not keep a sink alive; this does.
+  @MainActor private static var installed: [UnhandledKeystrokeSink] = []
+  @MainActor private static var keyWindowObserver: NSObjectProtocol?
 
   /// Appends a sink after the last responder reachable from `root`. Idempotent: a chain that already
   /// ends in a sink is left alone.
@@ -30,6 +49,31 @@ final class UnhandledKeystrokeSink: NSResponder {
     guard !(last is UnhandledKeystrokeSink) else { return }
     let sink = UnhandledKeystrokeSink()
     last.nextResponder = sink
-    installed = sink
+    installed.append(sink)
   }
+
+  /// Caps the application chain now, and every window's chain as it becomes key. A window whose
+  /// chain already drains into the capped application chain (SwiftUI's) is a no-op; a window whose
+  /// chain ends at itself or its controller gets its own cap. Re-run on each key change because
+  /// AppKit resets a window's `nextResponder` when a controller is assigned.
+  @MainActor
+  static func installEverywhere() {
+    install(after: NSApp)
+    guard keyWindowObserver == nil else { return }
+    keyWindowObserver = NotificationCenter.default.addObserver(
+      forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+    ) { note in
+      // The notification's object crosses into the main-actor closure boxed, the same way
+      // `DesktopAutomationWindowPresentation` carries it; `.main` queue delivery makes this sound.
+      let box = KeyWindowBox(value: note.object)
+      MainActor.assumeIsolated {
+        guard let window = box.value as? NSWindow else { return }
+        install(after: window)
+      }
+    }
+  }
+}
+
+private struct KeyWindowBox: @unchecked Sendable {
+  let value: Any?
 }

--- a/desktop/macos/Desktop/Tests/StrayTypingRouterTests.swift
+++ b/desktop/macos/Desktop/Tests/StrayTypingRouterTests.swift
@@ -1,0 +1,338 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// Typing on a page with nothing focused lands in the page's field — the search bar, or Chat's
+/// composer — instead of being silently dropped. The router is driven here with a hand-cranked
+/// scheduler so every run-loop turn is explicit: the claim happens on the key, the re-send happens
+/// on a later turn once a text view holds the caret, keys typed in between queue behind the first,
+/// and a key whose caret never arrives is dropped.
+@MainActor
+final class StrayTypingRouterTests: XCTestCase {
+  /// Stands in for the main run loop: each `turn()` runs what one `DispatchQueue.main.async` would have.
+  private final class Turns {
+    private var queued: [@MainActor () -> Void] = []
+    var pendingCount: Int { queued.count }
+    func enqueue(_ work: @escaping @MainActor () -> Void) { queued.append(work) }
+    @MainActor func turn() {
+      let batch = queued
+      queued.removeAll()
+      for work in batch { work() }
+    }
+  }
+
+  /// What the router sees of AppKit: the caret, the delivery path, and the key-down monitor.
+  private final class Seams {
+    var delivered: [NSEvent] = []
+    var caretPresent = true
+    /// The handler the router installed, while installed. Keys "typed" during the wait go through it.
+    var monitor: (@MainActor (NSEvent) -> NSEvent?)?
+    var installs = 0
+    var removals = 0
+  }
+
+  private struct Harness {
+    let router: StrayTypingRouter
+    let turns: Turns
+    let textView: NSTextView
+    let seams: Seams
+  }
+
+  private func makeHarness(caretPresentInitially: Bool = true) -> Harness {
+    let turns = Turns()
+    let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+    let seams = Seams()
+    seams.caretPresent = caretPresentInitially
+    let router = StrayTypingRouter(
+      schedule: { turns.enqueue($0) },
+      caretHolder: { _ in seams.caretPresent ? textView : nil },
+      deliver: { seams.delivered.append($0) },
+      installMonitor: { handler in
+        seams.monitor = handler
+        seams.installs += 1
+        return NSObject()
+      },
+      removeMonitor: { _ in
+        seams.monitor = nil
+        seams.removals += 1
+      })
+    return Harness(router: router, turns: turns, textView: textView, seams: seams)
+  }
+
+  private func key(
+    _ characters: String, ignoringModifiers: String? = nil, flags: NSEvent.ModifierFlags = [],
+    keyCode: UInt16 = 0, windowNumber: Int = 0
+  ) throws -> NSEvent {
+    try XCTUnwrap(
+      NSEvent.keyEvent(
+        with: .keyDown, location: .zero, modifierFlags: flags, timestamp: 0, windowNumber: windowNumber,
+        context: nil, characters: characters, charactersIgnoringModifiers: ignoringModifiers ?? characters,
+        isARepeat: false, keyCode: keyCode))
+  }
+
+  /// A window that survives `close()` under ARC (plain windows release themselves on close).
+  private func makeWindow() -> NSWindow {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 300, height: 200), styleMask: [.titled], backing: .buffered,
+      defer: false)
+    window.isReleasedWhenClosed = false
+    return window
+  }
+
+  // MARK: Policy
+
+  func testPrintableCharactersAreTypingAndCommandKeysArrowsAndWhitespaceAreNot() {
+    typealias P = StrayTypingPolicy
+    XCTAssertTrue(P.isTyping(characters: "a", charactersIgnoringModifiers: "a", modifierFlags: []))
+    XCTAssertTrue(P.isTyping(characters: "A", charactersIgnoringModifiers: "a", modifierFlags: .shift))
+    XCTAssertTrue(P.isTyping(characters: "é", charactersIgnoringModifiers: "e", modifierFlags: .option))
+    XCTAssertTrue(P.isTyping(characters: "7", charactersIgnoringModifiers: "7", modifierFlags: []))
+    XCTAssertTrue(P.isTyping(characters: "?", charactersIgnoringModifiers: "/", modifierFlags: .shift))
+    XCTAssertTrue(
+      P.isTyping(characters: "", charactersIgnoringModifiers: "e", modifierFlags: .option),
+      "a dead key arrives with empty characters; the field editor composes it")
+
+    XCTAssertFalse(P.isTyping(characters: "a", charactersIgnoringModifiers: "a", modifierFlags: .command))
+    XCTAssertFalse(P.isTyping(characters: "a", charactersIgnoringModifiers: "a", modifierFlags: .control))
+    XCTAssertFalse(
+      P.isTyping(characters: "\u{F702}", charactersIgnoringModifiers: "\u{F702}", modifierFlags: .function),
+      "left arrow")
+    XCTAssertFalse(P.isTyping(characters: "\u{1B}", charactersIgnoringModifiers: "\u{1B}", modifierFlags: []), "Escape")
+    XCTAssertFalse(P.isTyping(characters: "\t", charactersIgnoringModifiers: "\t", modifierFlags: []), "Tab")
+    XCTAssertFalse(P.isTyping(characters: "\r", charactersIgnoringModifiers: "\r", modifierFlags: []), "Return")
+    XCTAssertFalse(P.isTyping(characters: "\u{7F}", charactersIgnoringModifiers: "\u{7F}", modifierFlags: []), "Delete")
+    XCTAssertFalse(P.isTyping(characters: " ", charactersIgnoringModifiers: " ", modifierFlags: []), "Space")
+    XCTAssertFalse(P.isTyping(characters: nil, charactersIgnoringModifiers: nil, modifierFlags: []))
+  }
+
+  // MARK: Routing
+
+  func testWithNoFieldRegisteredAKeyIsNotRouted() throws {
+    let h = makeHarness()
+    XCTAssertFalse(h.router.route(try key("a")))
+    h.turns.turn()
+    XCTAssertTrue(h.seams.delivered.isEmpty)
+    XCTAssertEqual(h.seams.installs, 0, "nothing to wait for, so no keys are held")
+  }
+
+  func testAKeyClaimsTheFieldNowAndIsReSentOnceTheCaretIsInIt() throws {
+    let h = makeHarness()
+    var claims = 0
+    h.router.register(window: nil, priority: .secondary) { claims += 1 }
+    h.textView.string = "cla"
+    h.textView.setSelectedRange(NSRange(location: 0, length: 3))  // what becoming first responder does
+
+    let event = try key("u")
+    XCTAssertTrue(h.router.route(event))
+    XCTAssertEqual(claims, 1, "the claim runs on the key itself, so the field lights up as you type")
+    XCTAssertTrue(h.seams.delivered.isEmpty, "the re-send waits for the focus claim to land")
+
+    h.turns.turn()
+    XCTAssertEqual(h.seams.delivered.count, 1)
+    XCTAssertTrue(try XCTUnwrap(h.seams.delivered.first) === event, "the same event, so the field editor interprets it")
+    XCTAssertEqual(
+      h.textView.selectedRange(), NSRange(location: 3, length: 0),
+      "the caret continues the existing search rather than replacing it")
+    XCTAssertEqual(h.turns.pendingCount, 0)
+    XCTAssertEqual(h.seams.removals, 1, "the hold on following keys is lifted once delivered")
+  }
+
+  func testKeysTypedWhileTheCaretIsOnItsWayQueueBehindTheFirstInOrder() throws {
+    let h = makeHarness(caretPresentInitially: false)
+    h.router.register(window: nil, priority: .secondary) {}
+
+    let first = try key("a")
+    XCTAssertTrue(h.router.route(first))
+    let monitor = try XCTUnwrap(h.seams.monitor, "a monitor holds the keys that follow")
+
+    // Typed before the focus claim landed: these would otherwise race the first key into the field.
+    let second = try key("b")
+    let third = try key("c")
+    XCTAssertNil(monitor(second), "held")
+    XCTAssertNil(monitor(third), "held")
+    let escape = try key("\u{1B}", keyCode: 53)
+    XCTAssertTrue(monitor(escape) === escape, "a key that is not typing passes straight through")
+
+    h.turns.turn()
+    XCTAssertTrue(h.seams.delivered.isEmpty)
+    h.seams.caretPresent = true
+    h.turns.turn()
+    XCTAssertEqual(
+      h.seams.delivered.map { $0.characters ?? "" }, ["a", "b", "c"], "in the order typed, never transposed")
+    XCTAssertNil(h.seams.monitor, "the hold is lifted once delivered")
+  }
+
+  func testTheReSendGivesUpWhenTheCaretNeverArrivesAndDropsTheWholeQueue() throws {
+    let h = makeHarness(caretPresentInitially: false)
+    h.router.register(window: nil, priority: .secondary) {}
+
+    XCTAssertTrue(h.router.route(try key("b")))
+    _ = try XCTUnwrap(h.seams.monitor)(try key("c"))
+    for _ in 0..<StrayTypingRouter.deliveryAttempts { h.turns.turn() }
+    XCTAssertEqual(h.turns.pendingCount, 0, "gave up")
+    XCTAssertTrue(h.seams.delivered.isEmpty, "a key whose caret never arrived is dropped, not delivered late")
+    XCTAssertNil(h.seams.monitor, "and the hold is lifted so ordinary typing resumes")
+
+    h.seams.caretPresent = true
+    XCTAssertTrue(h.router.route(try key("d")), "a dropped key does not jam the router")
+    h.turns.turn()
+    XCTAssertEqual(h.seams.delivered.count, 1)
+  }
+
+  func testTheComposerOutranksTheSearchBarAndTheBarTakesOverWhenTheComposerLeaves() throws {
+    let h = makeHarness()
+    var claimed: [String] = []
+    h.router.register(window: nil, priority: .secondary) { claimed.append("bar") }
+    let composer = h.router.register(window: nil, priority: .primary) { claimed.append("composer") }
+    h.router.register(window: nil, priority: .secondary) { claimed.append("later-bar") }
+
+    XCTAssertTrue(h.router.route(try key("a")))
+    h.turns.turn()
+    XCTAssertEqual(claimed, ["composer"], "priority beats registration order")
+
+    h.router.unregister(composer)
+    XCTAssertTrue(h.router.route(try key("b")))
+    h.turns.turn()
+    XCTAssertEqual(claimed, ["composer", "later-bar"], "among equals the most recently mounted wins")
+  }
+
+  func testAModalDrawnInsideTheWindowBlocksTypingFromReachingTheBarBehindIt() throws {
+    let h = makeHarness()
+    var claims = 0
+    h.router.register(window: nil, priority: .primary) { claims += 1 }
+    let modal = h.router.register(window: nil, priority: .blocking)
+
+    XCTAssertFalse(h.router.route(try key("h")), "swallowed, not aimed at the bar behind the scrim")
+    h.turns.turn()
+    XCTAssertEqual(claims, 0)
+    XCTAssertTrue(h.seams.delivered.isEmpty)
+
+    h.router.unregister(modal)
+    XCTAssertTrue(h.router.route(try key("h")), "the modal is gone; the bar is back")
+    XCTAssertEqual(claims, 1)
+  }
+
+  func testAKeyIsOnlyAimedAtAFieldInTheWindowItWasTypedInto() throws {
+    let h = makeHarness()
+    let shell = makeWindow()
+    let other = makeWindow()
+    defer {
+      shell.close()
+      other.close()
+    }
+    var claims: [String] = []
+    h.router.register(window: shell, priority: .secondary) { claims.append("shell-bar") }
+
+    let inOther = try key("a", windowNumber: other.windowNumber)
+    XCTAssertTrue(inOther.window === other, "the synthetic event resolves to its window")
+    XCTAssertFalse(h.router.route(inOther), "another window's typing must not light up the shell's bar")
+    XCTAssertFalse(h.router.route(try key("a")), "nor does a windowless key match a windowed field")
+
+    let inShell = try key("a", windowNumber: shell.windowNumber)
+    XCTAssertTrue(h.router.route(inShell))
+    XCTAssertEqual(claims, ["shell-bar"])
+  }
+
+  func testAKeyBeingReSentIsRecognisedAndNotRoutedAgain() throws {
+    let turns = Turns()
+    let textView = NSTextView(frame: .zero)
+    final class Box {
+      var router: StrayTypingRouter?
+      var reentered: [Bool] = []
+    }
+    let box = Box()
+    let router = StrayTypingRouter(
+      schedule: { turns.enqueue($0) },
+      caretHolder: { _ in textView },
+      deliver: { event in
+        // The field declined it and the chain brought it back to the sink.
+        box.reentered.append(box.router?.route(event) ?? true)
+      },
+      installMonitor: { _ in nil },
+      removeMonitor: { _ in })
+    box.router = router
+    router.register(window: nil, priority: .secondary) {}
+
+    XCTAssertTrue(router.route(try key("a")))
+    turns.turn()
+    XCTAssertEqual(box.reentered, [false], "the same event must not start a second claim — that is the loop")
+  }
+
+  func testAKeyFromAChildWindowOrSheetIsNotAimedAtTheBarBehindIt() {
+    // A sheet cannot be presented headless, so the child-window half of the rule stands in for it:
+    // both are windows whose keyboard belongs to their own controls.
+    let parent = makeWindow()
+    let child = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 100), styleMask: [.borderless], backing: .buffered,
+      defer: false)
+    child.isReleasedWhenClosed = false
+    defer {
+      parent.removeChildWindow(child)
+      child.close()
+      parent.close()
+    }
+    XCTAssertTrue(StrayTypingPolicy.windowAcceptsStrays(nil))
+    XCTAssertTrue(StrayTypingPolicy.windowAcceptsStrays(parent))
+    parent.addChildWindow(child, ordered: .above)
+    XCTAssertFalse(StrayTypingPolicy.windowAcceptsStrays(child))
+  }
+
+  // MARK: The anchor
+
+  func testTheAnchorRegistersForItsWindowAndLeavesWhenRemoved() throws {
+    // The production registry, because the anchor is what wires views into it. Exercised through the
+    // sink so the whole path from key to claim runs; a fresh router cannot be injected into the view.
+    let window = makeWindow()
+    defer { window.close() }
+    let anchor = StrayTypingAnchorView(frame: .zero)
+    var claims = 0
+    anchor.claim = { claims += 1 }
+    try XCTUnwrap(window.contentView).addSubview(anchor)
+
+    let sink = UnhandledKeystrokeSink()
+    sink.keyDown(with: try key("a", windowNumber: window.windowNumber))
+    XCTAssertEqual(claims, 1, "in the window: the anchor's field is claimed")
+
+    anchor.removeFromSuperview()
+    sink.keyDown(with: try key("b", windowNumber: window.windowNumber))
+    XCTAssertEqual(claims, 1, "out of the window: no registration is left behind")
+  }
+
+  // MARK: Through the sink
+
+  func testTheSinkHandsTypingToTheRouterAndStillForwardsNothing() throws {
+    final class NextResponderProbe: NSResponder {
+      private(set) var forwardedKeys = 0
+      override func keyDown(with event: NSEvent) { forwardedKeys += 1 }
+    }
+    let h = makeHarness()
+    var claims = 0
+    h.router.register(window: nil, priority: .secondary) { claims += 1 }
+    let sink = UnhandledKeystrokeSink(router: h.router)
+    let probe = NextResponderProbe()
+    sink.nextResponder = probe
+
+    sink.keyDown(with: try key("a"))
+    h.turns.turn()
+    XCTAssertEqual(claims, 1)
+    XCTAssertEqual(h.seams.delivered.count, 1)
+
+    sink.keyDown(with: try key("\u{F702}", flags: .function))  // an arrow is not typing
+    h.turns.turn()
+    XCTAssertEqual(claims, 1)
+    XCTAssertEqual(probe.forwardedKeys, 0, "routed or swallowed, never forwarded — forwarding beeps")
+  }
+
+  func testAPlainWindowsChainIsCappedToo() {
+    // A window that is not SwiftUI's never reaches `NSApp`; its chain ends at itself (or its
+    // controller) and beeps there. `install(after:)` on the window caps that end.
+    let window = makeWindow()
+    defer { window.close() }
+    XCTAssertNil(window.nextResponder, "a controller-less window's chain ends at the window")
+    UnhandledKeystrokeSink.install(after: window)
+    XCTAssertTrue(window.nextResponder is UnhandledKeystrokeSink)
+    UnhandledKeystrokeSink.install(after: window)
+    XCTAssertNil(window.nextResponder?.nextResponder, "idempotent")
+  }
+}

--- a/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
+++ b/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// Typing with no field focused used to produce the system alert sound: the keystroke fell off the
+/// end of the responder chain and AppKit's `noResponderFor(keyDown:)` beeped. Both chains the app
+/// owns — the application chain SwiftUI windows drain into (capped by `UnhandledKeystrokeSink`) and
+/// the floating panel (which has no window controller and ends at itself) — must absorb an
+/// unhandled key instead of forwarding it.
+@MainActor
+final class UnhandledKeystrokeSilenceTests: XCTestCase {
+  /// Sits after the responder under test; if it hears the key, the key fell through.
+  private final class NextResponderProbe: NSResponder {
+    private(set) var forwardedKeys = 0
+    override func keyDown(with event: NSEvent) { forwardedKeys += 1 }
+  }
+
+  private func plainKey(_ character: String, keyCode: UInt16 = 0) throws -> NSEvent {
+    try XCTUnwrap(
+      NSEvent.keyEvent(
+        with: .keyDown, location: .zero, modifierFlags: [], timestamp: 0, windowNumber: 0,
+        context: nil, characters: character, charactersIgnoringModifiers: character,
+        isARepeat: false, keyCode: keyCode))
+  }
+
+  func testAProbeAfterAPlainResponderHearsTheKeyItForwards() throws {
+    // The control: proves the probe measures forwarding at all, so a silent delegate below is a
+    // result and not a broken probe.
+    let plain = NSResponder()
+    let probe = NextResponderProbe()
+    plain.nextResponder = probe
+    plain.keyDown(with: try plainKey("a"))
+    XCTAssertEqual(probe.forwardedKeys, 1)
+  }
+
+  func testTheSinkAbsorbsAKeyNothingElseHandled() throws {
+    let sink = UnhandledKeystrokeSink()
+    let probe = NextResponderProbe()
+    sink.nextResponder = probe
+    sink.keyDown(with: try plainKey("a"))
+    XCTAssertEqual(probe.forwardedKeys, 0, "an unhandled keystroke must end at the sink; forwarding it is what beeps")
+  }
+
+  func testInstallCapsTheEndOfTheChainExactlyOnce() throws {
+    let root = NSResponder()
+    let middle = NSResponder()
+    root.nextResponder = middle
+
+    UnhandledKeystrokeSink.install(after: root)
+    XCTAssertTrue(
+      middle.nextResponder is UnhandledKeystrokeSink, "the sink goes after the last responder, not after the root")
+
+    UnhandledKeystrokeSink.install(after: root)
+    XCTAssertNil(middle.nextResponder?.nextResponder, "a second install must not stack a second sink")
+  }
+
+  func testTheFloatingPanelAbsorbsUnhandledKeysButStillActsOnEscape() throws {
+    let window = FloatingControlBarWindow(
+      contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+    defer { window.close() }
+    let probe = NextResponderProbe()
+    window.nextResponder = probe
+
+    window.keyDown(with: try plainKey("a"))
+    XCTAssertEqual(probe.forwardedKeys, 0, "a plain key with no field focused must not leave the panel")
+
+    window.state.showingAIConversation = true
+    window.state.aiInputText = "draft"
+    window.keyDown(with: try plainKey("\u{1B}", keyCode: 53))
+    XCTAssertEqual(window.state.aiInputText, "", "Escape is still the panel's own key")
+    XCTAssertEqual(probe.forwardedKeys, 0)
+  }
+}

--- a/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
+++ b/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
@@ -70,5 +70,9 @@ final class UnhandledKeystrokeSilenceTests: XCTestCase {
     window.keyDown(with: try plainKey("\u{1B}", keyCode: 53))
     XCTAssertEqual(window.state.aiInputText, "", "Escape is still the panel's own key")
     XCTAssertEqual(probe.forwardedKeys, 0)
+
+    // Tab is answered by the window itself (key-view navigation) rather than forwarded.
+    window.keyDown(with: try plainKey("\t", keyCode: 48))
+    XCTAssertEqual(probe.forwardedKeys, 0)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260905-silence-keystroke-beep.json
+++ b/desktop/macos/changelog/unreleased/20260905-silence-keystroke-beep.json
@@ -1,0 +1,3 @@
+{
+  "change": "Typing when no text field is focused no longer plays the system alert sound."
+}

--- a/desktop/macos/changelog/unreleased/20260905-silence-keystroke-beep.json
+++ b/desktop/macos/changelog/unreleased/20260905-silence-keystroke-beep.json
@@ -1,3 +1,3 @@
 {
-  "change": "Typing when no text field is focused no longer plays the system alert sound."
+  "change": "Typing with no text field focused now starts a search in the page's search bar (or lands in the chat composer on Chat) instead of playing the system alert sound"
 }

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -6,6 +6,7 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
+  - desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
   - desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/Startup/UnhandledKeystrokeSink.swift
+  - desktop/macos/Desktop/Sources/Startup/StrayTypingRouter.swift
   - desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift


### PR DESCRIPTION
## What

Typing on a page with no text field focused used to play the system alert sound and go nowhere. Now it is silent, and the keystroke lands where you meant it:

- **Tasks, Apps, Memories, Conversations, Rewind, Brain Map, Settings** — the first letter you type goes into the page's search bar at the top and starts a search.
- **Chat** — typing goes into the chat composer, not the search bar above it. If the composer is off screen (results mode), the search bar takes over. The task chat panel on Tasks behaves the same way: its composer outranks the Tasks search bar while it is open.
- **No cursor until you type.** Nothing is focused ahead of time. The bar sits with no caret and no focus stroke; it lights up as your first letter appears in it, so it reads as "I started typing and it went to the right place" rather than a field that was waiting for you.
- **Fast typing is safe.** Letters typed while the field is still taking focus queue behind the first one and arrive in order — no dropped or transposed letters.
- **Modals stay modal.** Typing over an in-window modal (Add memory, the Apps sheets, Settings confirmations) does not start a search in the bar behind the scrim.
- **Every window is quiet.** The notch / floating bar with its input closed, the Feedback window, the prompt editors: unhandled typing no longer beeps anywhere.

## Why the pop

The keystroke fell off the end of the responder chain. SwiftUI windows drain into window → window controller → `NSApp` → app delegate; when nothing handles a key, AppKit's `noResponderFor(keyDown:)` beeps. Plain AppKit windows end at the window or its controller and beep there; the floating panel has no window controller and ends at itself. Nothing else was wrong.

## How

- `UnhandledKeystrokeSink` is appended after the last responder in the application chain at launch, and after each plain window's chain as it becomes key (`installEverywhere`), so SwiftUI `onKeyPress` handlers, menu key equivalents and focused controls have all already declined by the time a key reaches it. `FloatingControlBarWindow.keyDown` absorbs everything but Escape and Tab (Tab still walks the key-view loop for Full Keyboard Access).
- The sink offers each key to `StrayTypingRouter`. Search bars (`QuerySearchBar`, `RewindSearchBar`, Settings search) and the chat composers register while on screen via `straysTypingHere`. Registrations are anchored by a zero-size AppKit view that learns its window in `viewDidMoveToWindow` (the same pattern as `EscapeKeyHandler`), so a key is only ever aimed at a field **in the window it was typed into**, and a registration leaves when its view leaves the window or is freed. Composers register at `.primary`; `ShellModalScrim` registers as `.blocking`.
- A **typing** key — printable, no ⌘/⌃ — runs the winner's focus claim immediately. A local key-down monitor then holds every further typing key for that window. On the next run-loop turn, once an editable text view holds the caret, the caret is parked at the end of any existing text and the queued events are re-sent in order, so dead keys, input methods and ⌥-modified characters compose in the field editor instead of being appended as strings.
- **Not typing:** Space, Return, Tab, arrows, Escape, Delete, function keys. Tasks uses Space/Return on the selected row and Rewind uses the arrows, so those keep meaning what they meant.
- Guards: a key from a sheet or child window is not routed; a blocking registration swallows; a queue whose caret never arrives is dropped (as before) and the hold is lifted; a re-sent event that reaches the sink again is recognised by identity, so there is no loop; delivery requires an editable text view, so a selectable read-only transcript can never receive the key.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

Both are path matches (`OmiApp.swift`, `QueryShellHome.swift`, `ChatInputView.swift`). No auth or chat-timeline behaviour changes: the edits are installing the sink at launch and registering the existing composers as typing targets.

## Tests

- `StrayTypingRouterTests` (13): policy table; claim-now / re-send-later with the caret at the end; keys typed during the wait queue in order and non-typing keys pass through the hold; give-up drops the queue and lifts the hold; composer outranks bar and bar takes over on unregister; a blocking registration swallows; a key is only aimed at a field in its own window; re-entry refused; child window refused; the anchor registers for its window and leaves when removed; through the sink nothing is forwarded; a plain window's chain is capped idempotently.
- `UnhandledKeystrokeSilenceTests` (4): a plain responder forwards (control); the sink does not; `install` caps the chain exactly once; the floating panel absorbs keys but still acts on Escape and answers Tab itself.

Commands run (all green):

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Desktop \
  --filter 'StrayTypingRouterTests|UnhandledKeystrokeSilenceTests'   # 17 tests, 0 failures
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Desktop   # full suite, see note
./scripts/swift-format-wrapper.sh lint <changed files>
python3 scripts/check_desktop_test_quality.py
OMI_APP_NAME=omi-keyboard-pop-click-fix ./run.sh --yolo --no-wait      # named bundle, signed in
```

Full suite: 7,111 tests, 2 failures, both in `JITProactivityRuntimeTests` (ambient nano admission reasons). They pass in isolation on this branch and on clean `origin/main`, so they are order-dependent state leakage inside that suite, not touched by this diff.

Exercised live in the `omi-keyboard-pop-click-fix` named bundle (signed in, built from this branch), driven with `omi-ctl navigate` + `cliclick` and screenshotted before/after:

- Tasks, nothing focused, type `zqx`: before, the bar shows only its placeholder with no caret or focus stroke; after, the bar reads `zqx` with the caret at the end and the list is filtered ("No Matching Tasks"). All three letters landed — the first one that triggered the claim included.
- Tasks, nothing focused, press Space: bar untouched, no caret.
- Chat, type `qzx`: the letters land in the composer ("Ask a follow-up…"); the search bar above stays empty.
- Tasks, nothing focused, `cliclick -w 0 t:quickbrownfox` (zero inter-key delay, so the whole burst is queued before the focus claim lands): the bar reads `quickbrownfox`, complete and in order, list filtered.

An independent multi-angle code review of the diff was run before the revision; its confirmed findings (fast-typing transposition and drop, in-window modals, task chat composer, stale registrations across window close, plain AppKit windows still beeping, Tab in the floating panel) are the reason for the queue, the window-anchored registration, the blocking scrim, `installEverywhere` and the Tab branch above.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5818 -> 5827 | `keyDown` gains a Tab branch (key-view navigation for Full Keyboard Access) and a doc comment explaining why the panel absorbs unhandled keys
Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1660 -> 1663 | one call installing `UnhandledKeystrokeSink` at launch plus a two-line pointer comment; the mechanism lives in its own file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgiPE5hbApigRa7pPrctqe
