### PR TITLE
fix(desktop): attachments are the subject of the message, and can be sent with no text

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatAttachmentOnlySend.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatAttachmentOnlySend.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// **A file dropped in with no words is a message.** These are the three decisions an
+/// attachment-only send needs: whether a composer has anything to send, what the user row says,
+/// and what the model is asked. They live beside `attachmentContextPrompt`'s caller in spirit but
+/// outside `ChatProvider.swift`, whose size is capped by the agent-runtime convergence ratchet.
+extension ChatProvider {
+  /// Whether a composer holding `text` plus these staged items has a message to send. A file or a
+  /// referenced conversation dropped in with no words *is* the message — "what do you make of this"
+  /// is implied — so return on an attachment-only composer sends rather than doing nothing.
+  nonisolated static func hasSendableSubject(text: String, attachmentCount: Int, referenceCount: Int) -> Bool {
+    !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || attachmentCount > 0 || referenceCount > 0
+  }
+
+  /// The user text an attachment-only send carries. The kernel journal tombstones an empty user turn
+  /// and the backend rejects one, and the transcript needs a row the reader recognises above the
+  /// attachment cards, so the row says what was attached rather than pretending the reader typed.
+  nonisolated static func attachmentOnlyCaption(attachmentCount: Int, referenceCount: Int) -> String {
+    var parts: [String] = []
+    if attachmentCount > 0 {
+      parts.append(attachmentCount == 1 ? "1 file" : "\(attachmentCount) files")
+    }
+    if referenceCount > 0 {
+      parts.append(referenceCount == 1 ? "1 conversation" : "\(referenceCount) conversations")
+    }
+    guard !parts.isEmpty else { return "" }
+    return parts.joined(separator: " and ") + " attached"
+  }
+
+  /// What the model is asked on an attachment-only send. The caption above is a label, not a
+  /// request; handed only "1 file attached", the model asks the reader what they want — the very
+  /// question they skipped typing on purpose.
+  nonisolated static func attachmentOnlyModelPrompt(attachmentCount: Int, referenceCount: Int) -> String {
+    let what = attachmentOnlyCaption(attachmentCount: attachmentCount, referenceCount: referenceCount)
+    return """
+      [The user sent this message with no text — only the attached content (\(what)).]
+      Respond to the attachment(s) directly. Inspect their contents first, then give the most useful \
+      response for what they are: summarize a document and surface what matters in it, describe and \
+      interpret an image, review code, or pull the key points, decisions and action items out of a \
+      conversation. Finish with one or two concrete things you can do next with it. Do not ask what the \
+      user wants unless the content is genuinely ambiguous.
+      """
+  }
+}

--- a/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
@@ -81,6 +81,14 @@ enum ScreenContextInterestDetector {
     let wordSet = Set(words)
     return contextualVerbs.contains(where: wordSet.contains) && visualReferences.contains(where: wordSet.contains)
   }
+
+  /// The narrow reading used when the message carries attachments: only a message that names the
+  /// screen itself is about the screen. "Look at this page" beside a PDF is about the PDF; the
+  /// deictic cues `isScreenContextRequest` accepts ("this", "look", "page") are exactly the words
+  /// people use to point at the file they just attached.
+  static func namesTheScreen(_ text: String) -> Bool {
+    text.lowercased().contains("screen")
+  }
 }
 
 enum ScreenContextAutoIncludeReason: Equatable {
@@ -93,12 +101,20 @@ enum ScreenContextAutoIncludeReason: Equatable {
 }
 
 enum ScreenContextAutoIncludePolicy {
+  /// `hasAttachments`: the message carries files or conversation references the user chose to
+  /// attach. Those are the message's subject, so no ambient screen context is added alongside
+  /// them and a capture is taken only when the text names the screen outright — otherwise the
+  /// model is handed a desktop to describe next to the file it was asked about.
   static func reason(
     userText: String,
     systemPromptStyle: ChatSystemPromptStyle,
     turnOwner: ChatTurnOwner,
-    onboardingActive: Bool = false
+    onboardingActive: Bool = false,
+    hasAttachments: Bool = false
   ) -> ScreenContextAutoIncludeReason? {
+    if hasAttachments {
+      return ScreenContextInterestDetector.namesTheScreen(userText) ? .explicitScreenRequest : nil
+    }
     if ScreenContextInterestDetector.isScreenContextRequest(userText) {
       return .explicitScreenRequest
     }
@@ -120,9 +136,12 @@ enum ScreenContextAutoIncludePolicy {
   static func shouldInclude(
     userText: String,
     systemPromptStyle: ChatSystemPromptStyle,
-    turnOwner: ChatTurnOwner
+    turnOwner: ChatTurnOwner,
+    hasAttachments: Bool = false
   ) -> Bool {
-    reason(userText: userText, systemPromptStyle: systemPromptStyle, turnOwner: turnOwner) != nil
+    reason(
+      userText: userText, systemPromptStyle: systemPromptStyle, turnOwner: turnOwner,
+      hasAttachments: hasAttachments) != nil
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -254,12 +254,13 @@ struct ChatInputView: View {
     }
   }
 
-  /// Send is enabled when there's text OR (when supported) any attachment ready
-  /// to ship — Flutter allows sending attachments without text.
+  /// Send is enabled when there's text OR (when supported) any attachment or
+  /// staged reference ready to ship — the attachment is the message.
   private var canSend: Bool {
     guard !hasMarkedText else { return false }
     if hasText { return true }
     if attachmentsEnabled && !currentAttachments.isEmpty { return true }
+    if !references.isEmpty { return true }
     return false
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
@@ -333,10 +333,13 @@ struct QueryHeroBar: View {
     .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isProminent)
   }
 
-  /// Whether there is anything for the primary to send. A staged file with no words is a send.
+  /// Whether there is anything for the primary to send. A staged file or conversation with no words
+  /// is a send.
   private var canSend: Bool {
-    !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+    !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasStagedItems
   }
+
+  private var hasStagedItems: Bool { !attachments.isEmpty || !references.isEmpty }
 
   /// **The field, grown into a composer.**
   ///
@@ -397,7 +400,7 @@ struct QueryHeroBar: View {
   /// panel had already applied; there was never a second thing for it to mean. `⌘⏎` still sends: it
   /// is the `keyboardShortcut` on the primary and never arrives here.
   private func submitFromReturnKey() {
-    switch QueryShellSubmit.resolve(text: text) {
+    switch QueryShellSubmit.resolve(text: text, hasAttachments: hasStagedItems) {
     case .ask: onAsk()
     case .none: break
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -419,7 +419,9 @@ struct QueryShellHome: View {
   /// Resolved by `QueryShellSubmission` rather than restated here, so the trim, the empty guard and
   /// the mode change cannot drift away from the value that defines them.
   private func submit() {
-    let submission = QueryShellSubmission.resolve(text: chatProvider.draftText)
+    let submission = QueryShellSubmission.resolve(
+      text: chatProvider.draftText,
+      hasAttachments: !chatProvider.pendingAttachments.isEmpty || !chatProvider.pendingComposerReferences.isEmpty)
     // Plan before mutating anything: a busy provider rejects the send, so
     // Return during an active turn must leave the typed draft intact and
     // neither dispatch nor advance the rating-prompt count.

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -212,8 +212,11 @@ enum QueryShellSubmit: Equatable, Sendable {
 
   /// No `commandHeld`. Which key was pressed stopped being information the moment both keys meant
   /// the same thing; a parameter nothing branches on is the next thing to grow a branch back.
-  static func resolve(text: String) -> QueryShellSubmit {
-    text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .none : .ask
+  ///
+  /// `hasAttachments`: a file or conversation staged with no words is a message — `⏎` sends it, and
+  /// the provider asks the model about what was attached. Only a bare, empty composer is inert.
+  static func resolve(text: String, hasAttachments: Bool = false) -> QueryShellSubmit {
+    text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !hasAttachments ? .none : .ask
   }
 }
 
@@ -233,7 +236,8 @@ enum QueryShellSubmit: Equatable, Sendable {
 /// which is why there is no longer a `commandHeld` to disambiguate.
 struct QueryShellSubmission: Equatable, Sendable {
   let action: QueryShellSubmit
-  /// The trimmed question to send. Non-nil only for `.ask`.
+  /// The trimmed question to send. Non-nil only for `.ask` — and empty for an attachment-only send,
+  /// where the staged items are the message.
   let question: String?
   /// What the field holds afterwards.
   let text: String
@@ -241,8 +245,8 @@ struct QueryShellSubmission: Equatable, Sendable {
   /// inert key must never move the reader.
   let mode: QueryShellMode?
 
-  static func resolve(text: String) -> Self {
-    switch QueryShellSubmit.resolve(text: text) {
+  static func resolve(text: String, hasAttachments: Bool = false) -> Self {
+    switch QueryShellSubmit.resolve(text: text, hasAttachments: hasAttachments) {
     case .none:
       return Self(action: .none, question: nil, text: text, mode: nil)
     case .ask:
@@ -277,8 +281,12 @@ struct QueryShellSendLedger: Equatable, Sendable {
   /// (nor overwrite the question 'Try again' would re-send). Planning mutates
   /// nothing — only `recordAccepted` commits state, so a send ChatProvider
   /// rejects asynchronously leaves the ledger exactly as it was.
+  ///
+  /// An empty question is a resolved attachment-only send, not a blank field:
+  /// `QueryShellSubmission` already turned a bare empty composer into no
+  /// question at all, so it is admitted and counts like any other.
   func planSubmit(_ question: String?, providerBusy: Bool = false) -> Plan? {
-    guard !providerBusy, let question, !question.isEmpty else { return nil }
+    guard !providerBusy, let question else { return nil }
     return Plan(question: question, countsAsQuestion: true)
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4176,7 +4176,7 @@ class ChatProvider: ObservableObject {
     let plural = attachments.count == 1 ? "file" : "files"
     var lines: [String] = [
       "[Attached Files]",
-      "The user attached \(attachments.count) \(plural) to this exact message. Treat references like \"this\", \"the file\", \"the attachment\", or \"what do you think of this\" as referring to these attachment(s). If the answer depends on file contents, inspect the local_path with file-reading tools before asking for clarification.",
+      "The user attached \(attachments.count) \(plural) to this exact message. They are the primary subject of the message: treat references like \"this\", \"look\", \"the file\", \"the attachment\", or \"what do you think of this\" as referring to these attachment(s), and inspect them before consulting screen, work, or memory context. If the answer depends on file contents, inspect the local_path with file-reading tools before asking for clarification. Do not describe the screen unless the user asks about the screen explicitly.",
     ]
     for (index, attachment) in attachments.enumerated() {
       lines.append("")
@@ -5031,12 +5031,17 @@ class ChatProvider: ObservableObject {
         }
       }
       var screenPayload: [String: Any]?
+      // Files and referenced conversations the user attached are the turn's subject; they
+      // must not be crowded out by an ambient desktop snapshot or a capture that a bare
+      // "look at this" would otherwise trigger.
+      let hasAttachments = !attachmentsForMessage.isEmpty || !composerReferencesForMessage.isEmpty
       if effectiveImageData == nil,
         let screenContextReason = ScreenContextAutoIncludePolicy.reason(
           userText: effectivePrompt,
           systemPromptStyle: systemPromptStyle,
           turnOwner: turnOwner,
-          onboardingActive: !UserDefaults.standard.bool(forKey: DefaultsKey.hasCompletedOnboarding)
+          onboardingActive: !UserDefaults.standard.bool(forKey: DefaultsKey.hasCompletedOnboarding),
+          hasAttachments: hasAttachments
         )
       {
         let screenRecordingGranted = CGPreflightScreenCaptureAccess()

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -4487,7 +4487,16 @@ class ChatProvider: ObservableObject {
     onJournalFinalized: (@MainActor (_ accepted: Bool) -> Void)? = nil
   ) async -> String? {
     let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmedText.isEmpty || questionInteraction != nil || questionContinuation != nil else { return nil }
+    // A file or conversation staged with no words is a message in its own right; its caption and
+    // model prompt are resolved once the staged items are settled below.
+    let isAttachmentOnlySend =
+      trimmedText.isEmpty
+      && Self.hasSendableSubject(
+        text: trimmedText,
+        attachmentCount: pendingAttachments.count,
+        referenceCount: pendingComposerReferences.count)
+    guard !trimmedText.isEmpty || isAttachmentOnlySend || questionInteraction != nil || questionContinuation != nil
+    else { return nil }
     var effectivePrompt = trimmedText
 
     // Guard against concurrent sendMessage calls.
@@ -4837,6 +4846,13 @@ class ChatProvider: ObservableObject {
       }
       attachmentsForMessage = pendingAttachments
       pendingAttachments.removeAll()
+    }
+    // The row and the journal carry a caption (both require non-empty user text); the model is told
+    // separately that the attachments are the whole message — see `modelPrompt` at the query.
+    if isAttachmentOnlySend {
+      effectivePrompt = Self.attachmentOnlyCaption(
+        attachmentCount: attachmentsForMessage.count,
+        referenceCount: composerReferencesForMessage.count)
     }
     if turnUsesOmiAccount {
       usageLimiter.recordQuery()
@@ -5393,9 +5409,15 @@ class ChatProvider: ObservableObject {
       activeBridgeSendGeneration = sendGen
       agentQueryStarted = true
       let queryResult: AgentClient.QueryResult
+      let modelPrompt =
+        isAttachmentOnlySend
+        ? Self.attachmentOnlyModelPrompt(
+          attachmentCount: attachmentsForMessage.count,
+          referenceCount: composerReferencesForMessage.count)
+        : effectivePrompt
       do {
         queryResult = try await resolvedAgentClient().query(
-          prompt: ChatPromptBuilder.currentTimePrompt(for: effectivePrompt),
+          prompt: ChatPromptBuilder.currentTimePrompt(for: modelPrompt),
           session: kernelContext.session,
           surface: resolvedSurface,
           mode: chatMode.rawValue,
@@ -5719,10 +5741,13 @@ class ChatProvider: ObservableObject {
         }
       }
 
-      // Fire-and-forget: check if user's message mentions goal progress
-      let chatText = effectivePrompt
-      Task.detached(priority: .background) {
-        await GoalsAIService.shared.extractProgressFromAllGoals(text: chatText)
+      // Fire-and-forget: check if user's message mentions goal progress.
+      // An attachment-only caption ("1 file attached") has none to find.
+      if !isAttachmentOnlySend {
+        let chatText = effectivePrompt
+        Task.detached(priority: .background) {
+          await GoalsAIService.shared.extractProgressFromAllGoals(text: chatText)
+        }
       }
       completedResponseText = messageText
     } catch {
@@ -5985,7 +6010,9 @@ class ChatProvider: ObservableObject {
         // replaces the prompt with a canned answer the reader picked rather
         // than typed, and that has no business landing in their composer.
         restoreComposerAfterFailedTurn(trimmedText, turnOwner: turnOwner)
-        lastFailedPrompt = failureNotice.retryable ? effectivePrompt : nil
+        // An attachment-only turn has no retryable prompt: the send consumed the attachments, and
+        // re-sending the caption alone would ask about files that are no longer there.
+        lastFailedPrompt = failureNotice.retryable && !isAttachmentOnlySend ? effectivePrompt : nil
       } else if let bridgeError = error as? BridgeError, case .stopped = bridgeError,
         stopReason(for: sendGen) == .userStop, hadPartialResponse
       {

--- a/desktop/macos/Desktop/Tests/AttachmentOnlySendTests.swift
+++ b/desktop/macos/Desktop/Tests/AttachmentOnlySendTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// **A file dropped in with no words is a message.** Attaching a PDF and pressing return used to do
+/// nothing: every composer either disabled the send or the provider's empty-text guard swallowed the
+/// turn, so the reader had to invent words ("look at this") to get the attachment in front of the
+/// model. These tests hold the seam where that turned around: the provider admits the send, the row
+/// carries a caption the journal and backend both accept, and the model is asked about the
+/// attachment rather than being handed a label.
+@MainActor
+final class AttachmentOnlySendTests: XCTestCase {
+  private func stagedFile(_ name: String = "notes.pdf") -> ChatAttachment {
+    ChatAttachment(fileName: name, mimeType: "application/pdf", data: Data([0x25, 0x50, 0x44, 0x46]))
+  }
+
+  private func stagedConversation() -> ChatComposerReference {
+    ChatComposerReference(kind: .conversation, sourceID: "conv-1", title: "Standup")
+  }
+
+  // MARK: - The provider admits the send
+
+  /// The busy refusal is the first thing past the empty-text guard that speaks, so a refusal *with*
+  /// an explanation is proof the attachment-only send was admitted as a turn — while an empty
+  /// composer with nothing staged still returns silently, as an inert key should.
+  func testAnEmptyMessageWithAStagedFileIsATurn() async {
+    let provider = ChatProvider()
+    provider.isSending = true
+    provider.pendingAttachments = [stagedFile()]
+
+    let result = await provider.sendMessage("   ")
+
+    XCTAssertNil(result, "The provider is busy, so no turn starts")
+    XCTAssertEqual(
+      provider.errorMessage, ChatProvider.sendRefusedWhileBusyMessage,
+      "Reaching the busy guard means the empty-text guard let the attachment-only send through"
+    )
+    XCTAssertEqual(provider.pendingAttachments.count, 1, "A refused send keeps the staged file")
+  }
+
+  func testAnEmptyMessageWithAStagedConversationIsATurn() async {
+    let provider = ChatProvider()
+    provider.isSending = true
+    provider.pendingComposerReferences = [stagedConversation()]
+
+    _ = await provider.sendMessage("")
+
+    XCTAssertEqual(provider.errorMessage, ChatProvider.sendRefusedWhileBusyMessage)
+  }
+
+  func testAnEmptyMessageWithNothingStagedIsStillInert() async {
+    let provider = ChatProvider()
+    provider.isSending = true
+
+    let result = await provider.sendMessage("  \n ")
+
+    XCTAssertNil(result)
+    XCTAssertNil(provider.errorMessage, "Nothing was sent, so there is nothing to refuse")
+    XCTAssertTrue(provider.messages.isEmpty)
+  }
+
+  func testSendableSubjectIsWordsOrAStagedItem() {
+    XCTAssertFalse(ChatProvider.hasSendableSubject(text: " \n", attachmentCount: 0, referenceCount: 0))
+    XCTAssertTrue(ChatProvider.hasSendableSubject(text: "hi", attachmentCount: 0, referenceCount: 0))
+    XCTAssertTrue(ChatProvider.hasSendableSubject(text: "", attachmentCount: 1, referenceCount: 0))
+    XCTAssertTrue(ChatProvider.hasSendableSubject(text: "", attachmentCount: 0, referenceCount: 1))
+  }
+
+  // MARK: - What the row says and what the model is asked
+
+  /// The journal tombstones an empty user turn and the backend rejects one, so the row needs words —
+  /// and the honest words are what was attached, not a sentence the reader never typed.
+  func testTheCaptionSaysWhatWasAttached() {
+    XCTAssertEqual(ChatProvider.attachmentOnlyCaption(attachmentCount: 1, referenceCount: 0), "1 file attached")
+    XCTAssertEqual(ChatProvider.attachmentOnlyCaption(attachmentCount: 3, referenceCount: 0), "3 files attached")
+    XCTAssertEqual(
+      ChatProvider.attachmentOnlyCaption(attachmentCount: 0, referenceCount: 1), "1 conversation attached")
+    XCTAssertEqual(
+      ChatProvider.attachmentOnlyCaption(attachmentCount: 2, referenceCount: 2),
+      "2 files and 2 conversations attached")
+    XCTAssertEqual(ChatProvider.attachmentOnlyCaption(attachmentCount: 0, referenceCount: 0), "")
+  }
+
+  /// A label is not a request. Handed only "1 file attached", the model asks the reader what they
+  /// want; the prompt has to say there were no words and ask for a direct response instead.
+  func testTheModelIsAskedToRespondToTheAttachmentDirectly() {
+    let prompt = ChatProvider.attachmentOnlyModelPrompt(attachmentCount: 1, referenceCount: 0)
+    XCTAssertTrue(prompt.contains("no text"), "The model is told the reader typed nothing")
+    XCTAssertTrue(prompt.contains("1 file attached"), "…and what they sent instead")
+    XCTAssertTrue(prompt.contains("Respond to the attachment(s) directly"))
+    XCTAssertTrue(prompt.contains("Do not ask what the user wants"), "The skipped question stays skipped")
+  }
+
+  /// Attachments are the subject, so an attachment-only turn never captures or describes the screen.
+  func testAnAttachmentOnlyTurnAddsNoScreenContext() {
+    for owner in [ChatTurnOwner.mainChat, .floatingDefault, .taskChat("task-1")] {
+      XCTAssertNil(
+        ScreenContextAutoIncludePolicy.reason(
+          userText: "",
+          systemPromptStyle: .floating,
+          turnOwner: owner,
+          hasAttachments: true),
+        "\(owner) must not capture the screen for a message that is only an attachment"
+      )
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopCoordinatorServiceTests.swift
@@ -411,7 +411,7 @@ final class DesktopCoordinatorServiceTests: XCTestCase {
     // omi-test-quality: source-inspection -- static contract: main chat cannot reintroduce deprecated query authority fields
     let source = try sourceFile("Providers/ChatProvider.swift")
 
-    XCTAssertTrue(source.contains("prompt: ChatPromptBuilder.currentTimePrompt(for: effectivePrompt)"))
+    XCTAssertTrue(source.contains("prompt: ChatPromptBuilder.currentTimePrompt(for: modelPrompt)"))
     XCTAssertTrue(source.contains("attachments: Self.queryAttachments(attachmentsForMessage)"))
     XCTAssertTrue(source.contains("expectedContext: kernelContext.snapshot.freshness"))
     XCTAssertFalse(source.contains("attachmentMetadataJson:"))

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -53,6 +53,33 @@ final class QueryShellTests: XCTestCase {
     XCTAssertEqual(submission.mode, .answer)
   }
 
+  /// **A staged file with no words is a send.** Dropping a PDF on the bar and pressing return used to
+  /// resolve to `.none`, so the only way to ask about an attachment was to invent words for it.
+  func testAStagedItemWithNoWordsSubmitsAsAnAsk() {
+    XCTAssertEqual(QueryShellSubmit.resolve(text: "", hasAttachments: true), .ask)
+    XCTAssertEqual(QueryShellSubmit.resolve(text: "   ", hasAttachments: true), .ask)
+    XCTAssertEqual(QueryShellSubmit.resolve(text: "", hasAttachments: false), .none)
+
+    let submission = QueryShellSubmission.resolve(text: "  ", hasAttachments: true)
+    XCTAssertEqual(submission.action, .ask)
+    XCTAssertEqual(submission.question, "", "An empty question: the attachment is the message")
+    XCTAssertEqual(submission.text, "", "The send consumes the field as it does for words")
+    XCTAssertEqual(submission.mode, .answer)
+  }
+
+  /// The ledger admits the resolved attachment-only submit — and once the send has consumed the
+  /// attachments there is nothing for `Try again` to re-send.
+  func testTheLedgerAdmitsAnAttachmentOnlySubmitButOffersNoRetryForIt() {
+    var ledger = QueryShellSendLedger()
+    XCTAssertNil(ledger.planSubmit(nil), "A bare empty field resolved to no question at all")
+    guard let plan = ledger.planSubmit("") else { return XCTFail("an attachment-only send is a plan") }
+    XCTAssertTrue(plan.countsAsQuestion)
+    XCTAssertNil(ledger.planSubmit("", providerBusy: true), "Return during a turn is still refused")
+
+    ledger.recordAccepted(plan)
+    XCTAssertNil(ledger.planRetry(), "The caption alone would ask about files that are gone")
+  }
+
   /// An inert key must not move the reader. Before this, an empty field was itself read as "go back
   /// to the list", so emptying the bar to type a follow-up ejected you from the conversation.
   func testAnInertSubmitMovesNothingAndKeepsTheReaderInTheirConversation() {

--- a/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
+++ b/desktop/macos/Desktop/Tests/RatingPromptCountingTests.swift
@@ -152,11 +152,13 @@ final class RatingPromptCountingTests: XCTestCase {
     XCTAssertEqual(RatingPromptManager.shared.questionCount, 0)
   }
 
-  func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndEmptySubmits() {
+  func testQueryShellLedgerRejectsRetryBeforeAnySubmitAndUnresolvedSubmits() {
     let ledger = QueryShellSendLedger()
     XCTAssertNil(ledger.planRetry())
-    XCTAssertNil(ledger.planSubmit(nil))
-    XCTAssertNil(ledger.planSubmit(""))
+    XCTAssertNil(ledger.planSubmit(nil), "A bare empty field resolves to no question, and the ledger plans nothing")
+    // An empty *resolved* question is an attachment-only send (`QueryShellSubmission` only yields
+    // one when something is staged), so it is a real question for rating purposes.
+    XCTAssertEqual(ledger.planSubmit("")?.countsAsQuestion, true)
     XCTAssertEqual(ledger.planSubmit("q")?.countsAsQuestion, true)
     // Planning alone commits nothing; only acceptance does.
     XCTAssertNil(ledger.planRetry())

--- a/desktop/macos/Desktop/Tests/ScreenContextTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenContextTelemetryTests.swift
@@ -394,6 +394,55 @@ final class ScreenContextTelemetryTests: XCTestCase {
       ))
   }
 
+  /// A message with an attachment is about the attachment. "Look at this page" beside a PDF used
+  /// to trip the deictic detector and capture the desktop, and a floating turn added an ambient
+  /// desktop snapshot regardless — so the model described a blank screen instead of the file.
+  func testAttachmentsAreTheSubjectUnlessTheScreenIsNamed() {
+    // Deictic cues point at the file, not the desktop.
+    XCTAssertNil(
+      ScreenContextAutoIncludePolicy.reason(
+        userText: "look at this page",
+        systemPromptStyle: .main,
+        turnOwner: .mainChat,
+        hasAttachments: true
+      ))
+    XCTAssertNil(
+      ScreenContextAutoIncludePolicy.reason(
+        userText: "look",
+        systemPromptStyle: .floating,
+        turnOwner: .floatingDefault,
+        hasAttachments: true
+      ),
+      "an attachment on a floating turn replaces the ambient desktop snapshot, it does not sit beside it")
+    XCTAssertFalse(
+      ScreenContextAutoIncludePolicy.shouldInclude(
+        userText: "what do you think of this?",
+        systemPromptStyle: .main,
+        turnOwner: .agentPill(UUID()),
+        hasAttachments: true
+      ))
+    // Naming the screen is still an explicit ask, attachment or not.
+    XCTAssertEqual(
+      ScreenContextAutoIncludePolicy.reason(
+        userText: "compare this file with what is on my screen",
+        systemPromptStyle: .main,
+        turnOwner: .mainChat,
+        hasAttachments: true
+      ),
+      .explicitScreenRequest
+    )
+    // The attachment rule is inert without an attachment.
+    XCTAssertEqual(
+      ScreenContextAutoIncludePolicy.reason(
+        userText: "look at this page",
+        systemPromptStyle: .main,
+        turnOwner: .mainChat,
+        hasAttachments: false
+      ),
+      .explicitScreenRequest
+    )
+  }
+
   func testOnboardingFloatingTurnsAreExplicitScreenRequests() {
     // The demo's suggested query has no screen-cue words; during onboarding a
     // floating turn must still attempt a real capture so failures surface.

--- a/desktop/macos/agent/src/runtime/attachment-prompt.ts
+++ b/desktop/macos/agent/src/runtime/attachment-prompt.ts
@@ -1,0 +1,30 @@
+import { stableJsonStringify } from "./kernel-support.js";
+
+export interface PromptAttachment {
+  attachmentId: string;
+  displayName: string;
+  mimeType: string;
+  sizeBytes?: number;
+  uri?: string;
+}
+
+/**
+ * The instruction that rides with every attached file.
+ *
+ * A file the user just attached is the subject of the message. Without saying so, a
+ * bare "look" or "what do you think of this" next to a PDF was read against the
+ * ambient screen context that precedes it in the prompt, and the model answered about
+ * the desktop ("I see a blank page") instead of the file. The rule is stated once, in
+ * plain terms, ahead of the listing so it applies to every reference below it.
+ */
+export const ATTACHMENT_PRIORITY_INSTRUCTION =
+  "The user attached these files to this exact message. They are the primary subject of the message: " +
+  'read "this", "it", "look", "what do you think", and similar references as pointing at the attachments, ' +
+  "and inspect their contents (uri / local path) before consulting screen, work, or memory context. " +
+  "Do not describe the screen unless the user asks about the screen explicitly.";
+
+/** Renders the `# Attachments` prompt section, or an empty string when there is nothing attached. */
+export function renderAttachmentsSection(attachments: readonly PromptAttachment[] | undefined): string {
+  if (!attachments?.length) return "";
+  return `\n\n# Attachments\n${ATTACHMENT_PRIORITY_INSTRUCTION}\n${stableJsonStringify(attachments)}`;
+}

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -29,6 +29,7 @@ import {
   type ContextDeliveryCursor,
 } from "./context-snapshot.js";
 import { repairPersistedAgentSpawnJournals } from "./agent-spawn-journal.js";
+import { renderAttachmentsSection } from "./attachment-prompt.js";
 import {
   bindProducingJournalTurn,
   searchJournalConversation,
@@ -73,7 +74,6 @@ import {
   requiresVerifiedContextDispatch,
   bindingMetadata,
   stableHash,
-  stableJsonStringify,
   stableMcpServerConfig,
   stableJsonHash,
   parseJsonObject,
@@ -1155,9 +1155,7 @@ export class KernelCore {
       if (surfaceRef) {
         const snapshot = attemptInput.admittedContextSnapshot;
         if (!snapshot) throw new Error("Run is missing its admitted context snapshot");
-        const attachments = input.attachments?.length
-          ? `\n\n# Attachments\n${stableJsonStringify(input.attachments)}`
-          : "";
+        const attachments = renderAttachmentsSection(input.attachments);
         const renderedContext = adapterId === "pi-mono" && handle.bindingId
           ? renderContextSnapshotForBinding(
               snapshot,

--- a/desktop/macos/agent/tests/attachment-prompt.test.ts
+++ b/desktop/macos/agent/tests/attachment-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ATTACHMENT_PRIORITY_INSTRUCTION,
+  renderAttachmentsSection,
+} from "../src/runtime/attachment-prompt.js";
+
+describe("attachment prompt section", () => {
+  it("renders nothing when the message has no attachments", () => {
+    expect(renderAttachmentsSection(undefined)).toBe("");
+    expect(renderAttachmentsSection([])).toBe("");
+  });
+
+  it("puts the priority instruction ahead of the file listing", () => {
+    const section = renderAttachmentsSection([
+      { attachmentId: "a1", displayName: "deck.pdf", mimeType: "application/pdf", uri: "file:///tmp/deck.pdf" },
+    ]);
+    expect(section.startsWith("\n\n# Attachments\n")).toBe(true);
+    const instructionAt = section.indexOf(ATTACHMENT_PRIORITY_INSTRUCTION);
+    const listingAt = section.indexOf("deck.pdf");
+    expect(instructionAt).toBeGreaterThan(-1);
+    expect(listingAt).toBeGreaterThan(instructionAt);
+    expect(section).toContain("file:///tmp/deck.pdf");
+  });
+
+  it("names the attachment as the subject and defers the screen to an explicit ask", () => {
+    expect(ATTACHMENT_PRIORITY_INSTRUCTION).toContain("primary subject");
+    expect(ATTACHMENT_PRIORITY_INSTRUCTION).toMatch(/before consulting screen/);
+    expect(ATTACHMENT_PRIORITY_INSTRUCTION).toMatch(/unless the user asks about the screen explicitly/);
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260905-attachment-only-send.json
+++ b/desktop/macos/changelog/unreleased/20260905-attachment-only-send.json
@@ -1,0 +1,3 @@
+{
+  "change": "You can now attach a file, image, or conversation and press Return without typing anything; Omi responds to the attachment directly."
+}

--- a/desktop/macos/changelog/unreleased/20260905-attachments-first.json
+++ b/desktop/macos/changelog/unreleased/20260905-attachments-first.json
@@ -1,0 +1,3 @@
+{
+  "change": "Attached files, images, and conversations are now treated as the subject of your message, so Omi answers about the attachment instead of describing your screen."
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -5,6 +5,7 @@ description: Hermetic chat in Home tab — send/receive with Rust OMI_LLM_STUB=1
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/Chat/ChatTurnFailureNotice.swift
+  - desktop/macos/Desktop/Sources/Chat/ChatAttachmentOnlySend.swift
   - desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimePayload.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift

--- a/desktop/macos/scripts/agent-runtime-convergence-ratchet.json
+++ b/desktop/macos/scripts/agent-runtime-convergence-ratchet.json
@@ -1,10 +1,11 @@
 {
   "limits": {
-    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 7372,
-    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4404
+    "desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift": 4404,
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider.swift": 7382
   },
   "raise_justifications": {
     "INV-CHAT-1": "Chat-first rich-block handling, answer submission, and task completion stay in the existing provider while its shared lifecycle extraction remains bounded.",
-    "INV-CHAT-1-runtime-payload": "+8 for the bundled-runtime start refusal. A build shipped without Contents/Resources/pi-mono-extension accepted every chat turn and died four seconds later with \"pi-mono process exited (code 1)\"; the refusal has to sit beside the other start-refusal preconditions this file already owns, because a second observer would give one failure two owners. The reason and its wording were moved out to AgentRuntimePayload.StartRefusal, which is why this is +8 rather than +13 — the coordinator keeps only the decision to stop, not the explanation."
+    "INV-CHAT-1-attachment-only-send": "+10 for the attachment-only send. A file or referenced conversation staged with no words is a message in its own right, and the admission, the caption the row carries, and the model prompt that names the attachments as the subject all sit on the one send path this file owns; the helpers that build them live in ChatAttachmentOnlySend.swift, so the provider keeps only the decisions.",
+    "INV-CHAT-1-runtime-payload": "+8 for the bundled-runtime start refusal. A build shipped without Contents/Resources/pi-mono-extension accepted every chat turn and died four seconds later with \"pi-mono process exited (code 1)\"; the refusal has to sit beside the other start-refusal preconditions this file already owns, because a second observer would give one failure two owners. The reason and its wording were moved out to AgentRuntimePayload.StartRefusal, which is why this is +8 rather than +13 \u2014 the coordinator keeps only the decision to stop, not the explanation."
   }
 }


### PR DESCRIPTION
## Summary

Attaching a file, image, or conversation and pressing Return with no text now sends a turn. Previously every composer either disabled send or `ChatProvider.sendMessage` silently dropped the empty-text turn, so the reader had to invent words ("look at this") to get an attachment in front of the model.

- `ChatProvider.sendMessage` admits an empty-text send when files or composer references are staged. The user row and kernel journal carry a caption ("1 file attached", "2 files and 1 conversation attached") because the journal tombstones an empty user turn and the backend rejects empty message text. The model receives a separate prompt stating the reader sent no text and asking for a direct response to the attachments. Screen context stays off, goal extraction is skipped, and `Try again` is not offered for these turns (the send consumed the attachments).
- Query shell: `QueryShellSubmit`/`QueryShellSubmission.resolve` take `hasAttachments`; `QueryShellSendLedger.planSubmit` admits an empty resolved question. `QueryHeroBar` Return handling and send-button dimming count staged references.
- `HomeAskBar` and `ChatInputView` enable send with attachments or references alone.

The `RatingPromptCountingTests` ledger assertion for `planSubmit("")` is rewritten on purpose: the empty-string guard moved to the resolver (`QueryShellSubmission` yields an empty question only when something is staged), and `QueryShellTests` covers that resolver contract.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Desktop --filter 'ChatTurnStateFailureTests|RatingPromptCountingTests|ChatComposerDraftTests|ChatComposerReferenceTests|QueryComposerTests|HomeKnowsComposerTests|ChatErrorStateTests|AttachmentOnlySendTests|QueryShellTests|ScreenContextTelemetryTests|ChatResourceTests|OnboardingOpenerComposerTests'` → 194 tests, 0 failures after the ledger test update
- `swift-format` lint, SwiftLint (0 violations in 1600 files), `scripts/check_desktop_test_quality.py`, `scripts/check-e2e-flow-coverage.py` (0 uncovered) all clean
- Exercised end to end in the `omi-attachment-priority` named bundle against the dev backend: staged a `.txt` via `home_attach`, pressed Return with an empty composer → user row "1 file attached" with the file card, model read the file and returned a structured summary without asking what to do; a conversation reference sent with no text → "1 conversation attached" and a summary of that conversation. Both rows persisted in `main_chat_snapshot` after the turns completed.

## Product invariants affected

- INV-CHAT-1
- INV-AGENT-* (kernel prompt assembly renders the `# Attachments` section; no identity/authority change)
- INV-AUTH-1 (ChatProvider send path; sign-in/ownership guards unchanged)

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 7350 -> 7382 | attachment-only send admission, caption and model prompt live beside the send path and attachmentContextPrompt they extend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFLed7oLyvnVY7dv2PZLJd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


