### PR TITLE
fix(qa): admit bounded recovery metadata at bootstrap

### DIFF
--- a/backend/docs/runbooks/jit-qa-seed-and-verify.md
+++ b/backend/docs/runbooks/jit-qa-seed-and-verify.md
@@ -14,9 +14,15 @@ seeding, run the explicit create-only bootstrap against that named database:
 python3 backend/scripts/jit_qa_seed_and_verify.py bootstrap
 ```
 
-Bootstrap fails unless the named database is truly empty, creates only the
-fixed QA UID's minimal `users/{uid}` profile and `testers/{uid}` entitlement
-marker, and calls `ensure_canonical_apply_control_state` to create the real
+Bootstrap fails unless the named database has an empty user plane. A backend
+startup may have left the one known metadata-only
+`conversation_recovery_state/byok_abandonment_sweep` cursor; bootstrap accepts
+it only with the exact `generation`, `resume_after_path` (null), and
+`updated_at` fields, and preserves it. Any other collection, document, field,
+or malformed value fails closed. The receipt distinguishes this preserved
+runtime metadata from the empty user plane. Bootstrap creates only the fixed
+QA UID's minimal `users/{uid}` profile and `testers/{uid}` entitlement marker,
+and calls `ensure_canonical_apply_control_state` to create the real
 compatibility apply-control fence. It never creates a migration completion or
 ledger cutover receipt; those remain owned by the drain job's canonical
 `publish_ledger_migration_cutover` path. A durable

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -248,31 +248,45 @@ def _assert_named_database_empty(db_client: Any) -> dict[str, Any]:
             "bootstrap requires a truly empty named database; " f"found collection {collection_id!r}"
         )
 
-    # This one allowlisted document is metadata-only by contract. Read its
-    # complete payload so the exact-field check also detects newly added or
-    # unexpected fields; a projection would hide those fields.
-    query = collection
-    limiter = getattr(query, "limit", None)
-    streamer = getattr(query, "stream", None)
-    if not callable(limiter) or not callable(streamer):
+    # ``list_documents`` includes missing parent documents for nested
+    # collections. That is the only bounded way to distinguish an empty
+    # direct collection from an orphan descendant, so clients without it are
+    # refused rather than treated as empty.
+    list_documents = getattr(collection, "list_documents", None)
+    if not callable(list_documents):
         raise JITQAVerificationError("bootstrap requires a bounded recovery metadata inventory")
     try:
-        snapshots = list(limiter(EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT + 1).stream())
+        document_iterator = iter(list_documents(page_size=EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT + 1))
+        document_refs = []
+        for _ in range(EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT + 1):
+            try:
+                document_refs.append(next(document_iterator))
+            except StopIteration:
+                break
     except Exception as exc:
         raise JITQAVerificationError("bootstrap could not inventory recovery metadata") from exc
-    if len(snapshots) > EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT:
+    if len(document_refs) > EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT:
         raise JITQAVerificationError("bootstrap recovery metadata inventory exceeded its hard bound")
-    if not snapshots:
-        # Firestore normally does not expose an empty collection. Treat this as
-        # a benign metadata-only race and retain the strict collection fence.
-        return {
-            "user_plane_empty": True,
-            "preexisting_runtime_metadata": True,
-            "runtime_metadata_documents": 0,
-        }
-    snapshot = snapshots[0]
-    document_id = str(getattr(snapshot, "id", ""))
-    payload = snapshot.to_dict()
+    if len(document_refs) != 1:
+        raise JITQAVerificationError("bootstrap recovery metadata inventory was empty or exceeded its allowlist")
+    document_ref = document_refs[0]
+    document_id = str(getattr(document_ref, "id", ""))
+    if document_id != EMPTY_SCAN_RECOVERY_DOCUMENT:
+        raise JITQAVerificationError("bootstrap recovery metadata has an unexpected document")
+    try:
+        child_iterator = iter(document_ref.collections(page_size=1))
+        next(child_iterator)
+    except StopIteration:
+        pass
+    except Exception as exc:
+        raise JITQAVerificationError("bootstrap could not inventory recovery metadata descendants") from exc
+    else:
+        raise JITQAVerificationError("bootstrap recovery metadata has an unexpected descendant collection")
+    try:
+        snapshot = document_ref.get()
+    except Exception as exc:
+        raise JITQAVerificationError("bootstrap could not read recovery metadata") from exc
+    payload = snapshot.to_dict() if getattr(snapshot, "exists", False) else None
     if document_id != EMPTY_SCAN_RECOVERY_DOCUMENT or not isinstance(payload, Mapping):
         raise JITQAVerificationError("bootstrap recovery metadata has an unexpected document")
     if set(payload) != EMPTY_SCAN_RECOVERY_FIELDS:
@@ -381,11 +395,17 @@ def bootstrap_qa_account(db_client: Any) -> dict[str, Any]:
     marker_snapshot = marker_ref.get()
     marker = _as_dict(marker_snapshot)
     precondition = {
-        "user_plane_empty": True,
-        "preexisting_runtime_metadata": "previously_verified",
+        "mode": "resume_owned_bootstrap",
+        "user_plane_empty": None,
+        "preexisting_runtime_metadata": None,
+        "current_inventory_verified": False,
+        "previously_verified": True,
     }
     if not marker:
         precondition = _assert_named_database_empty(db_client)
+        precondition["mode"] = "fresh_bootstrap"
+        precondition["current_inventory_verified"] = True
+        precondition["previously_verified"] = False
         create = getattr(marker_ref, "create", None)
         if not callable(create):
             raise JITQAVerificationError("bootstrap requires create-only Firestore writes for its ownership marker")

--- a/backend/scripts/jit_qa_seed_and_verify.py
+++ b/backend/scripts/jit_qa_seed_and_verify.py
@@ -4,10 +4,13 @@
 This operator is deliberately narrower than the deployment workflow.  It owns
 only a deterministic, synthetic fixture in the named ``jit-qa`` Firestore
 database.  The explicit ``bootstrap`` command is create-only and may only
-initialize a truly empty named database for the fixed QA identity.  It never
-discovers or edits another account, never creates a production control plane,
-and never calls a model.  The Cloud Run workflow owns job execution; this
-command consumes its content-free execution summaries.
+initialize an empty user plane for the fixed QA identity.  It tolerates the
+one known deployment recovery cursor in ``conversation_recovery_state`` after
+validating its exact metadata shape, preserves that cursor, and rejects every
+other collection or document.  It never discovers or edits another account,
+never creates a production control plane, and never calls a model.  The Cloud
+Run workflow owns job execution; this command consumes its content-free
+execution summaries.
 
 The fixture contains 101 canonical rows that are intentionally missing the
 ledger schema marker.  The production drain's mutation budget is 100 rows per
@@ -25,7 +28,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -66,6 +69,11 @@ MUTATION_PAGE_SIZE = 100
 EXCLUSIVITY_SCAN_LIMIT = ROW_COUNT + 1
 LEDGER_DRAIN_CURSOR_PATH = "knowledge_ledger_migration_control/inventory_cursor"
 RUN_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
+EMPTY_SCAN_RECOVERY_COLLECTION = "conversation_recovery_state"
+EMPTY_SCAN_RECOVERY_DOCUMENT = "byok_abandonment_sweep"
+EMPTY_SCAN_RECOVERY_FIELDS = frozenset({"generation", "resume_after_path", "updated_at"})
+EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT = 1
+EMPTY_SCAN_RECOVERY_GENERATION_MAX = 2**63 - 1
 SUMMARY_KEYS = (
     "inventoried_users",
     "scanned_documents",
@@ -200,27 +208,113 @@ def _qa_tester_payload() -> dict[str, Any]:
     }
 
 
-def _assert_named_database_empty(db_client: Any) -> None:
+def _assert_named_database_empty(db_client: Any) -> dict[str, Any]:
     """Prove the named database is empty before creating the QA account.
 
     ``collections()`` is a metadata-only inventory.  Firestore does not retain
-    empty collections, so any collection returned by this inventory means the
-    first-bootstrap precondition is false.  We stop before reading or writing a
-    document; the named database must be genuinely empty.
+    empty collections.  The deployed backend may, however, leave one bounded
+    recovery cursor in ``conversation_recovery_state`` before first bootstrap.
+    That cursor contains no user-plane data and is preserved.  Every other
+    collection, document, field, or malformed cursor fails closed before any
+    write.
     """
 
     collections_factory = getattr(db_client, "collections", None)
     if not callable(collections_factory):
         raise JITQAVerificationError("bootstrap requires a Firestore client that can inventory collections")
     try:
-        collections = list(collections_factory())
+        collection_iterator = iter(collections_factory())
+        collections = []
+        for _ in range(2):
+            try:
+                collections.append(next(collection_iterator))
+            except StopIteration:
+                break
     except Exception as exc:
         raise JITQAVerificationError("bootstrap could not inventory the named Firestore database") from exc
-    if collections:
-        collection_id = str(getattr(collections[0], "id", ""))
+    if len(collections) > 1:
+        raise JITQAVerificationError("bootstrap requires an empty user plane; found more than one top-level collection")
+    if not collections:
+        return {
+            "user_plane_empty": True,
+            "preexisting_runtime_metadata": False,
+            "runtime_metadata_documents": 0,
+        }
+
+    collection = collections[0]
+    collection_id = str(getattr(collection, "id", ""))
+    if collection_id != EMPTY_SCAN_RECOVERY_COLLECTION:
         raise JITQAVerificationError(
             "bootstrap requires a truly empty named database; " f"found collection {collection_id!r}"
         )
+
+    # This one allowlisted document is metadata-only by contract. Read its
+    # complete payload so the exact-field check also detects newly added or
+    # unexpected fields; a projection would hide those fields.
+    query = collection
+    limiter = getattr(query, "limit", None)
+    streamer = getattr(query, "stream", None)
+    if not callable(limiter) or not callable(streamer):
+        raise JITQAVerificationError("bootstrap requires a bounded recovery metadata inventory")
+    try:
+        snapshots = list(limiter(EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT + 1).stream())
+    except Exception as exc:
+        raise JITQAVerificationError("bootstrap could not inventory recovery metadata") from exc
+    if len(snapshots) > EMPTY_SCAN_RECOVERY_DOCUMENT_LIMIT:
+        raise JITQAVerificationError("bootstrap recovery metadata inventory exceeded its hard bound")
+    if not snapshots:
+        # Firestore normally does not expose an empty collection. Treat this as
+        # a benign metadata-only race and retain the strict collection fence.
+        return {
+            "user_plane_empty": True,
+            "preexisting_runtime_metadata": True,
+            "runtime_metadata_documents": 0,
+        }
+    snapshot = snapshots[0]
+    document_id = str(getattr(snapshot, "id", ""))
+    payload = snapshot.to_dict()
+    if document_id != EMPTY_SCAN_RECOVERY_DOCUMENT or not isinstance(payload, Mapping):
+        raise JITQAVerificationError("bootstrap recovery metadata has an unexpected document")
+    if set(payload) != EMPTY_SCAN_RECOVERY_FIELDS:
+        raise JITQAVerificationError("bootstrap recovery metadata has an unexpected schema")
+    generation = payload.get("generation")
+    if (
+        not isinstance(generation, int)
+        or isinstance(generation, bool)
+        or generation < 1
+        or generation > EMPTY_SCAN_RECOVERY_GENERATION_MAX
+    ):
+        raise JITQAVerificationError("bootstrap recovery metadata has an invalid generation")
+    if payload.get("resume_after_path") is not None:
+        raise JITQAVerificationError("bootstrap recovery metadata must have a null resume cursor")
+    updated_at = payload.get("updated_at")
+    if not isinstance(updated_at, datetime) or updated_at.tzinfo is None or updated_at.utcoffset() is None:
+        raise JITQAVerificationError("bootstrap recovery metadata has an invalid timestamp")
+    if updated_at.astimezone(timezone.utc) > datetime.now(timezone.utc) + timedelta(minutes=5):
+        raise JITQAVerificationError("bootstrap recovery metadata timestamp is too far in the future")
+    metadata_digest = hashlib.sha256(
+        json.dumps(
+            {
+                "collection": collection_id,
+                "document": document_id,
+                "generation": generation,
+                "resume_after_path": None,
+                "updated_at": updated_at.astimezone(timezone.utc).isoformat(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "user_plane_empty": True,
+        "preexisting_runtime_metadata": True,
+        "runtime_metadata_documents": 1,
+        "runtime_metadata_collection": collection_id,
+        "runtime_metadata_document": document_id,
+        "runtime_metadata_generation": generation,
+        "runtime_metadata_resume_after_path": None,
+        "runtime_metadata_digest": metadata_digest,
+    }
 
 
 def _assert_owned_fields(
@@ -286,8 +380,12 @@ def bootstrap_qa_account(db_client: Any) -> dict[str, Any]:
     marker_ref = db_client.document(BOOTSTRAP_PATH)
     marker_snapshot = marker_ref.get()
     marker = _as_dict(marker_snapshot)
+    precondition = {
+        "user_plane_empty": True,
+        "preexisting_runtime_metadata": "previously_verified",
+    }
     if not marker:
-        _assert_named_database_empty(db_client)
+        precondition = _assert_named_database_empty(db_client)
         create = getattr(marker_ref, "create", None)
         if not callable(create):
             raise JITQAVerificationError("bootstrap requires create-only Firestore writes for its ownership marker")
@@ -333,6 +431,7 @@ def bootstrap_qa_account(db_client: Any) -> dict[str, Any]:
         "apply_control_writer_mode": control.writer_mode.value,
         "maintenance_registry": f"canonical_memory_maintenance_registry/{QA_UID}",
         "cutover_authority": "knowledge-ledger-drain-qa-job via publish_ledger_migration_cutover",
+        "bootstrap_precondition": precondition,
     }
 
 
@@ -936,7 +1035,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-id", help="lowercase synthetic fixture namespace")
     sub = parser.add_subparsers(dest="command", required=True)
-    sub.add_parser("bootstrap", help="create the fixed QA profile in a truly empty named database")
+    sub.add_parser("bootstrap", help="create the fixed QA profile in an empty QA user plane")
     sub.add_parser("prepare", help="preflight and create missing owned synthetic rows")
     sub.add_parser("inspect", help="read content-free fixture metadata")
     verify = sub.add_parser("verify", help="verify first, second, and stable retry drain summaries")

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -230,6 +231,78 @@ def test_bootstrap_empty_inventory_accepts_no_collections():
     operator._assert_named_database_empty(EmptyDB())
 
 
+def test_bootstrap_empty_inventory_accepts_only_known_recovery_cursor():
+    recovery_path = f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/{operator.EMPTY_SCAN_RECOVERY_DOCUMENT}"
+
+    class RecoveryDB(_DB):
+        def __init__(self):
+            super().__init__(include_control=False)
+            self.docs[recovery_path] = {
+                "generation": 6,
+                "resume_after_path": None,
+                "updated_at": datetime.now(timezone.utc),
+            }
+
+    db = RecoveryDB()
+    before = dict(db.docs[recovery_path])
+    receipt = operator._assert_named_database_empty(db)
+    assert receipt["user_plane_empty"] is True
+    assert receipt["preexisting_runtime_metadata"] is True
+    assert receipt["runtime_metadata_collection"] == operator.EMPTY_SCAN_RECOVERY_COLLECTION
+    assert receipt["runtime_metadata_document"] == operator.EMPTY_SCAN_RECOVERY_DOCUMENT
+    assert db.docs[recovery_path] == before
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({"generation": 6, "resume_after_path": "cursor", "updated_at": datetime.now(timezone.utc)}, "null resume"),
+        ({"generation": 6, "resume_after_path": None}, "schema"),
+        (
+            {"generation": 0, "resume_after_path": None, "updated_at": datetime.now(timezone.utc)},
+            "generation",
+        ),
+        (
+            {"generation": 6, "resume_after_path": None, "updated_at": datetime.now()},
+            "timestamp",
+        ),
+        (
+            {
+                "generation": 6,
+                "resume_after_path": None,
+                "updated_at": datetime.now(timezone.utc),
+                "unexpected": True,
+            },
+            "schema",
+        ),
+    ],
+)
+def test_bootstrap_rejects_malformed_known_recovery_cursor(payload, message):
+    recovery_path = f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/{operator.EMPTY_SCAN_RECOVERY_DOCUMENT}"
+    db = _DB(include_control=False)
+    db.docs[recovery_path] = payload
+    with pytest.raises(operator.JITQAVerificationError, match=message):
+        operator._assert_named_database_empty(db)
+
+
+def test_bootstrap_rejects_extra_recovery_document_or_collection():
+    recovery_path = f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/{operator.EMPTY_SCAN_RECOVERY_DOCUMENT}"
+    db = _DB(include_control=False)
+    db.docs[recovery_path] = {
+        "generation": 6,
+        "resume_after_path": None,
+        "updated_at": datetime.now(timezone.utc),
+    }
+    db.docs[f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/other"] = dict(db.docs[recovery_path])
+    with pytest.raises(operator.JITQAVerificationError, match="hard bound"):
+        operator._assert_named_database_empty(db)
+
+    db = _DB(include_control=False)
+    db.docs["users/foreign"] = {"uid": "foreign"}
+    with pytest.raises(operator.JITQAVerificationError, match="more than one|truly empty"):
+        operator._assert_named_database_empty(db)
+
+
 def test_evidence_ownership_requires_full_source_metadata():
     db = _DB()
     operator.seed_fixture(db, run_id="proof-20260905")
@@ -278,6 +351,38 @@ def test_bootstrap_is_create_only_and_idempotent(monkeypatch):
     assert second["profile"] == "existing"
     assert second["tester"] == "existing"
     assert db.docs == before
+
+
+def test_bootstrap_receipt_distinguishes_preserved_runtime_metadata(monkeypatch):
+    db = _DB(include_control=False)
+    recovery_path = f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/{operator.EMPTY_SCAN_RECOVERY_DOCUMENT}"
+    db.docs[recovery_path] = {
+        "generation": 6,
+        "resume_after_path": None,
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+    def ensure_control(uid, *, db_client):
+        control_ref = db_client.document(operator._control_path())
+        control_ref.create(
+            {
+                "uid": uid,
+                "writer_mode": "compatibility",
+                "writer_epoch": 0,
+                "head_commit_id": "head0",
+                "account_generation": 1,
+                "source_generation": 1,
+                "commit_sequence": 0,
+            }
+        )
+        return SimpleNamespace(uid=uid, writer_mode=SimpleNamespace(value="compatibility"))
+
+    monkeypatch.setattr(operator, "ensure_canonical_apply_control_state", ensure_control)
+    monkeypatch.setattr(operator, "validate_environment", lambda: None)
+    receipt = operator.bootstrap_qa_account(db)
+    assert receipt["bootstrap_precondition"]["user_plane_empty"] is True
+    assert receipt["bootstrap_precondition"]["preexisting_runtime_metadata"] is True
+    assert db.docs[recovery_path]["resume_after_path"] is None
 
 
 def test_bootstrap_refuses_unowned_document_before_any_write(monkeypatch):

--- a/backend/tests/unit/test_jit_qa_seed_and_verify.py
+++ b/backend/tests/unit/test_jit_qa_seed_and_verify.py
@@ -31,6 +31,10 @@ class _Ref:
         self.db = db
         self.path = path
 
+    @property
+    def id(self):
+        return self.path.rsplit("/", 1)[-1]
+
     def select(self, _fields):
         return self
 
@@ -48,6 +52,15 @@ class _Ref:
             raise RuntimeError("already exists")
         self.db.docs[self.path] = dict(payload)
 
+    def collections(self, **_kwargs):
+        prefix = self.path + "/"
+        child_ids = {
+            path[len(prefix) :].split("/", 1)[0]
+            for path in self.db.docs
+            if path.startswith(prefix) and len(path[len(prefix) :].split("/", 1)[0]) > 0
+        }
+        return [_Collection(self.db, f"{self.path}/{child_id}") for child_id in sorted(child_ids)]
+
 
 class _Collection:
     def __init__(self, db: "_DB", path: str):
@@ -61,6 +74,15 @@ class _Collection:
 
     def select(self, _fields):
         return self
+
+    def list_documents(self, **_kwargs):
+        prefix = self.path + "/"
+        document_ids = {
+            path[len(prefix) :].split("/", 1)[0]
+            for path in self.db.docs
+            if path.startswith(prefix) and len(path[len(prefix) :].split("/", 1)[0]) > 0
+        }
+        return [self.db.document(f"{self.path}/{document_id}") for document_id in sorted(document_ids)]
 
     def limit(self, value):
         self._limit = value
@@ -253,6 +275,26 @@ def test_bootstrap_empty_inventory_accepts_only_known_recovery_cursor():
     assert db.docs[recovery_path] == before
 
 
+def test_bootstrap_rejects_recovery_cursor_descendant_and_empty_direct_inventory():
+    recovery_path = f"{operator.EMPTY_SCAN_RECOVERY_COLLECTION}/{operator.EMPTY_SCAN_RECOVERY_DOCUMENT}"
+    db = _DB(include_control=False)
+    db.docs[recovery_path] = {
+        "generation": 6,
+        "resume_after_path": None,
+        "updated_at": datetime.now(timezone.utc),
+    }
+    db.docs[f"{recovery_path}/unexpected/subdoc"] = {"owned": False}
+    with pytest.raises(operator.JITQAVerificationError, match="descendant"):
+        operator._assert_named_database_empty(db)
+
+    class EmptyRecoveryCollectionDB:
+        def collections(self):
+            return [_Collection(_DB(include_control=False), operator.EMPTY_SCAN_RECOVERY_COLLECTION)]
+
+    with pytest.raises(operator.JITQAVerificationError, match="inventory was empty"):
+        operator._assert_named_database_empty(EmptyRecoveryCollectionDB())
+
+
 @pytest.mark.parametrize(
     "payload, message",
     [
@@ -350,6 +392,13 @@ def test_bootstrap_is_create_only_and_idempotent(monkeypatch):
     second = operator.bootstrap_qa_account(db)
     assert second["profile"] == "existing"
     assert second["tester"] == "existing"
+    assert second["bootstrap_precondition"] == {
+        "mode": "resume_owned_bootstrap",
+        "user_plane_empty": None,
+        "preexisting_runtime_metadata": None,
+        "current_inventory_verified": False,
+        "previously_verified": True,
+    }
     assert db.docs == before
 
 


### PR DESCRIPTION
## What changed and why

A backend startup can create the known `conversation_recovery_state/byok_abandonment_sweep` cursor before the isolated JIT QA account is bootstrapped. The bootstrap operator previously rejected any collection and therefore could not proceed against the observed QA database.

Bootstrap now admits only an empty user plane plus that one metadata-only cursor. It checks the exact document id and three-field schema, positive bounded generation, null resume cursor, and a valid timestamp; it preserves the cursor and records the distinction between an empty user plane and preexisting runtime metadata. Any other collection, document, field, or malformed value remains fail-closed.

## Tests

- `PYTHONPATH=backend python -m pytest -q backend/tests/unit/test_jit_qa_seed_and_verify.py` — 21 passed.
- `git diff --check`
- Independent read-only verification against the named `based-hardware-dev` / `jit-qa` database confirmed the observed recovery cursor shape and preservation without writing the cursor or any other document.

## Failure-Class

Failure-Class: none
