### PR TITLE
fix(backend): pin reasoning_effort on the file-chat Luna lanes

### DIFF
--- a/backend/llm_gateway/config/generated_route_overrides.yaml
+++ b/backend/llm_gateway/config/generated_route_overrides.yaml
@@ -51,6 +51,17 @@ generated_route_overrides:
   - feature: external_structure
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: low}
+  # File chat is no-tools single-shot completions capped at 2048 output tokens.
+  # Unpinned effort rides the provider default, which can spend that cap on
+  # hidden reasoning before any answer text (desktop proactivity's truncation
+  # failure mode); medium is the interactive-chat tier (chat_responses,
+  # persona_chat_premium).
+  - feature: file_chat_documents
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
+  - feature: file_chat_vision
+    primary: {provider: openai, model: gpt-5.6-luna}
+    provider_options: {reasoning_effort: medium}
   - feature: fair_use
     primary: {provider: openai, model: gpt-5.6-luna}
     provider_options: {reasoning_effort: medium}

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -248,6 +248,28 @@ def test_persona_auth_tiers_resolve_to_fixed_gateway_models():
     assert overrides['persona_chat_premium'].primary.model == 'gpt-5.6-luna'
 
 
+def test_every_gpt5_generated_lane_pins_an_explicit_reasoning_effort():
+    """A GPT-5 lane without a pinned effort rides the provider default.
+
+    File chat ran unpinned with a 2048-token output cap, and the provider
+    default can spend a capped completion budget on hidden reasoning before
+    any answer text — the truncation failure desktop proactivity hit on its
+    direct path. Every OpenAI GPT-5 lane must name its effort explicitly.
+    """
+    overrides = load_generated_route_overrides()
+
+    for feature in get_all_configured_features():
+        override = overrides.get(feature)
+        model = override.primary.model if override is not None else get_model(feature)
+        provider = override.primary.provider if override is not None else get_provider(feature)
+        if provider != 'openai' or not model.startswith('gpt-5'):
+            continue
+        options = get_route_options(feature, model, provider)
+        if override is not None:
+            options.update(override.provider_options)
+        assert 'reasoning_effort' in options, feature
+
+
 def test_only_background_flex_routes_allow_the_documented_flex_timeout():
     config = load_gateway_config(prod_mode=True)
 


### PR DESCRIPTION
## What

- `file_chat_vision` and `file_chat_documents` were the only GPT-5.6-luna generated gateway lanes with no `generated_route_overrides.yaml` entry, so they sent no `reasoning_effort` and rode the OpenAI provider default.
- Pin both lanes to `reasoning_effort: medium` — the interactive-chat tier already used by `chat_responses` and `persona_chat_premium`.
- Add a guardrail (`test_every_gpt5_generated_lane_pins_an_explicit_reasoning_effort`) that fails CI when any OpenAI GPT-5 lane ships without an explicit effort, so the class of gap cannot reopen.

## Why

File chat is a no-tools single-shot chat completion capped at 2048 output tokens (`_FILE_CHAT_COMPLETION_TOKENS`). With no pinned effort, the provider default can spend a capped completion budget on hidden reasoning before any answer text — the same truncation failure mode desktop proactivity hit on its direct path (`backend/routers/desktop_proactivity.py`), where unpinned reasoning exhausted the client token cap and returned truncated JSON.

## Scope

Gateway lanes only. The rare direct/degrade paths in `backend/utils/other/chat_file.py` (feature-mode off, gateway model-not-found fallback) still call OpenAI directly without an effort; pinning those is a separate change.

## Tests

- `pytest tests/unit/test_llm_gateway_coverage_guardrails.py tests/unit/test_llm_gateway_config.py` — 44 passed
- `pytest tests/unit/test_llm_gateway_coverage_guardrails.py tests/unit/test_llm_gateway_route_refs.py tests/unit/test_chat_file_gateway_surface.py tests/unit/test_chat_file_completions.py` — 56 passed
- Red-proof: the new guardrail fails on the unmodified `generated_route_overrides.yaml` (assertion names the missing file-chat features) and passes with this change.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

