### PR TITLE
fix(admin): stop labeling TV retention days as percents

### DIFF
--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -883,10 +883,34 @@
             "axisPlacement": "auto",
             "fillOpacity": 80,
             "lineWidth": 0
-          },
-          "unit": "percent"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Day"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retention"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "x": 0,

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -883,10 +883,34 @@
             "axisPlacement": "auto",
             "fillOpacity": 80,
             "lineWidth": 0
-          },
-          "unit": "percent"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Day"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retention"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "x": 0,

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -865,10 +865,34 @@
             "axisPlacement": "auto",
             "fillOpacity": 80,
             "lineWidth": 0
-          },
-          "unit": "percent"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Day"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retention"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -364,6 +364,35 @@ class BuilderIdempotencyTests(unittest.TestCase):
                          load("omi-tv-mobile"))
 
 
+class RetentionCurveAxisTests(unittest.TestCase):
+    """Day numbers on the 30d curve must not inherit unit=percent
+    (Grafana then labels 0/11/22 as 0%/11%/22%)."""
+
+    def test_day_axis_is_not_percent(self) -> None:
+        for uid in BOARDS:
+            panel = next(
+                p for p in load(uid)["panels"]
+                if build_dashboards.base_title(p).startswith("Retention curve")
+            )
+            self.assertIsNone(
+                panel["fieldConfig"]["defaults"].get("unit"), uid
+            )
+            overrides = {
+                o["matcher"]["options"]: o
+                for o in panel["fieldConfig"]["overrides"]
+            }
+            self.assertEqual(
+                overrides["Day"]["properties"],
+                [{"id": "unit", "value": "none"}],
+                uid,
+            )
+            self.assertEqual(
+                overrides["Retention"]["properties"],
+                [{"id": "unit", "value": "percent"}],
+                uid,
+            )
+
+
 class ApplyPreservesLayoutTests(unittest.TestCase):
     """An apply must never revert layout the user arranged in the Grafana UI
     (#12212 era: three same-day applies stamped checked-in gridPos over


### PR DESCRIPTION
## What changed and why

The TV **Retention curve — 30d cohorts** inherited Grafana `unit: percent` onto the Day field, so day 0/11/22 rendered as `0% / 11% / 22%`. Percent stays on Retention only; Day is `unit: none`.

Live macOS recompute (PostHog, same TV definition, 2026-09-06 UTC) — user-weighted vs unweighted, mature cohorts only:

- D1: 68.7% weighted / 59.6% unweighted (3728 users)
- D7: 59.1% weighted / 43.9% unweighted (3088 users)
- D28/W4: 29.5% weighted / 24.1% unweighted (1197 users)

Weighted mean is already serving (`bcb96bf`). W4 is ~29.5% now because the old Aug-5 blob (~52% D28) rolled out of the 30d window; window-start is Aug 7 (859 users, 33.2% D28). The right-hand cliff is survival `offset >= N`, not unweighted averaging.

## Product invariants affected

none

## How it was verified

`python3 web/admin/grafana/test_build_dashboards.py` — 26 passed, including `test_day_axis_is_not_percent` on all three boards.

## Failure-Class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

