### PR TITLE
fix(desktop): shorten settings search placeholder to "Search"

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -487,7 +487,7 @@ struct SettingsSidebar: View {
         .foregroundColor(isSearchFocused ? Ink.accent : Ink.secondary)
         .omiAnimation(.easeInOut(duration: 0.15), value: isSearchFocused)
 
-      TextField("Search settings...", text: $searchQuery)
+      TextField("Search", text: $searchQuery)
         .textFieldStyle(.plain)
         .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.primary)

--- a/desktop/macos/changelog/unreleased/20260906-settings-search-placeholder.json
+++ b/desktop/macos/changelog/unreleased/20260906-settings-search-placeholder.json
@@ -1,0 +1,3 @@
+{
+  "change": "Settings search field placeholder now reads \"Search\""
+}


### PR DESCRIPTION
## Summary

- The settings sidebar search field placeholder read "Search settings...". It now reads "Search".
- Adds the desktop changelog fragment.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eTpvB6TQcnjWC6ice14CK


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

