### PR TITLE
fix(desktop): simplify dashboard search placeholders

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatSessionsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatSessionsSidebar.swift
@@ -146,7 +146,7 @@ struct ChatSessionsSidebar: View {
         .scaledFont(size: OmiType.caption)
         .foregroundColor(Ink.secondary)
 
-      TextField("Search chats...", text: $chatProvider.searchQuery)
+      TextField("Search chat", text: $chatProvider.searchQuery)
         .textFieldStyle(.plain)
         .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.primary)

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
@@ -161,7 +161,7 @@ struct MemoryHubPage: View {
           QuerySearchBar(
             text: $brainMapSearchText,
             accessibilityID: "brain-map-search-field",
-            placeholder: "Search your entities…",
+            placeholder: "Search brain",
             searchSurface: .brainMap
           )
         },

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -181,7 +181,7 @@ struct ConversationsPage: View {
           QuerySearchBar(
             text: $searchQuery,
             accessibilityID: "conversations-search-field",
-            placeholder: "Search conversations…",
+            placeholder: "Search conversations",
             searchSurface: .conversations
           )
           .onChange(of: searchQuery) { _, newValue in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1945,7 +1945,7 @@ struct MemoriesPage: View {
           QuerySearchBar(
             text: $viewModel.searchText,
             accessibilityID: "memories-search-field",
-            placeholder: "Search memories…", searchSurface: .memories
+            placeholder: "Search memories", searchSurface: .memories
           )
         },
         content: { pageContent }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
@@ -79,7 +79,7 @@ struct ActivityHubTab: View {
     QuerySearchBar(
       text: $searchText,
       accessibilityID: "activity-search-field",
-      placeholder: "Search activity…",
+      placeholder: "Search activity",
       focus: nil,
       searchSurface: .activity
     )

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -866,8 +866,7 @@ struct RewindPage: View {
   private func searchField(showResultsCount: Bool = false) -> some View {
     RewindSearchBar(
       query: $viewModel.searchQuery,
-      placeholder: brainDestination == nil
-        ? RewindSearchMetrics.placeholder : "Search screen history…",
+      placeholder: "Search rewind",
       isSearching: viewModel.isSearching,
       countLabel: showResultsCount && viewModel.activeSearchQuery != nil
         ? RewindSearchResultsPanel.countLabel(

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -483,7 +483,7 @@ struct RewindPage: View {
         QuerySearchBar(
           text: $viewModel.searchQuery,
           accessibilityID: "rewind-search-field",
-          placeholder: "Search screen history…",
+          placeholder: "Search rewind",
           focus: $isSearchFocused, searchSurface: .rewind
         )
         .onChange(of: viewModel.searchQuery) { _, query in

--- a/desktop/macos/changelog/unreleased/20260906-search-placeholders.json
+++ b/desktop/macos/changelog/unreleased/20260906-search-placeholders.json
@@ -1,0 +1,3 @@
+{
+  "change": "Shortened the dashboard search placeholders: Search chat, Search activity, Search conversations, Search memories, Search rewind, and Search brain"
+}


### PR DESCRIPTION
Shortens the search placeholder text across the desktop dashboard and panel so every surface uses a plain two-word prompt with no trailing ellipsis.

| Surface | Before | After |
|---|---|---|
| Chat sidebar | Search chats... | Search chat |
| Activity | Search activity… | Search activity |
| Conversations | Search conversations… | Search conversations |
| Memories | Search memories… | Search memories |
| Rewind | Search screen history… | Search rewind |
| Brain map | Search your entities… | Search brain |

String-only change; no tests referenced the old placeholders. Changelog fragment included.

## Product invariants affected

- INV-CHAT-1
- INV-NAV-1

## Failure class (fixes)

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RAuWyYtfG4BPpv3wkfeLS


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

