### PR TITLE
fix(macos): harden skipped permission boundaries

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -526,6 +526,7 @@ class AppState: ObservableObject {
   /// recording policy or whether the microphone/meeting gate runs.
   var shouldCaptureSystemAudio: Bool {
     !UserDefaults.standard.bool(forKey: .disableSystemAudioCapture)
+      && !UserDefaults.standard.bool(forKey: .onboardingSystemAudioSkipped)
   }
   var vadGateService: VADGateService? {
     get { servicesCoordinator.vadGateService }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -958,6 +958,9 @@ extension AppState {
 
   /// Trigger accessibility permission prompt
   func triggerAccessibilityPermission() {
+    // A fresh Grant action supersedes the onboarding skip. If the user later
+    // revokes access, the sidebar must report the missing grant again.
+    UserDefaults.standard.set(false, forKey: .onboardingAccessibilitySkipped)
     let osVersion = ProcessInfo.processInfo.operatingSystemVersion
     let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
     log(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -446,6 +446,9 @@ extension AppState {
   /// Trigger system audio permission by actually testing capture
   /// This verifies system audio works by briefly starting and stopping capture
   func triggerSystemAudioPermission() {
+    // This call only comes from an explicit Grant action. It supersedes a
+    // prior onboarding skip before testing the process tap.
+    UserDefaults.standard.set(false, forKey: .onboardingSystemAudioSkipped)
     guard #available(macOS 14.4, *) else {
       log("System audio not supported on this macOS version")
       recordSystemAudioCaptureOutcome(.unsupported)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
@@ -446,14 +446,19 @@ extension AppState {
   /// Trigger system audio permission by actually testing capture
   /// This verifies system audio works by briefly starting and stopping capture
   func triggerSystemAudioPermission() {
-    // This call only comes from an explicit Grant action. It supersedes a
-    // prior onboarding skip before testing the process tap.
-    UserDefaults.standard.set(false, forKey: .onboardingSystemAudioSkipped)
     guard #available(macOS 14.4, *) else {
+      // No process tap exists on this OS, so nothing can be granted here. Leaving
+      // the skip marker intact keeps "an explicit Grant supersedes the skip" true
+      // only where a grant is real -- otherwise pressing Grant on an unsupported
+      // macOS would silently erase a choice it cannot act on.
       log("System audio not supported on this macOS version")
       recordSystemAudioCaptureOutcome(.unsupported)
       return
     }
+
+    // This call only comes from an explicit Grant action. It supersedes a
+    // prior onboarding skip before testing the process tap.
+    UserDefaults.standard.set(false, forKey: .onboardingSystemAudioSkipped)
 
     log("System audio: Testing capture...")
     let shellWasSuspended = ShellSummon.suspendForPermissionPrompt()

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -10,7 +10,11 @@ extension AppState {
       AssistantSettings.shared.audioRecordingMode = .off
     } else {
       let selected = AssistantSettings.shared.audioRecordingMode
-      AssistantSettings.shared.audioRecordingMode = selected == .off ? .onlyMeetings : selected
+      let requested: AssistantSettings.AudioRecordingMode = selected == .off ? .onlyMeetings : selected
+      if !AudioCaptureService.checkPermission() {
+        requestMicrophonePermission()
+      }
+      AssistantSettings.shared.audioRecordingMode = requested
     }
   }
 
@@ -164,7 +168,7 @@ extension AppState {
       // Local (Parakeet) mode has no WebSocket — start capture immediately instead.
       if sttSession.useLocalSTT {
         Task { [weak self] in
-          await self?.startAudioCapture(source: effectiveSource)
+          await self?.startAudioCapture(source: effectiveSource, userInitiated: userInitiated)
         }
       } else {
         transcriptionService?.start(
@@ -196,7 +200,7 @@ extension AppState {
             Task { @MainActor in
               log("Transcription: Connected to Python backend")
               // Start audio capture once connected
-              await self?.startAudioCapture(source: effectiveSource)
+              await self?.startAudioCapture(source: effectiveSource, userInitiated: userInitiated)
             }
           },
           onDisconnected: {
@@ -368,13 +372,16 @@ extension AppState {
 
   /// Start audio capture and pipe to transcription service
   /// - Parameter source: Audio source to capture from
-  func startAudioCapture(source: AudioSource = .microphone) async {
+  func startAudioCapture(
+    source: AudioSource = .microphone,
+    userInitiated: Bool = false
+  ) async {
     if source == .bleDevice {
       // Use BLE device audio
       await startBleAudioCapture()
     } else {
       // Use microphone (+ optional system audio)
-      await startMicrophoneAudioCapture()
+      await startMicrophoneAudioCapture(userInitiated: userInitiated)
     }
   }
 
@@ -404,7 +411,7 @@ extension AppState {
     }
   }
 
-  func startMicrophoneAudioCapture() async {
+  func startMicrophoneAudioCapture(userInitiated: Bool = false) async {
     guard let audioCaptureService = audioCaptureService else { return }
 
     // Authorization first, capture second. CoreAudio HAL capture never triggers the
@@ -415,14 +422,18 @@ extension AppState {
     // a hardware costume. startTranscription() has its own guard, but resume, the meeting
     // gate, and the watchdog's own rebuild all arm capture through here without passing it.
     var gateAction = MicrophoneCaptureAuthorizationPolicy.action(
-      for: AudioCaptureService.authorizationStatus())
+      for: AudioCaptureService.authorizationStatus(), userInitiated: userInitiated)
     if gateAction == .requestPermission {
       log("Transcription: microphone permission undetermined — requesting before capture")
       gateAction = MicrophoneCaptureAuthorizationPolicy.action(
         afterRequestGranted: await AudioCaptureService.requestPermission())
     }
     guard gateAction == .proceed else {
-      surfaceMicrophonePermissionAlert()
+      if gateAction == .surfacePermissionAlert {
+        surfaceMicrophonePermissionAlert()
+      } else {
+        log("Transcription: automatic capture abandoned after microphone authorization changed")
+      }
       stopTranscription()
       return
     }

--- a/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
@@ -55,7 +55,10 @@ enum MicrophoneCaptureAuthorizationPolicy {
     case .denied, .restricted:
       return .surfacePermissionAlert
     @unknown default:
-      return .proceed
+      // A future authorization state is not proof of consent. Fail closed so an
+      // automatic start cannot arm capture under a status this build does not
+      // understand, and an explicit start can surface the permission path.
+      return .surfacePermissionAlert
     }
   }
 

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -98,6 +98,9 @@ enum DefaultsKey: String {
   /// denied/notDetermined distinction for AX, so this is the only signal that keeps
   /// the sidebar from pulsing a deliberate skip as "denied".
   case onboardingAccessibilitySkipped = "onboardingAccessibilitySkipped"
+  /// System-audio process taps have no preflight API. Preserve an onboarding
+  /// skip separately so later microphone sessions do not test the tap anyway.
+  case onboardingSystemAudioSkipped = "onboardingSystemAudioSkipped"
   case screenAnalysisEnabled = "screenAnalysisEnabled"
   case ratingPromptQuestionCount = "ratingPromptQuestionCount"
   case ratingPromptSubmittedRating = "ratingPromptSubmittedRating"

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 struct FileIndexScanPolicy {
+  struct AutomaticScanPlan: Equatable {
+    let roots: [URL]
+    /// Existing index rows under roots omitted solely because TCC is unavailable
+    /// must survive this partial scan's deletion pass.
+    let retainedPrefixes: Set<String>
+  }
+
   enum DirectoryEntryPlan: Equatable {
     case skipSubtree
     case descend
@@ -67,14 +74,34 @@ struct FileIndexScanPolicy {
     applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
     fullDiskAccessGranted: Bool
   ) -> [URL] {
+    automaticScanPlan(
+      homeURL: homeURL,
+      applicationsURL: applicationsURL,
+      fullDiskAccessGranted: fullDiskAccessGranted
+    ).roots
+  }
+
+  func automaticScanPlan(
+    homeURL: URL,
+    applicationsURL: URL = URL(fileURLWithPath: "/Applications", isDirectory: true),
+    fullDiskAccessGranted: Bool
+  ) -> AutomaticScanPlan {
     let roots = standardScanRoots(homeURL: homeURL, applicationsURL: applicationsURL)
-    guard !fullDiskAccessGranted else { return roots }
-    return roots.filter { root in
+    guard !fullDiskAccessGranted else {
+      return AutomaticScanPlan(roots: roots, retainedPrefixes: [])
+    }
+    let allowedRoots = roots.filter { root in
       guard root.deletingLastPathComponent().standardizedFileURL == homeURL.standardizedFileURL else {
         return true
       }
       return !Self.tccProtectedFolderNames.contains(root.lastPathComponent)
     }
+    let allowedPaths = Set(allowedRoots.map(\.standardizedFileURL))
+    let retainedPrefixes = Set(
+      roots
+        .filter { !allowedPaths.contains($0.standardizedFileURL) }
+        .map { relativePath(for: $0, homePath: homeURL.path) })
+    return AutomaticScanPlan(roots: allowedRoots, retainedPrefixes: retainedPrefixes)
   }
 
   func shouldScanDirectory(atDepth depth: Int) -> Bool {

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -159,11 +159,14 @@ actor FileIndexerService {
     log("FileIndexer: Starting background rescan")
 
     let home = FileManager.default.homeDirectoryForCurrentUser
-    let folders = scanPolicy.automaticScanRoots(
+    let scanPlan = scanPolicy.automaticScanPlan(
       homeURL: home,
       fullDiskAccessGranted: fullDiskAccessGranted)
 
-    let count = await scanFolders(folders, incremental: true)
+    let count = await scanFolders(
+      scanPlan.roots,
+      incremental: true,
+      retentionProtectedPrefixes: scanPlan.retainedPrefixes)
     log("FileIndexer: Background rescan complete, \(count) files indexed")
   }
 
@@ -175,6 +178,7 @@ actor FileIndexerService {
   func scanFolders(
     _ folders: [URL],
     incremental: Bool = false,
+    retentionProtectedPrefixes: Set<String> = [],
     shouldContinue: @escaping @Sendable () -> Bool = { !Task.isCancelled }
   ) async -> Int {
     activeScanOperations += 1
@@ -195,7 +199,7 @@ actor FileIndexerService {
     // revoked, transient I/O). Files under these were not scanned, but that is
     // a read error — not deletion — so they must be excluded from the retention
     // diff (otherwise a single unreadable folder purges its whole index subtree).
-    var failedDirectories = Set<String>()
+    var failedDirectories = retentionProtectedPrefixes
 
     if incremental {
       log("FileIndexer: Loaded \(existingIndex.count) existing paths for incremental scan")

--- a/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+++ b/desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
@@ -195,10 +195,13 @@ actor FileIndexerService {
     // For incremental scans, load existing index for O(1) lookup
     let existingIndex: [String: Date?] = incremental ? loadExistingIndex(from: db) : [:]
     var scannedPaths = Set<String>()
-    // ~-relative prefixes of directories whose enumeration FAILED (permission
-    // revoked, transient I/O). Files under these were not scanned, but that is
-    // a read error — not deletion — so they must be excluded from the retention
-    // diff (otherwise a single unreadable folder purges its whole index subtree).
+    // ~-relative prefixes of subtrees that were NOT scanned, for either of two
+    // reasons: enumeration failed (permission revoked, transient I/O), or the
+    // caller deliberately omitted a TCC-protected root it has no access to and
+    // passed it in as `retentionProtectedPrefixes`. Neither is deletion, so both
+    // must be excluded from the retention diff — otherwise one unreadable folder,
+    // or one root left out for want of Full Disk Access, purges its whole index
+    // subtree.
     var failedDirectories = retentionProtectedPrefixes
 
     if incremental {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -120,6 +120,7 @@ final class PTTAttemptLifecycleRecorder {
     case committed
     case silentRejected = "silent_rejected"
     case tooShort = "too_short"
+    case permissionDenied = "permission_denied"
     case cancelled
   }
 
@@ -142,6 +143,7 @@ final class PTTAttemptLifecycleRecorder {
     case recoveryOutcomeNotJudgeable = "recovery_outcome_not_judgeable"
     case committed
     case tooShortAudible = "too_short_audible"
+    case permissionDenied = "permission_denied"
     case cancelled
   }
 
@@ -505,6 +507,7 @@ final class PTTAttemptLifecycleRecorder {
     if resolvedRecoveryOutcome == .notJudgeable { return .recoveryOutcomeNotJudgeable }
 
     if disposition == .cancelled { return .cancelled }
+    if disposition == .permissionDenied { return .permissionDenied }
 
     // (1) Capture never became operational for this press: the start failed, it
     // was requested but never delivered a callback before the turn ended

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1966,7 +1966,7 @@ class PushToTalkManager: ObservableObject {
     {
       log("PushToTalkManager: microphone permission denied — ending turn without a re-request")
       if let turnID = currentVoiceTurnID {
-        voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .permissionDenied))
+        finishMicrophonePermissionDeniedAttempt(turnID: turnID)
       }
       return
     }
@@ -1986,14 +1986,31 @@ class PushToTalkManager: ObservableObject {
           self.startAudioTranscription()
         } else {
           log("PushToTalkManager: microphone permission denied")
-          self.voiceTurnCoordinator.publish(
-            .finish(turnID: permissionTurnID, reason: .permissionDenied))
+          self.finishMicrophonePermissionDeniedAttempt(turnID: permissionTurnID)
         }
       }
       return
     }
 
     startRealtimePTTRoute(startMicrophoneCapture: true)
+  }
+
+  private func finishMicrophonePermissionDeniedAttempt(turnID: VoiceTurnID) {
+    guard voiceTurnCoordinator.activeTurnID == turnID else { return }
+    pttLifecycle.noteRelease()
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: currentPTTMode(),
+      committed: false,
+      transcriptLength: 0)
+    pttLifecycle.terminate(
+      disposition: .permissionDenied,
+      source: "permission_gate",
+      peak: nil,
+      rms: nil,
+      turnAudioSeconds: nil,
+      voicedAudioSeconds: nil,
+      judgeable: false)
+    voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .permissionDenied))
   }
 
   /// A connected socket is not necessarily admitted for this turn's immutable
@@ -3668,7 +3685,8 @@ extension PushToTalkManager {
       batchAudioLock.lock()
       batchAudioBuffer = Data()
       batchAudioLock.unlock()
-      startMicCapture(overrideDeviceID: preferredPTTInputOverrideDeviceID())  // route PTT input override (user mic / Bluetooth built-in fallback)
+      // Route PTT input override (user mic / Bluetooth built-in fallback).
+      startMicCapture(overrideDeviceID: preferredPTTInputOverrideDeviceID())
     }
     Task { @MainActor [weak self] in
       guard let self, self.isOmniSTT,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -2001,7 +2001,11 @@ class PushToTalkManager: ObservableObject {
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: currentPTTMode(),
       committed: false,
-      transcriptLength: 0)
+      // Nothing was ever captured, so there is no transcript to measure. `0` would
+      // report an empty transcript and drag the transcript-length distribution
+      // down with attempts that never reached STT; `floatingBarPTTEnded` omits the
+      // property entirely when this is nil.
+      transcriptLength: nil)
     pttLifecycle.terminate(
       disposition: .permissionDenied,
       source: "permission_gate",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1997,6 +1997,14 @@ class PushToTalkManager: ObservableObject {
 
   private func finishMicrophonePermissionDeniedAttempt(turnID: VoiceTurnID) {
     guard voiceTurnCoordinator.activeTurnID == turnID else { return }
+    // Matching the granted branch's guard, and for the same reason. The turn can leave
+    // recording while the system permission dialog is still up -- the user releases the
+    // key, finalization starts -- and the denial then resolves against a turn that is
+    // already terminating. `activeTurnID` still matches there, so it alone does not
+    // catch this: without the phase check the attempt emits a second floatingBarPTTEnded,
+    // a second lifecycle terminate, and a second `.finish`, which is precisely the
+    // doubled terminal event INV-VOICE-1 says a denied attempt must not produce.
+    guard voiceTurnCoordinator.activeTurn?.phase.isRecording == true else { return }
     pttLifecycle.noteRelease()
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: currentPTTMode(),

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/SystemCaptureControls.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/SystemCaptureControls.swift
@@ -19,6 +19,16 @@ enum SystemCaptureOutcome: Equatable, Sendable {
   var resultingIsOn: Bool { self == .enabled }
 }
 
+enum AudioRecordingPermissionTransitionPolicy {
+  static func shouldRequestPermission(
+    currentMode: AssistantSettings.AudioRecordingMode,
+    requestedMode: AssistantSettings.AudioRecordingMode,
+    permissionGranted: Bool
+  ) -> Bool {
+    currentMode == .off && requestedMode != .off && !permissionGranted
+  }
+}
+
 /// Single owner of the screen-capture and audio-recording toggle transitions.
 ///
 /// The menu-bar toggles and the notch control cluster are two surfaces over one piece of
@@ -85,7 +95,15 @@ enum SystemCaptureControls {
     }
 
     let current = AssistantSettings.shared.audioRecordingMode
-    AssistantSettings.shared.audioRecordingMode = enabled ? (current == .off ? .onlyMeetings : current) : .off
+    let requested: AssistantSettings.AudioRecordingMode = enabled ? (current == .off ? .onlyMeetings : current) : .off
+    let shouldRequestPermission = AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+      currentMode: current,
+      requestedMode: requested,
+      permissionGranted: AudioCaptureService.checkPermission())
+    AssistantSettings.shared.audioRecordingMode = requested
+    if shouldRequestPermission {
+      AppState.current?.requestMicrophonePermission()
+    }
     return enabled ? .enabled : .disabled
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -251,6 +251,7 @@ extension SettingsContentView {
     Binding(
       get: { audioRecordingMode },
       set: { mode in
+        let previousMode = audioRecordingMode
         audioRecordingModeRaw = mode.rawValue
         AnalyticsManager.shared.settingToggled(
           setting: "audio_recording_mode_\(mode.rawValue)", enabled: mode != .off)
@@ -259,7 +260,11 @@ extension SettingsContentView {
         // starts never raise the TCC sheet. Enabling listening here IS an explicit
         // user action, so it owns the one-shot permission request itself (same
         // contract as the Listen control's `cycleListening`).
-        if mode != .off, !appState.hasMicrophonePermission {
+        if AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+          currentMode: previousMode,
+          requestedMode: mode,
+          permissionGranted: appState.hasMicrophonePermission)
+        {
           appState.requestMicrophonePermission()
         }
       }

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -248,9 +248,9 @@ enum OnboardingFlow {
   ///   the `.userDidSignOut` / `.resetOnboardingRequested` handlers in
   ///   DesktopHomeView (plus a belt-and-suspenders removeObject at the reset
   ///   site, which restarts the app anyway).
-  /// - "screenAnalysisEnabled": SettingsSyncManager overwrites it from the
-  ///   server within ~200ms of sign-in; onboarding force-starts monitoring
-  ///   regardless of this setting.
+  /// - "screenAnalysisEnabled": this is the product's standing capture
+  ///   preference, not onboarding-only state; SettingsSyncManager reconciles
+  ///   it with the signed-in account.
   /// - `SBOnboardingIntroGate.playedKey`: install-scoped, not account-scoped,
   ///   and the one key the two clearing sites treat differently. A re-auth is
   ///   involuntary — a session expired, someone signed back in — and owes them
@@ -273,6 +273,7 @@ enum OnboardingFlow {
     "sbOnboardingResumeStep",
     "sbOnboardingShortcutsCompleted",
     "onboardingRole",
+    DefaultsKey.onboardingSystemAudioSkipped.rawValue,
     "onboardingGoalDraft",
     "onboardingJustCompleted",
     completionOwnerKey,

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -340,7 +340,10 @@ extension SBOnboardingModel {
     advance(userAnswer: allowed ? "Allowed" : "Skip", to: .systemAudio)
   }
 
-  func answerSystemAudio() { advance(userAnswer: sysState == .on ? "Allowed" : "Skip", to: .screen) }
+  func answerSystemAudio() {
+    UserDefaults.standard.set(sysState != .on, forKey: .onboardingSystemAudioSkipped)
+    advance(userAnswer: sysState == .on ? "Allowed" : "Skip", to: .screen)
+  }
 
   /// Skip on the screen step is a durable off for screen analysis — completion and
   /// every later automatic restore read this as the user's standing intent instead
@@ -349,13 +352,17 @@ extension SBOnboardingModel {
     AssistantSettings.shared.screenAnalysisEnabled = scrState == .on
     advance(userAnswer: scrState == .on ? "Allowed" : "Skip", to: .files)
   }
-  /// Restores the legacy Files-stage contract: scan what is readable after the
-  /// Full Disk Access choice, then form the aggregate local-file memories
-  /// before moving on. A skipped FDA grant still scans folders macOS permits.
+  /// A granted Files step builds the local-file profile. A skipped step must
+  /// not enumerate Desktop/Documents/Downloads: touching those folders can
+  /// itself raise Files & Folders consent when Full Disk Access is absent.
   func answerFiles() {
+    guard fdaState == .on else {
+      advance(userAnswer: "Skip", to: .accessibility)
+      return
+    }
     switch localFileProfileState {
     case .idle:
-      thread.append(Msg(isOmi: false, text: fdaState == .on ? "Allowed" : "Skip"))
+      thread.append(Msg(isOmi: false, text: "Allowed"))
       startLocalFileScan()
     case .scanning:
       break

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -311,10 +311,9 @@ final class SBOnboardingModel: ObservableObject {
     case .systemAudio:
       return "Now system audio, so I hear the other side too: Zoom, Meet, calls."
     case .screen:
-      // Says what granting this actually starts. `complete()` turns
-      // `screenAnalysisEnabled` on unconditionally, and Rewind then captures every few seconds for
-      // as long as the app runs — the single most consequential thing the product does, and the app
-      // used to state it in exactly one place the user reaches days later (Rewind's empty state).
+      // Says what granting this actually starts. `complete()` preserves this
+      // explicit intent, and Rewind then captures every few seconds for as long
+      // as the app runs — the single most consequential thing the product does.
       // "Every few seconds" rather than a number: the interval is a setting
       // (`RewindSettings.captureInterval`, 3s by default, tripled on battery). "The pictures" rather
       // than "it": the images do stay on this Mac, but `ScreenActivitySyncService` syncs their OCR
@@ -860,8 +859,12 @@ final class SBOnboardingModel: ObservableObject {
       appState.checkScreenRecordingPermission()
       let screenGranted = appState.hasScreenRecordingPermission
       AssistantSettings.shared.screenAnalysisEnabled =
-        Self.screenAnalysisIntentAtCompletion(screenRecordingGranted: screenGranted)
-      if screenGranted, !ProactiveAssistantsPlugin.shared.isMonitoring {
+        Self.screenAnalysisIntentAtCompletion(
+          intentEnabled: AssistantSettings.shared.screenAnalysisEnabled,
+          screenRecordingGranted: screenGranted)
+      if AssistantSettings.shared.screenAnalysisEnabled,
+        !ProactiveAssistantsPlugin.shared.isMonitoring
+      {
         ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
       }
     }
@@ -904,8 +907,11 @@ final class SBOnboardingModel: ObservableObject {
   /// Recording keeps the capture intent on; a skipped or denied one turns it off —
   /// "not forced on" is not enough, because every automatic restore path and the
   /// sidebar's denied pulse read this flag as the user's standing intent.
-  static func screenAnalysisIntentAtCompletion(screenRecordingGranted: Bool) -> Bool {
-    screenRecordingGranted
+  static func screenAnalysisIntentAtCompletion(
+    intentEnabled: Bool,
+    screenRecordingGranted: Bool
+  ) -> Bool {
+    intentEnabled && screenRecordingGranted
   }
 
   /// Cancel every live task/monitor this model owns. Safe to call repeatedly.

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -862,10 +862,16 @@ final class SBOnboardingModel: ObservableObject {
         Self.screenAnalysisIntentAtCompletion(
           intentEnabled: AssistantSettings.shared.screenAnalysisEnabled,
           screenRecordingGranted: screenGranted)
-      if AssistantSettings.shared.screenAnalysisEnabled,
-        !ProactiveAssistantsPlugin.shared.isMonitoring
-      {
-        ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+      if AssistantSettings.shared.screenAnalysisEnabled {
+        if !ProactiveAssistantsPlugin.shared.isMonitoring {
+          ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+        }
+      } else if ProactiveAssistantsPlugin.shared.isMonitoring {
+        // Unreachable today: monitoring needs the screen grant, and a skip leaves
+        // no grant to have started the demo with. Stopping anyway makes "a
+        // resolved-off intent is not capturing" a property of this line rather
+        // than of that argument, which a later demo change could quietly break.
+        ProactiveAssistantsPlugin.shared.stopMonitoring(reason: .userToggle)
       }
     }
     Task { [appState] in

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -2229,9 +2229,14 @@ class ChatToolExecutor {
       else { return authorizedOwnerChangedResult() }
       // A denied grant is spent: `requestAccess` never resurfaces it, and forcing
       // System Settings from a chat turn repeats the auto-reprompt class. Report it.
-      if MicrophoneCaptureAuthorizationPolicy.action(for: AudioCaptureService.authorizationStatus())
-        == .surfacePermissionAlert
-      {
+      let microphoneAction = MicrophoneCaptureAuthorizationPolicy.action(
+        for: AudioCaptureService.authorizationStatus())
+      if microphoneAction == .surfacePermissionAlert {
+        guard
+          isPermissionAuthorizationCurrent(
+            expectedOwnerID,
+            authorizationSnapshot: authorizationSnapshot)
+        else { return authorizedOwnerChangedResult() }
         appState?.hasMicrophonePermission = false
         return permissionRequestResult(
           type: type, granted: false,
@@ -2269,14 +2274,14 @@ class ChatToolExecutor {
       else { return authorizedOwnerChangedResult() }
       // Same rule as microphone: a denied authorization is spent — no re-request,
       // no forced System Settings jump from a chat turn.
-      let preStatus = await withCheckedContinuation {
-        (continuation: CheckedContinuation<UNAuthorizationStatus, Never>) in
-        UserNotificationCallbackBridge.authorizationStatus { status in
-          continuation.resume(returning: status)
-        }
-      }
+      guard let preStatus = await notificationAuthorizationStatusDirectly(),
+        isPermissionAuthorizationCurrent(
+          expectedOwnerID,
+          authorizationSnapshot: authorizationSnapshot)
+      else { return authorizedOwnerChangedResult() }
       if preStatus == .denied {
         appState?.hasNotificationPermission = false
+        appState?.notificationAuthorizationStatus = .denied
         return permissionRequestResult(
           type: type, granted: false,
           pendingMessage:
@@ -2308,6 +2313,7 @@ class ChatToolExecutor {
           expectedOwnerID,
           authorizationSnapshot: authorizationSnapshot)
       else { return authorizedOwnerChangedResult() }
+      UserDefaults.standard.set(false, forKey: .onboardingAccessibilitySkipped)
       requestAccessibilityPermissionDirectly(
         expectedOwnerID: expectedOwnerID,
         authorizationSnapshot: authorizationSnapshot)
@@ -2535,6 +2541,14 @@ class ChatToolExecutor {
     await awaitCancellablePermissionRequest { completion in
       UserNotificationCallbackBridge.authorizationStatus { authorizationStatus in
         completion(authorizationStatus == .authorized)
+      }
+    }
+  }
+
+  private static func notificationAuthorizationStatusDirectly() async -> UNAuthorizationStatus? {
+    await awaitCancellablePermissionRequest { completion in
+      UserNotificationCallbackBridge.authorizationStatus { authorizationStatus in
+        completion(authorizationStatus)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -2295,6 +2295,10 @@ class ChatToolExecutor {
       else { return authorizedOwnerChangedResult() }
       appState?.hasNotificationPermission = granted
       if !granted, preStatus == .notDetermined {
+        // The user just answered the system prompt with No, so the real TCC state
+        // is now .denied. Without this the cache still reads .notDetermined and a
+        // later caller treats a spent authorization as still askable.
+        appState?.notificationAuthorizationStatus = .denied
         _ = openNotificationPrivacySettings(
           expectedOwnerID: expectedOwnerID,
           authorizationSnapshot: authorizationSnapshot)

--- a/desktop/macos/Desktop/Tests/FileIndexScanPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexScanPolicyTests.swift
@@ -52,6 +52,13 @@ final class FileIndexScanPolicyTests: XCTestCase {
         "/tmp/omi-test-home/Applications",
       ]
     )
+
+    let plan = policy.automaticScanPlan(
+      homeURL: home, applicationsURL: applications, fullDiskAccessGranted: false)
+    XCTAssertEqual(
+      plan.retainedPrefixes,
+      ["~/Desktop", "~/Documents", "~/Downloads"],
+      "Rows under intentionally omitted roots must not look deleted after a partial scan")
   }
 
   func testAutomaticScanRootsWithFullDiskAccessMatchStandardRoots() {
@@ -63,6 +70,10 @@ final class FileIndexScanPolicyTests: XCTestCase {
       policy.automaticScanRoots(
         homeURL: home, applicationsURL: applications, fullDiskAccessGranted: true),
       policy.standardScanRoots(homeURL: home, applicationsURL: applications))
+    XCTAssertTrue(
+      policy.automaticScanPlan(
+        homeURL: home, applicationsURL: applications, fullDiskAccessGranted: true
+      ).retainedPrefixes.isEmpty)
   }
 
   func testSkipFoldersAreRejectedBeforeRecursiveDescent() {

--- a/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/FileIndexerServiceTests.swift
@@ -116,6 +116,31 @@ final class FileIndexerServiceTests: XCTestCase {
     XCTAssertTrue(try fetchIndexedRecords().isEmpty)
   }
 
+  func testPartialIncrementalScanPreservesRowsUnderAnIntentionallyOmittedRoot() async throws {
+    let documents = temporaryRoot.appendingPathComponent("Documents", isDirectory: true)
+    let projects = temporaryRoot.appendingPathComponent("Projects", isDirectory: true)
+    try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+    let privateFile = try writeFile("keep", at: documents.appendingPathComponent("private.md"))
+    let deletedFile = try writeFile("delete", at: projects.appendingPathComponent("old.md"))
+
+    let service = FileIndexerService(databasePool: databasePool, batchSize: 2)
+    _ = await service.scanFolders([documents, projects])
+    let privateIndexedPath = try XCTUnwrap(
+      fetchIndexedRecords().first { $0.filename == privateFile.lastPathComponent }?.path)
+    let protectedDocumentsPrefix = (privateIndexedPath as NSString).deletingLastPathComponent
+    try FileManager.default.removeItem(at: deletedFile)
+
+    _ = await service.scanFolders(
+      [projects],
+      incremental: true,
+      retentionProtectedPrefixes: [protectedDocumentsPrefix])
+
+    let records = try fetchIndexedRecords()
+    XCTAssertNotNil(records.first { $0.path == privateIndexedPath })
+    XCTAssertNil(records.first { $0.filename == deletedFile.lastPathComponent })
+  }
+
   private func writeFile(_ contents: String, at url: URL) throws -> URL {
     try FileManager.default.createDirectory(
       at: url.deletingLastPathComponent(),

--- a/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPermissionToolTests.swift
@@ -133,6 +133,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
       fileScanRunner: { _ in .failed(message: "No readable folders") },
       onComplete: nil)
     model.step = .files
+    model.fdaState = .on
 
     model.answerFiles()
     await model.localFileScanTask?.value
@@ -162,6 +163,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
       },
       onComplete: nil)
     model.step = .files
+    model.fdaState = .on
 
     model.answerFiles()
     await fulfillment(of: [firstScanStarted], timeout: 1)
@@ -173,6 +175,7 @@ final class OnboardingPermissionToolTests: XCTestCase {
     releaseFirstScan.fulfill()
     await model.localFileScanTask?.value
     model.step = .files
+    model.fdaState = .on
     model.answerFiles()
     await model.localFileScanTask?.value
 

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -41,6 +41,7 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
       "sbOnboardingResumeStep",
       "sbOnboardingShortcutsCompleted",
       "onboardingRole",
+      DefaultsKey.onboardingSystemAudioSkipped.rawValue,
       OnboardingFlow.completionOwnerKey,
     ]
     for key in required {

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -44,6 +44,24 @@ import XCTest
       XCTAssertEqual(snap.firstChunksEnergyBucket, .none)
     }
 
+    func testPermissionDenialClosesAttemptWithItsOwnTerminalClass() {
+      let recorder = makeRecorder()
+      begin(recorder)
+
+      let snap = recorder.terminate(
+        disposition: .permissionDenied,
+        source: "permission_gate",
+        peak: nil,
+        rms: nil,
+        turnAudioSeconds: nil,
+        voicedAudioSeconds: nil,
+        judgeable: false)
+
+      XCTAssertEqual(snap.failureClass, .permissionDenied)
+      XCTAssertEqual(snap.turnDisposition, .permissionDenied)
+      XCTAssertEqual(snap.captureStartOutcome, .notRequested)
+    }
+
     // MARK: - Failure classification 2: zero / near-zero samples
 
     func testOperationalCaptureWithOnlyZeroSamplesClassifiesZeroSamples() {

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -46,7 +46,10 @@ import XCTest
 
     func testPermissionDenialClosesAttemptWithItsOwnTerminalClass() {
       let recorder = makeRecorder()
-      begin(recorder)
+      // Not the shared `begin` helper: that seeds micPermissionGranted: true, which
+      // would emit tcc_microphone_granted: true on the snapshot for an attempt the
+      // microphone permission is what refused.
+      recorder.beginAttempt(mode: "hold", hubActive: true, micPermissionGranted: false)
 
       let snap = recorder.terminate(
         disposition: .permissionDenied,

--- a/desktop/macos/Desktop/Tests/SBOnboardingSkipPermissionIntentTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingSkipPermissionIntentTests.swift
@@ -20,12 +20,16 @@ final class SBOnboardingSkipPermissionIntentTests: XCTestCase {
       AssistantSettings.audioRecordingModeDefaultsKey,
       DefaultsKey.screenAnalysisEnabled.rawValue,
       DefaultsKey.onboardingAccessibilitySkipped.rawValue,
+      DefaultsKey.onboardingSystemAudioSkipped.rawValue,
+      DefaultsKey.disableSystemAudioCapture.rawValue,
     ] {
       savedDefaults[key] = defaults.object(forKey: key)
     }
     defaults.removeObject(forKey: AssistantSettings.audioRecordingModeDefaultsKey)
     defaults.removeObject(forKey: DefaultsKey.screenAnalysisEnabled.rawValue)
     defaults.removeObject(forKey: DefaultsKey.onboardingAccessibilitySkipped.rawValue)
+    defaults.removeObject(forKey: DefaultsKey.onboardingSystemAudioSkipped.rawValue)
+    defaults.removeObject(forKey: DefaultsKey.disableSystemAudioCapture.rawValue)
   }
 
   override func tearDown() async throws {
@@ -106,10 +110,73 @@ final class SBOnboardingSkipPermissionIntentTests: XCTestCase {
 
   func testCompletionNeverForcesScreenAnalysisOnForASkippedGrant() {
     XCTAssertEqual(
-      SBOnboardingModel.screenAnalysisIntentAtCompletion(screenRecordingGranted: false), false,
-      "Completion must not force-enable screen analysis after a skip or denial")
+      SBOnboardingModel.screenAnalysisIntentAtCompletion(
+        intentEnabled: false, screenRecordingGranted: true),
+      false,
+      "A pre-existing TCC grant must not overwrite the user's explicit skip")
     XCTAssertEqual(
-      SBOnboardingModel.screenAnalysisIntentAtCompletion(screenRecordingGranted: true), true)
+      SBOnboardingModel.screenAnalysisIntentAtCompletion(
+        intentEnabled: true, screenRecordingGranted: false),
+      false,
+      "Intent alone cannot start capture without a live grant")
+    XCTAssertEqual(
+      SBOnboardingModel.screenAnalysisIntentAtCompletion(
+        intentEnabled: true, screenRecordingGranted: true),
+      true)
+  }
+
+  // MARK: - System audio skip
+
+  func testExistingInstallWithoutSystemAudioSkipKeepsCaptureAvailable() {
+    XCTAssertNil(UserDefaults.standard.object(forKey: DefaultsKey.onboardingSystemAudioSkipped.rawValue))
+    XCTAssertTrue(appState.shouldCaptureSystemAudio)
+    UserDefaults.standard.set(true, forKey: .disableSystemAudioCapture)
+    XCTAssertFalse(appState.shouldCaptureSystemAudio)
+  }
+
+  func testSkipSystemAudioDisablesLaterAutomaticTapAttempts() {
+    let model = makeModel()
+    model.step = .systemAudio
+    model.sysState = .ask
+
+    model.answerSystemAudio()
+
+    XCTAssertTrue(UserDefaults.standard.bool(forKey: .onboardingSystemAudioSkipped))
+    XCTAssertFalse(appState.shouldCaptureSystemAudio)
+  }
+
+  func testAllowSystemAudioClearsAnEarlierSkip() {
+    let model = makeModel()
+    UserDefaults.standard.set(true, forKey: .onboardingSystemAudioSkipped)
+    model.step = .systemAudio
+    model.sysState = .on
+
+    model.answerSystemAudio()
+
+    XCTAssertFalse(UserDefaults.standard.bool(forKey: .onboardingSystemAudioSkipped))
+    XCTAssertTrue(appState.shouldCaptureSystemAudio)
+  }
+
+  // MARK: - Files skip
+
+  func testSkipFilesDoesNotStartAProtectedFolderScan() {
+    var scanCalls = 0
+    let model = SBOnboardingModel(
+      appState: appState,
+      chatProvider: ChatProvider(),
+      fileScanRunner: { _ in
+        scanCalls += 1
+        return .complete(fileCount: 1, memoryCount: 1, deniedFolders: [])
+      },
+      onComplete: nil)
+    model.step = .files
+    model.fdaState = .ask
+
+    model.answerFiles()
+
+    XCTAssertEqual(scanCalls, 0)
+    XCTAssertNil(model.localFileScanTask)
+    XCTAssertNotEqual(model.step, .files)
   }
 
   // MARK: - Accessibility skip marker

--- a/desktop/macos/Desktop/Tests/SBOnboardingSkipPermissionIntentTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingSkipPermissionIntentTests.swift
@@ -176,7 +176,10 @@ final class SBOnboardingSkipPermissionIntentTests: XCTestCase {
 
     XCTAssertEqual(scanCalls, 0)
     XCTAssertNil(model.localFileScanTask)
-    XCTAssertNotEqual(model.step, .files)
+    // answerFiles guards on fdaState == .on and otherwise advances to .accessibility.
+    // Asserting only that the step changed would pass on a wrong destination, or on a
+    // restart back at .promise.
+    XCTAssertEqual(model.step, .accessibility)
   }
 
   // MARK: - Accessibility skip marker

--- a/desktop/macos/Desktop/Tests/SystemCaptureControlsTests.swift
+++ b/desktop/macos/Desktop/Tests/SystemCaptureControlsTests.swift
@@ -23,4 +23,28 @@ final class SystemCaptureOutcomeTests: XCTestCase {
     XCTAssertNotEqual(SystemCaptureOutcome.failedToStart, .disabled)
     XCTAssertNotEqual(SystemCaptureOutcome.blockedPaywall, .blockedPermission)
   }
+
+  func testMicrophonePromptOnlyBelongsToAnOffToEnabledTransition() {
+    XCTAssertTrue(
+      AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+        currentMode: .off,
+        requestedMode: .onlyMeetings,
+        permissionGranted: false))
+    XCTAssertFalse(
+      AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+        currentMode: .onlyMeetings,
+        requestedMode: .always,
+        permissionGranted: false),
+      "Changing enabled modes must not reopen a denied permission flow")
+    XCTAssertFalse(
+      AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+        currentMode: .off,
+        requestedMode: .always,
+        permissionGranted: true))
+    XCTAssertFalse(
+      AudioRecordingPermissionTransitionPolicy.shouldRequestPermission(
+        currentMode: .always,
+        requestedMode: .off,
+        permissionGranted: false))
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260905-onboarding-permission-hardening.json
+++ b/desktop/macos/changelog/unreleased/20260905-onboarding-permission-hardening.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed remaining macOS permission prompts and file-index loss after skipping onboarding permissions"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -28,7 +28,6 @@ covers:
   - desktop/macos/Desktop/Sources/AgentVMService.swift
   - desktop/macos/Desktop/Sources/APIKeyService.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
-  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
   - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
   - desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -2,8 +2,8 @@ version: 2
 name: onboarding-flow
 tier: manual
 description: >
-  Onboarding orchestration after BYOK removal. Reset into onboarding, walk Goal → Tasks,
-  and confirm there is no Bring Your Own Keys step and the 2nd-brain label has no background.
+  Onboarding orchestration and durable permission skips. Reset into onboarding, skip
+  private-data permissions, prove activation/relaunch stays quiet, then walk Goal → Tasks.
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/Automation/DesktopAutomationFirstUsePopupActions.swift
@@ -13,6 +13,8 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
   - desktop/macos/Desktop/Sources/PostOnboardingPromptViews.swift
   - desktop/macos/Desktop/Sources/FileIndexing/FileIndexingView.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexerService.swift
+  - desktop/macos/Desktop/Sources/FileIndexing/FileIndexScanPolicy.swift
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingAnswerWriteGate.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -32,6 +34,7 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/OnboardingGlassChrome.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingIntroGate.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingPermissionRuntime.swift
+  - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingPermissionIntentPolicy.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBPostOnboardingGuidance.swift
   - desktop/macos/Desktop/Sources/FileIndexing/OnboardingLoadingAnimation.swift
 preconditions:
@@ -46,16 +49,24 @@ steps:
         - "What's your name"
 
   - id: S2
+    name: Skip private-data permissions
+    do: "At Microphone, System Audio, Screen Recording, and Files, choose Skip. Confirm Files advances immediately without a scan or a Files & Folders prompt."
+
+  - id: S3
     name: Advance to Goal
     do: "Skip or complete earlier steps until the Goal screen. Confirm progress reaches Goal without a Bring Your Own Keys / API keys page."
 
-  - id: S3
+  - id: S4
     name: Goal continues to Tasks
     do: "Continue or Skip on Goal. The next screen must be Tasks (not Bring your own keys)."
     expect:
       text_visible:
         - "Take me to Omi"
 
-  - id: S4
+  - id: S5
     name: 2nd brain label has no background
     do: "On any split onboarding step with the graph pane, confirm 'This is your 2nd brain' has no pill fill and no bottom gradient behind the label."
+
+  - id: S6
+    name: Permission skips survive automatic lifecycle work
+    do: "Finish onboarding, switch to another app and back, then quit and reopen Omi. Confirm no microphone, system-audio, screen-recording, notification, or Files & Folders consent UI appears. Trigger an automatic file rescan without Full Disk Access and confirm existing indexed rows under Documents, Desktop, and Downloads remain present."

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -70,3 +70,7 @@ steps:
   - id: S6
     name: Permission skips survive automatic lifecycle work
     do: "Finish onboarding, switch to another app and back, then quit and reopen Omi. Confirm no microphone, system-audio, screen-recording, notification, or Files & Folders consent UI appears. Trigger an automatic file rescan without Full Disk Access and confirm existing indexed rows under Documents, Desktop, and Downloads remain present."
+
+  - id: S7
+    name: A skip does not read as denied in the sidebar
+    do: "With onboarding finished and Screen Recording and Accessibility both skipped, open the sidebar permission rows. Confirm neither is shown as denied: a skip is a deliberate choice, not macOS refusing, and flagging it red asks the user to undo a decision they just made. Then grant Screen Recording from the sidebar and confirm the row stops offering it."

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -12,7 +12,6 @@ covers:
   - desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
   - desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
-  - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingPermissionIntentPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AnimatedGIFView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPageChrome.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift


### PR DESCRIPTION
## What changed and why

Skipping macOS onboarding permissions could still start a protected-folder scan, re-enable screen capture when an older OS grant existed, or test system audio during a later microphone session. A background scan without Full Disk Access also treated deliberately omitted folders as deleted and removed their existing index rows.

This follows up on #12722 and #12695 by carrying explicit permission intent through the remaining capture and indexing boundaries:

- Preserve screen and system-audio skip choices; an explicit Grant action clears the corresponding skip marker.
- Advance past a skipped Files step without starting its scan. Automatic rescans retain existing rows beneath TCC-protected roots they omit, while still deleting genuinely removed files from scanned roots.
- Carry user initiation through the lower microphone capture boundary and refuse unknown authorization states. Explicit audio enable actions own the permission request; changing between enabled recording modes does not request again.
- Keep chat permission callbacks cancellable and check their original owner before publishing permission state. Cache denied notification status consistently.
- Finish denied push-to-talk attempts with a balanced terminal event and a permission-denied lifecycle classification.

## Product invariants affected

- INV-AUTH-1: delayed permission results remain bound to the original authorization owner.
- INV-CHAT-1: permission tools retain the existing chat execution and cancellation boundaries.
- INV-VOICE-1: denied microphone attempts finish once with a specific terminal classification.

## How it was verified

- Manual macOS validation: the user passed the fresh named-bundle onboarding skip, app reactivation, and quit/relaunch flow during fix validation. That build preceded this follow-up's move onto current main; it is evidence for the user flow, not a claim that every later hardening branch was physically exercised.
- Focused Swift regressions: 80 tests passed; owner/cancellation, notification, capture-readiness, and settings-restoration suites: 52 tests passed.
- After the final rebase onto `origin/main`, all seven changed regression suites passed 65/65 tests.
- Desktop launcher checks, 230 Python desktop-backend tests, and all 798 Swift suites passed. One combined Swift batch exited nonzero, so the runner reran all 25 suites from that batch in isolation; every suite passed.
- Strict E2E coverage mapping: all 16 changed production Swift files covered. This is a metadata check, not a claim that every mapped flow was run.
- Desktop test-quality and whitespace checks passed.

## Tests

Behavioral regressions cover screen intent versus OS grant, System Audio skip/allow, legacy installs without a skip preference, skipped Files never invoking the scan runner, database retention during partial scans, explicit audio-mode transitions, and denied PTT lifecycle termination. The existing Files-stage tests now explicitly grant FDA before testing scanning; this preserves their scan/failure/cancellation assertions while separating them from the skip contract reported in #12695.

The shared scan plan returns both admitted roots and retained prefixes, so omission and deletion eligibility are decided together. No new source-text checker or ratchet is introduced. E2E coverage metadata now describes the actual onboarding permission flow.

## Failure class

Failure-Class: FC-privileged-consent-resampled-on-timer

Denied or skipped permissions are terminal for automatic work. A later explicit user action can request the capability again. Existing installs with no System Audio skip marker preserve their previous capture behavior; the debug disable preference continues to take precedence.

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift | 1768 -> 1779 | carries user initiation through the existing shared-capture permission boundary; extracting this narrow state transition would obscure its capture owner and expand the change.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 3954 -> 3984 | balances the denied microphone attempt inside the existing PTT lifecycle owner; a file split would be unrelated to this terminal-state fix.

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift | 3834 -> 3852 | keeps delayed permission callbacks and cancellation checks beside the existing chat tool owner; extraction would broaden a focused authorization fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



