### PR TITLE
feat(backend): plan-gate desktop Gemini generate for basic non-BYOK users (S14)

### DIFF
--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -246,7 +246,7 @@ surfaces:
   feature: desktop_vertex
   plan_gating: basic_not_entitled
   funding_owner: omi
-  fallback_on_deny: none_unwired
+  fallback_on_deny: http_402
   call_sites:
   - routers/desktop_proxy.py::host:generativelanguage.googleapis.com
   - utils/llm/vertex_pt_routing.py::host:aiplatform.googleapis.com
@@ -257,7 +257,8 @@ surfaces:
     and back to Gemini native in the gateway Vertex adapter
   gateway_lane_capability_needed: desktop vertex lanes with PT pin/overflow and multi-region host policy in VertexGeminiProvider;
     OpenAI-shaped /v1/embeddings with task_type pass-through
-  migration_status: gateway_routed_desktop_vertex; the BFF keeps auth, trial paywall, redis metering, body limits, and model
+  migration_status: gateway_routed_desktop_vertex; the BFF keeps auth, trial paywall, S14 generate/stream
+    plan gate (402 plan_gated via authorize_managed_compute on screen_frame_judge; embedContent ungated), redis metering, body limits, and model
     allowlist; PT pin/overflow/host policy moved into the gateway provider via vertex_pt_routing (no second policy); FEATURE_MODE=off
     keeps the legacy direct Vertex path
   test_guardrail_coverage: backend/tests/unit/test_desktop_proxy.py and backend/tests/unit/test_vertex_pt_routing.py

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -35,6 +35,7 @@ from utils.llm.desktop_llm_stub import (
 from utils.journey_metrics_contract import ClientKind, resolve_client_kind_from_headers
 from utils.observability.fallback import record_fallback
 from utils.observability.journeys import ClientJourneyAttempt
+from utils.managed_compute import Decision, authorize_managed_compute
 from utils.other.endpoints import get_current_user_uid
 from utils.subscription import is_desktop_trial_paywalled
 
@@ -1622,11 +1623,51 @@ async def _authorized_desktop_user(uid: str = Depends(get_current_user_uid)) -> 
     return uid
 
 
+# Gen-1 Gemini generate/stream is the screen-intelligence spend path (free-tier S14).
+# screen_frame_judge is the configured Gemini-provider feature, so a request-scoped
+# Gemini BYOK key satisfies authorize_managed_compute. embedContent stays ungated
+# here (TBD-4 / S24). desktop_proactivity completions are the JIT/context-bucket
+# lane and are intentionally not gated in this shard — a blanket 402 there would
+# kill the ambient nano triage (S24) and the shipped completion lane
+# (test_legacy_clients_are_not_gated_by_jit_rollout).
+_PLAN_GATED_PROXY_ACTIONS = frozenset({'generateContent', 'streamGenerateContent'})
+_PLAN_GATED_PROXY_FEATURE = 'screen_frame_judge'
+
+
+def _plan_gate_detail(decision: Decision) -> dict[str, str]:
+    plan_type = decision.plan.value if decision.plan is not None else 'basic'
+    return {'error': 'plan_gated', 'plan_type': plan_type, 'reason': decision.reason}
+
+
+async def _enforce_managed_plan_gate(uid: str, path: str) -> None:
+    try:
+        _, _, action = _path_parts(path)
+    except HTTPException:
+        return
+    if action not in _PLAN_GATED_PROXY_ACTIONS:
+        return
+    funding_owner = 'byok' if get_byok_key('gemini') else 'omi'
+    decision = await run_blocking(
+        db_executor,
+        authorize_managed_compute,
+        uid,
+        _PLAN_GATED_PROXY_FEATURE,
+        funding_owner,
+    )
+    if decision.allowed:
+        return
+    if decision.reason == 'authorization_unavailable':
+        raise HTTPException(status_code=503, detail='plan authorization is temporarily unavailable')
+    raise HTTPException(status_code=402, detail=_plan_gate_detail(decision))
+
+
 @router.post('/v1/proxy/gemini/{path:path}')
 async def gemini_proxy(request: Request, path: str, uid: str = Depends(_authorized_desktop_user)) -> Response:
+    await _enforce_managed_plan_gate(uid, path)
     return await _proxy(request, path, False, uid)
 
 
 @router.post('/v1/proxy/gemini-stream/{path:path}')
 async def gemini_stream_proxy(request: Request, path: str, uid: str = Depends(_authorized_desktop_user)) -> Response:
+    await _enforce_managed_plan_gate(uid, path)
     return await _proxy(request, path, True, uid)

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -18,7 +18,9 @@ if str(BACKEND_DIR) not in sys.path:
 os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
 
 from routers import desktop_proxy
+from utils.managed_compute import Decision
 from utils.observability import journeys
+from config.plan_catalog import PlanType
 
 
 def make_request(
@@ -155,6 +157,203 @@ async def test_gemini_proxy_rejects_paywalled_desktop_user(monkeypatch):
 
     assert error.value.status_code == 402
     assert error.value.detail == "trial_expired"
+
+
+def _decision(*, allowed: bool, reason: str, plan: PlanType | None = PlanType.basic) -> Decision:
+    return Decision(
+        allowed=allowed,
+        reason=reason,
+        feature=desktop_proxy._PLAN_GATED_PROXY_FEATURE,
+        funding_owner="omi",
+        plan=plan,
+        plan_resolved=plan is not None,
+    )
+
+
+async def _passthrough_run_blocking(_, function, *args, **kwargs):
+    return function(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_gemini_proxy_rejects_basic_generate_with_structured_402(monkeypatch):
+    """Route-level S14 gate: basic + generateContent never reaches the provider.
+
+    red-proof: drop the gemini_proxy await _enforce_managed_plan_gate call and
+    this test still passes if it only drove _proxy.
+    """
+    provider_calls = []
+
+    async def should_not_proxy(*_args, **_kwargs):
+        provider_calls.append(True)
+        raise AssertionError("provider must not run for a plan-gated basic user")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(
+        desktop_proxy,
+        "authorize_managed_compute",
+        lambda *_args, **_kwargs: _decision(allowed=False, reason="basic_not_entitled"),
+    )
+    monkeypatch.setattr(desktop_proxy, "_proxy", should_not_proxy)
+
+    with pytest.raises(HTTPException) as error:
+        await desktop_proxy.gemini_proxy(
+            make_request(),
+            "models/gemini-2.5-flash:generateContent",
+            "basic-uid",
+        )
+
+    assert error.value.status_code == 402
+    assert error.value.detail == {
+        "error": "plan_gated",
+        "plan_type": "basic",
+        "reason": "basic_not_entitled",
+    }
+    assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_gemini_stream_proxy_rejects_basic_stream_generate(monkeypatch):
+    provider_calls = []
+
+    async def should_not_proxy(*_args, **_kwargs):
+        provider_calls.append(True)
+        raise AssertionError("stream provider must not run for a plan-gated basic user")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(
+        desktop_proxy,
+        "authorize_managed_compute",
+        lambda *_args, **_kwargs: _decision(allowed=False, reason="basic_not_entitled"),
+    )
+    monkeypatch.setattr(desktop_proxy, "_proxy", should_not_proxy)
+
+    with pytest.raises(HTTPException) as error:
+        await desktop_proxy.gemini_stream_proxy(
+            make_request(),
+            "models/gemini-2.5-flash:streamGenerateContent",
+            "basic-uid",
+        )
+
+    assert error.value.status_code == 402
+    assert error.value.detail["error"] == "plan_gated"
+    assert provider_calls == []
+
+
+@pytest.mark.asyncio
+async def test_gemini_proxy_allows_paid_generate_to_reach_the_provider(monkeypatch):
+    from fastapi.responses import Response
+
+    seen = []
+
+    async def fake_proxy(request, path, streaming, uid):
+        seen.append((path, streaming, uid))
+        return Response(b'{"ok":true}', media_type="application/json")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(
+        desktop_proxy,
+        "authorize_managed_compute",
+        lambda *_args, **_kwargs: _decision(allowed=True, reason="plan_paid", plan=PlanType.plus),
+    )
+    monkeypatch.setattr(desktop_proxy, "_proxy", fake_proxy)
+
+    response = await desktop_proxy.gemini_proxy(
+        make_request(),
+        "models/gemini-2.5-flash:generateContent",
+        "plus-uid",
+    )
+
+    assert response.status_code == 200
+    assert seen == [("models/gemini-2.5-flash:generateContent", False, "plus-uid")]
+
+
+@pytest.mark.asyncio
+async def test_gemini_proxy_allows_basic_byok_generate(monkeypatch):
+    from fastapi.responses import Response
+
+    funding = []
+
+    def authorize(uid, feature, funding_owner, **_kwargs):
+        funding.append((uid, feature, funding_owner))
+        return Decision(
+            allowed=True,
+            reason="byok",
+            feature=feature,
+            funding_owner=funding_owner,
+            plan=PlanType.basic,
+            plan_resolved=True,
+        )
+
+    async def fake_proxy(*_args, **_kwargs):
+        return Response(b'{"ok":true}', media_type="application/json")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda provider: "gk" if provider == "gemini" else None)
+    monkeypatch.setattr(desktop_proxy, "authorize_managed_compute", authorize)
+    monkeypatch.setattr(desktop_proxy, "_proxy", fake_proxy)
+
+    response = await desktop_proxy.gemini_proxy(
+        make_request(),
+        "models/gemini-2.5-flash:generateContent",
+        "byok-basic",
+    )
+
+    assert response.status_code == 200
+    assert funding == [("byok-basic", "screen_frame_judge", "byok")]
+
+
+@pytest.mark.asyncio
+async def test_gemini_proxy_does_not_plan_gate_embed_content(monkeypatch):
+    from fastapi.responses import Response
+
+    auth_calls = []
+
+    def authorize(*_args, **_kwargs):
+        auth_calls.append(True)
+        return _decision(allowed=False, reason="basic_not_entitled")
+
+    async def fake_proxy(*_args, **_kwargs):
+        return Response(b'{"embedding":{"values":[1]}}', media_type="application/json")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(desktop_proxy, "authorize_managed_compute", authorize)
+    monkeypatch.setattr(desktop_proxy, "_proxy", fake_proxy)
+
+    response = await desktop_proxy.gemini_proxy(
+        make_request(),
+        "models/gemini-embedding-001:embedContent",
+        "basic-uid",
+    )
+
+    assert response.status_code == 200
+    assert auth_calls == [], "embedContent is TBD-4 / S24 and must not inherit the generate gate"
+
+
+@pytest.mark.asyncio
+async def test_gemini_proxy_fails_closed_when_authorization_is_unavailable(monkeypatch):
+    provider_calls = []
+
+    async def should_not_proxy(*_args, **_kwargs):
+        provider_calls.append(True)
+        raise AssertionError("unavailable authorization must not fall through to the provider")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(
+        desktop_proxy,
+        "authorize_managed_compute",
+        lambda *_args, **_kwargs: _decision(allowed=False, reason="authorization_unavailable", plan=None),
+    )
+    monkeypatch.setattr(desktop_proxy, "_proxy", should_not_proxy)
+
+    with pytest.raises(HTTPException) as error:
+        await desktop_proxy.gemini_proxy(
+            make_request(),
+            "models/gemini-2.5-flash:generateContent",
+            "basic-uid",
+        )
+
+    assert error.value.status_code == 503
+    assert provider_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## S14 — server plan gate on desktop Gemini generate/stream

Shard S14 of the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S14; spec `30-desktop-proactivity.md` §3.2), scoped to the Gen-1 Gemini proxy only.

`authorize_managed_compute` has been on `main` since S1. `POST /v1/proxy/gemini/**` still spent Omi-billed Gemini for every basic non-BYOK desktop user (~37 generate calls per active hour). This PR closes that door at the route.

### What changed

- `gemini_proxy` and `gemini_stream_proxy` now call `authorize_managed_compute` on `generateContent` / `streamGenerateContent` before `_proxy`.
- Feature is `screen_frame_judge` (the configured Gemini-provider key) so a request-scoped Gemini BYOK key counts; funding owner is `byok` when that key is present, otherwise `omi`.
- Denied basic users get **402** with `{'error': 'plan_gated', 'plan_type': 'basic', 'reason': ...}`. 70-status 2026-09-04 settled this over the shard's original 403: these endpoints already return 402 for `trial_expired`, and chat already discriminates on a structured 402 body. A new 403 would make every shipped desktop build learn a second refusal code.
- `authorization_unavailable` is 503, not a fall-through to a live key.
- `embedContent` is not gated (TBD-4 / S24).
- Inventory `desktop_gemini_proxy.fallback_on_deny` moves `none_unwired` → `http_402`.

### Deliberately not this PR

`desktop_proactivity.py` completions are the JIT / context-bucket lane. S24 already warned that a blanket 403/402 on `proactive_extraction` kills the ambient nano triage, and `test_legacy_clients_are_not_gated_by_jit_rollout` exists because a previous 403 on that lane silently killed the shipped fleet. S14's remaining half waits on that lane's owner.

### Automatic-or-dead check

`test_desktop_proxy.py` now drives the **route functions** (`gemini_proxy` / `gemini_stream_proxy`), not only `_authorized_desktop_user`:

- basic + generateContent → 402 `plan_gated`, `_proxy` never runs
- basic + streamGenerateContent → same
- paid → `_proxy` runs
- basic + Gemini BYOK → `_proxy` runs, authorize sees `funding_owner=byok`
- embedContent → authorize is not consulted
- `authorization_unavailable` → 503, `_proxy` never runs

Red-proof (in the generate test docstring): drop the `await _enforce_managed_plan_gate` in `gemini_proxy` and the test fails because it would reach `_proxy`.

### Proof

- `tests/unit/test_desktop_proxy.py` 106 passed (2m31s), including the six new route-level cases and the existing paywall test.
- `test_inventory_surfaces_have_status_guardrails_and_resolvable_code_paths` passed after the inventory update.

Live dest check after merge: a basic dogfood account hitting `POST /v1/proxy/gemini/models/gemini-2.5-flash:generateContent` must 402 `plan_gated` on the auto-deployed dev revision; a paid/BYOK account must still 200.

### Cut list

- Gating `desktop_proactivity` completions (JIT lane; S24 / other agent).
- Pixel-vs-text discrimination inside generateContent (S24).
- `embedContent` / screen-vector 403 (TBD-4 / S24).
- Client `.planGated` (S13).
- Paid-tier ceilings.

### Line-count ratchet

Line-Count-Exception: backend/routers/desktop_proxy.py | 1632 -> 1673 | S14 route-level plan gate on generate/stream; the check lives next to the existing trial paywall, not in a new module

### Product invariants

none

### Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

