### PR TITLE
fix(qa): use pinned Typesense image entrypoint

### DIFF
--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -147,7 +147,15 @@ jobs:
           smoke_name="jit-qa-typesense-smoke-${GITHUB_RUN_ID}"
           smoke_port=18108
           smoke_key="jit-qa-typesense-local-smoke-key"
-          cleanup_smoke() { docker rm -f "$smoke_name" >/dev/null 2>&1 || true; }
+          smoke_passed=0
+          cleanup_smoke() {
+            if [[ "$smoke_passed" != 1 ]] && docker inspect "$smoke_name" >/dev/null 2>&1; then
+              echo "Typesense smoke container diagnostics:" >&2
+              docker inspect --format='status={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' "$smoke_name" >&2 || true
+              docker logs --tail 200 "$smoke_name" 2>&1 | sed "s/${smoke_key}/[redacted]/g" >&2 || true
+            fi
+            docker rm -f "$smoke_name" >/dev/null 2>&1 || true
+          }
           trap cleanup_smoke EXIT
           docker run --detach --name "$smoke_name" --publish "$smoke_port:8080" \
             --env "TYPESENSE_API_KEY=$smoke_key" --env TYPESENSE_DATA_DIR=/tmp/typesense "$typesense_tag" >/dev/null
@@ -179,6 +187,7 @@ jobs:
             "$smoke_url/collections/jit_qa_smoke/documents/export?include_fields=id,content" > "$export_response"
           grep -Fq '"id":"smoke-1"' "$export_response"
           grep -Fq '"content":"isolated QA smoke"' "$export_response"
+          smoke_passed=1
           if [[ "$MODE" == "prove" ]]; then
             python3 backend/scripts/runtime_image_contracts.py smoke \
               --dockerfile backend/Dockerfile --image "$runner_tag"

--- a/backend/scripts/jit_qa_typesense_entrypoint.sh
+++ b/backend/scripts/jit_qa_typesense_entrypoint.sh
@@ -5,8 +5,11 @@ set -eu
 
 if command -v typesense-server >/dev/null 2>&1; then
     typesense_binary="$(command -v typesense-server)"
-elif [ -x /opt/typesense-server/typesense-server ]; then
-    typesense_binary="/opt/typesense-server/typesense-server"
+elif [ -x /opt/typesense-server ]; then
+    # The pinned docker.io/typesense/typesense:27.1 image exposes the server
+    # binary directly at /opt/typesense-server (its image entrypoint), rather
+    # than in an /opt/typesense-server/ directory.
+    typesense_binary="/opt/typesense-server"
 else
     echo "Typesense server binary is unavailable in the pinned image" >&2
     exit 78

--- a/backend/tests/unit/test_jit_qa_cloud_run_contract.py
+++ b/backend/tests/unit/test_jit_qa_cloud_run_contract.py
@@ -468,6 +468,12 @@ def test_typesense_workflow_smokes_images_before_publish_and_has_unready_bootstr
     assert '"status": "not_qualified"' in text
     assert '"readiness_marker": "absent"' in text
     assert "group: jit-isolated-qa-cloud-run-development" in text
+    assert 'smoke_passed=0' in text
+    assert (
+        'docker inspect --format=\'status={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}\'' in text
+    )
+    assert 'docker logs --tail 200 "$smoke_name"' in text
+    assert 'smoke_passed=1' in text
 
 
 def test_bounded_proactivity_capability_is_required_on_qa_http_and_gateway_only():

--- a/backend/tests/unit/test_jit_qa_typesense_projection.py
+++ b/backend/tests/unit/test_jit_qa_typesense_projection.py
@@ -65,6 +65,8 @@ def test_typesense_entrypoint_keeps_api_key_out_of_process_arguments():
     entrypoint = (ROOT / "scripts" / "jit_qa_typesense_entrypoint.sh").read_text(encoding="utf-8")
     assert "TYPESENSE_API_KEY" in entrypoint
     assert "--api-key" not in entrypoint
+    assert 'elif [ -x /opt/typesense-server ]; then' in entrypoint
+    assert "/opt/typesense-server/typesense-server" not in entrypoint
 
 
 def test_runtime_environment_rejects_shared_data_plane_and_emulator():


### PR DESCRIPTION
## Problem
The pinned Typesense 27.1 image exposes `/opt/typesense-server` as its entrypoint, but the QA wrapper looked for `/opt/typesense-server/typesense-server`. The image exited before health, so the bootstrap workflow failed without container diagnostics.

## Change
- Resolve the pinned image's direct binary path.
- Emit failure-only, redacted container status and tail logs before cleanup.
- Add focused regression assertions for the path and diagnostics.

## Validation
- `backend/.venv/bin/python -m pytest -q backend/tests/unit/test_jit_qa_typesense_projection.py backend/tests/unit/test_jit_qa_cloud_run_contract.py` (47 passed)
- `sh -n backend/scripts/jit_qa_typesense_entrypoint.sh`
- `git diff --check`

Failure-Class: FC-image-build-tool-not-copied


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

