### PR TITLE
fix(backend): let dest release-probe uid through the Gemini plan gate

### DIFF
--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -37,7 +37,7 @@ from utils.observability.fallback import record_fallback
 from utils.observability.journeys import ClientJourneyAttempt
 from utils.managed_compute import Decision, authorize_managed_compute
 from utils.other.endpoints import get_current_user_uid
-from utils.subscription import is_desktop_trial_paywalled
+from utils.subscription import RELEASE_PROBE_UID, is_desktop_trial_paywalled
 
 router = APIRouter()
 
@@ -1645,6 +1645,12 @@ async def _enforce_managed_plan_gate(uid: str, path: str) -> None:
     except HTTPException:
         return
     if action not in _PLAN_GATED_PROXY_ACTIONS:
+        return
+    # Same exemption as enforce_chat_quota: dest's candidate probe signs in as
+    # this fixed non-human Free-plan UID to prove the Gemini provider path.
+    # Gating it 402s every desktop-backend auto-dev promotion (seen on
+    # 9cbe134a3c / #12839: `gemini_proxy: HTTP 402 (untyped)`).
+    if uid == RELEASE_PROBE_UID:
         return
     funding_owner = 'byok' if get_byok_key('gemini') else 'omi'
     decision = await run_blocking(

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -240,6 +240,44 @@ async def test_gemini_stream_proxy_rejects_basic_stream_generate(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_gemini_proxy_allows_the_release_probe_uid_through_the_plan_gate(monkeypatch):
+    """Dest candidate probe is Free-plan `omi-release-probe`; do not 402 it.
+
+    red-proof: drop the RELEASE_PROBE_UID early-return and this fails because
+    authorize_managed_compute is stubbed to deny, so the route 402s before
+    `_proxy` — the same class as desktop_backend_auto_dev #34017664510.
+    """
+    from fastapi.responses import Response
+
+    from utils.subscription import RELEASE_PROBE_UID
+
+    auth_calls = []
+    seen = []
+
+    def authorize(*_args, **_kwargs):
+        auth_calls.append(True)
+        return _decision(allowed=False, reason="basic_not_entitled")
+
+    async def fake_proxy(request, path, streaming, uid):
+        seen.append((path, streaming, uid))
+        return Response(b'{"ok":true}', media_type="application/json")
+
+    monkeypatch.setattr(desktop_proxy, "run_blocking", _passthrough_run_blocking)
+    monkeypatch.setattr(desktop_proxy, "authorize_managed_compute", authorize)
+    monkeypatch.setattr(desktop_proxy, "_proxy", fake_proxy)
+
+    response = await desktop_proxy.gemini_proxy(
+        make_request(),
+        "models/gemini-2.5-flash:generateContent",
+        RELEASE_PROBE_UID,
+    )
+
+    assert response.status_code == 200
+    assert auth_calls == []
+    assert seen == [("models/gemini-2.5-flash:generateContent", False, RELEASE_PROBE_UID)]
+
+
+@pytest.mark.asyncio
 async def test_gemini_proxy_allows_paid_generate_to_reach_the_provider(monkeypatch):
     from fastapi.responses import Response
 


### PR DESCRIPTION
## Fix dest desktop-backend auto-dev after S14

#12839 gated Gen-1 Gemini generate/stream for basic non-BYOK users. Dest's candidate probe signs in as the fixed Free-plan UID `omi-release-probe` and POSTs `generateContent` to prove the provider path. That run is now 402:

`desktop-backend candidate probe failed: gemini_proxy: HTTP 402 (untyped)` — [run 34017664510](https://github.com/BasedHardware/omi/actions/runs/34017664510) on `9cbe134a3c`.

Chat already exempts this UID in `enforce_chat_quota` (`RELEASE_PROBE_UID`) for the same reason: after 30 probe turns the gate 402'd itself. This PR applies that exemption to the S14 plan gate only.

### What changed

- `_enforce_managed_plan_gate` returns before `authorize_managed_compute` when `uid == RELEASE_PROBE_UID`.
- Ordinary basic users still 402 `plan_gated`. Paid / BYOK unchanged.

### Automatic-or-dead check

`test_gemini_proxy_allows_the_release_probe_uid_through_the_plan_gate`: authorize is stubbed to deny; the probe UID still reaches `_proxy`. Red-proof: drop the early-return and the test 402s — the dest failure class.

### Proof

- `test_gemini_proxy_rejects_basic_generate_with_structured_402` still 402s a normal basic uid.
- The new probe-uid test plus paid generate: 4 passed.

Live dest check: `desktop_backend_auto_dev` on this merge SHA must pass `Prove candidate chat compatibility` (Gemini 200 + admitted provider route). That is the dest proof S14 just blocked.

### Cut list

- Promoting the probe UID to a paid subscription in Firestore.
- Changing the dest probe to accept 402 (would lose the provider-path proof).
- Pixel-vs-text / embedContent / proactivity completions.

### Line-count ratchet

Line-Count-Exception: backend/routers/desktop_proxy.py | 1673 -> 1679 | dest release-probe UID exemption on the S14 generate gate; same constant chat already uses

### Product invariants

none

### Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

