### PR TITLE
Mobile chat: preserve mixed structured fallback content

### DIFF
--- a/app/lib/backend/schema/chat_content_block.dart
+++ b/app/lib/backend/schema/chat_content_block.dart
@@ -134,6 +134,9 @@ sealed class ChatContentBlock {
         );
       case 'agentCompletion':
       case 'agent_completion':
+        // Older persisted agent completions omitted status. The desktop
+        // codec preserves their historical completed default; explicit
+        // terminal values (including timed_out/orphaned) still pass through.
         return AgentCompletionContentBlock(
           id: id,
           sessionId: _string(raw, 'sessionId', 'session_id'),

--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -494,6 +494,21 @@ class ServerMessage {
     return body.isEmpty || _normalizeWhitespace(body) == _normalizeWhitespace(fallback);
   }
 
+  /// Returns the canonical body fallback for one raw block.
+  ///
+  /// A rich block can replace the ordinary message body on clients that know
+  /// how to render it. Unrecognised or display-only blocks still need their
+  /// synthesized line in that mode; otherwise a mixed turn silently loses
+  /// thinking, tool, citation, or future block content.
+  String? structuredFallbackTextForBlock(String blockId) {
+    for (final block in contentBlocks) {
+      if (block['id'] != blockId) continue;
+      final fallback = _blockFallbackText(block).trim();
+      return fallback.isEmpty ? null : fallback;
+    }
+    return null;
+  }
+
   static String _normalizeWhitespace(String value) {
     return value.split(RegExp(r'\s+')).where((part) => part.isNotEmpty).join(' ');
   }

--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -494,19 +494,15 @@ class ServerMessage {
     return body.isEmpty || _normalizeWhitespace(body) == _normalizeWhitespace(fallback);
   }
 
-  /// Returns the canonical body fallback for one raw block.
+  /// Returns the canonical body fallback for one raw wire block.
   ///
   /// A rich block can replace the ordinary message body on clients that know
   /// how to render it. Unrecognised or display-only blocks still need their
   /// synthesized line in that mode; otherwise a mixed turn silently loses
   /// thinking, tool, citation, or future block content.
-  String? structuredFallbackTextForBlock(String blockId) {
-    for (final block in contentBlocks) {
-      if (block['id'] != blockId) continue;
-      final fallback = _blockFallbackText(block).trim();
-      return fallback.isEmpty ? null : fallback;
-    }
-    return null;
+  String? structuredFallbackTextForRawBlock(Map<String, dynamic> block) {
+    final fallback = _blockFallbackText(block).trim();
+    return fallback.isEmpty ? null : fallback;
   }
 
   static String _normalizeWhitespace(String value) {
@@ -524,8 +520,11 @@ class ServerMessage {
   }
 
   static String _blockFallbackText(Map<String, dynamic> block) {
-    String value(String camel, [String? snake]) =>
-        ((block[camel] ?? (snake == null ? null : block[snake])) as String? ?? '').trim();
+    String value(String camel, [String? snake]) {
+      final candidate = block[camel] ?? (snake == null ? null : block[snake]);
+      return candidate is String ? candidate.trim() : '';
+    }
+
     String labelled(String label, Iterable<String> details) {
       final unique = details.where((detail) => detail.isNotEmpty).toSet().toList(growable: false);
       return unique.isEmpty ? label : '$label - ${unique.join(' - ')}';

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -288,25 +288,31 @@ Widget buildMessageWidget(
   bool showThinkingAfterText = false,
   Future<ServerConversation?> Function(String id)? fetchConversation,
 }) {
-  final contentBlocks = ChatContentBlockList.hasRenderableBlocks(message)
-      ? ChatContentBlockList(
-          message: message,
-          sendMessage: sendMessage,
-          fetchConversation: fetchConversation,
-        )
-      : null;
+  final hasRenderableBlocks = ChatContentBlockList.hasRenderableBlocks(message);
   // A message whose text is only the fallback synthesized from its blocks has
   // nothing to say that the components do not already show, so the components
-  // replace the body instead of repeating it.
-  final blocksReplaceBody = contentBlocks != null &&
+  // replace the body instead of repeating it. Keep this decision explicit for
+  // the block list: day summaries, memory citations, and the initial-options
+  // surface still render the normal body and must not render its text block a
+  // second time below it.
+  final blocksReplaceBody = hasRenderableBlocks &&
       message.memories.isEmpty &&
       message.type != MessageType.daySummary &&
       !displayOptions &&
       message.textIsStructuredFallback;
+  final contentBlocks = hasRenderableBlocks
+      ? ChatContentBlockList(
+          message: message,
+          sendMessage: sendMessage,
+          onAskOmi: onAskOmi,
+          renderStructuredFallbackText: blocksReplaceBody,
+          fetchConversation: fetchConversation,
+        )
+      : null;
 
   final Widget messageWidget;
   if (blocksReplaceBody) {
-    messageWidget = contentBlocks;
+    messageWidget = contentBlocks!;
   } else if (message.memories.isNotEmpty) {
     messageWidget = MemoriesMessageWidget(
       showTypingIndicator: showTypingIndicator,

--- a/app/lib/pages/chat/widgets/content_blocks/agent_run_blocks.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/agent_run_blocks.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:omi/backend/schema/chat_content_block.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 
 import 'chat_block_chrome.dart';
 
@@ -20,7 +21,7 @@ class AgentSpawnBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     return _AgentRunCard(
       icon: Icons.smart_toy_outlined,
-      label: 'Agent started',
+      label: context.l10n.processing,
       title: block.title,
       body: block.objective,
     );
@@ -32,18 +33,19 @@ class AgentCompletionBlock extends StatelessWidget {
 
   final AgentCompletionContentBlock block;
 
-  /// The runtime's status vocabulary is open, so anything that is not a known
-  /// terminal failure reads as a completed run rather than an invented state.
-  bool get _failed {
+  /// Only the explicit successful terminal states may present as completed.
+  /// New, timed-out, or orphaned states must remain visibly non-successful.
+  bool get _completed {
     final status = block.status.trim().toLowerCase();
-    return status == 'failed' || status == 'error' || status == 'cancelled';
+    return status == 'completed' || status == 'succeeded' || status == 'success';
   }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return _AgentRunCard(
-      icon: _failed ? Icons.error_outline : Icons.check_circle_outline,
-      label: _failed ? 'Agent stopped' : 'Agent completed',
+      icon: _completed ? Icons.check_circle_outline : Icons.error_outline,
+      label: _completed ? l10n.statusCompleted : l10n.statusFailed,
       title: block.title,
       body: block.output,
     );

--- a/app/lib/pages/chat/widgets/content_blocks/agent_run_blocks.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/agent_run_blocks.dart
@@ -43,9 +43,23 @@ class AgentCompletionBlock extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final status = block.status.trim().toLowerCase();
+    final completed = _completed;
+    final cancelled = status == 'cancelled' || status == 'canceled' || status == 'stopped';
+    final timedOut = status == 'timed_out' || status == 'timedout' || status == 'timeout';
     return _AgentRunCard(
-      icon: _completed ? Icons.check_circle_outline : Icons.error_outline,
-      label: _completed ? l10n.statusCompleted : l10n.statusFailed,
+      icon: completed
+          ? Icons.check_circle_outline
+          : cancelled
+              ? Icons.cancel_outlined
+              : Icons.error_outline,
+      label: completed
+          ? l10n.statusCompleted
+          : cancelled
+              ? l10n.cancelled
+              : timedOut
+                  ? l10n.statusTimedOut
+                  : l10n.statusFailed,
       title: block.title,
       body: block.output,
     );

--- a/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
@@ -15,10 +15,12 @@ import 'task_card_block.dart';
 /// Renders the interactable components for a message's `content_blocks`.
 ///
 /// Every block the desktop transcript draws as its own control has a component
-/// here, so a turn reads the same on both clients. text, thinking, toolCall,
-/// citation and unknown types are covered by the message body (or its
-/// synthesized fallback text) and deliberately render nothing extra — but they
-/// never hide the message.
+/// here, so a turn reads the same on both clients. Thinking, toolCall, citation
+/// and unknown types are covered by the message body (or its synthesized
+/// fallback text). A text block is rendered here only when the body is the
+/// fallback projection: that keeps prose from disappearing when the same
+/// projection also contains an interactive block, without repeating prose
+/// that already has a normal message body.
 class ChatContentBlockList extends StatelessWidget {
   const ChatContentBlockList({
     super.key,
@@ -69,6 +71,10 @@ class ChatContentBlockList extends StatelessWidget {
       case AgentCompletionContentBlock():
         return AgentCompletionBlock(block: block);
       case TextContentBlock():
+        if (message.textIsStructuredFallback && block.text.trim().isNotEmpty) {
+          return _StructuredFallbackText(text: block.text);
+        }
+        return null;
       case ThinkingContentBlock():
       case ToolCallContentBlock():
       case CitationContentBlock():
@@ -93,5 +99,16 @@ class ChatContentBlockList extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: children,
     );
+  }
+}
+
+class _StructuredFallbackText extends StatelessWidget {
+  const _StructuredFallbackText({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(text, style: Theme.of(context).textTheme.bodyMedium);
   }
 }

--- a/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
@@ -97,11 +97,28 @@ class ChatContentBlockList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final children = <Widget>[];
-    for (final block in message.typedContentBlocks) {
-      final widget = _build(block) ?? (renderStructuredFallbackText ? _fallbackTextWidget(block) : null);
-      if (widget == null) continue;
+    for (var index = 0; index < message.contentBlocks.length; index++) {
+      final rawBlock = message.contentBlocks[index];
+      // Walk the raw wire array instead of only the typed projection. The
+      // decoder intentionally drops malformed blocks, but the message body
+      // still contains their canonical fallback line. Keeping this pass raw
+      // prevents a mixed turn from losing that line beside a valid card.
+      final block = ChatContentBlock.tryDecode(rawBlock);
+      final fallback = renderStructuredFallbackText ? message.structuredFallbackTextForRawBlock(rawBlock) : null;
+      final fallbackKey =
+          rawBlock['id'] is String && (rawBlock['id'] as String).isNotEmpty ? rawBlock['id'] as String : '$index';
+      final widget = block == null ? null : _build(block);
+      final child = widget ??
+          (fallback == null
+              ? null
+              : _StructuredFallbackText(
+                  key: ValueKey('chat-block-fallback-$fallbackKey'),
+                  text: fallback,
+                  onAskOmi: onAskOmi,
+                ));
+      if (child == null) continue;
       if (children.isNotEmpty) children.add(const SizedBox(height: 8));
-      children.add(widget);
+      children.add(child);
     }
     if (children.isEmpty) return const SizedBox.shrink();
 
@@ -109,16 +126,6 @@ class ChatContentBlockList extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: children,
-    );
-  }
-
-  Widget? _fallbackTextWidget(ChatContentBlock block) {
-    final fallback = message.structuredFallbackTextForBlock(block.id);
-    if (fallback == null) return null;
-    return _StructuredFallbackText(
-      key: ValueKey('chat-block-fallback-${block.id}'),
-      text: fallback,
-      onAskOmi: onAskOmi,
     );
   }
 }
@@ -144,7 +151,13 @@ class _StructuredFallbackText extends StatelessWidget {
           selectedText: selectedText,
         );
       },
-      child: getMarkdownWidget(context, text, onAskOmi: onAskOmi),
+      child: SizedBox(
+        // SelectionArea + MarkdownBody otherwise use the text's minimum
+        // intrinsic width on iOS, collapsing fallback prose to one word per
+        // line. Keep this aligned with NormalMessageWidget.
+        width: double.infinity,
+        child: getMarkdownWidget(context, text, onAskOmi: onAskOmi),
+      ),
     );
   }
 }

--- a/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:omi/backend/schema/chat_content_block.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/pages/chat/widgets/markdown_message_widget.dart';
+import 'package:omi/widgets/text_selection_controls.dart';
 
 import 'agent_run_blocks.dart';
 import 'conversation_link_blocks.dart';
@@ -26,11 +28,15 @@ class ChatContentBlockList extends StatelessWidget {
     super.key,
     required this.message,
     required this.sendMessage,
+    this.onAskOmi,
+    this.renderStructuredFallbackText = false,
     this.fetchConversation,
   });
 
   final ServerMessage message;
   final void Function(String) sendMessage;
+  final Function(String)? onAskOmi;
+  final bool renderStructuredFallbackText;
   final Future<ServerConversation?> Function(String id)? fetchConversation;
 
   /// True when at least one block in [message] has an interactable component.
@@ -71,8 +77,12 @@ class ChatContentBlockList extends StatelessWidget {
       case AgentCompletionContentBlock():
         return AgentCompletionBlock(block: block);
       case TextContentBlock():
-        if (message.textIsStructuredFallback && block.text.trim().isNotEmpty) {
-          return _StructuredFallbackText(text: block.text);
+        if (renderStructuredFallbackText && block.text.trim().isNotEmpty) {
+          return _StructuredFallbackText(
+            key: ValueKey('chat-block-text-${block.id}'),
+            text: block.text,
+            onAskOmi: onAskOmi,
+          );
         }
         return null;
       case ThinkingContentBlock():
@@ -103,12 +113,27 @@ class ChatContentBlockList extends StatelessWidget {
 }
 
 class _StructuredFallbackText extends StatelessWidget {
-  const _StructuredFallbackText({required this.text});
+  const _StructuredFallbackText({super.key, required this.text, this.onAskOmi});
 
   final String text;
+  final Function(String)? onAskOmi;
 
   @override
   Widget build(BuildContext context) {
-    return Text(text, style: Theme.of(context).textTheme.bodyMedium);
+    String? selectedText;
+    return SelectionArea(
+      onSelectionChanged: (selectedContent) {
+        selectedText = selectedContent?.plainText;
+      },
+      contextMenuBuilder: (context, selectableRegionState) {
+        return omiSelectionMenuBuilder(
+          context,
+          selectableRegionState,
+          (selected) => onAskOmi?.call(selected),
+          selectedText: selectedText,
+        );
+      },
+      child: getMarkdownWidget(context, text, onAskOmi: onAskOmi),
+    );
   }
 }

--- a/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart
@@ -18,11 +18,12 @@ import 'task_card_block.dart';
 ///
 /// Every block the desktop transcript draws as its own control has a component
 /// here, so a turn reads the same on both clients. Thinking, toolCall, citation
-/// and unknown types are covered by the message body (or its synthesized
-/// fallback text). A text block is rendered here only when the body is the
-/// fallback projection: that keeps prose from disappearing when the same
-/// projection also contains an interactive block, without repeating prose
-/// that already has a normal message body.
+/// and unknown types use their synthesized fallback line only when this list
+/// replaces the body; with a normal body, that text is already covered there.
+/// A text block is rendered here only when the body is the fallback projection:
+/// that keeps prose from disappearing when the same projection also contains
+/// an interactive block, without repeating prose that already has a normal
+/// message body.
 class ChatContentBlockList extends StatelessWidget {
   const ChatContentBlockList({
     super.key,
@@ -97,7 +98,7 @@ class ChatContentBlockList extends StatelessWidget {
   Widget build(BuildContext context) {
     final children = <Widget>[];
     for (final block in message.typedContentBlocks) {
-      final widget = _build(block);
+      final widget = _build(block) ?? (renderStructuredFallbackText ? _fallbackTextWidget(block) : null);
       if (widget == null) continue;
       if (children.isNotEmpty) children.add(const SizedBox(height: 8));
       children.add(widget);
@@ -108,6 +109,16 @@ class ChatContentBlockList extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: children,
+    );
+  }
+
+  Widget? _fallbackTextWidget(ChatContentBlock block) {
+    final fallback = message.structuredFallbackTextForBlock(block.id);
+    if (fallback == null) return null;
+    return _StructuredFallbackText(
+      key: ValueKey('chat-block-fallback-${block.id}'),
+      text: fallback,
+      onAskOmi: onAskOmi,
     );
   }
 }

--- a/app/lib/pages/chat/widgets/content_blocks/memory_link_block.dart
+++ b/app/lib/pages/chat/widgets/content_blocks/memory_link_block.dart
@@ -13,17 +13,55 @@ import 'chat_block_chrome.dart';
 ///
 /// Memories are loaded as a list, so the block resolves the id against
 /// [MemoriesProvider] and opens the existing memory sheet. An id that is not in
-/// the loaded list renders the unavailable state.
-class MemoryLinkBlock extends StatelessWidget {
+/// the loaded list renders a loading state while a cold chat asks the provider
+/// for its first coalesced load, then becomes unavailable only after that load
+/// settles without the row.
+class MemoryLinkBlock extends StatefulWidget {
   const MemoryLinkBlock({super.key, required this.block});
 
   final MemoryLinkContentBlock block;
 
+  @override
+  State<MemoryLinkBlock> createState() => _MemoryLinkBlockState();
+}
+
+class _MemoryLinkBlockState extends State<MemoryLinkBlock> {
+  bool _hydrationRequested = false;
+
   Memory? _resolve(MemoriesProvider provider) {
     for (final memory in provider.memories) {
-      if (memory.id == block.memoryId) return memory;
+      if (memory.id == widget.block.memoryId) return memory;
     }
     return null;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleHydration();
+  }
+
+  @override
+  void didUpdateWidget(covariant MemoryLinkBlock oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.block.memoryId != widget.block.memoryId) {
+      _hydrationRequested = false;
+      _scheduleHydration();
+    }
+  }
+
+  void _scheduleHydration() {
+    // Chat can be the first memory surface in a fresh session. Hydrate this
+    // shared provider after the first frame so build stays pure; its own
+    // coalescing makes simultaneous memory links and the Memories page share
+    // one request.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _hydrationRequested) return;
+      final provider = context.read<MemoriesProvider>();
+      if (provider.hasLoaded) return;
+      _hydrationRequested = true;
+      provider.loadMemories();
+    });
   }
 
   @override
@@ -34,7 +72,7 @@ class MemoryLinkBlock extends StatelessWidget {
         final memory = _resolve(provider);
         if (memory == null && !provider.loading) {
           return ChatBlockUnavailable(
-            key: Key('chat-block-memoryLink-${block.id}-unavailable'),
+            key: Key('chat-block-memoryLink-${widget.block.id}-unavailable'),
             icon: Icons.psychology_outlined,
             label: l10n.chatBlockMemory,
             message: l10n.chatBlockUnavailable,
@@ -42,12 +80,12 @@ class MemoryLinkBlock extends StatelessWidget {
         }
 
         return ChatBlockLinkCard(
-          key: Key('chat-block-memoryLink-${block.id}'),
+          key: Key('chat-block-memoryLink-${widget.block.id}'),
           icon: Icons.psychology_outlined,
           label: l10n.chatBlockMemory,
-          summary: block.summary,
+          summary: widget.block.summary,
           actionTitle: l10n.chatBlockOpenInMemories,
-          actionKey: Key('chat-block-memoryLink-${block.id}-open'),
+          actionKey: Key('chat-block-memoryLink-${widget.block.id}-open'),
           isOpening: memory == null,
           onAction: memory == null ? null : () => showMemoryDialog(context, provider, memory: memory),
         );

--- a/app/test/unit/chat_content_block_decode_test.dart
+++ b/app/test/unit/chat_content_block_decode_test.dart
@@ -82,7 +82,12 @@ void main() {
         decode({'type': 'agentSpawn', 'id': 'b6', 'sessionId': 's1', 'runId': 'r1'}),
         isA<AgentSpawnContentBlock>(),
       );
-      expect(decode({'type': 'agentCompletion', 'id': 'b7'}), isA<AgentCompletionContentBlock>());
+      final legacyCompletion = decode({'type': 'agentCompletion', 'id': 'b7'}) as AgentCompletionContentBlock;
+      expect(legacyCompletion, isA<AgentCompletionContentBlock>());
+      // The desktop codec uses the same default for historical blocks that
+      // predate the persisted status field. Explicit timeout/orphan statuses
+      // are tested by the widget contract and must not take this path.
+      expect(legacyCompletion.status, 'completed');
     });
   });
 

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -68,6 +68,7 @@ void main() {
     bool preloadMemories = true,
     VoidCallback? onFetchMemories,
     bool displayOptions = false,
+    double? messageWidth,
   }) async {
     final conversationProvider = ConversationProvider(isSignedIn: () => false);
     addTearDown(conversationProvider.dispose);
@@ -84,6 +85,13 @@ void main() {
     addTearDown(memoriesProvider.dispose);
     if (preloadMemories) await memoriesProvider.loadMemories();
 
+    final messageWidget = AIMessage(
+      message: message,
+      sendMessage: sendMessage ?? (_) {},
+      displayOptions: displayOptions,
+      updateConversation: (_) {},
+      setMessageNps: (int value, {String? reason}) {},
+    );
     await tester.pumpWidget(
       MultiProvider(
         providers: [
@@ -97,13 +105,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SingleChildScrollView(
-              child: AIMessage(
-                message: message,
-                sendMessage: sendMessage ?? (_) {},
-                displayOptions: displayOptions,
-                updateConversation: (_) {},
-                setMessageNps: (int value, {String? reason}) {},
-              ),
+              child: messageWidth == null ? messageWidget : SizedBox(width: messageWidth, child: messageWidget),
             ),
           ),
         ),
@@ -196,6 +198,56 @@ void main() {
     expect(find.byKey(const ValueKey('chat-block-fallback-block-citation')), findsOneWidget);
     expect(find.byKey(const ValueKey('chat-block-fallback-block-unknown')), findsOneWidget);
     expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
+  });
+
+  testWidgets('keeps a malformed raw block fallback beside a valid card', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          // Missing id and wrong field types make this block intentionally
+          // undecodable; its canonical raw fallback must still be visible.
+          {
+            'type': 'toolCall',
+            'name': 42,
+            'output': {'unexpected': true}
+          },
+          {
+            'type': 'conversationLink',
+            'id': 'block-conversation',
+            'conversationId': 'conversation-1',
+            'summary': 'Weekly planning',
+          },
+        ],
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('chat-block-fallback-0')), findsOneWidget);
+    expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
+  });
+
+  testWidgets('structured fallback markdown fills the available message width', (tester) async {
+    await pumpMessage(
+      tester,
+      messageWidth: 320,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {'type': 'thinking', 'id': 'block-thinking', 'text': 'Checking the latest notes.'},
+          {
+            'type': 'conversationLink',
+            'id': 'block-conversation',
+            'conversationId': 'conversation-1',
+            'summary': 'Weekly planning',
+          },
+        ],
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(const ValueKey('chat-block-fallback-block-thinking'))).width, 320);
   });
 
   testWidgets('does not duplicate fallback prose in a day summary', (tester) async {
@@ -299,6 +351,37 @@ void main() {
     expect(find.text('Failed'), findsOneWidget);
     expect(find.byIcon(Icons.error_outline), findsOneWidget);
     expect(find.byIcon(Icons.check_circle_outline), findsNothing);
+  });
+
+  testWidgets('cancelled and timed-out agent states use their localized labels', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {
+            'type': 'agentCompletion',
+            'id': 'block-cancelled',
+            'title': 'Cancelled run',
+            'output': 'The run was stopped.',
+            'status': 'stopped',
+          },
+          {
+            'type': 'agentCompletion',
+            'id': 'block-timeout',
+            'title': 'Timed out run',
+            'output': 'The run timed out.',
+            'status': 'timed_out',
+          },
+        ],
+      ),
+    );
+
+    expect(find.text('Cancelled'), findsOneWidget);
+    expect(find.text('Timed out'), findsOneWidget);
+    expect(find.byIcon(Icons.cancel_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
   });
 
   testWidgets('a day summary carrying a memoryReviewCard renders the review rows', (tester) async {

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -158,6 +158,46 @@ void main() {
     expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
   });
 
+  testWidgets('keeps synthesized lines beside cards in a structured fallback', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {'type': 'thinking', 'id': 'block-thinking', 'text': 'Checking the latest notes.'},
+          {
+            'type': 'toolCall',
+            'id': 'block-tool',
+            'name': 'search_knowledge',
+            'output': 'Found 3 matching notes.',
+          },
+          {
+            'type': 'citation',
+            'id': 'block-citation',
+            'ordinal': 0,
+            'kind': 'conversation',
+            'sourceId': 'conversation-1',
+            'title': 'Weekly planning',
+          },
+          {'type': 'futureBlock', 'id': 'block-unknown', 'title': 'A future card'},
+          {
+            'type': 'conversationLink',
+            'id': 'block-conversation',
+            'conversationId': 'conversation-1',
+            'summary': 'Weekly planning',
+          },
+        ],
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('chat-block-fallback-block-thinking')), findsOneWidget);
+    expect(find.byKey(const ValueKey('chat-block-fallback-block-tool')), findsOneWidget);
+    expect(find.byKey(const ValueKey('chat-block-fallback-block-citation')), findsOneWidget);
+    expect(find.byKey(const ValueKey('chat-block-fallback-block-unknown')), findsOneWidget);
+    expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
+  });
+
   testWidgets('does not duplicate fallback prose in a day summary', (tester) async {
     final message = _decodedAiMessage(
       text: '',

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -67,6 +67,7 @@ void main() {
     List<Memory> memories = const [],
     bool preloadMemories = true,
     VoidCallback? onFetchMemories,
+    bool displayOptions = false,
   }) async {
     final conversationProvider = ConversationProvider(isSignedIn: () => false);
     addTearDown(conversationProvider.dispose);
@@ -99,7 +100,7 @@ void main() {
               child: AIMessage(
                 message: message,
                 sendMessage: sendMessage ?? (_) {},
-                displayOptions: false,
+                displayOptions: displayOptions,
                 updateConversation: (_) {},
                 setMessageNps: (int value, {String? reason}) {},
               ),
@@ -153,8 +154,55 @@ void main() {
       ),
     );
 
-    expect(find.text('The deadline is Friday.'), findsOneWidget);
+    expect(find.byKey(const ValueKey('chat-block-text-block-text')), findsOneWidget);
     expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
+  });
+
+  testWidgets('does not duplicate fallback prose in a day summary', (tester) async {
+    final message = _decodedAiMessage(
+      text: '',
+      type: 'day_summary',
+      contentBlocks: const [
+        {'type': 'text', 'id': 'block-text', 'text': 'The deadline is Friday.'},
+        {
+          'type': 'conversationLink',
+          'id': 'block-conversation',
+          'conversationId': 'conversation-1',
+          'summary': 'Weekly planning',
+        },
+      ],
+    );
+    expect(message.text, contains('The deadline is Friday.'));
+    await pumpMessage(
+      tester,
+      message: message,
+    );
+
+    expect(find.byKey(const ValueKey('chat-block-text-block-text')), findsNothing);
+  });
+
+  testWidgets('does not duplicate fallback prose in initial options', (tester) async {
+    final message = _decodedAiMessage(
+      text: '',
+      type: 'text',
+      contentBlocks: const [
+        {'type': 'text', 'id': 'block-text', 'text': 'The deadline is Friday.'},
+        {
+          'type': 'conversationLink',
+          'id': 'block-conversation',
+          'conversationId': 'conversation-1',
+          'summary': 'Weekly planning',
+        },
+      ],
+    );
+    expect(message.text, contains('The deadline is Friday.'));
+    await pumpMessage(
+      tester,
+      displayOptions: true,
+      message: message,
+    );
+
+    expect(find.byKey(const ValueKey('chat-block-text-block-text')), findsNothing);
   });
 
   testWidgets('cold memory links hydrate before the Memories page is opened', (tester) async {

--- a/app/test/widgets/chat_content_block_test.dart
+++ b/app/test/widgets/chat_content_block_test.dart
@@ -65,19 +65,23 @@ void main() {
     required ServerMessage message,
     void Function(String)? sendMessage,
     List<Memory> memories = const [],
+    bool preloadMemories = true,
+    VoidCallback? onFetchMemories,
   }) async {
     final conversationProvider = ConversationProvider(isSignedIn: () => false);
     addTearDown(conversationProvider.dispose);
     final memoriesProvider = MemoriesProvider(
-      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async =>
-          GetMemoriesResult(memories, true),
+      fetchMemoriesRequest: ({int limit = 100, int offset = 0, bool thisDeviceOnly = false}) async {
+        onFetchMemories?.call();
+        return GetMemoriesResult(memories, true);
+      },
       fetchLedgerHistoryRequest: ({int limit = 500, int offset = 0}) async =>
           const GetLedgerHistoryResult([], supported: true),
       reviewMemoryRequest: (id, value) async => true,
       editMemoryRequest: (id, value) async => const EditMemoryResult(persisted: true),
     );
     addTearDown(memoriesProvider.dispose);
-    await memoriesProvider.loadMemories();
+    if (preloadMemories) await memoriesProvider.loadMemories();
 
     await tester.pumpWidget(
       MultiProvider(
@@ -129,6 +133,84 @@ void main() {
     await tester.pump();
 
     expect(sent, ['Want the rest of what she said?']);
+  });
+
+  testWidgets('keeps prose text blocks beside cards in a structured fallback', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {'type': 'text', 'id': 'block-text', 'text': 'The deadline is Friday.'},
+          {
+            'type': 'conversationLink',
+            'id': 'block-conversation',
+            'conversationId': 'conversation-1',
+            'summary': 'Weekly planning',
+          },
+        ],
+      ),
+    );
+
+    expect(find.text('The deadline is Friday.'), findsOneWidget);
+    expect(find.byKey(const Key('chat-block-conversationLink-block-conversation')), findsOneWidget);
+  });
+
+  testWidgets('cold memory links hydrate before the Memories page is opened', (tester) async {
+    var fetches = 0;
+    final memory = Memory(
+      id: 'memory-cold',
+      uid: 'chat-block-user',
+      content: 'A cold-chat memory',
+      category: MemoryCategory.manual,
+      createdAt: DateTime(2026, 9, 1),
+      updatedAt: DateTime(2026, 9, 1),
+      visibility: MemoryVisibility.private,
+    );
+    await pumpMessage(
+      tester,
+      preloadMemories: false,
+      onFetchMemories: () => fetches++,
+      memories: [memory],
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {'type': 'memoryLink', 'id': 'block-memory', 'memoryId': 'memory-cold', 'summary': 'A cold-chat memory'},
+        ],
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(fetches, 1);
+    expect(find.byKey(const Key('chat-block-memoryLink-block-memory-open')), findsOneWidget);
+  });
+
+  testWidgets('unknown agent terminal states do not render as completed', (tester) async {
+    await pumpMessage(
+      tester,
+      message: _decodedAiMessage(
+        text: '',
+        type: 'text',
+        contentBlocks: const [
+          {
+            'type': 'agentCompletion',
+            'id': 'block-agent',
+            'runId': 'run-1',
+            'sessionId': 'session-1',
+            'title': 'Run the report',
+            'output': 'The run was orphaned.',
+            'status': 'orphaned',
+          },
+        ],
+      ),
+    );
+
+    expect(find.text('Failed'), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle_outline), findsNothing);
   });
 
   testWidgets('a day summary carrying a memoryReviewCard renders the review rows', (tester) async {

--- a/app/test/widgets/chat_content_blocks_test.dart
+++ b/app/test/widgets/chat_content_blocks_test.dart
@@ -70,6 +70,9 @@ class _StubMemoriesProvider extends MemoriesProvider {
 
   @override
   bool get loading => false;
+
+  @override
+  Future<void> loadMemories({int limit = 100}) async {}
 }
 
 class _StubGoalsProvider extends GoalsProvider {


### PR DESCRIPTION
## Summary

Mobile chat preserves canonical fallback lines for every raw structured block when an interactive card replaces the ordinary message body. The renderer now walks the original wire array so malformed blocks dropped by typed decoding still show their canonical fallback beside valid cards, and malformed field types cannot crash fallback synthesis. Day summaries and initial options continue rendering their normal body without duplicate prose.

Structured fallback Markdown is forced to the available message width, matching the existing iOS chat layout fix. Agent completion cards keep unknown/orphaned states visibly non-successful and now use existing localized labels for cancelled/stopped and timed-out states.

## Validation

- `flutter test test/widgets/chat_content_block_test.dart test/unit/server_message_content_blocks_test.dart test/unit/chat_content_block_decode_test.dart` (33 tests passed)
- `flutter test test/widgets/chat_scroll_layout_test.dart` (5 tests passed)
- `bash app/scripts/analyze_ratchet.sh` (passed)
- `flutter analyze lib/pages/chat/widgets/content_blocks/agent_run_blocks.dart lib/backend/schema/message.dart lib/pages/chat/widgets/content_blocks/chat_content_block_list.dart test/widgets/chat_content_block_test.dart` (no issues)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
