### PR TITLE
fix(backend): stop memory-maintenance when Flex budget is exhausted

### DIFF
--- a/.github/failure-classes/FC-flex-budget-stop-swallowed.json
+++ b/.github/failure-classes/FC-flex-budget-stop-swallowed.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-flex-budget-stop-swallowed",
+  "violated_contract": "When Flex can no longer fit a reservation in the one-hour memory-maintenance budget, the current UID must stop after the deferred batch is recorded and the cron page must leave the durable registry cursor on that unfinished UID. Swallowing PromotionFlexDeferred as a per-item continue lets the job scan the rest of the 400-user page until Cloud Run kills it at 3600s (Completed=False, exit 0).",
+  "canonical_prevention": "Re-raise PromotionFlexDeferred after recording the deferred batch and releasing leases without spending the quality-retry budget. Keep the cron's existing page-stop and cursor contract. Prove a later consolidation batch on the same UID is not entered.",
+  "canonical_prevention_artifact": [
+    "backend/utils/memory/canonical_consolidation.py",
+    "backend/tests/unit/test_canonical_consolidation.py",
+    "backend/tests/unit/test_canonical_short_term_maintenance_cron.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/utils/memory/canonical_consolidation.py",
+    "backend/utils/memory/canonical_short_term_maintenance_cron.py",
+    "backend/modal/memory_maintenance_job.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_canonical_consolidation.py
+++ b/backend/tests/unit/test_canonical_consolidation.py
@@ -1716,8 +1716,9 @@ def test_run_consolidation_defers_flex_unavailability_without_applying_or_spendi
             return_value=_context([item]),
         ),
         patch("utils.memory.canonical_consolidation.apply_consolidation_decision") as apply_route,
+        pytest.raises(PromotionFlexDeferred, match="RateLimitError"),
     ):
-        report = run_canonical_consolidation(
+        run_canonical_consolidation(
             UID,
             db_client=db,
             run_id="flex-deferred",
@@ -1730,9 +1731,48 @@ def test_run_consolidation_defers_flex_unavailability_without_applying_or_spendi
     assert state is not None
     assert state.attempt_count == 0
     assert state.status == "retryable"
-    assert report.retryable_memory_ids == [item.memory_id]
-    assert report.watermark_blocked is True
     apply_route.assert_not_called()
+
+
+def test_run_consolidation_stops_the_uid_after_flex_deferral(monkeypatch):
+    from utils.memory.promotion_flex import PromotionFlexDeferred
+
+    first = _item("mem_flex_first", "First batch is deferred")
+    second = _item("mem_flex_second", "Second batch must not run")
+    control = MemoryControlState(uid=UID, head_commit_id="head0", account_generation=1, source_generation=1)
+    db = _FakeDb({f"users/{UID}/memory_state/apply_control": control.model_dump(mode="python")})
+    gathered_ids: list[str] = []
+
+    def defer(_prompt):
+        raise PromotionFlexDeferred("job_budget")
+
+    def gather(uid, pending_items, **_kwargs):
+        gathered_ids.extend(item.memory_id for item in pending_items)
+        return _context(pending_items)
+
+    monkeypatch.setenv("MEMORY_CANONICAL_CONSOLIDATION_BATCH_CAP", "1")
+    with (
+        patch(
+            "utils.memory.canonical_consolidation.list_pending_consolidation_items",
+            return_value=[first, second],
+        ),
+        patch(
+            "utils.memory.canonical_consolidation.gather_consolidation_candidates",
+            side_effect=gather,
+        ),
+        pytest.raises(PromotionFlexDeferred, match="job_budget"),
+    ):
+        run_canonical_consolidation(
+            UID,
+            db_client=db,
+            run_id="flex-stop-page",
+            now=NOW,
+            llm_invoke=defer,
+            attempt_lease_seconds=1_200,
+        )
+
+    assert gathered_ids == [first.memory_id]
+    assert consolidation._read_retry_state(UID, second, db_client=db) is None
 
 
 def test_new_revision_does_not_inherit_old_revision_quarantine():

--- a/backend/utils/memory/canonical_consolidation.py
+++ b/backend/utils/memory/canonical_consolidation.py
@@ -2114,9 +2114,6 @@ def run_canonical_consolidation(
                 now=current_time,
                 db_client=client,
             )
-            # Cron stops the page and leaves the registry cursor on this UID.
-            # Continuing here scanned the rest of the 400-user hour after Flex
-            # budget was already exhausted (dest timeout-kill class).
             raise
         batches_run += 1
         pending_by_id = {item.memory_id: item for item in llm_pending_batch}

--- a/backend/utils/memory/canonical_consolidation.py
+++ b/backend/utils/memory/canonical_consolidation.py
@@ -2114,8 +2114,10 @@ def run_canonical_consolidation(
                 now=current_time,
                 db_client=client,
             )
-            offset += effective_batch_cap
-            continue
+            # Cron stops the page and leaves the registry cursor on this UID.
+            # Continuing here scanned the rest of the 400-user hour after Flex
+            # budget was already exhausted (dest timeout-kill class).
+            raise
         batches_run += 1
         pending_by_id = {item.memory_id: item for item in llm_pending_batch}
 
@@ -2177,8 +2179,7 @@ def run_canonical_consolidation(
                     now=current_time,
                     db_client=client,
                 )
-                offset += effective_batch_cap
-                continue
+                raise
 
         for signal in agent_batch.recurrence_signals:
             recurrence_signals_by_id[signal.stable_loop_key] = signal


### PR DESCRIPTION
## Stop dest memory-maintenance timeout-kill

Dest `memory-maintenance-job` has been killed at the 3600s Cloud Run wall for ~20 days (`Completed=False`, exit 0). The cron already stops the 400-UID page when `PromotionFlexDeferred` is raised and leaves the registry cursor on the unfinished UID (`ARCHITECTURE.md`, `test_flex_deferral_stops_the_page_without_advancing_past_the_uid`).

Consolidation swallowed that exception: it recorded the deferred batch, then continued remaining batches and returned a report. Dest logs show a flood of per-memory `flex_deferred` at ~40 minutes, then the job keeps scanning until Cloud Run kills it. The legacy 250-user frame-retention safety pass is **not** the hour sink (~25s before cron start). Dest still has no independent `frame-request-retention-job`, so the healthy-flag flip remains closed.

This PR re-raises after the deferred batch is recorded (leases released, quality-retry budget unspent) so the cron contract can fire and the job exits 0 before the wall.

### What changed

- `run_canonical_consolidation` re-raises `PromotionFlexDeferred` / `PromotionFlexControlChanged` after `_record_deferred_batch_failure`.
- Same stop after a Flex control-changed `result_guard`.
- Tests: durable retry state still recorded; a later batch on the same UID is not gathered.

### Automatic-or-dead check

`test_run_consolidation_stops_the_uid_after_flex_deferral`: batch cap 1, two pending items, `job_budget` on the first invoke. The second item is never gathered or claimed. Red-proof: restore the `continue` and the second item is entered.

### Proof

- `test_run_consolidation_defers_flex_unavailability_without_applying_or_spending_attempt` still records retryable/unspent attempts, now via the raised exception.
- `test_flex_deferral_stops_the_page_without_advancing_past_the_uid` still leaves the cursor on the prior UID.
- Focused pytest: 4 passed.

Live dest check: after `gcp_memory_maintenance_job_auto_dev` on this merge SHA, a dest execution must reach `canonical_short_term_maintenance_cron: done` with `flex_deferred=True` (or finish the page) and `Completed=True` inside 3600s.

### Cut list

- Flipping `FRAME_REQUEST_RETENTION_INDEPENDENT_HEALTHY` (independent job is not deployed on dest).
- Dispatching prod `memory-maintenance-job` (workflow_dispatch only).
- Deploying `frame-request-retention-job` or changing its overlay contract.
- JIT ledger-drain / daily-sweep / Typesense.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

This change does not admit new intake, invent tiers, or add a promotion pass. It only stops a Flex-budget deferral from continuing remaining consolidation batches so the existing one-route-per-item cron can persist its cursor.

### Failure class

Failure-Class: new

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

