### PR TITLE
fix(qa): normalize Typesense API key bytes

### DIFF
--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -146,7 +146,22 @@ jobs:
 
           smoke_name="jit-qa-typesense-smoke-${GITHUB_RUN_ID}"
           smoke_port=18108
-          smoke_key="jit-qa-typesense-local-smoke-key"
+          smoke_key="$(printf 'a%.0s' {1..64})"
+          smoke_key_raw="$RUNNER_TEMP/typesense-smoke-key.raw"
+          smoke_key_normalized="$RUNNER_TEMP/typesense-smoke-key.normalized"
+          smoke_env="$RUNNER_TEMP/typesense-smoke.env"
+          printf '%s\n' "$smoke_key" > "$smoke_key_raw"
+          smoke_shape="$(python3 backend/scripts/jit_qa_typesense_key_shape.py \
+            --normalize-file "$smoke_key_raw" --output "$smoke_key_normalized")"
+          [[ "$smoke_shape" == "legacy_trailing_lf" ]] || {
+            echo "Typesense auth smoke did not exercise the legacy newline shape" >&2
+            exit 1
+          }
+          {
+            printf 'TYPESENSE_API_KEY='
+            cat "$smoke_key_normalized"
+            printf '\nTYPESENSE_DATA_DIR=/tmp/typesense\n'
+          } > "$smoke_env"
           smoke_passed=0
           cleanup_smoke() {
             if [[ "$smoke_passed" != 1 ]] && docker inspect "$smoke_name" >/dev/null 2>&1; then
@@ -158,7 +173,7 @@ jobs:
           }
           trap cleanup_smoke EXIT
           docker run --detach --name "$smoke_name" --publish "$smoke_port:8080" \
-            --env "TYPESENSE_API_KEY=$smoke_key" --env TYPESENSE_DATA_DIR=/tmp/typesense "$typesense_tag" >/dev/null
+            --env-file "$smoke_env" "$typesense_tag" >/dev/null
           smoke_url="http://127.0.0.1:${smoke_port}"
           for attempt in {1..30}; do
             if curl --fail --silent --show-error "$smoke_url/health" | grep -q '"ok":true'; then
@@ -240,7 +255,12 @@ jobs:
             gcloud secrets create "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" \
               --replication-policy=user-managed --locations="$QA_REGION" \
               --labels=managed-by=github-actions,jit-qa=true --quiet
-            openssl rand -hex 32 | gcloud secrets versions add "$QA_TYPESENSE_SECRET" \
+            # Secret Manager preserves stdin bytes. Normalize the newline that
+            # openssl emits before storing the first admin key, otherwise the
+            # server receives a different key from the request-side probes.
+            openssl rand -hex 32 \
+              | python3 backend/scripts/jit_qa_typesense_key_shape.py --normalize-stdin \
+              | gcloud secrets versions add "$QA_TYPESENSE_SECRET" \
               --project "$QA_PROJECT" --data-file=- >/dev/null
           else
             metadata="$RUNNER_TEMP/typesense-secret.json"
@@ -254,6 +274,33 @@ jobs:
           PY
             state="$(gcloud secrets versions describe latest --secret "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" --format='value(state)')"
             [[ "$state" == "ENABLED" ]] || { echo "dedicated Typesense key has no enabled latest version" >&2; exit 1; }
+            key_dir="$RUNNER_TEMP/jit-qa-typesense-key"
+            install -d -m 700 "$key_dir"
+            raw_key="$key_dir/raw"
+            normalized_key="$key_dir/normalized"
+            umask 077
+            gcloud secrets versions access latest --secret "$QA_TYPESENSE_SECRET" \
+              --project "$QA_PROJECT" --out-file="$raw_key"
+            chmod 600 "$raw_key"
+            set +e
+            key_shape="$(python3 backend/scripts/jit_qa_typesense_key_shape.py \
+              --normalize-file "$raw_key" --output "$normalized_key")"
+            key_shape_status=$?
+            set -e
+            case "$key_shape_status:$key_shape" in
+              0:valid)
+                ;;
+              2:legacy_trailing_lf)
+                # Repair only the exact historical pipe-generated shape. Any
+                # other bytes fail closed rather than guessing at a credential.
+                gcloud secrets versions add "$QA_TYPESENSE_SECRET" \
+                  --project "$QA_PROJECT" --data-file="$normalized_key" >/dev/null
+                ;;
+              *)
+                echo "dedicated Typesense key has an unexpected byte shape" >&2
+                exit 1
+                ;;
+            esac
           fi
           gcloud secrets add-iam-policy-binding "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" \
             --member="serviceAccount:${QA_RUNTIME_SERVICE_ACCOUNT}" --role=roles/secretmanager.secretAccessor \

--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -150,6 +150,18 @@ jobs:
           smoke_key_raw="$RUNNER_TEMP/typesense-smoke-key.raw"
           smoke_key_normalized="$RUNNER_TEMP/typesense-smoke-key.normalized"
           smoke_env="$RUNNER_TEMP/typesense-smoke.env"
+          umask 077
+          smoke_passed=0
+          cleanup_smoke() {
+            if [[ "$smoke_passed" != 1 ]] && docker inspect "$smoke_name" >/dev/null 2>&1; then
+              echo "Typesense smoke container diagnostics:" >&2
+              docker inspect --format='status={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' "$smoke_name" >&2 || true
+              docker logs --tail 200 "$smoke_name" 2>&1 | sed "s/${smoke_key}/[redacted]/g" >&2 || true
+            fi
+            docker rm -f "$smoke_name" >/dev/null 2>&1 || true
+            rm -f "$smoke_key_raw" "$smoke_key_normalized" "$smoke_env"
+          }
+          trap cleanup_smoke EXIT
           printf '%s\n' "$smoke_key" > "$smoke_key_raw"
           # The helper intentionally returns 2 for the one repairable legacy
           # shape. Capture that status explicitly: set -e must not turn a
@@ -172,16 +184,6 @@ jobs:
             cat "$smoke_key_normalized"
             printf '\nTYPESENSE_DATA_DIR=/tmp/typesense\n'
           } > "$smoke_env"
-          smoke_passed=0
-          cleanup_smoke() {
-            if [[ "$smoke_passed" != 1 ]] && docker inspect "$smoke_name" >/dev/null 2>&1; then
-              echo "Typesense smoke container diagnostics:" >&2
-              docker inspect --format='status={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' "$smoke_name" >&2 || true
-              docker logs --tail 200 "$smoke_name" 2>&1 | sed "s/${smoke_key}/[redacted]/g" >&2 || true
-            fi
-            docker rm -f "$smoke_name" >/dev/null 2>&1 || true
-          }
-          trap cleanup_smoke EXIT
           docker run --detach --name "$smoke_name" --publish "$smoke_port:8080" \
             --env-file "$smoke_env" "$typesense_tag" >/dev/null
           smoke_url="http://127.0.0.1:${smoke_port}"

--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -151,12 +151,22 @@ jobs:
           smoke_key_normalized="$RUNNER_TEMP/typesense-smoke-key.normalized"
           smoke_env="$RUNNER_TEMP/typesense-smoke.env"
           printf '%s\n' "$smoke_key" > "$smoke_key_raw"
+          # The helper intentionally returns 2 for the one repairable legacy
+          # shape. Capture that status explicitly: set -e must not turn a
+          # validated repair into an early smoke-step failure.
+          set +e
           smoke_shape="$(python3 backend/scripts/jit_qa_typesense_key_shape.py \
             --normalize-file "$smoke_key_raw" --output "$smoke_key_normalized")"
-          [[ "$smoke_shape" == "legacy_trailing_lf" ]] || {
-            echo "Typesense auth smoke did not exercise the legacy newline shape" >&2
-            exit 1
-          }
+          smoke_shape_status=$?
+          set -e
+          case "$smoke_shape_status:$smoke_shape" in
+            2:legacy_trailing_lf)
+              ;;
+            *)
+              echo "Typesense auth smoke did not exercise the legacy newline shape" >&2
+              exit 1
+              ;;
+          esac
           {
             printf 'TYPESENSE_API_KEY='
             cat "$smoke_key_normalized"
@@ -251,17 +261,39 @@ jobs:
       - name: Create or verify the dedicated QA Typesense key secret
         run: |
           set -euo pipefail
+          key_dir="$RUNNER_TEMP/jit-qa-typesense-key"
+          install -d -m 700 "$key_dir"
+          raw_key="$key_dir/raw"
+          normalized_key="$key_dir/normalized"
+          umask 077
+          cleanup_key_material() {
+            rm -f "$raw_key" "$normalized_key"
+            rmdir "$key_dir" 2>/dev/null || true
+          }
+          trap cleanup_key_material EXIT
           if ! gcloud secrets describe "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" >/dev/null 2>&1; then
+            # Stage and validate the exact bytes before mutating Secret
+            # Manager. Do not pipe an unvalidated generator into an upload.
+            openssl rand -hex 32 > "$raw_key"
+            chmod 600 "$raw_key"
+            set +e
+            key_shape="$(python3 backend/scripts/jit_qa_typesense_key_shape.py \
+              --normalize-file "$raw_key" --output "$normalized_key")"
+            key_shape_status=$?
+            set -e
+            case "$key_shape_status:$key_shape" in
+              0:valid|2:legacy_trailing_lf)
+                ;;
+              *)
+                echo "new Typesense key has an unexpected byte shape" >&2
+                exit 1
+                ;;
+            esac
             gcloud secrets create "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" \
               --replication-policy=user-managed --locations="$QA_REGION" \
               --labels=managed-by=github-actions,jit-qa=true --quiet
-            # Secret Manager preserves stdin bytes. Normalize the newline that
-            # openssl emits before storing the first admin key, otherwise the
-            # server receives a different key from the request-side probes.
-            openssl rand -hex 32 \
-              | python3 backend/scripts/jit_qa_typesense_key_shape.py --normalize-stdin \
-              | gcloud secrets versions add "$QA_TYPESENSE_SECRET" \
-              --project "$QA_PROJECT" --data-file=- >/dev/null
+            gcloud secrets versions add "$QA_TYPESENSE_SECRET" \
+              --project "$QA_PROJECT" --data-file="$normalized_key" >/dev/null
           else
             metadata="$RUNNER_TEMP/typesense-secret.json"
             gcloud secrets describe "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" --format=json > "$metadata"
@@ -274,11 +306,6 @@ jobs:
           PY
             state="$(gcloud secrets versions describe latest --secret "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT" --format='value(state)')"
             [[ "$state" == "ENABLED" ]] || { echo "dedicated Typesense key has no enabled latest version" >&2; exit 1; }
-            key_dir="$RUNNER_TEMP/jit-qa-typesense-key"
-            install -d -m 700 "$key_dir"
-            raw_key="$key_dir/raw"
-            normalized_key="$key_dir/normalized"
-            umask 077
             gcloud secrets versions access latest --secret "$QA_TYPESENSE_SECRET" \
               --project "$QA_PROJECT" --out-file="$raw_key"
             chmod 600 "$raw_key"
@@ -439,18 +466,18 @@ jobs:
           set -euo pipefail
           api_key="$(gcloud secrets versions access latest --secret "$QA_TYPESENSE_SECRET" --project "$QA_PROJECT")"
           curl --fail --silent --show-error "$TYPESENSE_URL/health" | python3 -c 'import json,sys; payload=json.load(sys.stdin); assert payload.get("ok") is True'
-          marker_status="$(curl --silent --show-error -o "$RUNNER_TEMP/typesense-marker.json" -w '%{http_code}' \
+          marker_status="$(curl --silent --show-error -o /dev/null -w '%{http_code}' \
             -H "X-TYPESENSE-API-KEY: $api_key" \
             "$TYPESENSE_URL/collections/jit_qa_typesense_readiness/documents/jit_qa_projection_readiness")"
           [[ "$marker_status" == "404" ]] || {
-            echo "bootstrap requires an absent readiness marker; run prove to rehydrate an existing service" >&2
+            echo "bootstrap readiness marker status=$marker_status; expected 404 (run prove to rehydrate an existing service)" >&2
             exit 1
           }
-          collection_status="$(curl --silent --show-error -o "$RUNNER_TEMP/typesense-collection.json" -w '%{http_code}' \
+          collection_status="$(curl --silent --show-error -o /dev/null -w '%{http_code}' \
             -H "X-TYPESENSE-API-KEY: $api_key" \
             "$TYPESENSE_URL/collections/$QA_TYPESENSE_COLLECTION")"
           [[ "$collection_status" == "404" ]] || {
-            echo "bootstrap requires an empty projection collection; run prove to repair an existing service" >&2
+            echo "bootstrap projection collection status=$collection_status; expected 404 (run prove to repair an existing service)" >&2
             exit 1
           }
           receipt="$RUNNER_TEMP/jit-qa-typesense/bootstrap.json"

--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -242,6 +242,16 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.admit.outputs.source_sha }}
+          fetch-depth: 1
+      - name: Verify the checked-in Typesense key-shape helper
+        run: |
+          set -euo pipefail
+          helper="backend/scripts/jit_qa_typesense_key_shape.py"
+          test -r "$helper"
+          python3 "$helper" --help >/dev/null
       - uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}

--- a/backend/docs/runbooks/jit-qa-typesense-projection.md
+++ b/backend/docs/runbooks/jit-qa-typesense-projection.md
@@ -18,6 +18,16 @@ so the secret never appears in the process argument list. No Firestore, Firebase
 customer credential, queue, Redis, or production Typesense binding is given to
 the service.
 
+The workflow stores exactly 64 lowercase hexadecimal bytes. Secret Manager
+preserves uploaded bytes, so new keys pass through
+`backend/scripts/jit_qa_typesense_key_shape.py` before upload rather than being
+piped directly from a newline-terminated command. An existing labeled QA secret
+may be repaired only when it has the one known historical shape (64 lowercase
+hex bytes followed by one LF); a valid 64-byte key is reused and every other
+shape fails closed. The build smoke runs the same legacy-shape normalization
+before starting the server, then authenticates collection and export requests
+with the normalized bytes.
+
 The rehydrate step runs the existing
 `utils.memory.atom_keyword_index.rebuild_atom_keyword_index` against the named
 `based-hardware-dev/jit-qa` Firestore database and fixed QA UID. It verifies the

--- a/backend/scripts/jit_qa_typesense_key_shape.py
+++ b/backend/scripts/jit_qa_typesense_key_shape.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate and normalize the isolated QA Typesense API-key byte shape.
+
+Secret Manager preserves the bytes written by the workflow.  This helper keeps
+the deployment boundary explicit: a key is exactly 64 lowercase hex bytes, or
+the one legacy shape produced by piping ``openssl rand -hex 32`` to a secret
+upload (64 lowercase hex bytes followed by one LF).  No key bytes are printed
+by the file-oriented command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Literal
+
+KEY_BYTES = 32
+KEY_HEX_LENGTH = KEY_BYTES * 2
+LEGACY_TRAILING_LF_LENGTH = KEY_HEX_LENGTH + 1
+KeyShape = Literal["valid", "legacy_trailing_lf", "invalid"]
+_HEX_KEY_RE = re.compile(rb"[0-9a-f]{64}\Z")
+
+
+def classify_typesense_api_key(value: bytes) -> KeyShape:
+    """Classify without decoding or logging the secret bytes."""
+
+    if len(value) == KEY_HEX_LENGTH and _HEX_KEY_RE.fullmatch(value):
+        return "valid"
+    if len(value) == LEGACY_TRAILING_LF_LENGTH and value[-1:] == b"\n" and _HEX_KEY_RE.fullmatch(value[:-1]):
+        return "legacy_trailing_lf"
+    return "invalid"
+
+
+def normalize_typesense_api_key(value: bytes) -> bytes:
+    """Return the exact server key, repairing only the known legacy shape."""
+
+    shape = classify_typesense_api_key(value)
+    if shape == "valid":
+        return value
+    if shape == "legacy_trailing_lf":
+        return value[:-1]
+    raise ValueError("Typesense API key has an unexpected byte shape")
+
+
+def _write_private_file(path: Path, value: bytes) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(value)
+    except BaseException:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--normalize-stdin", action="store_true")
+    modes.add_argument("--normalize-file", type=Path)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        if args.normalize_stdin:
+            if args.output is not None:
+                raise ValueError("--output is only valid with --normalize-file")
+            normalized = normalize_typesense_api_key(sys.stdin.buffer.read())
+            sys.stdout.buffer.write(normalized)
+            return 0
+
+        if args.output is None:
+            raise ValueError("--output is required with --normalize-file")
+        raw = args.normalize_file.read_bytes()
+        shape = classify_typesense_api_key(raw)
+        if shape == "invalid":
+            raise ValueError("Typesense API key has an unexpected byte shape")
+        _write_private_file(args.output, normalize_typesense_api_key(raw))
+        print(shape)
+        # Exit 2 identifies the one repairable legacy shape without exposing
+        # any secret material to the workflow log.
+        return 2 if shape == "legacy_trailing_lf" else 0
+    except (OSError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/jit_qa_typesense_key_shape.py
+++ b/backend/scripts/jit_qa_typesense_key_shape.py
@@ -21,7 +21,7 @@ KEY_BYTES = 32
 KEY_HEX_LENGTH = KEY_BYTES * 2
 LEGACY_TRAILING_LF_LENGTH = KEY_HEX_LENGTH + 1
 KeyShape = Literal["valid", "legacy_trailing_lf", "invalid"]
-_HEX_KEY_RE = re.compile(rb"[0-9a-f]{64}\Z")
+_HEX_KEY_RE = re.compile(rb"[0-9a-f]+\Z")
 
 
 def classify_typesense_api_key(value: bytes) -> KeyShape:

--- a/backend/tests/unit/test_jit_qa_cloud_run_contract.py
+++ b/backend/tests/unit/test_jit_qa_cloud_run_contract.py
@@ -476,6 +476,20 @@ def test_typesense_workflow_smokes_images_before_publish_and_has_unready_bootstr
     assert 'smoke_passed=1' in text
 
 
+def test_typesense_provision_checks_out_admitted_source_before_auth_and_mutation():
+    text = TYPESENSE_WORKFLOW.read_text(encoding="utf-8")
+    provision = text[text.index("  provision:") : text.index("\n  deploy:")]
+    checkout = provision.index("uses: actions/checkout@v7")
+    helper_check = provision.index("Verify the checked-in Typesense key-shape helper")
+    auth = provision.index("uses: google-github-actions/auth@v3")
+    first_secret_mutation = provision.index('gcloud secrets create "$QA_TYPESENSE_SECRET"')
+    assert checkout < helper_check < auth < first_secret_mutation
+    assert 'ref: ${{ needs.admit.outputs.source_sha }}' in provision
+    assert 'fetch-depth: 1' in provision
+    assert 'test -r "$helper"' in provision
+    assert 'python3 "$helper" --help >/dev/null' in provision
+
+
 def test_bounded_proactivity_capability_is_required_on_qa_http_and_gateway_only():
     key = "OMI_JIT_PROACTIVITY_BUDGET_CONTRACT"
     for profile in ("backend", "desktop", "gateway"):

--- a/backend/tests/unit/test_jit_qa_typesense_key_shape.py
+++ b/backend/tests/unit/test_jit_qa_typesense_key_shape.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -59,7 +60,8 @@ def test_normalize_stdin_accepts_exact_key_without_adding_bytes():
     assert completed.stderr == b""
 
 
-def test_file_mode_reports_legacy_shape_without_printing_key(tmp_path: Path):
+def test_file_mode_reports_repair_status_for_set_e_shell_boundary(tmp_path: Path):
+    """The workflow must capture the helper's intentional exit-2 status."""
     raw = tmp_path / "raw"
     normalized = tmp_path / "normalized"
     raw.write_bytes(KEY + b"\n")
@@ -76,3 +78,31 @@ def test_file_mode_reports_legacy_shape_without_printing_key(tmp_path: Path):
     assert normalized.stat().st_mode & 0o777 == 0o600
     assert KEY not in completed.stdout
     assert KEY not in completed.stderr
+
+
+def test_bash_boundary_captures_repair_status_under_set_e(tmp_path: Path):
+    raw = tmp_path / "raw"
+    normalized = tmp_path / "normalized"
+    raw.write_bytes(KEY + b"\n")
+    raw_arg = shlex.quote(str(raw))
+    normalized_arg = shlex.quote(str(normalized))
+    script_arg = shlex.quote(str(SCRIPT))
+    shell = f"""
+set -euo pipefail
+set +e
+shape="$(python3 {script_arg} --normalize-file {raw_arg} --output {normalized_arg})"
+status=$?
+set -e
+case "$status:$shape" in
+  2:legacy_trailing_lf) ;;
+  *) exit 1 ;;
+esac
+"""
+    completed = subprocess.run(
+        ["/bin/bash", "-c", shell],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr.decode()
+    assert normalized.read_bytes() == KEY

--- a/backend/tests/unit/test_jit_qa_typesense_key_shape.py
+++ b/backend/tests/unit/test_jit_qa_typesense_key_shape.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "jit_qa_typesense_key_shape.py"
+KEY = b"a" * 64
+spec = importlib.util.spec_from_file_location("jit_qa_typesense_key_shape_for_test", SCRIPT)
+assert spec is not None and spec.loader is not None
+KEY_SHAPE = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(KEY_SHAPE)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (KEY, "valid"),
+        (KEY + b"\n", "legacy_trailing_lf"),
+        (KEY + b"\r\n", "invalid"),
+        (KEY.upper(), "invalid"),
+        (KEY[:-1], "invalid"),
+        (KEY + b" ", "invalid"),
+    ],
+)
+def test_key_shape_is_strict_and_content_free(value: bytes, expected: str):
+    assert KEY_SHAPE.classify_typesense_api_key(value) == expected
+    if expected == "invalid":
+        with pytest.raises(ValueError, match="unexpected byte shape"):
+            KEY_SHAPE.normalize_typesense_api_key(value)
+
+
+def test_normalize_stdin_repairs_only_the_known_legacy_newline_shape():
+    legacy = KEY + b"\n"
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--normalize-stdin"],
+        input=legacy,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    assert completed.stdout == KEY
+    assert completed.stderr == b""
+
+
+def test_normalize_stdin_accepts_exact_key_without_adding_bytes():
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--normalize-stdin"],
+        input=KEY,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    assert completed.stdout == KEY
+    assert completed.stderr == b""
+
+
+def test_file_mode_reports_legacy_shape_without_printing_key(tmp_path: Path):
+    raw = tmp_path / "raw"
+    normalized = tmp_path / "normalized"
+    raw.write_bytes(KEY + b"\n")
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--normalize-file", str(raw), "--output", str(normalized)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert completed.stdout == b"legacy_trailing_lf\n"
+    assert completed.stderr == b""
+    assert normalized.read_bytes() == KEY
+    assert normalized.stat().st_mode & 0o777 == 0o600
+    assert KEY not in completed.stdout
+    assert KEY not in completed.stderr


### PR DESCRIPTION
## Problem

The isolated QA Typesense bootstrap could receive a different API key from its request probes when Secret Manager preserved the newline emitted by `openssl rand -hex 32`. The resulting marker probe returned HTTP 401 while `/health` remained healthy. The existing Docker smoke also did not exercise this injected-secret byte shape, and its helper's intentional repair status could be treated as a `set -e` failure.

## Change

- Validate Typesense admin-key bytes as exactly 64 lowercase hexadecimal bytes.
- Repair only the explicitly owned historical 64-hex-byte-plus-LF shape; reject all other shapes without printing key material.
- Stage and validate new key bytes before Secret Manager upload, and clean private key files on every workflow exit.
- Exercise the legacy newline shape in the pinned-image Docker auth smoke, capturing the helper's exit-2 repair status explicitly.
- Make bootstrap readiness diagnostics status-only, without saving HTTP response bodies.
- Check out the admitted source before provisioning auth, verify the checked-in helper before Secret Manager mutation, and lock that ordering with a workflow contract test.

The newline cause is source-supported inference from the existing Secret Manager creation command and shell command substitution; no secret bytes were read or emitted.

## Validation

- `actionlint .github/workflows/jit_qa_typesense_projection.yml`
- `scripts/backend-python-format --check backend/scripts/jit_qa_typesense_key_shape.py backend/tests/unit/test_jit_qa_typesense_key_shape.py`
- `PYTHONPATH=backend /Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python -m pytest -q backend/tests/unit/test_jit_qa_typesense_key_shape.py backend/tests/unit/test_jit_qa_typesense_projection.py backend/tests/unit/test_jit_qa_cloud_run_contract.py` (58 passed)

No cloud deployment, secret read, app launch, or auth action was performed.

Failure-Class: none
