### PR TITLE
Fix Typesense projection image import smoke

### DIFF
--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -219,7 +219,7 @@ jobs:
             python3 backend/scripts/runtime_image_contracts.py smoke \
               --dockerfile backend/Dockerfile --image "$runner_tag"
             docker run --rm --entrypoint python3 \
-              -e ENCRYPTION_SECRET=jit-qa-import-smoke-secret \
+              -e ENCRYPTION_SECRET=0123456789abcdef0123456789abcdef \
               "$runner_tag" scripts/jit_qa_typesense_projection.py --help >/dev/null
           fi
           docker push "$typesense_tag" >/dev/null

--- a/backend/runtime_images.json
+++ b/backend/runtime_images.json
@@ -35,6 +35,9 @@
                 "ENCRYPTION_SECRET": "0123456789abcdef0123456789abcdef"
             },
             "dependency_probe_smoke": true,
+            "dependency_probe_exclusions": {
+                "omi_plugin_sdk": "models.structured has a built-in fallback when the optional plugin SDK is absent from backend images."
+            },
             "pull_request_smoke": true
         },
         {

--- a/backend/tests/unit/test_jit_qa_cloud_run_contract.py
+++ b/backend/tests/unit/test_jit_qa_cloud_run_contract.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -463,6 +464,8 @@ def test_typesense_workflow_smokes_images_before_publish_and_has_unready_bootstr
     assert "unauthenticated_status" in text
     assert '"$smoke_url/collections/jit_qa_smoke/documents/export?include_fields=id,content"' in text
     assert 'scripts/jit_qa_typesense_projection.py --help' in text
+    import_smoke_secrets = re.findall(r"-e ENCRYPTION_SECRET=([A-Za-z0-9_-]+)", text)
+    assert import_smoke_secrets and all(len(secret) >= 32 for secret in import_smoke_secrets)
     assert "if: ${{ inputs.mode == 'prove' }}" in text
     assert "if: ${{ inputs.mode == 'bootstrap' }}" in text
     assert '"status": "not_qualified"' in text

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -232,13 +232,17 @@ assert structured.Structured(title="fallback").title == "fallback"
 '''
     environment = dict(os.environ)
     environment['PYTHONPATH'] = str(tmp_path)
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, '-c', probe],
         cwd=tmp_path,
         env=environment,
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, (
+        'SDK-absent fallback import failed; ' f'stdout={result.stdout[-2000:]!r} stderr={result.stderr[-2000:]!r}'
     )
 
 

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -195,6 +195,13 @@ def test_jit_projection_declares_optional_plugin_sdk_fallback(contracts_module):
     )
     dependencies = contracts_module.third_party_dependency_modules(unfiltered)
     assert 'omi_plugin_sdk.models.ActionItem' in dependencies
+    filtered = replace(unfiltered, dependency_probe_exclusions=projection.dependency_probe_exclusions)
+    filtered_dependencies = contracts_module.third_party_dependency_modules(filtered)
+    assert not any(
+        dependency == 'omi_plugin_sdk' or dependency.startswith('omi_plugin_sdk.')
+        for dependency in filtered_dependencies
+    )
+    assert 'pydantic' in filtered_dependencies
     assert projection.dependency_probe_exclusions == frozenset({'omi_plugin_sdk'})
 
 

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -1,5 +1,8 @@
 import importlib.util
 import json
+import os
+import shutil
+import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -171,6 +174,64 @@ def test_pusher_dependency_probe_includes_jsonschema(contracts_module):
     assert 'jsonschema' in dependencies
     assert not any(
         dependency == 'omi_plugin_sdk' or dependency.startswith('omi_plugin_sdk.') for dependency in dependencies
+    )
+
+
+def test_jit_projection_declares_optional_plugin_sdk_fallback(contracts_module):
+    projection = _contract(contracts_module, 'jit-qa-typesense-projection-runner')
+
+    # The static import walk sees the optional SDK symbols inside the
+    # ModuleNotFoundError-protected branch of models.structured.  The image
+    # intentionally relies on that backend-owned fallback, so the exclusion
+    # must be scoped to this SDK prefix rather than weakening all dependency
+    # probes.
+    # Walk only the defining module here; the full projection entrypoint graph
+    # is covered by the registry/source-closure checks and is too expensive for
+    # the per-test fast-unit CPU budget.
+    unfiltered = replace(
+        projection,
+        entrypoints=('models.structured',),
+        dependency_probe_exclusions=frozenset(),
+    )
+    dependencies = contracts_module.third_party_dependency_modules(unfiltered)
+    assert 'omi_plugin_sdk.models.ActionItem' in dependencies
+    assert projection.dependency_probe_exclusions == frozenset({'omi_plugin_sdk'})
+
+
+def test_structured_model_fallback_imports_without_plugin_sdk(tmp_path):
+    models_root = tmp_path / 'models'
+    models_root.mkdir()
+    shutil.copy(BACKEND_DIR / 'models' / '__init__.py', models_root / '__init__.py')
+    shutil.copy(BACKEND_DIR / 'models' / 'conversation_enums.py', models_root / 'conversation_enums.py')
+    shutil.copy(BACKEND_DIR / 'models' / 'structured.py', models_root / 'structured.py')
+
+    probe = '''
+import builtins
+
+real_import = builtins.__import__
+
+def block_optional_sdk(name, *args, **kwargs):
+    if name == "omi_plugin_sdk" or name.startswith("omi_plugin_sdk."):
+        raise ModuleNotFoundError(name)
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = block_optional_sdk
+from models import structured
+
+assert structured.ActionItem.__module__ == "models.structured"
+assert structured.Event.__module__ == "models.structured"
+assert structured.Section.__module__ == "models.structured"
+assert structured.Structured(title="fallback").title == "fallback"
+'''
+    environment = dict(os.environ)
+    environment['PYTHONPATH'] = str(tmp_path)
+    subprocess.run(
+        [sys.executable, '-c', probe],
+        cwd=tmp_path,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
     )
 
 


### PR DESCRIPTION
## Problem
App-plane workflow `34022627644` failed its registered runtime-image smoke because the Typesense projection runner’s static dependency probe treated `omi_plugin_sdk.models.ActionItem`, `Event`, `Section`, and `Structured` as required. The backend image intentionally omits this optional plugin SDK and uses the backend-owned fallback in `models.structured`.

The same prove path used a 26-character `ENCRYPTION_SECRET` for the direct projection import smoke, while the encryption module requires at least 32 characters.

## Change
- Scope the optional `omi_plugin_sdk` exclusion to `jit-qa-typesense-projection-runner` in `backend/runtime_images.json`.
- Add static dependency and SDK-absent fallback import regression tests.
- Use a 32-character smoke secret and assert the workflow contract keeps it valid.

## Validation
- `make runtime-image-source-closure`
- 68 focused backend tests across runtime-image, Typesense projection, and QA Cloud Run contracts
- `backend/test.sh` for `test_runtime_image_contracts.py`: 20 passed within the fast-unit timing guard
- Isolated backend-layout `jit_qa_typesense_projection.py --help` with only `ENCRYPTION_SECRET`, bounded to 20 seconds: passed
- Local pre-push: 31 preflight checks passed

Real Docker image smoke remains a CI/deployment gate. No cloud deployment was performed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

