### PR TITLE
fix(backend): stop maintenance UIDs when Flex budget is gone

### DIFF
--- a/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
+++ b/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
@@ -285,6 +285,9 @@ def test_enabled_flex_uid_routes_promotion_and_l2_with_long_leases_and_guards(mo
         def llm_for_uid(self, uid, **_kwargs):
             return object() if uid == "uid-flex" else None
 
+        def job_budget_fits(self) -> bool:
+            return True
+
         assert_result_current = staticmethod(result_guard)
 
     def maintenance(uid, **kwargs):
@@ -373,6 +376,48 @@ def test_flex_deferral_stops_the_page_without_advancing_past_the_uid(monkeypatch
     assert db.docs[cron.CANONICAL_MEMORY_MAINTENANCE_CURSOR_PATH]["last_uid"] == "uid-a"
 
 
+def test_job_budget_stop_skips_later_uids_without_flex_invoke(monkeypatch):
+    _enable(monkeypatch)
+    calls = []
+
+    class _FlexRouter:
+        def __init__(self, *, db_client, force_enabled=False):
+            self.control = type("Control", (), {"enabled": True})()
+            self._checks = 0
+
+        def llm_invoke_for_uid(self, _uid):
+            return None
+
+        def llm_for_uid(self, _uid, **_kwargs):
+            return None
+
+        def job_budget_fits(self) -> bool:
+            self._checks += 1
+            return self._checks == 1
+
+    def maintenance(uid, **_kwargs):
+        calls.append(uid)
+        return cron.CanonicalShortTermMaintenanceReport(uid=uid)
+
+    monkeypatch.setattr(cron, "PromotionFlexRunRouter", _FlexRouter)
+    monkeypatch.setattr(cron, "run_canonical_short_term_maintenance", maintenance)
+    monkeypatch.setattr(cron, "count_active_short_term", lambda uid, db_client, cap=11: 3)
+    monkeypatch.setattr(cron, "recently_dreamed", lambda uid, db_client, now: False)
+
+    db = _Db(
+        [
+            _Snapshot("canonical_memory_maintenance_registry/uid-a"),
+            _Snapshot("canonical_memory_maintenance_registry/uid-b"),
+            _Snapshot("canonical_memory_maintenance_registry/uid-c"),
+        ]
+    )
+    summary = cron.run_universal_short_term_maintenance(db_client=db, now=NOW, inventory_limit=3)
+
+    assert calls == ["uid-a"]
+    assert summary.flex_deferred is True
+    assert db.docs[cron.CANONICAL_MEMORY_MAINTENANCE_CURSOR_PATH]["last_uid"] == "uid-a"
+
+
 def test_registry_cursor_persists_after_empty_short_term_skip(monkeypatch):
     _enable(monkeypatch)
     calls = []
@@ -413,6 +458,9 @@ def test_maintenance_flex_env_forces_the_router(monkeypatch):
         def llm_for_uid(self, _uid, **_kwargs):
             return None
 
+        def job_budget_fits(self) -> bool:
+            return True
+
     monkeypatch.setattr(cron, "PromotionFlexRunRouter", _FlexRouter)
     monkeypatch.setattr(
         cron,
@@ -441,6 +489,9 @@ def test_overflow_queue_bypasses_recent_dream_cooldown(monkeypatch):
 
         def llm_for_uid(self, _uid, **_kwargs):
             return object()
+
+        def job_budget_fits(self) -> bool:
+            return True
 
         assert_result_current = staticmethod(lambda: None)
 

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -678,6 +678,13 @@ def run_universal_short_term_maintenance(
     )
     completed_uids: set[str] = set()
     for uid in uids:
+        if promotion_flex.control.enabled and not promotion_flex.job_budget_fits():
+            summary.flex_deferred = True
+            logger.info(
+                "canonical_short_term_maintenance_cron: uid=%s flex_deferred=job_budget",
+                uid,
+            )
+            break
         stm_count = count_active_short_term(uid, db_client=client)
         if stm_count == 0:
             summary.skipped_no_short_term += 1

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -594,7 +594,7 @@ def run_universal_short_term_maintenance(
         return CanonicalShortTermMaintenanceCronSummary(run_id=effective_run_id, user_count=0)
 
     client = db_client if db_client is not None else default_db_client
-    promotion_flex = PromotionFlexRunRouter(db_client=client, force_enabled=maintenance_flex_forced())
+    flex_run = PromotionFlexRunRouter(db_client=client, force_enabled=maintenance_flex_forced())
     expiry_inventory = ExpiryOrderedMaintenanceInventory(uids=())
     registry_uids: tuple[str, ...] = ()
     registry_cursor_generation = 0
@@ -674,11 +674,11 @@ def run_universal_short_term_maintenance(
         "canonical_short_term_maintenance_cron: start run_id=%s user_count=%d flex=%s",
         effective_run_id,
         len(uids),
-        promotion_flex.control.enabled,
+        flex_run.control.enabled,
     )
     completed_uids: set[str] = set()
     for uid in uids:
-        if promotion_flex.control.enabled and not promotion_flex.job_budget_fits():
+        if flex_run.control.enabled and not flex_run.job_budget_fits():
             summary.flex_deferred = True
             logger.info(
                 "canonical_short_term_maintenance_cron: uid=%s flex_deferred=job_budget",
@@ -706,7 +706,7 @@ def run_universal_short_term_maintenance(
             completed_uids.add(uid)
             logger.info("canonical_short_term_maintenance_cron: uid=%s skipped_reason=writer_mode_ledger", uid)
             continue
-        promotion_llm_invoke = promotion_flex.llm_invoke_for_uid(uid)
+        promotion_llm_invoke = flex_run.llm_invoke_for_uid(uid)
         try:
             report = run_canonical_short_term_maintenance(
                 uid,
@@ -722,7 +722,7 @@ def run_universal_short_term_maintenance(
                     else CONSOLIDATION_ATTEMPT_LEASE_SECONDS
                 ),
                 consolidation_result_guard=(
-                    promotion_flex.assert_result_current if promotion_llm_invoke is not None else None
+                    flex_run.assert_result_current if promotion_llm_invoke is not None else None
                 ),
             )
         except PromotionFlexDeferred as exc:

--- a/backend/utils/memory/promotion_flex.py
+++ b/backend/utils/memory/promotion_flex.py
@@ -224,6 +224,14 @@ class PromotionFlexRunRouter:
             or isinstance(exc, (ConnectionError, TimeoutError))
         )
 
+    def job_budget_fits(self) -> bool:
+        """Whether one more Flex reservation still fits the one-hour job budget."""
+        elapsed = max(self._monotonic() - self._started_at, 0.0)
+        return (
+            elapsed + BACKGROUND_FLEX_TIMEOUT_SECONDS
+            <= BACKGROUND_FLEX_JOB_BUDGET_SECONDS - BACKGROUND_FLEX_JOB_SAFETY_SECONDS
+        )
+
     def invoke_flex(
         self,
         *,
@@ -233,12 +241,7 @@ class PromotionFlexRunRouter:
         flex_feature: str,
         workload: str,
     ) -> Any:
-        elapsed = max(self._monotonic() - self._started_at, 0.0)
-        flex_has_time = (
-            elapsed + BACKGROUND_FLEX_TIMEOUT_SECONDS
-            <= BACKGROUND_FLEX_JOB_BUDGET_SECONDS - BACKGROUND_FLEX_JOB_SAFETY_SECONDS
-        )
-        if not flex_has_time:
+        if not self.job_budget_fits():
             raise PromotionFlexDeferred("job_budget")
 
         self.assert_control_current()


### PR DESCRIPTION
## Stop the maintenance page when Flex budget is gone

#12845 re-raises `PromotionFlexDeferred` from consolidation so a Flex invoke can stop the 400-UID page. Dest execution `memory-maintenance-job-vhfvn` on `764f82a` (image of that merge) still ran past the Flex reservation window: after LLM calls stopped, the cron kept TTL/vector work on later UIDs that never invoke Flex, which is the remaining path to the 3600s Cloud Run kill.

`ARCHITECTURE.md` already says remaining users run only until the 15-minute Flex reservation no longer fits the one-hour budget. This PR applies that same `job_budget` predicate at the start of each UID, not only inside `invoke_flex`.

### What changed

- `PromotionFlexRunRouter.job_budget_fits()` is the shared predicate `invoke_flex` already used.
- `run_universal_short_term_maintenance` breaks with `flex_deferred=True` and leaves the registry cursor on the last finished UID when the next reservation would not fit.

### Automatic-or-dead check

`test_job_budget_stop_skips_later_uids_without_flex_invoke`: Flex is enabled, maintenance never raises, budget fails on the second UID. Only `uid-a` is dreamed; cursor stays on `uid-a`. Red-proof: drop the loop check and `uid-b`/`uid-c` run.

### Proof

- Existing `test_flex_deferral_stops_the_page_without_advancing_past_the_uid` still holds.
- Existing `test_router_defers_instead_of_using_standard_when_flex_cannot_fit_job_budget` still holds.
- Focused pytest: 5 passed.

Live dest check: after `gcp_memory_maintenance_job_auto_dev` on this merge SHA, a dest execution must emit `canonical_short_term_maintenance_cron: done` with `flex_deferred=True` and `Completed=True` inside 3600s.

### Cut list

- Flipping `FRAME_REQUEST_RETENTION_INDEPENDENT_HEALTHY`.
- Dispatching prod `memory-maintenance-job`.
- JIT ledger-drain / daily-sweep / Typesense.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

This does not add a promotion pass or invent tiers. It stops the already-scheduled Flex page when the existing one-hour budget is exhausted.

### Failure class

Failure-Class: FC-flex-budget-stop-swallowed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

