### PR TITLE
Fix JIT QA gateway accounting contract

### DIFF
--- a/backend/scripts/jit_qa_cloud_run_contract.py
+++ b/backend/scripts/jit_qa_cloud_run_contract.py
@@ -621,6 +621,11 @@ def resource_environment(
                 "OMI_JIT_QA_UID_ALLOWLIST": QA_UID,
                 "OMI_LLM_GATEWAY_PROD": "false",
                 "LLM_GATEWAY_ALLOWED_CALLERS": "backend,desktop",
+                # QA cost evidence reads the gateway's durable attempt ledger;
+                # keep its explicit accounting gate in the exact resource
+                # contract so post-deploy validation cannot reject it as an
+                # unapproved extra environment entry.
+                "LLM_GATEWAY_ACCOUNTING_ENABLED": "true",
                 "OMI_LLM_GATEWAY_BUILD_IDENTITY": "jit-qa",
                 "OMI_JIT_PROACTIVITY_BUDGET_CONTRACT": "jit-cloud-qa-v1",
             },

--- a/backend/tests/unit/test_jit_qa_cloud_run_contract.py
+++ b/backend/tests/unit/test_jit_qa_cloud_run_contract.py
@@ -280,6 +280,50 @@ def test_gateway_resource_is_fenced_to_the_fixed_qa_uid():
     assert literals["OMI_JIT_QA_UID_ALLOWLIST"] == CONTRACT.QA_UID
 
 
+def test_gateway_resource_requires_accounting_enabled():
+    image = "gcr.io/based-hardware-dev/llm-gateway-jit-qa@sha256:" + "b" * 64
+    resource = _resource("gateway", "service", image)
+    resource["metadata"]["name"] = CONTRACT.LLM_GATEWAY_SERVICE
+    expected_environment, expected_secret_bindings = CONTRACT.resource_environment("gateway")
+    assert expected_environment["LLM_GATEWAY_ACCOUNTING_ENABLED"] == "true"
+
+    CONTRACT.validate_cloud_run_resource(
+        resource,
+        kind="service",
+        expected_image=image,
+        expected_environment=expected_environment,
+        expected_secret_bindings=expected_secret_bindings,
+        expected_name=CONTRACT.LLM_GATEWAY_SERVICE,
+    )
+
+    accounting = next(
+        entry
+        for entry in resource["spec"]["template"]["spec"]["containers"][0]["env"]
+        if entry["name"] == "LLM_GATEWAY_ACCOUNTING_ENABLED"
+    )
+    accounting["value"] = "false"
+    with pytest.raises(CONTRACT.JITQAContractError, match="unexpected value"):
+        CONTRACT.validate_cloud_run_resource(
+            resource,
+            kind="service",
+            expected_image=image,
+            expected_environment=expected_environment,
+            expected_secret_bindings=expected_secret_bindings,
+            expected_name=CONTRACT.LLM_GATEWAY_SERVICE,
+        )
+
+    resource["spec"]["template"]["spec"]["containers"][0]["env"].remove(accounting)
+    with pytest.raises(CONTRACT.JITQAContractError, match="missing required environment"):
+        CONTRACT.validate_cloud_run_resource(
+            resource,
+            kind="service",
+            expected_image=image,
+            expected_environment=expected_environment,
+            expected_secret_bindings=expected_secret_bindings,
+            expected_name=CONTRACT.LLM_GATEWAY_SERVICE,
+        )
+
+
 def _typesense_resource(image: str) -> dict:
     return {
         "metadata": {"name": CONTRACT.TYPESENSE_SERVICE},
@@ -433,6 +477,8 @@ def test_workflow_is_manual_main_only_and_cannot_reach_prod_or_scheduler():
     assert "--set-env-vars \"$drain_env\"" in text
     assert 'LLM_GATEWAY_ALLOWED_CALLERS=backend,desktop' in text
     assert 'LLM_GATEWAY_ACCOUNTING_ENABLED=true' in text
+    gateway_environment, _ = CONTRACT.resource_environment("gateway")
+    assert gateway_environment["LLM_GATEWAY_ACCOUNTING_ENABLED"] == "true"
     assert 'gcloud firestore databases describe --database "$QA_FIRESTORE_DATABASE"' in text
     assert 'gcloud redis instances describe "$QA_REDIS_INSTANCE"' in text
     assert "POSTHOG_PROJECT_API_KEY=POSTHOG_PROJECT_API_KEY:latest" in text


### PR DESCRIPTION
## What changed and why

The isolated JIT QA workflow already deploys `LLM_GATEWAY_ACCOUNTING_ENABLED=true` so gateway provider attempts are persisted for cost evidence. The post-deploy contract omitted that literal and rejected the correctly configured gateway as an unapproved environment entry. This declares the literal in the gateway profile and adds regression coverage for acceptance plus false and missing values.

## Product invariants affected

none

## How it was verified

- `make preflight` — 26 checks passed
- `uv run --offline --project backend --with pytest pytest --noconftest -q backend/tests/unit/test_jit_qa_cloud_run_contract.py` — 38 passed
- `git diff --check` — passed
- No cloud, app, model, or provider calls were performed.

## Tests

`test_gateway_resource_requires_accounting_enabled` validates the exact live shape, wrong value, and missing value. The workflow contract test checks workflow literal/profile consistency.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

