### PR TITLE
fix(backend): bind in-UID maintenance to the job clock

### DIFF
--- a/.github/failure-classes/FC-flex-budget-stop-swallowed.json
+++ b/.github/failure-classes/FC-flex-budget-stop-swallowed.json
@@ -2,16 +2,22 @@
   "schema_version": 1,
   "id": "FC-flex-budget-stop-swallowed",
   "violated_contract": "When Flex can no longer fit a reservation in the one-hour memory-maintenance budget, the current UID must stop after the deferred batch is recorded and the cron page must leave the durable registry cursor on that unfinished UID. Swallowing PromotionFlexDeferred as a per-item continue lets the job scan the rest of the 400-user page until Cloud Run kills it at 3600s (Completed=False, exit 0).",
-  "canonical_prevention": "Re-raise PromotionFlexDeferred after recording the deferred batch and releasing leases without spending the quality-retry budget. Keep the cron's existing page-stop and cursor contract. Prove a later consolidation batch on the same UID is not entered.",
+  "canonical_prevention": "Re-raise PromotionFlexDeferred after recording the deferred batch and releasing leases without spending the quality-retry budget. Keep the cron's existing page-stop and cursor contract. Bind in-UID TTL/outbox work to the same job_budget_fits clock. A Flex stop with residual non-outbox errors exits 0; outbox and cursor_persist still fail the job.",
   "canonical_prevention_artifact": [
     "backend/utils/memory/canonical_consolidation.py",
+    "backend/utils/memory/short_term_promotion.py",
+    "backend/utils/memory/promotion_flex.py",
+    "backend/modal/memory_maintenance_job.py",
     "backend/tests/unit/test_canonical_consolidation.py",
-    "backend/tests/unit/test_canonical_short_term_maintenance_cron.py"
+    "backend/tests/unit/test_canonical_short_term_maintenance_cron.py",
+    "backend/tests/unit/test_short_term_maintenance_job_budget.py",
+    "backend/tests/unit/test_notifications_job_orchestrator.py"
   ],
   "evidence_prs": [],
   "scope_hints": [
     "backend/utils/memory/canonical_consolidation.py",
     "backend/utils/memory/canonical_short_term_maintenance_cron.py",
+    "backend/utils/memory/short_term_promotion.py",
     "backend/modal/memory_maintenance_job.py"
   ],
   "status": "open"

--- a/.github/failure-classes/FC-flex-budget-stop-swallowed.json
+++ b/.github/failure-classes/FC-flex-budget-stop-swallowed.json
@@ -2,14 +2,14 @@
   "schema_version": 1,
   "id": "FC-flex-budget-stop-swallowed",
   "violated_contract": "When Flex can no longer fit a reservation in the one-hour memory-maintenance budget, the current UID must stop after the deferred batch is recorded and the cron page must leave the durable registry cursor on that unfinished UID. Swallowing PromotionFlexDeferred as a per-item continue lets the job scan the rest of the 400-user page until Cloud Run kills it at 3600s (Completed=False, exit 0).",
-  "canonical_prevention": "Re-raise PromotionFlexDeferred after recording the deferred batch and releasing leases without spending the quality-retry budget. Keep the cron's existing page-stop and cursor contract. Bind in-UID TTL/outbox work to the same job_budget_fits clock. A Flex stop with residual non-outbox errors exits 0; outbox and cursor_persist still fail the job.",
+  "canonical_prevention": "Re-raise PromotionFlexDeferred after recording the deferred batch and releasing leases without spending the quality-retry budget. Keep the cron's existing page-stop and cursor contract. Prove a later consolidation batch on the same UID is not entered.",
   "canonical_prevention_artifact": [
     "backend/utils/memory/canonical_consolidation.py",
+    "backend/tests/unit/test_canonical_consolidation.py",
+    "backend/tests/unit/test_canonical_short_term_maintenance_cron.py",
     "backend/utils/memory/short_term_promotion.py",
     "backend/utils/memory/promotion_flex.py",
     "backend/modal/memory_maintenance_job.py",
-    "backend/tests/unit/test_canonical_consolidation.py",
-    "backend/tests/unit/test_canonical_short_term_maintenance_cron.py",
     "backend/tests/unit/test_short_term_maintenance_job_budget.py",
     "backend/tests/unit/test_notifications_job_orchestrator.py"
   ],
@@ -17,7 +17,6 @@
   "scope_hints": [
     "backend/utils/memory/canonical_consolidation.py",
     "backend/utils/memory/canonical_short_term_maintenance_cron.py",
-    "backend/utils/memory/short_term_promotion.py",
     "backend/modal/memory_maintenance_job.py"
   ],
   "status": "open"

--- a/backend/modal/memory_maintenance_job.py
+++ b/backend/modal/memory_maintenance_job.py
@@ -30,6 +30,18 @@ logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger(__name__)
 
+_FATAL_ERROR_MARKERS = ("outbox_delivery_failed", "cursor_persist:")
+
+
+def _fatal_job_errors(errors: list[str], *, flex_deferred: bool) -> list[str]:
+    """Outbox/cursor failures always fail the job; a Flex stop does not retry the page."""
+    fatal = [error for error in errors if any(marker in error for marker in _FATAL_ERROR_MARKERS)]
+    if fatal:
+        return fatal
+    if flex_deferred:
+        return []
+    return list(errors)
+
 
 def _init_firebase() -> None:
     service_account_json = os.getenv("SERVICE_ACCOUNT_JSON")
@@ -58,8 +70,18 @@ def main() -> None:
             recurrence_signal_consumer=drain_recurrence_inbox_for_maintenance,
         )
     )
-    if summary.errors:
-        raise RuntimeError(f"memory-maintenance-job completed with {len(summary.errors)} error(s)")
+    fatal_errors = _fatal_job_errors(
+        list(summary.errors or []),
+        flex_deferred=bool(getattr(summary, "flex_deferred", False)),
+    )
+    if summary.errors and not fatal_errors:
+        logger.warning(
+            "memory-maintenance-job: flex stop with residual errors count=%d errors=%s",
+            len(summary.errors),
+            summary.errors,
+        )
+    if fatal_errors:
+        raise RuntimeError(f"memory-maintenance-job completed with {len(fatal_errors)} error(s)")
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
+++ b/backend/tests/unit/test_canonical_short_term_maintenance_cron.py
@@ -288,6 +288,10 @@ def test_enabled_flex_uid_routes_promotion_and_l2_with_long_leases_and_guards(mo
         def job_budget_fits(self) -> bool:
             return True
 
+        def require_job_budget(self) -> None:
+            if not self.job_budget_fits():
+                raise cron.PromotionFlexDeferred("job_budget")
+
         assert_result_current = staticmethod(result_guard)
 
     def maintenance(uid, **kwargs):
@@ -309,6 +313,7 @@ def test_enabled_flex_uid_routes_promotion_and_l2_with_long_leases_and_guards(mo
     assert flex_kwargs["consolidation_attempt_lease_seconds"] == cron.MEMORY_PROMOTION_FLEX_LEASE_SECONDS
     assert flex_kwargs["consolidation_result_guard"] is result_guard
     assert flex_kwargs["required_processing_limit"] == 0
+    assert callable(flex_kwargs["job_budget_guard"])
     assert "required_processor" not in flex_kwargs
     standard_kwargs = calls[1][1]
     assert standard_kwargs["llm_invoke"] is None
@@ -395,6 +400,10 @@ def test_job_budget_stop_skips_later_uids_without_flex_invoke(monkeypatch):
             self._checks += 1
             return self._checks == 1
 
+        def require_job_budget(self) -> None:
+            if not self.job_budget_fits():
+                raise cron.PromotionFlexDeferred("job_budget")
+
     def maintenance(uid, **_kwargs):
         calls.append(uid)
         return cron.CanonicalShortTermMaintenanceReport(uid=uid)
@@ -416,6 +425,47 @@ def test_job_budget_stop_skips_later_uids_without_flex_invoke(monkeypatch):
     assert calls == ["uid-a"]
     assert summary.flex_deferred is True
     assert db.docs[cron.CANONICAL_MEMORY_MAINTENANCE_CURSOR_PATH]["last_uid"] == "uid-a"
+
+
+def test_in_uid_job_budget_guard_stops_the_page_without_finishing_the_uid(monkeypatch):
+    _enable(monkeypatch)
+    calls = []
+
+    class _FlexRouter:
+        def __init__(self, *, db_client, force_enabled=False):
+            self.control = type("Control", (), {"enabled": True})()
+
+        def llm_invoke_for_uid(self, _uid):
+            return None
+
+        def job_budget_fits(self) -> bool:
+            return True
+
+        def require_job_budget(self) -> None:
+            raise cron.PromotionFlexDeferred("job_budget")
+
+    def maintenance(uid, **kwargs):
+        calls.append(uid)
+        kwargs["job_budget_guard"]()
+        raise AssertionError("in-UID work must not continue after the clock is gone")
+
+    monkeypatch.setattr(cron, "PromotionFlexRunRouter", _FlexRouter)
+    monkeypatch.setattr(cron, "run_canonical_short_term_maintenance", maintenance)
+    monkeypatch.setattr(cron, "count_active_short_term", lambda uid, db_client, cap=11: 3)
+    monkeypatch.setattr(cron, "recently_dreamed", lambda uid, db_client, now: False)
+
+    db = _Db(
+        [
+            _Snapshot("canonical_memory_maintenance_registry/uid-a"),
+            _Snapshot("canonical_memory_maintenance_registry/uid-b"),
+        ]
+    )
+    summary = cron.run_universal_short_term_maintenance(db_client=db, now=NOW, inventory_limit=2)
+
+    assert calls == ["uid-a"]
+    assert summary.flex_deferred is True
+    assert summary.dreamed_users == 0
+    assert cron.CANONICAL_MEMORY_MAINTENANCE_CURSOR_PATH not in db.docs
 
 
 def test_registry_cursor_persists_after_empty_short_term_skip(monkeypatch):
@@ -461,6 +511,10 @@ def test_maintenance_flex_env_forces_the_router(monkeypatch):
         def job_budget_fits(self) -> bool:
             return True
 
+        def require_job_budget(self) -> None:
+            if not self.job_budget_fits():
+                raise cron.PromotionFlexDeferred("job_budget")
+
     monkeypatch.setattr(cron, "PromotionFlexRunRouter", _FlexRouter)
     monkeypatch.setattr(
         cron,
@@ -492,6 +546,10 @@ def test_overflow_queue_bypasses_recent_dream_cooldown(monkeypatch):
 
         def job_budget_fits(self) -> bool:
             return True
+
+        def require_job_budget(self) -> None:
+            if not self.job_budget_fits():
+                raise cron.PromotionFlexDeferred("job_budget")
 
         assert_result_current = staticmethod(lambda: None)
 

--- a/backend/tests/unit/test_memory_promotion_flex.py
+++ b/backend/tests/unit/test_memory_promotion_flex.py
@@ -307,3 +307,15 @@ def test_router_defers_instead_of_using_standard_when_flex_cannot_fit_job_budget
     with pytest.raises(promotion_flex.PromotionFlexDeferred, match="job_budget"):
         model.invoke("late")
     assert calls == []
+
+
+def test_require_job_budget_raises_when_the_one_hour_clock_is_gone():
+    control = promotion_flex.PromotionFlexControl(enabled=True, generation=1)
+    router = promotion_flex.PromotionFlexRunRouter(
+        db_client=object(),
+        control_reader=lambda **_kwargs: control,
+        monotonic=lambda: 2_401.0,
+        started_at=0.0,
+    )
+    with pytest.raises(promotion_flex.PromotionFlexDeferred, match="job_budget"):
+        router.require_job_budget()

--- a/backend/tests/unit/test_notifications_job_orchestrator.py
+++ b/backend/tests/unit/test_notifications_job_orchestrator.py
@@ -84,10 +84,40 @@ def test_memory_maintenance_job_entrypoint_calls_cron_runner():
 
 def test_memory_maintenance_job_exits_with_failure_when_cron_reports_outbox_error(monkeypatch, memory_maintenance_job):
     async def failed_cron(**_kwargs):
-        return SimpleNamespace(errors=["uid=test: outbox_delivery_failed"])
+        return SimpleNamespace(errors=["uid=test: outbox_delivery_failed"], flex_deferred=False)
 
     monkeypatch.setattr(memory_maintenance_job, "_init_firebase", lambda: None)
     monkeypatch.setattr(memory_maintenance_job, "run_canonical_short_term_maintenance_cron", failed_cron)
+    monkeypatch.setattr(memory_maintenance_job, "run_frame_request_retention_maintenance", lambda **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match=r"completed with 1 error\(s\)"):
+        memory_maintenance_job.main()
+
+
+def test_memory_maintenance_job_exits_zero_when_flex_stop_has_non_outbox_errors(monkeypatch, memory_maintenance_job):
+    async def deferred_cron(**_kwargs):
+        return SimpleNamespace(
+            errors=["uid=test: consolidation_failed:blocked=0:retryable=1:quarantined=0:errors=1"],
+            flex_deferred=True,
+        )
+
+    monkeypatch.setattr(memory_maintenance_job, "_init_firebase", lambda: None)
+    monkeypatch.setattr(memory_maintenance_job, "run_canonical_short_term_maintenance_cron", deferred_cron)
+    monkeypatch.setattr(memory_maintenance_job, "run_frame_request_retention_maintenance", lambda **_kwargs: None)
+
+    memory_maintenance_job.main()
+
+
+def test_memory_maintenance_job_still_fails_outbox_errors_after_flex_stop(monkeypatch, memory_maintenance_job):
+    async def deferred_cron(**_kwargs):
+        return SimpleNamespace(
+            errors=["uid=test: outbox_delivery_failed:retryable=1:dead_letter=0:ack=0:errors=0"],
+            flex_deferred=True,
+        )
+
+    monkeypatch.setattr(memory_maintenance_job, "_init_firebase", lambda: None)
+    monkeypatch.setattr(memory_maintenance_job, "run_canonical_short_term_maintenance_cron", deferred_cron)
+    monkeypatch.setattr(memory_maintenance_job, "run_frame_request_retention_maintenance", lambda **_kwargs: None)
 
     with pytest.raises(RuntimeError, match=r"completed with 1 error\(s\)"):
         memory_maintenance_job.main()

--- a/backend/tests/unit/test_short_term_maintenance_job_budget.py
+++ b/backend/tests/unit/test_short_term_maintenance_job_budget.py
@@ -1,0 +1,111 @@
+"""In-UID TTL/outbox work must stop on the same one-hour job clock."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from models.product_memory import MemoryLayer
+from utils.memory.promotion_flex import PromotionFlexDeferred
+from utils.memory.short_term_promotion import (
+    _drain_canonical_outbox,
+    run_canonical_short_term_ttl_lifecycle,
+)
+
+NOW = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def test_ttl_lifecycle_stops_before_the_next_item_when_job_budget_is_gone(monkeypatch):
+    items = [
+        SimpleNamespace(tier=MemoryLayer.short_term, memory_id="mem-a"),
+        SimpleNamespace(tier=MemoryLayer.short_term, memory_id="mem-b"),
+        SimpleNamespace(tier=MemoryLayer.short_term, memory_id="mem-c"),
+    ]
+    processed: list[object] = []
+
+    def budget_guard() -> None:
+        if len(processed) >= 1:
+            raise PromotionFlexDeferred("job_budget")
+
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.ensure_canonical_apply_control_state",
+        lambda uid, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.fetch_expired_short_term_memory_items_firestore",
+        lambda **_kwargs: items,
+    )
+
+    def process(item, **_kwargs):
+        processed.append(item)
+        return None, False
+
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.process_short_term_lifecycle_item",
+        process,
+    )
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.effective_short_term_expiry",
+        lambda _item: NOW,
+    )
+
+    with pytest.raises(PromotionFlexDeferred, match="job_budget"):
+        run_canonical_short_term_ttl_lifecycle(
+            "uid-ttl-budget",
+            db_client=object(),
+            now=NOW,
+            run_id="run-ttl-budget",
+            job_budget_guard=budget_guard,
+        )
+
+    assert processed == [items[0]]
+
+
+def test_outbox_drain_checks_the_clock_between_vector_deletes(monkeypatch):
+    ticks: list[int] = []
+
+    def fake_tick(**kwargs):
+        ticks.append(kwargs["config"].limit)
+        return {
+            "leased_count": 1,
+            "delivered_count": 1,
+            "stale_settled_count": 0,
+            "barrier_count": 0,
+            "retryable_failure_count": 0,
+            "dead_letter_count": 0,
+            "ack_failed_count": 0,
+            "actions": [],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion.run_canonical_memory_outbox_worker_tick",
+        fake_tick,
+    )
+    monkeypatch.setattr(
+        "utils.memory.short_term_promotion._canonical_outbox_side_effects",
+        lambda **_kwargs: object(),
+    )
+
+    remaining = [True, True, False]
+
+    def budget_guard() -> None:
+        if remaining:
+            fits = remaining.pop(0)
+        else:
+            fits = False
+        if not fits:
+            raise PromotionFlexDeferred("job_budget")
+
+    with pytest.raises(PromotionFlexDeferred, match="job_budget"):
+        _drain_canonical_outbox(
+            "uid-outbox-budget",
+            db_client=object(),
+            run_id="run-outbox-budget",
+            now=NOW,
+            job_budget_guard=budget_guard,
+        )
+
+    assert ticks == [1, 1]

--- a/backend/utils/memory/ARCHITECTURE.md
+++ b/backend/utils/memory/ARCHITECTURE.md
@@ -135,8 +135,12 @@ with expiry-ordered accounts first. It skips accounts with no active Short-term
 row, and skips non-urgent accounts dreamed in the last 20 hours unless they
 already have more than 10 active Short-term rows (hourly overflow drain).
 Remaining users run until the 15-minute Flex
-reservation no longer fits in the one-hour job budget. A Flex deferral leaves
+reservation no longer fits in the one-hour job budget. In-UID TTL apply and
+outbox/vector drain use that same `job_budget_fits` predicate so one account
+cannot consume the remaining hour. A Flex deferral leaves
 the durable cursor on the unfinished UID so later accounts are not skipped.
+A successful Flex stop with residual non-outbox errors exits 0; outbox and
+cursor_persist failures still fail the job.
 The job does not run a separate required-processing LLM: explicit submissions
 enter the consolidation batch with `requires_normalization=true`, and apply
 stamps the L2 receipt then the route from that one decision. Promote

--- a/backend/utils/memory/canonical_short_term_maintenance_cron.py
+++ b/backend/utils/memory/canonical_short_term_maintenance_cron.py
@@ -724,6 +724,7 @@ def run_universal_short_term_maintenance(
                 consolidation_result_guard=(
                     flex_run.assert_result_current if promotion_llm_invoke is not None else None
                 ),
+                job_budget_guard=flex_run.require_job_budget if flex_run.control.enabled else None,
             )
         except PromotionFlexDeferred as exc:
             summary.flex_deferred = True

--- a/backend/utils/memory/promotion_flex.py
+++ b/backend/utils/memory/promotion_flex.py
@@ -232,6 +232,11 @@ class PromotionFlexRunRouter:
             <= BACKGROUND_FLEX_JOB_BUDGET_SECONDS - BACKGROUND_FLEX_JOB_SAFETY_SECONDS
         )
 
+    def require_job_budget(self) -> None:
+        """Stop in-UID TTL/outbox work when the same one-hour clock is gone."""
+        if not self.job_budget_fits():
+            raise PromotionFlexDeferred("job_budget")
+
     def invoke_flex(
         self,
         *,

--- a/backend/utils/memory/short_term_promotion.py
+++ b/backend/utils/memory/short_term_promotion.py
@@ -139,10 +139,10 @@ def _canonical_outbox_side_effects(*, db_client: Any) -> CanonicalMemoryOutboxSi
     )
 
 
-def _canonical_outbox_worker_config(*, run_id: str) -> CanonicalMemoryOutboxWorkerConfig:
+def _canonical_outbox_worker_config(*, run_id: str, event_limit: int = 100) -> CanonicalMemoryOutboxWorkerConfig:
     return CanonicalMemoryOutboxWorkerConfig(
         worker_id=f"canonical-maintenance:{run_id}"[:200],
-        limit=100,
+        limit=event_limit,
         scan_limit=500,
         lease_seconds=300,
         max_attempts=5,
@@ -158,9 +158,14 @@ def _drain_canonical_outbox(
     run_id: str,
     now: datetime,
     max_ticks: int = 5,
+    job_budget_guard: Optional[Callable[[], None]] = None,
 ) -> Dict[str, Any]:
     """Drain a bounded pass, not just one page, so one maintenance run projects its own commits."""
-    config = _canonical_outbox_worker_config(run_id=run_id)
+    # When the job clock is bound, one tick is one event so the clock is
+    # checked between vector deletes instead of after a 100-event page.
+    event_limit = 1 if job_budget_guard is not None else 100
+    tick_limit = 500 if job_budget_guard is not None else max_ticks
+    config = _canonical_outbox_worker_config(run_id=run_id, event_limit=event_limit)
     aggregate: Dict[str, Any] = {
         "uid": uid,
         "worker_id": config.worker_id,
@@ -176,7 +181,9 @@ def _drain_canonical_outbox(
         "errors": [],
     }
     side_effects = _canonical_outbox_side_effects(db_client=db_client)
-    for _tick in range(max_ticks):
+    for _tick in range(tick_limit):
+        if job_budget_guard is not None:
+            job_budget_guard()
         summary = run_canonical_memory_outbox_worker_tick(
             db_client=db_client,
             uid=uid,
@@ -244,6 +251,7 @@ def run_canonical_short_term_ttl_lifecycle(
     now: Optional[datetime] = None,
     run_id: str,
     limit: Optional[int] = None,
+    job_budget_guard: Optional[Callable[[], None]] = None,
 ) -> CanonicalShortTermLifecycleReport:
     """Audit expiry and settle indexed Short-term items through canonical L2 apply."""
     client: Any = db_client if db_client is not None else default_db_client
@@ -264,6 +272,8 @@ def run_canonical_short_term_ttl_lifecycle(
     existing = 0
     terminal = 0
     for item in items:
+        if job_budget_guard is not None:
+            job_budget_guard()
         disposition = None
         expired = item.tier == MemoryLayer.short_term and effective_short_term_expiry(item) <= current_time
         if expired and not belief_model_enabled():
@@ -363,6 +373,7 @@ def run_canonical_short_term_maintenance(
     required_processing_limit: int = 0,
     consolidation_attempt_lease_seconds: int = CONSOLIDATION_ATTEMPT_LEASE_SECONDS,
     consolidation_result_guard: Optional[Callable[[], None]] = None,
+    job_budget_guard: Optional[Callable[[], None]] = None,
 ) -> CanonicalShortTermMaintenanceReport:
     """Drain prior projections, run maintenance phases, then project their commits."""
     client: Any = db_client if db_client is not None else default_db_client
@@ -377,7 +388,10 @@ def run_canonical_short_term_maintenance(
         db_client=client,
         run_id=run_id,
         now=pre_outbox_now,
+        job_budget_guard=job_budget_guard,
     )
+    if job_budget_guard is not None:
+        job_budget_guard()
     if required_processing_limit > 0:
         required_processing = run_required_memory_processing(
             uid,
@@ -395,7 +409,10 @@ def run_canonical_short_term_maintenance(
         db_client=client,
         now=current_time,
         run_id=run_id,
+        job_budget_guard=job_budget_guard,
     )
+    if job_budget_guard is not None:
+        job_budget_guard()
     consolidation = run_canonical_consolidation(
         uid,
         db_client=client,
@@ -408,12 +425,15 @@ def run_canonical_short_term_maintenance(
     )
     # In production, use a post-commit timestamp so events created during this
     # pass are immediately due. Explicit test/replay clocks remain deterministic.
+    if job_budget_guard is not None:
+        job_budget_guard()
     outbox_now = current_time if now is not None else datetime.now(timezone.utc)
     post_outbox = _drain_canonical_outbox(
         uid,
         db_client=client,
         run_id=run_id,
         now=outbox_now,
+        job_budget_guard=job_budget_guard,
     )
     outbox = _merge_canonical_outbox_summaries(pre_outbox, post_outbox)
     return CanonicalShortTermMaintenanceReport(


### PR DESCRIPTION
## Bind in-UID TTL/vector work to the job clock and exit 0 on Flex stop

#12850 checks `job_budget_fits()` at the start of each UID. Dest execution `memory-maintenance-job-wkxbv` on `c6779addc7` still died inside one account's `delete_canonical_memory_vectors` tail: TTL apply and outbox/vector drain were not on that clock. The earlier dest retry (`vhfvn`) also proved a successful Flex stop (`flex_deferred=True` in ~8m) then exited 1 because residual non-outbox `summary.errors` made `main()` raise, which Cloud Run retried.

This keeps the existing Flex budget constants and cursor contract. In-UID TTL and outbox ticks call `require_job_budget()` (the same `job_budget_fits` predicate). A Flex stop with residual non-outbox errors exits 0; `outbox_delivery_failed` and `cursor_persist:` still fail the job.

### What changed

- `PromotionFlexRunRouter.require_job_budget()` raises `PromotionFlexDeferred("job_budget")` when the one-hour clock is gone.
- `run_canonical_short_term_maintenance` / TTL / outbox drain take `job_budget_guard`. Budgeted outbox ticks are one event so the clock is checked between vector deletes.
- Cron passes `flex_run.require_job_budget` when Flex is enabled.
- `memory_maintenance_job.main()` fails only on outbox/cursor errors, or on any errors when the page was not Flex-stopped.

### Automatic-or-dead check

`test_ttl_lifecycle_stops_before_the_next_item_when_job_budget_is_gone` and `test_outbox_drain_checks_the_clock_between_vector_deletes`: the guard fires after the first item/tick; later work does not run. Red-proof: drop the guard calls and both tests process the leftover items.

`test_memory_maintenance_job_exits_zero_when_flex_stop_has_non_outbox_errors`: `flex_deferred=True` plus `consolidation_failed` returns. Red-proof: restore `if summary.errors: raise` and the test raises.

`test_memory_maintenance_job_still_fails_outbox_errors_after_flex_stop` keeps the outbox fatal class.

### Proof

- `test_in_uid_job_budget_guard_stops_the_page_without_finishing_the_uid`: cursor stays unadvanced.
- Existing `test_job_budget_stop_skips_later_uids_without_flex_invoke` and `test_memory_maintenance_job_exits_with_failure_when_cron_reports_outbox_error` still hold.
- Focused pytest: 10 passed.

Live dest check: after `gcp_memory_maintenance_job_auto_dev` on this merge SHA, a dest execution must emit `canonical_short_term_maintenance_cron: done` with `Completed=True` inside 3600s. A Flex stop may log residual non-outbox errors and still exit 0.

### Cut list

- Flipping `FRAME_REQUEST_RETENTION_INDEPENDENT_HEALTHY`.
- Dispatching prod `memory-maintenance-job`.
- Deploying an independent dest retention job.
- JIT ledger-drain / daily-sweep / Typesense.

## Product invariants affected

- INV-MEM-4
- INV-MEM-1

This does not add a promotion pass or invent tiers. It binds already-scheduled in-UID TTL/vector work to the existing one-hour Flex job clock, and treats a successful Flex stop as job success unless outbox/cursor persistence failed.

### Failure class

Failure-Class: FC-flex-budget-stop-swallowed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

