### PR TITLE
fix(app): keep the bottom tab bar above the Android system navigation bar

### DIFF
--- a/.github/failure-classes/FC-bottom-control-under-system-inset.json
+++ b/.github/failure-classes/FC-bottom-control-under-system-inset.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-bottom-control-under-system-inset",
+  "violated_contract": "A control anchored to the bottom of an edge-to-edge window must reserve the window's bottom view padding so its hit-test bounds stay inside the region the user can actually reach. Painting to the physical screen edge is fine; placing the control's tap targets there is not, because the system navigation bar owns that band and consumes the taps.",
+  "canonical_prevention": "Bottom-anchored chrome reserves MediaQuery.viewPaddingOf(context).bottom — through SafeArea, or by adding the inset to its own height and bottom padding when it must keep painting to the screen edge — and any sibling positioned against it carries the same inset so the pair stays in step. viewPadding rather than padding: the home Scaffold sets resizeToAvoidBottomInset: false, and padding.bottom collapses to zero while a keyboard is open, which would drop the control back under the system bar.",
+  "canonical_prevention_artifact": [
+    "app/test/widgets/bottom_nav_bar_test.dart"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "app/lib/widgets/bottom_nav_bar.dart",
+    "app/lib/pages/home/**"
+  ],
+  "status": "open"
+}

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -872,11 +872,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                               Positioned(
                                 left: 16,
                                 right: 16,
-                                // Anchored against the bottom nav row, which
-                                // reserves the same inset. Keeping them in step
-                                // preserves the existing gap instead of letting
-                                // the chat bar collide with the lifted row.
-                                bottom: 78 + MediaQuery.viewPaddingOf(context).bottom,
+                                // Derived from the nav row's own geometry so the
+                                // two cannot drift: changing the row's height or
+                                // the inset it reserves moves this with it,
+                                // instead of silently closing the gap.
+                                bottom: kBottomNavBarHeight -
+                                    kBottomNavChatBarGap +
+                                    bottomNavBarReservedInset(context),
                                 child: Row(
                                   children: [
                                     Expanded(child: _buildChatBar(context)),

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -872,7 +872,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                               Positioned(
                                 left: 16,
                                 right: 16,
-                                bottom: 78,
+                                // Anchored against the bottom nav row, which
+                                // reserves the same inset. Keeping them in step
+                                // preserves the existing gap instead of letting
+                                // the chat bar collide with the lifted row.
+                                bottom: 78 + MediaQuery.viewPaddingOf(context).bottom,
                                 child: Row(
                                   children: [
                                     Expanded(child: _buildChatBar(context)),

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -876,9 +876,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                 // two cannot drift: changing the row's height or
                                 // the inset it reserves moves this with it,
                                 // instead of silently closing the gap.
-                                bottom: kBottomNavBarHeight -
-                                    kBottomNavChatBarGap +
-                                    bottomNavBarReservedInset(context),
+                                bottom: kBottomNavBarHeight - kBottomNavChatBarGap + bottomNavBarReservedInset(context),
                                 child: Row(
                                   children: [
                                     Expanded(child: _buildChatBar(context)),

--- a/app/lib/widgets/bottom_nav_bar.dart
+++ b/app/lib/widgets/bottom_nav_bar.dart
@@ -28,12 +28,25 @@ class _BottomNavBarState extends State<BottomNavBar> {
     _navigation = Selector<HomeProvider, int>(
       selector: (_, home) => home.selectedIndex,
       builder: (context, selectedIndex, _) {
+        // The app targets SDK 36, so Android 15+ enforces edge-to-edge and this
+        // Stack extends under the system navigation bar. Reserve the bottom
+        // inset so the tab row stays above it; without this the row's tap
+        // targets sit behind the 3-button navigation bar. The sibling bars
+        // mounted in the same home Stack (MergeActionBar, TaskSelectionActionBar)
+        // already use SafeArea for the same reason.
+        //
+        // viewPadding, not padding: the home Scaffold sets
+        // resizeToAvoidBottomInset: false, and padding.bottom collapses to zero
+        // while a keyboard is open, which would drop the row back under the bar.
+        final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
         return Align(
           alignment: Alignment.bottomCenter,
           child: Container(
             width: double.infinity,
-            height: 100,
-            padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+            // The 80dp content box is unchanged; only the reserved inset grows,
+            // so a device reporting a zero inset lays out exactly as before.
+            height: 100 + bottomInset,
+            padding: EdgeInsets.fromLTRB(20, 20, 20, bottomInset),
             decoration: const BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topCenter,

--- a/app/lib/widgets/bottom_nav_bar.dart
+++ b/app/lib/widgets/bottom_nav_bar.dart
@@ -7,6 +7,22 @@ import 'package:provider/provider.dart';
 
 import 'package:omi/providers/home_provider.dart';
 
+/// Height of the bottom nav row above whatever system inset it reserves.
+const double kBottomNavBarHeight = 100;
+
+/// Gap between the top of the nav row and the home chat bar that floats above
+/// it. The chat bar derives its offset from this pair rather than repeating a
+/// literal, so changing the row's height cannot silently close the gap.
+const double kBottomNavChatBarGap = 22;
+
+/// The bottom inset the nav row reserves for system chrome. Anything
+/// positioned against the row must add this to stay in step with it.
+///
+/// viewPadding, not padding: the home Scaffold sets
+/// resizeToAvoidBottomInset: false, and padding.bottom collapses to zero while
+/// a keyboard is open, which would drop the row back under the system bar.
+double bottomNavBarReservedInset(BuildContext context) => MediaQuery.viewPaddingOf(context).bottom;
+
 class BottomNavBar extends StatefulWidget {
   const BottomNavBar({super.key, required this.onTabTap, this.onTabWarmup});
 
@@ -28,24 +44,20 @@ class _BottomNavBarState extends State<BottomNavBar> {
     _navigation = Selector<HomeProvider, int>(
       selector: (_, home) => home.selectedIndex,
       builder: (context, selectedIndex, _) {
-        // The app targets SDK 36, so Android 15+ enforces edge-to-edge and this
-        // Stack extends under the system navigation bar. Reserve the bottom
-        // inset so the tab row stays above it; without this the row's tap
-        // targets sit behind the 3-button navigation bar. The sibling bars
-        // mounted in the same home Stack (MergeActionBar, TaskSelectionActionBar)
-        // already use SafeArea for the same reason.
-        //
-        // viewPadding, not padding: the home Scaffold sets
-        // resizeToAvoidBottomInset: false, and padding.bottom collapses to zero
-        // while a keyboard is open, which would drop the row back under the bar.
-        final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
+        // Reserve whatever bottom inset the window reports so the tab row's tap
+        // targets stay above the system navigation bar. When the window is not
+        // drawn under that bar the reported inset is zero and this is a no-op,
+        // so the row can never be lifted twice. The sibling bars mounted in the
+        // same home Stack (MergeActionBar, TaskSelectionActionBar) already use
+        // SafeArea to reserve the same inset.
+        final bottomInset = bottomNavBarReservedInset(context);
         return Align(
           alignment: Alignment.bottomCenter,
           child: Container(
             width: double.infinity,
-            // The 80dp content box is unchanged; only the reserved inset grows,
-            // so a device reporting a zero inset lays out exactly as before.
-            height: 100 + bottomInset,
+            // The content box is unchanged; only the reserved inset grows, so a
+            // device reporting a zero inset lays out exactly as before.
+            height: kBottomNavBarHeight + bottomInset,
             padding: EdgeInsets.fromLTRB(20, 20, 20, bottomInset),
             decoration: const BoxDecoration(
               gradient: LinearGradient(

--- a/app/test/widgets/bottom_nav_bar_test.dart
+++ b/app/test/widgets/bottom_nav_bar_test.dart
@@ -65,6 +65,79 @@ void main() {
     expect(taps, [(2, false), (2, true)]);
     expect(warmups, [2, 2]);
   });
+
+  testWidgets('keeps the tab row clear of the system navigation bar inset', (tester) async {
+    // A 3-button Android navigation bar is roughly this tall and fully opaque.
+    const systemNavBarHeight = 48.0;
+
+    final withoutInset = await _layoutForBottomInset(tester, 0);
+    final withInset = await _layoutForBottomInset(tester, systemNavBarHeight);
+
+    final safeBottom = withInset.screenBottom - systemNavBarHeight;
+    for (final entry in withInset.iconBottoms.entries) {
+      expect(
+        entry.value,
+        lessThanOrEqualTo(safeBottom),
+        reason: 'the ${entry.key} tab must not be drawn behind the system navigation bar',
+      );
+    }
+
+    // The row lifts by exactly the reported inset, so a device that reports no
+    // bottom inset keeps today's layout.
+    for (final label in withoutInset.iconBottoms.keys) {
+      expect(
+        withoutInset.iconBottoms[label]! - withInset.iconBottoms[label]!,
+        moreOrLessEquals(systemNavBarHeight),
+        reason: 'the ${label} tab should lift by the bottom inset',
+      );
+    }
+  });
+}
+
+final _tabIcons = <(String, FaIconData)>[
+  ('Home', FontAwesomeIcons.house),
+  ('Conversations', FontAwesomeIcons.comments),
+  ('Tasks', FontAwesomeIcons.listCheck),
+  ('Apps', FontAwesomeIcons.puzzlePiece),
+];
+
+/// Pumps the bar under a bottom view padding of [bottomInset] and reports where
+/// the tab icons landed relative to the bottom of the screen.
+Future<({double screenBottom, Map<String, double> iconBottoms})> _layoutForBottomInset(
+  WidgetTester tester,
+  double bottomInset,
+) async {
+  final provider = HomeProvider();
+  addTearDown(provider.dispose);
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider<HomeProvider>.value(
+      value: provider,
+      child: MaterialApp(
+        home: Builder(
+          builder: (context) => MediaQuery(
+            // viewPadding is what survives a keyboard; the home Scaffold sets
+            // resizeToAvoidBottomInset: false, so that is the inset the bar
+            // has to respect.
+            data: MediaQuery.of(context).copyWith(
+              viewPadding: EdgeInsets.only(bottom: bottomInset),
+              padding: EdgeInsets.only(bottom: bottomInset),
+            ),
+            child: Scaffold(
+              body: BottomNavBar(onTabTap: (_, __) {}),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  return (
+    screenBottom: tester.getRect(find.byType(Scaffold)).bottom,
+    iconBottoms: {
+      for (final (label, icon) in _tabIcons) label: tester.getRect(_findIcon(icon)).bottom,
+    },
+  );
 }
 
 Finder _findIcon(FaIconData icon) => find.byWidgetPredicate((widget) => widget is FaIcon && widget.icon == icon.data);

--- a/app/test/widgets/bottom_nav_bar_test.dart
+++ b/app/test/widgets/bottom_nav_bar_test.dart
@@ -70,8 +70,12 @@ void main() {
     // A 3-button Android navigation bar is roughly this tall and fully opaque.
     const systemNavBarHeight = 48.0;
 
-    final withoutInset = await _layoutForBottomInset(tester, 0);
-    final withInset = await _layoutForBottomInset(tester, systemNavBarHeight);
+    final withoutInset = await _layoutForBottomInset(tester, viewPadding: 0, padding: 0);
+    final withInset = await _layoutForBottomInset(
+      tester,
+      viewPadding: systemNavBarHeight,
+      padding: systemNavBarHeight,
+    );
 
     final safeBottom = withInset.screenBottom - systemNavBarHeight;
     for (final entry in withInset.iconBottoms.entries) {
@@ -92,6 +96,31 @@ void main() {
       );
     }
   });
+
+  testWidgets('reserves viewPadding, which a keyboard does not collapse', (tester) async {
+    // The home Scaffold sets resizeToAvoidBottomInset: false, so an open
+    // keyboard leaves the system bar exactly where it was while driving
+    // padding.bottom to zero. Reading padding instead of viewPadding would put
+    // the tab row back under the navigation bar in precisely this state, so
+    // pin the distinction rather than the value: padding is zero here and only
+    // viewPadding is set.
+    const systemNavBarHeight = 48.0;
+
+    final keyboardOpen = await _layoutForBottomInset(
+      tester,
+      viewPadding: systemNavBarHeight,
+      padding: 0,
+    );
+
+    final safeBottom = keyboardOpen.screenBottom - systemNavBarHeight;
+    for (final entry in keyboardOpen.iconBottoms.entries) {
+      expect(
+        entry.value,
+        lessThanOrEqualTo(safeBottom),
+        reason: 'the ${entry.key} tab must reserve viewPadding, not padding',
+      );
+    }
+  });
 }
 
 final _tabIcons = <(String, FaIconData)>[
@@ -101,12 +130,14 @@ final _tabIcons = <(String, FaIconData)>[
   ('Apps', FontAwesomeIcons.puzzlePiece),
 ];
 
-/// Pumps the bar under a bottom view padding of [bottomInset] and reports where
-/// the tab icons landed relative to the bottom of the screen.
+/// Pumps the bar under the given bottom [viewPadding] and [padding] and reports
+/// where the tab icons landed relative to the bottom of the screen. The two are
+/// separate so a test can pin which inset the bar actually reads.
 Future<({double screenBottom, Map<String, double> iconBottoms})> _layoutForBottomInset(
-  WidgetTester tester,
-  double bottomInset,
-) async {
+  WidgetTester tester, {
+  required double viewPadding,
+  required double padding,
+}) async {
   final provider = HomeProvider();
   addTearDown(provider.dispose);
 
@@ -120,11 +151,11 @@ Future<({double screenBottom, Map<String, double> iconBottoms})> _layoutForBotto
             // resizeToAvoidBottomInset: false, so that is the inset the bar
             // has to respect.
             data: MediaQuery.of(context).copyWith(
-              viewPadding: EdgeInsets.only(bottom: bottomInset),
-              padding: EdgeInsets.only(bottom: bottomInset),
+              viewPadding: EdgeInsets.only(bottom: viewPadding),
+              padding: EdgeInsets.only(bottom: padding),
             ),
             child: Scaffold(
-              body: BottomNavBar(key: ValueKey(bottomInset), onTabTap: (_, __) {}),
+              body: BottomNavBar(key: ValueKey('$viewPadding/$padding'), onTabTap: (_, __) {}),
             ),
           ),
         ),

--- a/app/test/widgets/bottom_nav_bar_test.dart
+++ b/app/test/widgets/bottom_nav_bar_test.dart
@@ -87,8 +87,8 @@ void main() {
     for (final label in withoutInset.iconBottoms.keys) {
       expect(
         withoutInset.iconBottoms[label]! - withInset.iconBottoms[label]!,
-        moreOrLessEquals(systemNavBarHeight),
-        reason: 'the ${label} tab should lift by the bottom inset',
+        moreOrLessEquals(systemNavBarHeight, epsilon: 0.5),
+        reason: 'the $label tab should lift by the bottom inset',
       );
     }
   });
@@ -124,7 +124,7 @@ Future<({double screenBottom, Map<String, double> iconBottoms})> _layoutForBotto
               padding: EdgeInsets.only(bottom: bottomInset),
             ),
             child: Scaffold(
-              body: BottomNavBar(onTabTap: (_, __) {}),
+              body: BottomNavBar(key: ValueKey(bottomInset), onTabTap: (_, __) {}),
             ),
           ),
         ),


### PR DESCRIPTION
Fixes #12352

## What

On Android with 3-button navigation, the home tab row (Home / Conversations / Tasks / Apps) is drawn underneath the system navigation bar, so the icons are covered and the taps land on back/home/recents instead.

## Why it happens

`BottomNavBar` reserves no bottom safe-area inset:

```dart
height: 100,
padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),   // bottom: 0
```

It is mounted directly into the home `Scaffold.body` `Stack`, and there is no `SafeArea`, `MediaQuery.removePadding` or `bottomNavigationBar` anywhere on that path — so the body keeps the full window inset.

`app/android/app/build.gradle` sets `targetSdkVersion 36`. The four `styles.xml` still set `android:windowOptOutEdgeToEdgeEnforcement=true`, but per [Android 16 behavior changes](https://developer.android.com/about/versions/16/behavior-changes-16) that attribute is *"deprecated and disabled"* for apps targeting API 36, so on an Android 16 device the app goes edge-to-edge regardless and the body extends to the physical screen edge. On Android 15 the opt-out still holds, the system insets the window itself, and the reserved inset is `0` — the layout is unchanged there.

The container is 100dp with 20dp top padding, leaving an 80dp content box whose tap targets sit against the screen bottom. A 3-button navigation bar is ~48dp and opaque, so it covers most of that band. Under gesture navigation the inset is only ~16-24dp, which is why the report is specific to 3-button mode.

The two sibling bottom-anchored bars mounted in the same Stack — `MergeActionBar` and `TaskSelectionActionBar` — already wrap their content in `SafeArea`. `BottomNavBar` is the one that omits the inset.

## The change

- `app/lib/widgets/bottom_nav_bar.dart` — add `MediaQuery.viewPaddingOf(context).bottom` to the container height and bottom padding. The 80dp content box is untouched and the gradient still paints to the screen edge, so nothing shows through behind a translucent system bar. **On a device reporting a zero bottom inset the rendered layout is byte-identical to today.**
  `viewPadding` rather than `padding`: the home `Scaffold` sets `resizeToAvoidBottomInset: false`, and `padding.bottom` collapses to zero while a keyboard is open, which would drop the row back under the system bar.
- `app/lib/pages/home/page.dart` — the home-tab chat bar is `Positioned(bottom: 78)` in the same Stack, anchored against the nav row. It carries the same inset so the existing 38dp gap is preserved instead of the chat bar colliding with the lifted row.
- `app/test/widgets/bottom_nav_bar_test.dart` — regression test.

Three lines of behaviour; the rest is comments and the test.

## Verification

`app/test/widgets/bottom_nav_bar_test.dart` gains `keeps the tab row clear of the system navigation bar inset`, which pumps the bar under a 0dp and a 48dp bottom `viewPadding` and asserts:

1. every tab icon's bottom edge is at or above `screenBottom - 48` — i.e. clear of the system navigation band;
2. the row lifts by exactly the reported inset, so a zero-inset device keeps today's layout.

Geometry, which is what makes (1) fail on `main`: the icon is centred in the 80dp content box, so its bottom sits at `screenBottom - inset - 27`. With the fix and a 48dp inset that is `screenBottom - 75`, comfortably clear. Without the fix the inset term drops out and it stays at `screenBottom - 27`, which is 21dp *inside* the 48dp system band — so the first assertion fails on `main` and passes here. It is a real regression test, not a tautology.

I do not have an Android device or a Flutter toolchain in this environment, so I have not run `flutter test`, `make preflight` or `scripts/pr-preflight` myself and I am not claiming a device repro. The change was derived from the source and the reporter's screenshot; please let CI run the suite, and I will fix anything it turns up. If you would like a physical-device confirmation before merging, say so and I will arrange one rather than guess.

Failure-Class: new

`FC-bottom-control-under-system-inset`, added in `.github/failure-classes/` in this change.

**Root cause.** Edge-to-edge is not opt-in any more — it follows from `targetSdk >= 35`. A bottom-anchored control therefore cannot assume the window ends where the screen's usable area ends. `BottomNavBar` was written against the older model where the framework inset the window, so a bare `height: 100` was sufficient; once the window grew, the same constant silently moved the tap targets into the system bar's band. Nothing failed loudly, because painting still succeeded — only the hit-testing moved.

**Durable guard.** The canonical prevention artifact is `app/test/widgets/bottom_nav_bar_test.dart`, which asserts clearance against a non-zero bottom `viewPadding` rather than asserting a fixed height. A future change to the bar's geometry stays correct as long as the inset is respected, and any reintroduction of a screen-edge-anchored tap target fails the clearance assertion. The class's scope hints cover the nav bar and the home page so the same check is reached for the siblings positioned against it.

The distinction from the two neighbouring classes: `FC-ancestor-chrome-steals-control-taps` is an in-app ancestor absorbing hits, and `FC-transparent-top-level-window-occlusion` is a macOS window owning area beyond its visible surface. This one is the OS system bar occupying a band the app never reserved.

## Invariants

None named. `INV-UI-1` globs `app/lib/**` but states it should not be named in routine UI PRs — this touches no brand colour or accent. The other invariants with app-facing names (`INV-CHAT-1`, `INV-CHAT-2`, `INV-NAV-1`) glob `desktop/**` only, and this change touches no desktop path.