### PR TITLE
S13: desktop .planGated at Gemini and pixel lane clients

### DIFF
--- a/desktop/macos/Desktop/Sources/APIClient.swift
+++ b/desktop/macos/Desktop/Sources/APIClient.swift
@@ -392,7 +392,8 @@ actor APIClient {
     contextPlanID: String = "",
     stableCacheIdentity: String = "",
     dynamicContextIdentity: String = "",
-    contextCacheReplaced: Bool = false
+    contextCacheReplaced: Bool = false,
+    turnId: String = ""
   ) async {
     let base = rustBackendURL
     guard !base.isEmpty else { return }
@@ -405,25 +406,60 @@ actor APIClient {
     do {
       let headers = try await buildHeaders(requireAuth: true)
       for (k, v) in headers { request.setValue(v, forHTTPHeaderField: k) }
-      let body: [String: Any] = [
-        "provider": provider,
-        "model": model,
-        "input_text_tokens": inputText,
-        "input_audio_tokens": inputAudio,
-        "input_cached_tokens": inputCached,
-        "output_text_tokens": outputText,
-        "output_audio_tokens": outputAudio,
-        // Opaque hashes/plan identifiers only; no rendered context or user text.
-        "context_plan_id": contextPlanID,
-        "stable_cache_identity": stableCacheIdentity,
-        "dynamic_context_identity": dynamicContextIdentity,
-        "context_cache_replaced": contextCacheReplaced,
-      ]
+      let body = Self.realtimeUsageReportBody(
+        provider: provider,
+        model: model,
+        inputText: inputText,
+        inputAudio: inputAudio,
+        inputCached: inputCached,
+        outputText: outputText,
+        outputAudio: outputAudio,
+        contextPlanID: contextPlanID,
+        stableCacheIdentity: stableCacheIdentity,
+        dynamicContextIdentity: dynamicContextIdentity,
+        contextCacheReplaced: contextCacheReplaced,
+        turnId: turnId)
       request.httpBody = try JSONSerialization.data(withJSONObject: body)
       _ = try await session.data(for: request)
     } catch {
       log("APIClient: realtime usage report failed: \(error.localizedDescription)")
     }
+  }
+
+  /// Opaque turn identity only. Empty `turnId` is omitted so retries without a
+  /// turn stay on the backend's empty-string default.
+  static func realtimeUsageReportBody(
+    provider: String,
+    model: String,
+    inputText: Int,
+    inputAudio: Int,
+    inputCached: Int,
+    outputText: Int,
+    outputAudio: Int,
+    contextPlanID: String,
+    stableCacheIdentity: String,
+    dynamicContextIdentity: String,
+    contextCacheReplaced: Bool,
+    turnId: String
+  ) -> [String: Any] {
+    var body: [String: Any] = [
+      "provider": provider,
+      "model": model,
+      "input_text_tokens": inputText,
+      "input_audio_tokens": inputAudio,
+      "input_cached_tokens": inputCached,
+      "output_text_tokens": outputText,
+      "output_audio_tokens": outputAudio,
+      // Opaque hashes/plan identifiers only; no rendered context or user text.
+      "context_plan_id": contextPlanID,
+      "stable_cache_identity": stableCacheIdentity,
+      "dynamic_context_identity": dynamicContextIdentity,
+      "context_cache_replaced": contextCacheReplaced,
+    ]
+    if !turnId.isEmpty {
+      body["turn_id"] = turnId
+    }
+    return body
   }
 
   func performVoidRequest(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -1501,6 +1501,12 @@ extension RealtimeHubController {
           recoveryResult: .started)
         return
       }
+      if RealtimeHubUsageLimitPresentation.shouldPresent(
+        category: closeCategory, failoverStarted: false)
+      {
+        NotificationCenter.default.post(
+          name: .showUsageLimitPopup, object: nil, userInfo: ["reason": "realtime"])
+      }
       teardownSession()
       recordCloseResolution(
         turnOutcome: turnOutcome,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift
@@ -1450,6 +1450,7 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
           + "image_tokens=\(usageInImage)")
       activeScreenEvidence = nil
     }
+    let turnId = activeEventIdentity?.turnID.rawValue.uuidString ?? ""
     resetTurnUsage()
     guard auth.isEphemeral, it + ia + ic + ot + oa > 0 else { return }
     let providerName = provider == .gemini ? "gemini" : "openai"
@@ -1461,7 +1462,8 @@ final class RealtimeHubSession: NSObject, @unchecked Sendable {
         contextPlanID: self.contextPlanID,
         stableCacheIdentity: self.stableCacheIdentity,
         dynamicContextIdentity: self.dynamicContextIdentity,
-        contextCacheReplaced: self.contextCacheReplaced)
+        contextCacheReplaced: self.contextCacheReplaced,
+        turnId: turnId)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -112,7 +112,7 @@ enum SuggestionAssistantTelemetry {
           return .decodeFailed
         case .apiError(let message, _):
           return classifyAPIMessage(message)
-        case .missingAPIKey:
+        case .missingAPIKey, .planGated:
           return .other
         }
       }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -589,7 +589,7 @@ actor GeminiClient {
   }
 
   static func enforceManagedProactivity() async throws {
-    try requireManagedProactivity(await ManagedProactivityDecisionSource.shared.current())
+    try requireManagedProactivity(await ManagedProactivityDecisionSource.current())
   }
 
   /// Send a request to the Gemini API with an image

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -589,7 +589,7 @@ actor GeminiClient {
   }
 
   static func enforceManagedProactivity() async throws {
-    try requireManagedProactivity(await ManagedProactivityDecisionSource.current())
+    try requireManagedProactivity(await ManagedProactivityDecisionSource.shared.current())
   }
 
   /// Send a request to the Gemini API with an image

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -218,6 +218,9 @@ actor GeminiClient {
     case networkError(Error)
     case invalidResponse
     case apiError(String, retryable: Bool? = nil)
+    /// Identified basic + non-BYOK, or a typed 402 `plan_gated` from the proxy.
+    /// Non-retryable. Distinct from chat-quota 402 (`error` field).
+    case planGated
 
     /// The raw API message for internal logging (not shown to user).
     var internalMessage: String? {
@@ -243,7 +246,7 @@ actor GeminiClient {
           || lower.contains("internal error")
       case .networkError:
         return true
-      case .invalidResponse, .missingAPIKey:
+      case .invalidResponse, .missingAPIKey, .planGated:
         return false
       }
     }
@@ -259,7 +262,7 @@ actor GeminiClient {
         // A transport error after dispatch is ambiguous. Only a typed backend
         // response may authorize replay.
         return false
-      case .invalidResponse, .missingAPIKey:
+      case .invalidResponse, .missingAPIKey, .planGated:
         return false
       }
     }
@@ -278,7 +281,7 @@ actor GeminiClient {
           || lower.contains("usage limit")
           || lower.contains("quota exceeded")
           || lower.contains("http 402")
-      case .missingAPIKey:
+      case .missingAPIKey, .planGated:
         return true
       case .networkError, .invalidResponse:
         return false
@@ -295,6 +298,8 @@ actor GeminiClient {
         return "AI service returned an unexpected response. Please try again."
       case .apiError(let message, _):
         return Self.userFacingMessage(for: message)
+      case .planGated:
+        return "AI features require an active plan or BYOK keys."
       }
     }
 
@@ -417,6 +422,10 @@ actor GeminiClient {
     guard let httpResponse = response as? HTTPURLResponse else { return nil }
     let status = httpResponse.statusCode
     guard !(200..<300).contains(status) else { return nil }
+
+    if ManagedPlanGateHTTP.isPlanGated(status: status, data: data) {
+      return .planGated
+    }
 
     let body = String(data: data.prefix(512), encoding: .utf8) ?? ""
     let retryable: Bool?
@@ -551,7 +560,7 @@ actor GeminiClient {
           return "provider_5xx"
         }
         return "other"
-      case .invalidResponse, .missingAPIKey:
+      case .invalidResponse, .missingAPIKey, .planGated:
         return "other"
       }
     }
@@ -565,6 +574,22 @@ actor GeminiClient {
       "GeminiClient: transient error, retrying in \(delaySec)s (attempt \(attempt + 2)/3): \(error.localizedDescription)"
     )
     try await Task.sleep(nanoseconds: UInt64(delaySec) * 1_000_000_000)
+  }
+
+  /// Client UX gate. Server 402 `plan_gated` remains the invariant.
+  static func requireManagedProactivity(_ decision: SubscriptionEntitlementDecision) throws {
+    guard decision == .planGated else { return }
+    // TODO(free-tier local lane): when a local-proactivity flag flips, route to
+    // `LocalInferenceRuntime.generateStructuredFailClosed` / `runToolLoopFailClosed`.
+    // This shard only types the gate. Flag read is the seam; the lane is not built.
+    if ProcessInfo.processInfo.environment["OMI_LOCAL_PROACTIVITY"] == "1" {
+      // Local lane not shipped — still fail closed to `.planGated`.
+    }
+    throw GeminiClientError.planGated
+  }
+
+  static func enforceManagedProactivity() async throws {
+    try requireManagedProactivity(await ManagedProactivityDecisionSource.current())
   }
 
   /// Send a request to the Gemini API with an image
@@ -582,6 +607,7 @@ actor GeminiClient {
     responseSchema: GeminiRequest.GenerationConfig.ResponseSchema,
     thinkingBudget: Int = 0
   ) async throws -> String {
+    try await Self.enforceManagedProactivity()
     let maxRetries = 2
     var lastError: Error?
 
@@ -669,6 +695,7 @@ actor GeminiClient {
     timeout: TimeInterval = 300,
     thinkingBudget: Int = 0
   ) async throws -> String {
+    try await Self.enforceManagedProactivity()
     var lastError: Error?
 
     for attempt in 0...maxRetries {
@@ -741,6 +768,7 @@ actor GeminiClient {
     responseSchema: GeminiRequest.GenerationConfig.ResponseSchema,
     thinkingBudget: Int = 0
   ) async throws -> String {
+    try await Self.enforceManagedProactivity()
     let maxRetries = 2
     var lastError: Error?
 
@@ -1032,6 +1060,7 @@ extension GeminiClient {
     forceToolCall: Bool = false,
     thinkingBudget: Int = 0
   ) async throws -> ToolChatResult {
+    try await Self.enforceManagedProactivity()
     // Try the primary model first; if it keeps failing transiently, fall back to the
     // secondary model (e.g. Pro overloaded → Flash) before giving up.
     let models: [String] = {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -579,7 +579,7 @@ actor GeminiClient {
   /// Client UX gate. Server 402 `plan_gated` remains the invariant.
   static func requireManagedProactivity(_ decision: SubscriptionEntitlementDecision) throws {
     guard decision == .planGated else { return }
-    // TODO(free-tier local lane): when a local-proactivity flag flips, route to
+    // S24 / TBD-2 local-lane seam: when OMI_LOCAL_PROACTIVITY flips, route to
     // `LocalInferenceRuntime.generateStructuredFailClosed` / `runToolLoopFailClosed`.
     // This shard only types the gate. Flag read is the seam; the lane is not built.
     if ProcessInfo.processInfo.environment["OMI_LOCAL_PROACTIVITY"] == "1" {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -138,6 +138,9 @@ enum ProactiveLaneClientError: LocalizedError {
   case http(status: Int, retryAfterSeconds: Int?)
   case quotaCooldown(retryAfterSeconds: Int)
   case ownerChanged
+  /// Identified basic + non-BYOK pixel call, or a typed 402 `plan_gated`.
+  /// Text-only JIT completions stay open (S14 / S24 narrowing).
+  case planGated
 
   var errorDescription: String? {
     switch self {
@@ -149,6 +152,8 @@ enum ProactiveLaneClientError: LocalizedError {
       return "proactive_quota_cooldown status=429"
     case .ownerChanged:
       return "proactive_owner_changed"
+    case .planGated:
+      return "proactive_plan_gated"
     }
   }
 }
@@ -184,6 +189,8 @@ struct ProactiveLaneFailureClassification: Equatable, Sendable {
       return "invalid_structured_output status=\(status ?? 0)"
     case "quota_cooldown":
       return "quota_cooldown status=\(status ?? 0)"
+    case "plan_gated":
+      return "plan_gated status=\(status ?? 402)"
     case "network":
       return "network error_type=\(errorType ?? "unknown")"
     default:
@@ -206,6 +213,8 @@ struct ProactiveLaneFailureClassification: Equatable, Sendable {
         return ProactiveLaneFailureClassification(failure: "invalid_response", status: nil, errorType: nil)
       case .ownerChanged:
         return ProactiveLaneFailureClassification(failure: "owner_changed", status: nil, errorType: nil)
+      case .planGated:
+        return ProactiveLaneFailureClassification(failure: "plan_gated", status: 402, errorType: nil)
       }
     }
     if error is DecodingError {
@@ -257,6 +266,7 @@ actor ProactiveLaneClient {
     @Sendable (_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot, _ snapshot: JITTriggerSnapshot) async throws
       -> Void
   private let now: @Sendable () -> Date
+  private let managedPixelDecision: @Sendable () async -> SubscriptionEntitlementDecision
   private var quotaCooldownUntil: [String: Date] = [:]
   private var loggedQuotaSkip: Set<String> = []
   private var loggedQuotaClamp: Set<String> = []
@@ -321,7 +331,8 @@ actor ProactiveLaneClient {
       (
         @Sendable (_ authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot, _ snapshot: JITTriggerSnapshot)
           async throws -> Void
-      )? = nil
+      )? = nil,
+    managedPixelDecision: (@Sendable () async -> SubscriptionEntitlementDecision)? = nil
   ) {
     self.session = session
     self.baseURL = baseURL
@@ -344,6 +355,11 @@ actor ProactiveLaneClient {
         _ = try await KnowledgeLedgerMirrorCoordinator.shared.sync(
           authorizationSnapshot: authorizationSnapshot,
           knownAuthority: snapshot)
+      }
+    self.managedPixelDecision =
+      managedPixelDecision
+      ?? {
+        await ManagedProactivityDecisionSource.current()
       }
   }
 
@@ -434,6 +450,16 @@ actor ProactiveLaneClient {
     let currentOwner = authorizationSnapshot?.ownerID
     clearCooldownsIfOwnerChanged(currentOwner)
     try checkQuotaCooldown(operation: operation)
+    if imageData != nil {
+      if await managedPixelDecision() == .planGated {
+        // TODO(free-tier local lane): when a local-proactivity flag flips, route
+        // pixels to LocalInferenceRuntime. Text-only JIT stays ungated here.
+        if ProcessInfo.processInfo.environment["OMI_LOCAL_PROACTIVITY"] == "1" {
+          // Local lane not shipped — still fail closed to `.planGated`.
+        }
+        throw ProactiveLaneClientError.planGated
+      }
+    }
     if let authorizationSnapshot {
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
         throw ProactiveLaneClientError.ownerChanged
@@ -492,6 +518,14 @@ actor ProactiveLaneClient {
     let requestID = http.value(forHTTPHeaderField: "X-Omi-Request-ID")
     Self.logQuotaIfNeeded(operation: operation, response: http)
     guard (200..<300).contains(http.statusCode) else {
+      if ManagedPlanGateHTTP.isPlanGated(status: http.statusCode, data: data) {
+        await responseObserver?(
+          ProactiveLaneResponseObservation(
+            statusCode: http.statusCode,
+            requestID: requestID,
+            failure: ProactiveLaneFailureClassification.classify(ProactiveLaneClientError.planGated)))
+        throw ProactiveLaneClientError.planGated
+      }
       let retryAfter: Int?
       if http.statusCode == 429 {
         retryAfter = Self.parseRetryAfterSeconds(from: http)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -452,8 +452,8 @@ actor ProactiveLaneClient {
     try checkQuotaCooldown(operation: operation)
     if imageData != nil {
       if await managedPixelDecision() == .planGated {
-        // TODO(free-tier local lane): when a local-proactivity flag flips, route
-        // pixels to LocalInferenceRuntime. Text-only JIT stays ungated here.
+        // S24 local-lane seam: when OMI_LOCAL_PROACTIVITY flips, route pixels to
+        // LocalInferenceRuntime. Text-only completions stay ungated here.
         if ProcessInfo.processInfo.environment["OMI_LOCAL_PROACTIVITY"] == "1" {
           // Local lane not shipped — still fail closed to `.planGated`.
         }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -359,7 +359,7 @@ actor ProactiveLaneClient {
     self.managedPixelDecision =
       managedPixelDecision
       ?? {
-        await ManagedProactivityDecisionSource.shared.current()
+        await ManagedProactivityDecisionSource.current()
       }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -359,7 +359,7 @@ actor ProactiveLaneClient {
     self.managedPixelDecision =
       managedPixelDecision
       ?? {
-        await ManagedProactivityDecisionSource.current()
+        await ManagedProactivityDecisionSource.shared.current()
       }
   }
 

--- a/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
+++ b/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
@@ -44,11 +44,12 @@ enum SubscriptionEntitlement {
 /// Refresh on TTL and on auth/owner change. Fetch failure is unknown plan
 /// (allow; server decides). BYOK is re-read on every decision so a key change
 /// does not wait for the subscription TTL.
-actor SubscriptionEntitlementService {
+final class SubscriptionEntitlementService: @unchecked Sendable {
   static let shared = SubscriptionEntitlementService()
 
   static let defaultTTL: TimeInterval = 5 * 60
 
+  private let lock = NSLock()
   private var cached: (response: UserSubscriptionResponse, expiresAt: Date)?
   private var inflight: Task<UserSubscriptionResponse?, Never>?
   private var observers: [NSObjectProtocol] = []
@@ -75,13 +76,11 @@ actor SubscriptionEntitlementService {
       let center = NotificationCenter.default
       observers.append(
         center.addObserver(forName: .userDidSignOut, object: nil, queue: nil) { [weak self] _ in
-          guard let self else { return }
-          Task { await self.invalidate() }
+          self?.invalidate()
         })
       observers.append(
         center.addObserver(forName: .runtimeOwnerDidChange, object: nil, queue: nil) { [weak self] _ in
-          guard let self else { return }
-          Task { await self.invalidate() }
+          self?.invalidate()
         })
     }
   }
@@ -92,14 +91,22 @@ actor SubscriptionEntitlementService {
     }
   }
 
-  func invalidate() {
-    cached = nil
-    inflight?.cancel()
-    inflight = nil
+  private func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
   }
 
-  func cachedSnapshot() -> UserSubscriptionResponse? {
-    cached?.response
+  func invalidate() {
+    withLock {
+      cached = nil
+      inflight?.cancel()
+      inflight = nil
+    }
+  }
+
+  var cachedSnapshot: UserSubscriptionResponse? {
+    withLock { cached?.response }
   }
 
   func decisionForManagedProactivity() async -> SubscriptionEntitlementDecision {
@@ -111,14 +118,17 @@ actor SubscriptionEntitlementService {
   }
 
   func snapshot() async -> UserSubscriptionResponse? {
-    if let cached, cached.expiresAt > now() {
+    if let response = withLock({
+      guard let cached, cached.expiresAt > now() else { return nil as UserSubscriptionResponse? }
       return cached.response
+    }) {
+      return response
     }
-    if let inflight {
+    if let inflight = withLock({ inflight }) {
       return await inflight.value
     }
     let task = Task { await self.refresh() }
-    inflight = task
+    withLock { inflight = task }
     return await task.value
   }
 
@@ -129,9 +139,11 @@ actor SubscriptionEntitlementService {
     } catch {
       response = nil
     }
-    inflight = nil
-    if let response {
-      cached = (response, now().addingTimeInterval(ttl))
+    withLock {
+      inflight = nil
+      if let response {
+        cached = (response, now().addingTimeInterval(ttl))
+      }
     }
     return response
   }
@@ -139,20 +151,26 @@ actor SubscriptionEntitlementService {
 
 /// Test seam so Gemini / lane clients can pin a decision without touching
 /// `SubscriptionEntitlementService.shared`.
-actor ManagedProactivityDecisionSource {
-  static let shared = ManagedProactivityDecisionSource()
+enum ManagedProactivityDecisionSource {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var override: (@Sendable () async -> SubscriptionEntitlementDecision)?
 
-  private var override: (@Sendable () async -> SubscriptionEntitlementDecision)?
+  private static func withLock<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
 
-  func current() async -> SubscriptionEntitlementDecision {
-    if let override {
-      return await override()
+  static func current() async -> SubscriptionEntitlementDecision {
+    let pinned = withLock { override }
+    if let pinned {
+      return await pinned()
     }
     return await SubscriptionEntitlementService.shared.decisionForManagedProactivity()
   }
 
-  func setOverride(_ resolve: (@Sendable () async -> SubscriptionEntitlementDecision)?) {
-    override = resolve
+  static func setOverride(_ resolve: (@Sendable () async -> SubscriptionEntitlementDecision)?) {
+    withLock { override = resolve }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
+++ b/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
@@ -44,12 +44,11 @@ enum SubscriptionEntitlement {
 /// Refresh on TTL and on auth/owner change. Fetch failure is unknown plan
 /// (allow; server decides). BYOK is re-read on every decision so a key change
 /// does not wait for the subscription TTL.
-final class SubscriptionEntitlementService: @unchecked Sendable {
+actor SubscriptionEntitlementService {
   static let shared = SubscriptionEntitlementService()
 
   static let defaultTTL: TimeInterval = 5 * 60
 
-  private let lock = NSLock()
   private var cached: (response: UserSubscriptionResponse, expiresAt: Date)?
   private var inflight: Task<UserSubscriptionResponse?, Never>?
   private var observers: [NSObjectProtocol] = []
@@ -76,11 +75,13 @@ final class SubscriptionEntitlementService: @unchecked Sendable {
       let center = NotificationCenter.default
       observers.append(
         center.addObserver(forName: .userDidSignOut, object: nil, queue: nil) { [weak self] _ in
-          self?.invalidate()
+          guard let self else { return }
+          Task { await self.invalidate() }
         })
       observers.append(
         center.addObserver(forName: .runtimeOwnerDidChange, object: nil, queue: nil) { [weak self] _ in
-          self?.invalidate()
+          guard let self else { return }
+          Task { await self.invalidate() }
         })
     }
   }
@@ -92,17 +93,13 @@ final class SubscriptionEntitlementService: @unchecked Sendable {
   }
 
   func invalidate() {
-    lock.lock()
     cached = nil
     inflight?.cancel()
     inflight = nil
-    lock.unlock()
   }
 
-  var cachedSnapshot: UserSubscriptionResponse? {
-    lock.lock()
-    defer { lock.unlock() }
-    return cached?.response
+  func cachedSnapshot() -> UserSubscriptionResponse? {
+    cached?.response
   }
 
   func decisionForManagedProactivity() async -> SubscriptionEntitlementDecision {
@@ -114,19 +111,14 @@ final class SubscriptionEntitlementService: @unchecked Sendable {
   }
 
   func snapshot() async -> UserSubscriptionResponse? {
-    lock.lock()
     if let cached, cached.expiresAt > now() {
-      let response = cached.response
-      lock.unlock()
-      return response
+      return cached.response
     }
     if let inflight {
-      lock.unlock()
       return await inflight.value
     }
     let task = Task { await self.refresh() }
     inflight = task
-    lock.unlock()
     return await task.value
   }
 
@@ -137,36 +129,30 @@ final class SubscriptionEntitlementService: @unchecked Sendable {
     } catch {
       response = nil
     }
-    lock.lock()
     inflight = nil
     if let response {
       cached = (response, now().addingTimeInterval(ttl))
     }
-    lock.unlock()
     return response
   }
 }
 
 /// Test seam so Gemini / lane clients can pin a decision without touching
 /// `SubscriptionEntitlementService.shared`.
-enum ManagedProactivityDecisionSource {
-  private static let lock = NSLock()
-  nonisolated(unsafe) private static var override: (@Sendable () async -> SubscriptionEntitlementDecision)?
+actor ManagedProactivityDecisionSource {
+  static let shared = ManagedProactivityDecisionSource()
 
-  static func current() async -> SubscriptionEntitlementDecision {
-    lock.lock()
-    let override = self.override
-    lock.unlock()
+  private var override: (@Sendable () async -> SubscriptionEntitlementDecision)?
+
+  func current() async -> SubscriptionEntitlementDecision {
     if let override {
       return await override()
     }
     return await SubscriptionEntitlementService.shared.decisionForManagedProactivity()
   }
 
-  static func setOverride(_ resolve: (@Sendable () async -> SubscriptionEntitlementDecision)?) {
-    lock.lock()
+  func setOverride(_ resolve: (@Sendable () async -> SubscriptionEntitlementDecision)?) {
     override = resolve
-    lock.unlock()
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
+++ b/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// Client UX decision for paid-or-BYOK managed proactivity.
+///
+/// Unknown / unavailable plan fails open so the server remains the invariant.
+/// Identified `basic` without BYOK is the only locally gated case.
+enum SubscriptionEntitlementDecision: Equatable, Sendable {
+  case allowManagedProactivity
+  case planGated
+}
+
+enum SubscriptionEntitlement {
+  static let byokFeature = "byok"
+
+  /// Plan authority is `GET /v1/users/me/subscription`, not `TierManager` and
+  /// not the trial-paywall UserDefaults gate. `SubscriptionPlanType.hasPaidCapability`
+  /// treats `.unknown` as unpaid; this decision deliberately does not.
+  static func decision(
+    plan: SubscriptionPlanType?,
+    features: [String],
+    isByokActive: Bool
+  ) -> SubscriptionEntitlementDecision {
+    if isByokActive || hasByokFeature(features) {
+      return .allowManagedProactivity
+    }
+    guard let plan else {
+      return .allowManagedProactivity
+    }
+    switch plan {
+    case .basic:
+      return .planGated
+    case .unknown, .plus, .unlimited, .unlimitedV2, .architect, .pro, .operator:
+      return .allowManagedProactivity
+    }
+  }
+
+  static func hasByokFeature(_ features: [String]) -> Bool {
+    features.contains { $0.caseInsensitiveCompare(byokFeature) == .orderedSame }
+  }
+}
+
+/// Cached snapshot of `/v1/users/me/subscription` for S13 / S11.
+///
+/// Refresh on TTL and on auth/owner change. Fetch failure is unknown plan
+/// (allow; server decides). BYOK is re-read on every decision so a key change
+/// does not wait for the subscription TTL.
+final class SubscriptionEntitlementService: @unchecked Sendable {
+  static let shared = SubscriptionEntitlementService()
+
+  static let defaultTTL: TimeInterval = 5 * 60
+
+  private let lock = NSLock()
+  private var cached: (response: UserSubscriptionResponse, expiresAt: Date)?
+  private var inflight: Task<UserSubscriptionResponse?, Never>?
+  private var observers: [NSObjectProtocol] = []
+
+  var ttl: TimeInterval
+  var now: @Sendable () -> Date
+  var fetchSubscription: @Sendable () async throws -> UserSubscriptionResponse
+  var isByokActive: @Sendable () -> Bool
+
+  init(
+    ttl: TimeInterval = SubscriptionEntitlementService.defaultTTL,
+    observeAuthChanges: Bool = true,
+    now: @escaping @Sendable () -> Date = { Date() },
+    fetchSubscription: @escaping @Sendable () async throws -> UserSubscriptionResponse = {
+      try await APIClient.shared.getUserSubscription()
+    },
+    isByokActive: @escaping @Sendable () -> Bool = { APIKeyService.isByokActive }
+  ) {
+    self.ttl = ttl
+    self.now = now
+    self.fetchSubscription = fetchSubscription
+    self.isByokActive = isByokActive
+    if observeAuthChanges {
+      let center = NotificationCenter.default
+      observers.append(
+        center.addObserver(forName: .userDidSignOut, object: nil, queue: nil) { [weak self] _ in
+          self?.invalidate()
+        })
+      observers.append(
+        center.addObserver(forName: .runtimeOwnerDidChange, object: nil, queue: nil) { [weak self] _ in
+          self?.invalidate()
+        })
+    }
+  }
+
+  deinit {
+    for observer in observers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
+
+  func invalidate() {
+    lock.lock()
+    cached = nil
+    inflight?.cancel()
+    inflight = nil
+    lock.unlock()
+  }
+
+  var cachedSnapshot: UserSubscriptionResponse? {
+    lock.lock()
+    defer { lock.unlock() }
+    return cached?.response
+  }
+
+  func decisionForManagedProactivity() async -> SubscriptionEntitlementDecision {
+    let info = await snapshot()?.subscription
+    return SubscriptionEntitlement.decision(
+      plan: info?.plan,
+      features: info?.features ?? [],
+      isByokActive: isByokActive())
+  }
+
+  func snapshot() async -> UserSubscriptionResponse? {
+    lock.lock()
+    if let cached, cached.expiresAt > now() {
+      let response = cached.response
+      lock.unlock()
+      return response
+    }
+    if let inflight {
+      lock.unlock()
+      return await inflight.value
+    }
+    let task = Task { await self.refresh() }
+    inflight = task
+    lock.unlock()
+    return await task.value
+  }
+
+  private func refresh() async -> UserSubscriptionResponse? {
+    let response: UserSubscriptionResponse?
+    do {
+      response = try await fetchSubscription()
+    } catch {
+      response = nil
+    }
+    lock.lock()
+    inflight = nil
+    if let response {
+      cached = (response, now().addingTimeInterval(ttl))
+    }
+    lock.unlock()
+    return response
+  }
+}
+
+/// Test seam so Gemini / lane clients can pin a decision without touching
+/// `SubscriptionEntitlementService.shared`.
+enum ManagedProactivityDecisionSource {
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var override: (@Sendable () async -> SubscriptionEntitlementDecision)?
+
+  static func current() async -> SubscriptionEntitlementDecision {
+    lock.lock()
+    let override = self.override
+    lock.unlock()
+    if let override {
+      return await override()
+    }
+    return await SubscriptionEntitlementService.shared.decisionForManagedProactivity()
+  }
+
+  static func setOverride(_ resolve: (@Sendable () async -> SubscriptionEntitlementDecision)?) {
+    lock.lock()
+    override = resolve
+    lock.unlock()
+  }
+}
+
+enum ManagedPlanGateHTTP {
+  static func isPlanGated(status: Int, data: Data) -> Bool {
+    guard status == 402 else { return false }
+    if let object = try? JSONSerialization.jsonObject(with: data) {
+      if errorField(object) == "plan_gated" {
+        return true
+      }
+      if let root = object as? [String: Any], let detail = root["detail"] {
+        if errorField(detail) == "plan_gated" {
+          return true
+        }
+        if let detailString = detail as? String,
+          detailString.lowercased().contains("plan_gated")
+        {
+          return true
+        }
+      }
+    }
+    let body = String(data: data.prefix(512), encoding: .utf8)?.lowercased() ?? ""
+    return body.contains("plan_gated")
+  }
+
+  private static func errorField(_ object: Any) -> String? {
+    (object as? [String: Any])?["error"] as? String
+  }
+}
+
+enum RealtimeHubUsageLimitPresentation {
+  /// Mid-session provider quota 1008 is a usage-limit close. Gemini idle 1008
+  /// (`expectedIdleTeardown`) is not.
+  static func shouldPresent(category: RealtimeHubCloseCategory?, failoverStarted: Bool) -> Bool {
+    category == .providerQuotaExceeded && !failoverStarted
+  }
+}

--- a/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
+++ b/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
@@ -130,4 +130,54 @@ final class AIBackendErrorNormalizationTests: XCTestCase {
     XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.badURL)))
     XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.userAuthenticationRequired)))
   }
+
+  func testGeminiPlanGatedIsNotRetriedAndIsExpectedProductState() {
+    let error = GeminiClient.GeminiClientError.planGated
+    XCTAssertFalse(error.shouldAutoRetry)
+    XCTAssertFalse(error.isTransient)
+    XCTAssertTrue(error.isExpectedProductState)
+    XCTAssertFalse(GeminiClient.shouldAutoRetry(error))
+    XCTAssertEqual(error.localizedDescription, "AI features require an active plan or BYOK keys.")
+  }
+
+  func testGeminiHTTP402PlanGatedBodyMapsToPlanGatedAndIsNotRetried() throws {
+    let body = Data(#"{"detail":{"error":"plan_gated","plan_type":"basic"}}"#.utf8)
+    let response = try XCTUnwrap(
+      HTTPURLResponse(
+        url: URL(string: "https://api.omi.me/v1/proxy/gemini")!,
+        statusCode: 402,
+        httpVersion: nil,
+        headerFields: ["X-Omi-Retryable": "true"]
+      ))
+    let error = try XCTUnwrap(GeminiClient.httpError(response: response, data: body))
+    guard case .planGated = error else {
+      return XCTFail("expected planGated, got \(error)")
+    }
+    XCTAssertFalse(GeminiClient.shouldAutoRetry(error))
+  }
+
+  func testGeminiHTTP402ChatQuotaBodyStaysApiError() throws {
+    let body = Data(#"{"error":"trial_expired"}"#.utf8)
+    let response = try XCTUnwrap(
+      HTTPURLResponse(
+        url: URL(string: "https://api.omi.me/v1/proxy/gemini")!,
+        statusCode: 402,
+        httpVersion: nil,
+        headerFields: nil
+      ))
+    let error = try XCTUnwrap(GeminiClient.httpError(response: response, data: body))
+    guard case .apiError(let message, _) = error else {
+      return XCTFail("expected apiError for non-plan_gated 402, got \(error)")
+    }
+    XCTAssertTrue(message.contains("trial_expired"))
+  }
+
+  func testRequireManagedProactivityThrowsOnlyWhenGated() {
+    XCTAssertNoThrow(try GeminiClient.requireManagedProactivity(.allowManagedProactivity))
+    XCTAssertThrowsError(try GeminiClient.requireManagedProactivity(.planGated)) { error in
+      guard case GeminiClient.GeminiClientError.planGated = error else {
+        return XCTFail("expected planGated")
+      }
+    }
+  }
 }

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -237,6 +237,73 @@ final class ProactiveLaneClientTests: XCTestCase {
     XCTAssertEqual(
       ProactiveLaneClientError.quotaCooldown(retryAfterSeconds: 12).localizedDescription,
       "proactive_quota_cooldown status=429")
+    XCTAssertEqual(ProactiveLaneClientError.planGated.localizedDescription, "proactive_plan_gated")
+  }
+
+  func testPlanGatedIsNotClassifiedAsNetworkOrRetryableHTTP() {
+    let classified = ProactiveLaneFailureClassification.classify(ProactiveLaneClientError.planGated)
+    XCTAssertEqual(classified.failure, "plan_gated")
+    XCTAssertEqual(classified.status, 402)
+    XCTAssertNotEqual(classified.failure, "network")
+    XCTAssertNotEqual(classified.failure, "http_error")
+  }
+
+  func testPixelCompleteThrowsPlanGatedWithoutNetwork() async throws {
+    ProactiveLaneURLStub.reset()
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      managedPixelDecision: { .planGated })
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200, body: try successEnvelope(operation: ModelQoS.Proactivity.extractionOperation))
+    do {
+      _ = try await client.complete(
+        operation: ModelQoS.Proactivity.extractionOperation,
+        prompt: "extract",
+        imageData: Data("jpeg".utf8),
+        jsonSchema: ["type": "object"])
+      XCTFail("expected planGated")
+    } catch ProactiveLaneClientError.planGated {
+      XCTAssertTrue(ProactiveLaneURLStub.requestedPaths.isEmpty)
+    }
+  }
+
+  func testTextOnlyCompleteIsNotPreGatedByBasicPlan() async throws {
+    ProactiveLaneURLStub.reset()
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      managedPixelDecision: { .planGated })
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200, body: try successEnvelope(operation: ModelQoS.Proactivity.extractionOperation))
+    let result = try await client.complete(
+      operation: ModelQoS.Proactivity.extractionOperation,
+      prompt: "extract",
+      jsonSchema: ["type": "object"])
+    XCTAssertEqual(result.operation, ModelQoS.Proactivity.extractionOperation)
+    XCTAssertEqual(ProactiveLaneURLStub.requestedPaths, ["/v1/desktop/proactivity/completions"])
+  }
+
+  func testHTTP402PlanGatedBodyMapsToPlanGated() async throws {
+    ProactiveLaneURLStub.reset()
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      managedPixelDecision: { .allowManagedProactivity })
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 402,
+      body: Data(#"{"detail":{"error":"plan_gated","plan_type":"basic"}}"#.utf8))
+    do {
+      _ = try await client.complete(
+        operation: ModelQoS.Proactivity.extractionOperation,
+        prompt: "extract",
+        jsonSchema: ["type": "object"])
+      XCTFail("expected planGated")
+    } catch ProactiveLaneClientError.planGated {
+    }
   }
 
   func testUnprocessableEntityIsClassifiedAsInvalidStructuredOutputNotHttpError() throws {

--- a/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubCloseClassifierTests.swift
@@ -262,4 +262,19 @@ final class RealtimeHubCloseClassifierTests: XCTestCase {
 
     XCTAssertEqual(category, .providerQuotaExceeded)
   }
+
+  func testUsageLimitPopupIsOnlyForQuotaCloseAfterFailoverExhausts() {
+    XCTAssertTrue(
+      RealtimeHubUsageLimitPresentation.shouldPresent(
+        category: .providerQuotaExceeded, failoverStarted: false))
+    XCTAssertFalse(
+      RealtimeHubUsageLimitPresentation.shouldPresent(
+        category: .providerQuotaExceeded, failoverStarted: true))
+    XCTAssertFalse(
+      RealtimeHubUsageLimitPresentation.shouldPresent(
+        category: .expectedIdleTeardown, failoverStarted: false))
+    XCTAssertFalse(
+      RealtimeHubUsageLimitPresentation.shouldPresent(
+        category: .providerPolicyCloseFast, failoverStarted: false))
+  }
 }

--- a/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private final class TestCounter: @unchecked Sendable {
+  var value = 0
+}
+
+private final class TestFlag: @unchecked Sendable {
+  var value = false
+}
+
+final class SubscriptionEntitlementServiceTests: XCTestCase {
+  override func tearDown() {
+    ManagedProactivityDecisionSource.setOverride(nil)
+    super.tearDown()
+  }
+
+  func testIdentifiedBasicWithoutBYOKIsPlanGated() {
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: .basic, features: [], isByokActive: false),
+      .planGated)
+  }
+
+  func testPaidPlansAreAllowed() {
+    for plan in [
+      SubscriptionPlanType.plus, .unlimited, .unlimitedV2, .architect, .pro, .operator,
+    ] {
+      XCTAssertEqual(
+        SubscriptionEntitlement.decision(plan: plan, features: [], isByokActive: false),
+        .allowManagedProactivity,
+        "\(plan.rawValue) must stay allowed")
+    }
+  }
+
+  func testUnknownPlanFailsOpen() {
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: .unknown("neo"), features: [], isByokActive: false),
+      .allowManagedProactivity)
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: nil, features: [], isByokActive: false),
+      .allowManagedProactivity)
+  }
+
+  func testBYOKAllowsIdentifiedBasic() {
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: .basic, features: [], isByokActive: true),
+      .allowManagedProactivity)
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: .basic, features: ["byok"], isByokActive: false),
+      .allowManagedProactivity)
+  }
+
+  func testUnknownPlanDoesNotUseHasPaidCapability() {
+    XCTAssertFalse(SubscriptionPlanType.unknown("neo").hasPaidCapability)
+    XCTAssertEqual(
+      SubscriptionEntitlement.decision(plan: .unknown("neo"), features: [], isByokActive: false),
+      .allowManagedProactivity)
+  }
+
+  func testServiceCachesSnapshotAndRecomputesBYOKLive() async throws {
+    let fetches = TestCounter()
+    let byok = TestFlag()
+    let service = SubscriptionEntitlementService(
+      ttl: 60,
+      observeAuthChanges: false,
+      now: { Date(timeIntervalSince1970: 1_800_000_000) },
+      fetchSubscription: {
+        fetches.value += 1
+        return try Self.decodeSubscription(plan: "basic")
+      },
+      isByokActive: { byok.value })
+    XCTAssertEqual(await service.decisionForManagedProactivity(), .planGated)
+    XCTAssertEqual(fetches.value, 1)
+    byok.value = true
+    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    XCTAssertEqual(fetches.value, 1)
+  }
+
+  func testServiceFetchFailureFailsOpen() async {
+    let service = SubscriptionEntitlementService(
+      observeAuthChanges: false,
+      fetchSubscription: { throw URLError(.notConnectedToInternet) },
+      isByokActive: { false })
+    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+  }
+
+  func testAuthChangeInvalidatesCache() async throws {
+    let fetches = TestCounter()
+    let service = SubscriptionEntitlementService(
+      observeAuthChanges: true,
+      fetchSubscription: {
+        fetches.value += 1
+        return try Self.decodeSubscription(plan: "plus")
+      },
+      isByokActive: { false })
+    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    NotificationCenter.default.post(name: .userDidSignOut, object: nil)
+    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    XCTAssertEqual(fetches.value, 2)
+  }
+
+  func testRealtimeUsageBodyIncludesTurnIdWhenProvided() {
+    let withTurn = APIClient.realtimeUsageReportBody(
+      provider: "gemini",
+      model: "gemini-live",
+      inputText: 1,
+      inputAudio: 2,
+      inputCached: 0,
+      outputText: 3,
+      outputAudio: 4,
+      contextPlanID: "plan",
+      stableCacheIdentity: "stable",
+      dynamicContextIdentity: "dynamic",
+      contextCacheReplaced: false,
+      turnId: "turn-1")
+    XCTAssertEqual(withTurn["turn_id"] as? String, "turn-1")
+    let withoutTurn = APIClient.realtimeUsageReportBody(
+      provider: "gemini",
+      model: "gemini-live",
+      inputText: 1,
+      inputAudio: 2,
+      inputCached: 0,
+      outputText: 3,
+      outputAudio: 4,
+      contextPlanID: "plan",
+      stableCacheIdentity: "stable",
+      dynamicContextIdentity: "dynamic",
+      contextCacheReplaced: false,
+      turnId: "")
+    XCTAssertNil(withoutTurn["turn_id"])
+  }
+
+  func testManagedPlanGateHTTPReadsFastAPIDetail() {
+    let detail = Data(#"{"detail":{"error":"plan_gated","plan_type":"basic"}}"#.utf8)
+    XCTAssertTrue(ManagedPlanGateHTTP.isPlanGated(status: 402, data: detail))
+    let root = Data(#"{"error":"plan_gated"}"#.utf8)
+    XCTAssertTrue(ManagedPlanGateHTTP.isPlanGated(status: 402, data: root))
+    let quota = Data(#"{"error":"trial_expired"}"#.utf8)
+    XCTAssertFalse(ManagedPlanGateHTTP.isPlanGated(status: 402, data: quota))
+    XCTAssertFalse(ManagedPlanGateHTTP.isPlanGated(status: 403, data: detail))
+  }
+
+  private static func decodeSubscription(plan: String, features: [String] = []) throws
+    -> UserSubscriptionResponse
+  {
+    let featureJSON = String(data: try JSONSerialization.data(withJSONObject: features), encoding: .utf8) ?? "[]"
+    let json = """
+      {"subscription":{"plan":"\(plan)","status":"active","features":\(featureJSON),"cancel_at_period_end":false,"limits":{}}}
+      """
+    return try JSONDecoder().decode(UserSubscriptionResponse.self, from: Data(json.utf8))
+  }
+}

--- a/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
@@ -11,9 +11,9 @@ private final class TestFlag: @unchecked Sendable {
 }
 
 final class SubscriptionEntitlementServiceTests: XCTestCase {
-  override func tearDown() {
-    ManagedProactivityDecisionSource.setOverride(nil)
-    super.tearDown()
+  override func tearDown() async throws {
+    await ManagedProactivityDecisionSource.shared.setOverride(nil)
+    try await super.tearDown()
   }
 
   func testIdentifiedBasicWithoutBYOKIsPlanGated() {
@@ -96,6 +96,7 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
       isByokActive: { false })
     XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
     NotificationCenter.default.post(name: .userDidSignOut, object: nil)
+    await service.invalidate()
     XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
     XCTAssertEqual(fetches.value, 2)
   }

--- a/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
@@ -11,9 +11,9 @@ private final class TestFlag: @unchecked Sendable {
 }
 
 final class SubscriptionEntitlementServiceTests: XCTestCase {
-  override func tearDown() async throws {
-    await ManagedProactivityDecisionSource.shared.setOverride(nil)
-    try await super.tearDown()
+  override func tearDown() {
+    ManagedProactivityDecisionSource.setOverride(nil)
+    super.tearDown()
   }
 
   func testIdentifiedBasicWithoutBYOKIsPlanGated() {
@@ -96,7 +96,6 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
       isByokActive: { false })
     XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
     NotificationCenter.default.post(name: .userDidSignOut, object: nil)
-    await service.invalidate()
     XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
     XCTAssertEqual(fetches.value, 2)
   }

--- a/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
@@ -70,10 +70,12 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
         return try Self.decodeSubscription(plan: "basic")
       },
       isByokActive: { byok.value })
-    XCTAssertEqual(await service.decisionForManagedProactivity(), .planGated)
+    let first = await service.decisionForManagedProactivity()
+    XCTAssertEqual(first, .planGated)
     XCTAssertEqual(fetches.value, 1)
     byok.value = true
-    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    let second = await service.decisionForManagedProactivity()
+    XCTAssertEqual(second, .allowManagedProactivity)
     XCTAssertEqual(fetches.value, 1)
   }
 
@@ -82,7 +84,8 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
       observeAuthChanges: false,
       fetchSubscription: { throw URLError(.notConnectedToInternet) },
       isByokActive: { false })
-    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    let decision = await service.decisionForManagedProactivity()
+    XCTAssertEqual(decision, .allowManagedProactivity)
   }
 
   func testAuthChangeInvalidatesCache() async throws {
@@ -94,9 +97,11 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
         return try Self.decodeSubscription(plan: "plus")
       },
       isByokActive: { false })
-    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    let before = await service.decisionForManagedProactivity()
+    XCTAssertEqual(before, .allowManagedProactivity)
     NotificationCenter.default.post(name: .userDidSignOut, object: nil)
-    XCTAssertEqual(await service.decisionForManagedProactivity(), .allowManagedProactivity)
+    let after = await service.decisionForManagedProactivity()
+    XCTAssertEqual(after, .allowManagedProactivity)
     XCTAssertEqual(fetches.value, 2)
   }
 

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -130,6 +130,7 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
       (GeminiClient.GeminiClientError.apiError("HTTP 503: upstream body", retryable: true), .httpStatus5xx),
       (GeminiClient.GeminiClientError.apiError("HTTP 400: prompt leaked", retryable: false), .httpStatus4xx),
       (GeminiClient.GeminiClientError.missingAPIKey, .other),
+      (GeminiClient.GeminiClientError.planGated, .other),
     ]
     for (error, expected) in classified {
       XCTAssertEqual(SuggestionAssistantTelemetry.EvaluationFailureReason(error), expected, String(describing: error))

--- a/desktop/macos/changelog/unreleased/20260906-plan-gated-proactivity.json
+++ b/desktop/macos/changelog/unreleased/20260906-plan-gated-proactivity.json
@@ -1,0 +1,3 @@
+{
+  "change": "Free-plan screen proactivity now stops on the plan gate instead of retrying paid Gemini calls, and a mid-session voice quota close shows the usage-limit prompt."
+}

--- a/desktop/macos/e2e/flows/plan-usage.yaml
+++ b/desktop/macos/e2e/flows/plan-usage.yaml
@@ -4,6 +4,7 @@ tier: 2
 description: Hermetic Settings billing subscription snapshot on offline stack
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+AccountBilling.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/BillingWebFlow.swift

--- a/desktop/macos/e2e/flows/proactive-assistant-proxy-routing.yaml
+++ b/desktop/macos/e2e/flows/proactive-assistant-proxy-routing.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityPolicy.swift
   - desktop/macos/Desktop/Sources/Chat/KnowledgeLedgerPromptProjection.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+  - desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/KnowledgeLedgerTriggerObservationAdapters.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/KnowledgeLedgerTriggerProjection.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/KnowledgeLedgerTriggerRuntime.swift


### PR DESCRIPTION
## S13 — desktop `.planGated` at the two clients

Shard S13 of the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S13; spec `30-desktop-proactivity.md` §3.1). S14 already 402s Gen-1 Gemini generate/stream. This PR stops the desktop from retrying that refusal and builds the cached entitlement service S11 will consume.

### What changed

- New `SubscriptionEntitlementService` caches `GET /v1/users/me/subscription`. Authority is that snapshot, not `TierManager` and not the trial-paywall UserDefaults gate.
- Identified `basic` + non-BYOK → typed non-retryable `.planGated`. Unknown / fetch-failed plan fails open (server decides). This overrides `SubscriptionPlanType.hasPaidCapability`, which treats `.unknown` as unpaid.
- `GeminiClient` gates every public send **before** the retry loop, and maps HTTP 402 + `error=plan_gated` (including FastAPI `{detail:{error}}`) to `.planGated`. Chat-quota 402 (`trial_expired`) stays `.apiError`.
- `ProactiveLaneClient` pre-gates **pixels only** (`imageData != nil`). Text-only JIT nano triage stays open (S14 remaining half / S24 narrowing). HTTP 402 `plan_gated` still maps to `.planGated` so a later server gate is not retried as `http_error` / `network`.
- Thin `OMI_LOCAL_PROACTIVITY` flag read at the `.planGated` throw sites. No local-lane implementation.
- S15 desktop follow-ups: hub `/v2/realtime/usage` now sends `turn_id` when the session has one; mid-session provider-quota 1008 presents the usage-limit UI. Gemini idle 1008 (`expectedIdleTeardown`) does not.

### Automatic-or-dead check

- `GeminiClient.GeminiClientError.planGated.shouldAutoRetry == false` and `GeminiClient.shouldAutoRetry(.planGated) == false`.
- `GeminiClient.httpError` on 402 + `plan_gated` body → `.planGated` even when `X-Omi-Retryable: true`.
- Pixel `complete(imageData:)` with a gated decision throws `.planGated` and issues **no** network request.
- Text-only `complete` with the same gated decision still hits the lane (JIT survives).
- `ProactiveLaneFailureClassification.classify(.planGated)` is `plan_gated`, not `network` / `http_error`.
- Entitlement: basic+non-BYOK gated; paid allowed; unknown allowed; BYOK basic allowed.

Red-proof: drop the `try await Self.enforceManagedProactivity()` at the start of `sendTextRequest` and the 402 mapper in `httpError`, and the new tests fail.

### Proof

Hermetic desktop unit tests in this PR (`SubscriptionEntitlementServiceTests`, `AIBackendErrorNormalizationTests`, `ProactiveLaneClientTests`, `RealtimeHubCloseClassifierTests`). Local Xcode 16.4 is not installed on this Mac; GitHub `macos-15` Desktop Swift jobs are the compile+test proof.

Dest: desktop-only. Merging does not deploy Cloud Run. Hourly desktop beta train may pick the merge up; `FREE_PROACTIVITY_GATE` / `FREE_TIER_LOCAL_PROCESSING` stay off.

### Line-count ratchet

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSession.swift | 1819 -> 1821 | S15 follow-up: pass existing turn_id into hub usage reports
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1572 -> 1578 | S15 follow-up: present usage-limit UI only after quota 1008 failover exhausts

### Cut list

- Server gate on `desktop_proactivity` completions (JIT lane; do not take).
- Pixel-vs-text discrimination inside Gemini generateContent (S24).
- Local-lane implementation behind `OMI_LOCAL_PROACTIVITY` (S9/S24).
- S11 finalization wiring (consumes this entitlement service).
- Pusher-hardening decision 4; prod `memory-maintenance-job` create.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1

Path overlap only: `APIClient.swift` gained an optional `turn_id` on hub usage reports. Session death and transcript ownership are unchanged.

## How it was verified

- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — OK
- New/updated XCTest cases listed under Automatic-or-dead
- Did not run `run-swift-ci.sh` locally (requires Xcode 16.4; this host is 26.6)

## Tests

- `SubscriptionEntitlementServiceTests` — decision matrix, cache + live BYOK, fetch fail-open, auth invalidate, usage `turn_id`, 402 body parse
- `AIBackendErrorNormalizationTests` — `.planGated` not retried; 402 `plan_gated` vs `trial_expired`
- `ProactiveLaneClientTests` — pixel pre-gate, text-only open, 402 map, classify ≠ network
- `RealtimeHubCloseClassifierTests` — usage-limit UI only after quota failover exhausts
- `SuggestionAssistantTelemetryTests` — `.planGated` maps to `.other`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

