### PR TITLE
fix(app): re-read device storage after clearing recordings

### DIFF
--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -20,6 +20,26 @@ import 'synced_conversations_page.dart';
 import 'wal_item_detail/wal_item_detail_page.dart';
 import 'package:omi/pages/conversations/widgets/status_action_pill.dart';
 
+/// Clear device recordings, then re-read the device's storage snapshot.
+///
+/// The storage card renders the ring status this page read when it opened, so a
+/// clear performed while the page stayed open left the card showing the
+/// pre-clear numbers — the device still reported as full after its recordings
+/// were gone. The re-read has to follow the clear; taken first it would return
+/// exactly the stale numbers being corrected. It also runs when the clear throws,
+/// because a clear that failed part-way still deleted files and leaves the card
+/// just as wrong; the failure itself still propagates to the caller.
+Future<void> clearRecordingsThenRefreshStorage({
+  required Future<void> Function() clearRecordings,
+  required Future<void> Function() refreshDeviceStorage,
+}) async {
+  try {
+    await clearRecordings();
+  } finally {
+    await refreshDeviceStorage();
+  }
+}
+
 class AutoSyncPage extends StatefulWidget {
   const AutoSyncPage({super.key});
 
@@ -758,6 +778,9 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
   // ─────────────────────────────────────────
 
   void _showManageStorageSheet(BuildContext context, SyncProvider provider) {
+    // Captured before the sheet's async callbacks run, so the clear handlers do
+    // not reach through a BuildContext across an await.
+    final deviceProvider = context.read<DeviceProvider>();
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
@@ -773,7 +796,10 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await provider.deleteAllSyncedWals();
+            await clearRecordingsThenRefreshStorage(
+              clearRecordings: provider.deleteAllSyncedWals,
+              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
+            );
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -791,7 +817,10 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await provider.deleteAllPendingWals();
+            await clearRecordingsThenRefreshStorage(
+              clearRecordings: provider.deleteAllPendingWals,
+              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
+            );
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -809,7 +838,10 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await provider.deleteAllClearableWals();
+            await clearRecordingsThenRefreshStorage(
+              clearRecordings: provider.deleteAllClearableWals,
+              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
+            );
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -20,24 +20,39 @@ import 'synced_conversations_page.dart';
 import 'wal_item_detail/wal_item_detail_page.dart';
 import 'package:omi/pages/conversations/widgets/status_action_pill.dart';
 
-/// Clear device recordings, then re-read the device's storage snapshot.
+/// The Manage Storage clear actions, each paired with the storage re-read.
 ///
 /// The storage card renders the ring status this page read when it opened, so a
 /// clear performed while the page stayed open left the card showing the
 /// pre-clear numbers — the device still reported as full after its recordings
-/// were gone. The re-read has to follow the clear; taken first it would return
-/// exactly the stale numbers being corrected. It also runs when the clear throws,
-/// because a clear that failed part-way still deleted files and leaves the card
-/// just as wrong; the failure itself still propagates to the caller.
-Future<void> clearRecordingsThenRefreshStorage({
-  required Future<void> Function() clearRecordings,
+/// were gone. Pairing happens here, in one place, rather than in each handler:
+/// the original defect was three independent handlers that each had to remember
+/// the re-read, and none of which did.
+///
+/// The re-read has to follow the clear; taken first it would return exactly the
+/// stale numbers being corrected. It also runs when the clear throws, because a
+/// clear that failed part-way still deleted files and leaves the card just as
+/// wrong; the failure itself still propagates to the caller.
+({Future<void> Function() synced, Future<void> Function() pending, Future<void> Function() all})
+    buildStorageClearActions({
+  required Future<void> Function() clearSynced,
+  required Future<void> Function() clearPending,
+  required Future<void> Function() clearAll,
   required Future<void> Function() refreshDeviceStorage,
-}) async {
-  try {
-    await clearRecordings();
-  } finally {
-    await refreshDeviceStorage();
+}) {
+  Future<void> thenRefresh(Future<void> Function() clear) async {
+    try {
+      await clear();
+    } finally {
+      await refreshDeviceStorage();
+    }
   }
+
+  return (
+    synced: () => thenRefresh(clearSynced),
+    pending: () => thenRefresh(clearPending),
+    all: () => thenRefresh(clearAll),
+  );
 }
 
 class AutoSyncPage extends StatefulWidget {
@@ -778,9 +793,15 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
   // ─────────────────────────────────────────
 
   void _showManageStorageSheet(BuildContext context, SyncProvider provider) {
-    // Captured before the sheet's async callbacks run, so the clear handlers do
-    // not reach through a BuildContext across an await.
-    final deviceProvider = context.read<DeviceProvider>();
+    // Built before the sheet's async callbacks run, so the clear handlers do not
+    // reach through a BuildContext across an await — and so every action is
+    // paired with the storage re-read at a single construction site.
+    final clearActions = buildStorageClearActions(
+      clearSynced: provider.deleteAllSyncedWals,
+      clearPending: provider.deleteAllPendingWals,
+      clearAll: provider.deleteAllClearableWals,
+      refreshDeviceStorage: context.read<DeviceProvider>().refreshRingStorageStatus,
+    );
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
@@ -796,10 +817,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await clearRecordingsThenRefreshStorage(
-              clearRecordings: provider.deleteAllSyncedWals,
-              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
-            );
+            await clearActions.synced();
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -817,10 +835,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await clearRecordingsThenRefreshStorage(
-              clearRecordings: provider.deleteAllPendingWals,
-              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
-            );
+            await clearActions.pending();
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,
@@ -838,10 +853,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
             confirmColor: Colors.red,
           );
           if (confirmed == true && context.mounted) {
-            await clearRecordingsThenRefreshStorage(
-              clearRecordings: provider.deleteAllClearableWals,
-              refreshDeviceStorage: deviceProvider.refreshRingStorageStatus,
-            );
+            await clearActions.all();
             if (context.mounted) {
               ScaffoldMessenger.of(
                 context,

--- a/app/test/pages/auto_sync_storage_refresh_test.dart
+++ b/app/test/pages/auto_sync_storage_refresh_test.dart
@@ -1,0 +1,46 @@
+/// Clearing device recordings must re-read the device's storage snapshot.
+///
+/// The Sync page's storage card renders the ring-status snapshot loaded in
+/// `initState`. Clearing recordings while the page stayed open deleted the files
+/// but left that snapshot untouched, so the card kept reporting the device full
+/// (472 MB of 472 MB used, 12 KB free) until the user navigated away and back —
+/// which re-ran the page-open read and showed the true 0 B.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/conversations/auto_sync_page.dart';
+
+void main() {
+  test('the storage snapshot is re-read after the clear, not before it', () async {
+    final calls = <String>[];
+
+    await clearRecordingsThenRefreshStorage(
+      clearRecordings: () async => calls.add('clear'),
+      refreshDeviceStorage: () async => calls.add('refresh'),
+    );
+
+    // Order is the whole point: a read taken before the clear returns the
+    // pre-clear numbers, which is the stale reading users were left looking at.
+    expect(calls, ['clear', 'refresh']);
+  });
+
+  test('the storage snapshot is re-read even when the clear fails part-way', () async {
+    final calls = <String>[];
+
+    await expectLater(
+      clearRecordingsThenRefreshStorage(
+        clearRecordings: () async {
+          calls.add('clear');
+          throw StateError('device dropped the connection mid-delete');
+        },
+        refreshDeviceStorage: () async => calls.add('refresh'),
+      ),
+      throwsStateError,
+    );
+
+    // A clear that fails part-way still deleted some files, so the snapshot on
+    // screen is wrong in exactly the same way. The failure still surfaces.
+    expect(calls, ['clear', 'refresh']);
+  });
+}

--- a/app/test/pages/auto_sync_storage_refresh_test.dart
+++ b/app/test/pages/auto_sync_storage_refresh_test.dart
@@ -1,10 +1,14 @@
-/// Clearing device recordings must re-read the device's storage snapshot.
+/// Every Manage Storage clear must re-read the device's storage snapshot.
 ///
 /// The Sync page's storage card renders the ring-status snapshot loaded in
 /// `initState`. Clearing recordings while the page stayed open deleted the files
 /// but left that snapshot untouched, so the card kept reporting the device full
 /// (472 MB of 472 MB used, 12 KB free) until the user navigated away and back —
 /// which re-ran the page-open read and showed the true 0 B.
+///
+/// All three actions are asserted individually. The defect was three handlers
+/// that each had to remember the re-read, so a test covering only one of them
+/// would let the other two regress.
 library;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -12,35 +16,68 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/pages/conversations/auto_sync_page.dart';
 
 void main() {
-  test('the storage snapshot is re-read after the clear, not before it', () async {
+  /// Build the three actions over one shared call log, so each test can assert
+  /// what its action did and — just as importantly — what the others did not.
+  ({
+    List<String> calls,
+    ({Future<void> Function() synced, Future<void> Function() pending, Future<void> Function() all}) actions
+  }) subject({Future<void> Function()? clearPending}) {
     final calls = <String>[];
-
-    await clearRecordingsThenRefreshStorage(
-      clearRecordings: () async => calls.add('clear'),
-      refreshDeviceStorage: () async => calls.add('refresh'),
+    return (
+      calls: calls,
+      actions: buildStorageClearActions(
+        clearSynced: () async => calls.add('clear synced'),
+        clearPending: clearPending ?? () async => calls.add('clear pending'),
+        clearAll: () async => calls.add('clear all'),
+        refreshDeviceStorage: () async => calls.add('refresh'),
+      ),
     );
+  }
+
+  test('clearing synced recordings re-reads the storage snapshot afterwards', () async {
+    final s = subject();
+
+    await s.actions.synced();
 
     // Order is the whole point: a read taken before the clear returns the
     // pre-clear numbers, which is the stale reading users were left looking at.
-    expect(calls, ['clear', 'refresh']);
+    expect(s.calls, ['clear synced', 'refresh']);
+  });
+
+  test('clearing pending recordings re-reads the storage snapshot afterwards', () async {
+    final s = subject();
+
+    await s.actions.pending();
+
+    expect(s.calls, ['clear pending', 'refresh']);
+  });
+
+  test('clearing every recording re-reads the storage snapshot afterwards', () async {
+    final s = subject();
+
+    await s.actions.all();
+
+    expect(s.calls, ['clear all', 'refresh']);
+  });
+
+  test('each action clears only its own category', () async {
+    final s = subject();
+
+    await s.actions.pending();
+
+    expect(s.calls, isNot(contains('clear synced')));
+    expect(s.calls, isNot(contains('clear all')));
   });
 
   test('the storage snapshot is re-read even when the clear fails part-way', () async {
-    final calls = <String>[];
-
-    await expectLater(
-      clearRecordingsThenRefreshStorage(
-        clearRecordings: () async {
-          calls.add('clear');
-          throw StateError('device dropped the connection mid-delete');
-        },
-        refreshDeviceStorage: () async => calls.add('refresh'),
-      ),
-      throwsStateError,
+    final s = subject(
+      clearPending: () async => throw StateError('device dropped the connection mid-delete'),
     );
 
-    // A clear that fails part-way still deleted some files, so the snapshot on
+    await expectLater(s.actions.pending(), throwsStateError);
+
+    // A clear that failed part-way still deleted some files, so the snapshot on
     // screen is wrong in exactly the same way. The failure still surfaces.
-    expect(calls, ['clear', 'refresh']);
+    expect(s.calls, ['refresh']);
   });
 }


### PR DESCRIPTION
## What

Clearing recordings from the Sync page left the Device Storage card reporting the device as full. The files were deleted; only the number on screen was stale.

## Reproduced on a real device

| Step | Recordings | Device Storage |
|---|---|---|
| Before | 9 pending | 100% full · 472 MB of 472 MB used · **12 KB free** |
| After "Clear" on Pending | 1 pending | 100% full · 472 MB of 472 MB used · **12 KB free** |
| After backing out and re-entering the page | 0 | **0% full · 0 B of 472 MB used · 472 MB free** |

The snackbar said "Pending recordings deleted", and it was telling the truth — the recordings list updated correctly, and the storage really was freed. The card just never re-read it. Free space did not move by a single byte across the clear, which is what makes it a stale snapshot rather than a partial delete.

## Cause

`DeviceProvider.refreshRingStorageStatus()` had exactly one caller in the app: this page's `initState` (`auto_sync_page.dart:70`).

The three Manage Storage actions each did:

```dart
await provider.deleteAllPendingWals();   // refreshes the wal list, not the ring status
// snackbar
```

`SyncProvider.deleteAllPendingWals()` ends with `refreshWals()`, so the recordings list is correct. Nothing refreshes the `RingStatus` snapshot that `DeviceStorageCard` renders. Re-entering the page re-ran the `initState` read, which is why navigating away appeared to "fix" it.

## The change

All three actions — Synced, Pending, Clear All — are built at one construction site that pairs each clear with the re-read:

```dart
({Future<void> Function() synced, Future<void> Function() pending, Future<void> Function() all})
    buildStorageClearActions({ ...clears..., required Future<void> Function() refreshDeviceStorage }) {
  Future<void> thenRefresh(Future<void> Function() clear) async {
    try {
      await clear();
    } finally {
      await refreshDeviceStorage();
    }
  }
  return (synced: () => thenRefresh(clearSynced), ...);
}
```

The handlers no longer own the pairing, so one cannot be added or edited without it — which is what went wrong originally: three independent handlers each had to remember the re-read, and none did.

Two properties are deliberate:

- **The re-read follows the clear.** Taken first it would return exactly the pre-clear numbers being corrected.
- **The re-read runs when the clear throws.** A clear that failed part-way still deleted files, so the card is wrong in the same way. The failure still propagates to the caller.

The `DeviceProvider` method reference is taken once when the sheet is built rather than read from a `BuildContext` after an await.

## Why not a primitive

No new primitive. `refreshRingStorageStatus()` already exists and is documented as safe to call from the UI; this change gives it the callers it was missing. `buildStorageClearActions` is a top-level function in the page file so the pairing is testable, following the pattern already used for `buildConversationGroupEntries` in `conversations_group_widget.dart`.

## Scope note

`sync_page.dart` has the same three clear handlers but does not render `DeviceStorageCard`, so it has no stale gauge to correct. Left alone rather than widened.

## Verification

| Command | Result |
|---|---|
| `flutter test test/pages/auto_sync_storage_refresh_test.dart` before the change | fails — the actions do not exist |
| same, after | **5 passed** |
| `flutter test test/pages/ test/providers/` | **343 passed, 0 failed** |
| `flutter analyze` on both touched files | **No issues found** |
| `dart format --line-length 120` | applied |

The five cases cover each of the three actions individually, that an action clears only its own category, and that the re-read survives a clear that throws.

**Proven by mutation, not just by passing.** Replacing `pending: () => thenRefresh(clearPending)` with the bare `clearPending` — the original defect, reintroduced on one handler — fails two of them:

```
Expected: ['clear pending', 'refresh']
  Actual: ['clear pending']
```

Reverted after the check.

**I have not exercised the fixed build on the device.** The bug itself was found on the real user-facing path — the screenshots above are from a paired Omi ring — but no local iOS build of this change was produced, so the fix is proven by test and by reading the one call site, not by re-running the flow on hardware.

## Product invariants

`scripts/pr-preflight --suggest` reports no locked invariant path globs matched by this diff.

## Failure class

Failure-Class: none

One missed call site on one surface, not an instance of a recurring contract failure. Declaring a new class for a single instance would be the paperwork the guard-artifact ratchet exists to discourage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pEhHaD3Mjxwn1hYUTHbQM
