### PR TITLE
Fix external realtime completion text persistence

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1203,6 +1203,7 @@ actor AgentRuntimeProcess {
     harnessMode: String,
     binding: ExternalSurfaceRunBinding,
     terminalStatus: ExternalSurfaceRunTerminalStatus,
+    finalText: String? = nil,
     errorCode: String? = nil,
     transitionCleanupCapability: RuntimeOwnerTransitionCleanupCapability? = nil
   ) async throws -> ExternalSurfaceRunCompletion {
@@ -1247,6 +1248,7 @@ actor AgentRuntimeProcess {
         requestId: requestId,
         binding: binding,
         terminalStatus: terminalStatus,
+        finalText: finalText,
         errorCode: errorCode
       ),
       expectedKind: .externalSurfaceRunCompleteResult,
@@ -1272,7 +1274,9 @@ actor AgentRuntimeProcess {
       runID: binding.runID,
       attemptID: binding.attemptID,
       terminalStatus: confirmedStatus,
-      duplicate: result["duplicate"] as? Bool ?? false
+      duplicate: result["duplicate"] as? Bool ?? false,
+      finalTextPersisted: result["finalTextPersisted"] as? Bool ?? false,
+      journalMaterialized: result["journalMaterialized"] as? Bool ?? false
     )
   }
 
@@ -1524,6 +1528,7 @@ actor AgentRuntimeProcess {
     requestId: String,
     binding: ExternalSurfaceRunBinding,
     terminalStatus: ExternalSurfaceRunTerminalStatus,
+    finalText: String?,
     errorCode: String?
   ) -> [String: Any] {
     var message = protocolEnvelope(
@@ -1536,6 +1541,7 @@ actor AgentRuntimeProcess {
     message["runId"] = binding.runID
     message["attemptId"] = binding.attemptID
     message["terminalStatus"] = terminalStatus.rawValue
+    if let finalText, !finalText.isEmpty { message["finalText"] = finalText }
     if let errorCode, !errorCode.isEmpty { message["errorCode"] = errorCode }
     return message
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -1541,7 +1541,8 @@ actor AgentRuntimeProcess {
     message["runId"] = binding.runID
     message["attemptId"] = binding.attemptID
     message["terminalStatus"] = terminalStatus.rawValue
-    if let finalText, !finalText.isEmpty { message["finalText"] = finalText }
+    // Trimmed, not just non-empty; see ExternalSurfaceRunAnswer for why.
+    if let finalText = ExternalSurfaceRunAnswer.normalized(finalText) { message["finalText"] = finalText }
     if let errorCode, !errorCode.isEmpty { message["errorCode"] = errorCode }
     return message
   }

--- a/desktop/macos/Desktop/Sources/Chat/ExternalSurfaceRunAuthority.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ExternalSurfaceRunAuthority.swift
@@ -25,6 +25,8 @@ struct ExternalSurfaceRunCompletion: Sendable, Equatable {
   let attemptID: String
   let terminalStatus: ExternalSurfaceRunTerminalStatus
   let duplicate: Bool
+  let finalTextPersisted: Bool
+  let journalMaterialized: Bool
 }
 
 struct ExternalSurfaceAuthorityError: LocalizedError, Sendable, Equatable {

--- a/desktop/macos/Desktop/Sources/Chat/ExternalSurfaceRunAuthority.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ExternalSurfaceRunAuthority.swift
@@ -11,6 +11,22 @@ enum ExternalSurfaceRunTerminalStatus: String, Sendable {
   case cancelled
 }
 
+/// The single definition of a non-blank external answer.
+///
+/// The wire guard and the receipt validator disagreed about this: the wire used
+/// `!isEmpty` while the kernel trimmed, so a whitespace-only answer was sent,
+/// trimmed away kernel-side, reported as not persisted, and then thrown on by a
+/// validator that only checked `!= nil`. A run that had terminalized cleanly failed.
+/// It lives here, beside the binding and completion types both sides already use,
+/// rather than inside either caller.
+enum ExternalSurfaceRunAnswer {
+  static func normalized(_ text: String?) -> String? {
+    guard let text else { return nil }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}
+
 struct ExternalSurfaceRunBinding: Sendable, Equatable {
   let ownerID: String
   let sessionID: String

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
@@ -385,6 +385,7 @@ extension RealtimeHubController {
     }
 
     assistantText = presentedFailure
+    externalRunAuthorityState?.answer.replace(with: presentedFailure)
     _ = enqueueAuthoritativeScreenEvidenceFailurePersistence(
       ownerID: ownerID,
       assistantText: presentedFailure)
@@ -533,6 +534,7 @@ extension RealtimeHubController {
     guard !screenFailurePresented else { return }
     screenFailurePresented = true
     assistantText = failure.trimmingCharacters(in: .whitespacesAndNewlines)
+    externalRunAuthorityState?.answer.replace(with: assistantText)
     guard !assistantText.isEmpty else { return }
     // The moment the local string is actually spoken. Recording it here — not at the rejection —
     // makes the user-visible failure rate queryable without inferring it from fallback events

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -175,7 +175,8 @@ extension RealtimeHubController {
     externalRunAuthorityState = .init(
       ownerID: capturedOwnerID,
       turnID: turnID,
-      task: task)
+      task: task,
+      answer: RealtimeExternalRunAnswerAccumulator())
     return task
   }
 
@@ -384,6 +385,7 @@ extension RealtimeHubController {
             // pre-tool speculation keeps it out of the visible reply without
             // interrupting native provider audio or changing voices.
             self.assistantText = ""
+            self.externalRunAuthorityState?.answer.replace(with: receipt.assistantText)
             if let failedProvider = self.spawnFailureContinuationPolicy.takeFailedProvider(
               turnID: turnID.rawValue)
             {
@@ -827,6 +829,7 @@ extension RealtimeHubController {
     else { return }
     if !text.isEmpty {
       assistantText += text
+      externalRunAuthorityState?.answer.append(text)
       beginStreamingRealtimeProjectionIfNeeded()
       scheduleStreamingRealtimeProjectionFlush(continuityKey: turnIdempotencyKey)
       if let turnID = VoiceTurnCoordinator.shared.activeTurnID,
@@ -1104,6 +1107,7 @@ extension RealtimeHubController {
     let reply =
       acceptedSpawnJournalReceiptByContinuityKey[turnIdempotencyKey]?.receipt.assistantText
       ?? providerReply
+    externalRunAuthorityState?.answer.replace(with: reply)
     log(
       "RealtimeHub[\(providerTag)]: turn done — transcript_chars=\(heard.count) audio=\(audioReceivedThisTurn)"
     )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -176,7 +176,13 @@ extension RealtimeHubController {
       ownerID: capturedOwnerID,
       turnID: turnID,
       task: task,
-      answer: RealtimeExternalRunAnswerAccumulator())
+      // Seeded with what the provider has already streamed this turn. A tool can be
+      // requested mid-answer, and starting empty dropped everything said before it.
+      // The success path hides that -- `hubDidFinishTurn` replaces the whole text --
+      // but failed and cancelled turns read `snapshot` directly, so their diagnostic
+      // text was empty precisely when it mattered. The spawn and speculative
+      // slow-tool paths still clear explicitly; those clears are deliberate.
+      answer: RealtimeExternalRunAnswerAccumulator(seed: assistantText))
     return task
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -109,6 +109,7 @@ extension RealtimeHubController {
     completedAuthorizedRealtimeInvocationIDs.removeAll()
     let terminalStatus = RealtimeExternalRunTerminalPolicy.status(for: reason)
     let errorCode = terminalStatus == .failed ? reason.rawValue : nil
+    let finalText = state.answer.snapshot
     let terminalizationID = UUID()
     let task = Task { @MainActor [weak self] in
       let resolution = await awaitWithTimeout(
@@ -135,7 +136,8 @@ extension RealtimeHubController {
         return await self.terminalizeExternalRun(
           binding: binding,
           terminalStatus: terminalStatus,
-          errorCode: errorCode)
+          errorCode: errorCode,
+          finalText: finalText)
       case .some(.failed(let code)):
         log("RealtimeHub: external run completion failed code=\(code)")
         return ExternalRunTerminalizationResult(
@@ -158,6 +160,7 @@ extension RealtimeHubController {
       ownerID: state.ownerID,
       terminalStatus: terminalStatus,
       errorCode: errorCode,
+      finalText: finalText,
       task: task)
   }
 
@@ -165,6 +168,7 @@ extension RealtimeHubController {
     binding: ExternalSurfaceRunBinding,
     terminalStatus: ExternalSurfaceRunTerminalStatus,
     errorCode: String?,
+    finalText: String?,
     cleanupCapability: RuntimeOwnerTransitionCleanupCapability? = nil
   ) async -> ExternalRunTerminalizationResult {
     let effectiveCleanupCapability =
@@ -177,25 +181,30 @@ extension RealtimeHubController {
           try await ownerBoundaryExternalRunCompletion(
             binding,
             terminalStatus,
+            finalText,
             errorCode,
             effectiveCleanupCapability)
         } else {
-          _ = try await AgentRuntimeProcess.shared.completeExternalSurfaceRun(
+          let completion = try await AgentRuntimeProcess.shared.completeExternalSurfaceRun(
             clientId: Self.externalRunClientID,
             harnessMode: Self.externalRunHarnessMode,
             binding: binding,
             terminalStatus: terminalStatus,
+            finalText: finalText,
             errorCode: errorCode,
             transitionCleanupCapability: effectiveCleanupCapability)
+          try Self.validateExternalRunCompletion(completion, finalText: finalText)
         }
       #else
-        _ = try await AgentRuntimeProcess.shared.completeExternalSurfaceRun(
+        let completion = try await AgentRuntimeProcess.shared.completeExternalSurfaceRun(
           clientId: Self.externalRunClientID,
           harnessMode: Self.externalRunHarnessMode,
           binding: binding,
           terminalStatus: terminalStatus,
+          finalText: finalText,
           errorCode: errorCode,
           transitionCleanupCapability: effectiveCleanupCapability)
+        try Self.validateExternalRunCompletion(completion, finalText: finalText)
       #endif
       return ExternalRunTerminalizationResult(
         binding: binding,
@@ -215,17 +224,32 @@ extension RealtimeHubController {
     }
   }
 
+  nonisolated static func validateExternalRunCompletion(
+    _ completion: ExternalSurfaceRunCompletion,
+    finalText: String?
+  ) throws {
+    guard finalText != nil else { return }
+    if !completion.duplicate && !completion.finalTextPersisted {
+      throw ExternalSurfaceAuthorityError(code: "external_surface_final_text_not_persisted")
+    }
+    if completion.terminalStatus == .completed && !completion.journalMaterialized {
+      throw ExternalSurfaceAuthorityError(code: "external_surface_journal_not_materialized")
+    }
+  }
+
   func trackExternalRunTerminalization(
     id: UUID,
     ownerID: String,
     terminalStatus: ExternalSurfaceRunTerminalStatus,
     errorCode: String?,
+    finalText: String?,
     task: Task<ExternalRunTerminalizationResult, Never>
   ) {
     externalRunTerminalizations[id] = TrackedExternalRunTerminalization(
       ownerID: ownerID,
       terminalStatus: terminalStatus,
       errorCode: errorCode,
+      finalText: finalText,
       task: task)
 
     Task { @MainActor [weak self] in

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -228,7 +228,10 @@ extension RealtimeHubController {
     _ completion: ExternalSurfaceRunCompletion,
     finalText: String?
   ) throws {
-    guard finalText != nil else { return }
+    // Same normalization the wire uses. Validating on `!= nil` while the wire sent
+    // only non-blank text made a whitespace-only answer demand a persistence receipt
+    // for something that was never sent.
+    guard ExternalSurfaceRunAnswer.normalized(finalText) != nil else { return }
     if !completion.duplicate && !completion.finalTextPersisted {
       throw ExternalSurfaceAuthorityError(code: "external_surface_final_text_not_persisted")
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+VoiceOutput.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+VoiceOutput.swift
@@ -63,6 +63,7 @@ extension RealtimeHubController {
   func prepareVoiceOutputForDeterministicSlowToolAcknowledgement() {
     guard let activeLease = VoiceTurnCoordinator.shared.outputSnapshot.activeLease else {
       assistantText = ""
+      externalRunAuthorityState?.answer.replace(with: "")
       return
     }
     switch activeLease.lane {
@@ -74,6 +75,7 @@ extension RealtimeHubController {
     // A provider-authored pre-tool status must not be journaled beside the
     // final answer even when it raced ahead of the function call.
     assistantText = ""
+    externalRunAuthorityState?.answer.replace(with: "")
   }
 
   func acquireVoiceOutput(_ lane: VoiceOutputLane, reason: String) -> VoiceOutputLease? {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -8,6 +8,17 @@ import VoiceTurnDomain
 final class RealtimeExternalRunAnswerAccumulator {
   private var text = ""
 
+  /// Seeded with whatever the provider has already streamed for this turn.
+  ///
+  /// An external tool can be requested mid-answer, and a run created with an empty
+  /// accumulator loses everything said before it. That is invisible on the success
+  /// path, where `hubDidFinishTurn` replaces the whole text -- but a failed or
+  /// cancelled turn reads `snapshot` directly, so its diagnostic text came back
+  /// empty exactly when it was most wanted.
+  init(seed: String = "") {
+    text = seed
+  }
+
   func append(_ delta: String) {
     text += delta
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -5,6 +5,24 @@ import OmiSupport
 import VoiceTurnDomain
 
 @MainActor
+final class RealtimeExternalRunAnswerAccumulator {
+  private var text = ""
+
+  func append(_ delta: String) {
+    text += delta
+  }
+
+  func replace(with finalText: String) {
+    text = finalText
+  }
+
+  var snapshot: String? {
+    let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
+  }
+}
+
+@MainActor
 final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   static let shared = RealtimeHubController()
 
@@ -187,6 +205,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let ownerID: String
     let turnID: VoiceTurnID
     let task: Task<ExternalSurfaceRunBinding, Error>
+    let answer: RealtimeExternalRunAnswerAccumulator
   }
   struct ExternalRunTerminalizationResult: Sendable {
     let binding: ExternalSurfaceRunBinding?
@@ -202,6 +221,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     let ownerID: String
     let terminalStatus: ExternalSurfaceRunTerminalStatus
     let errorCode: String?
+    let finalText: String?
     let task: Task<ExternalRunTerminalizationResult, Never>
   }
   static let externalRunClientID = "omi-realtime-voice"
@@ -220,6 +240,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         @Sendable (
           ExternalSurfaceRunBinding,
           ExternalSurfaceRunTerminalStatus,
+          String?,
           String?,
           RuntimeOwnerTransitionCleanupCapability?
         ) async throws -> Void
@@ -516,6 +537,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
           binding: binding,
           terminalStatus: tracked.terminalStatus,
           errorCode: tracked.errorCode,
+          finalText: tracked.finalText,
           cleanupCapability: cleanupCapability)
       }
       if let usedCapability = result.cleanupCapability,
@@ -573,10 +595,12 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     func installOwnerBoundaryExternalRunFixture(
       ownerID: String,
       turnID: VoiceTurnID,
+      finalText: String? = nil,
       onComplete:
         @escaping @Sendable (
           ExternalSurfaceRunBinding,
           ExternalSurfaceRunTerminalStatus,
+          String?,
           String?,
           RuntimeOwnerTransitionCleanupCapability?
         ) async throws -> Void
@@ -589,10 +613,13 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         attemptID: "owner-boundary-attempt",
         duplicate: false)
       externalRunAuthorityState?.task.cancel()
+      let answer = RealtimeExternalRunAnswerAccumulator()
+      if let finalText { answer.replace(with: finalText) }
       externalRunAuthorityState = ExternalRunAuthorityState(
         ownerID: ownerID,
         turnID: turnID,
-        task: Task { binding })
+        task: Task { binding },
+        answer: answer)
       ownerBoundaryExternalRunCompletion = onComplete
     }
 
@@ -610,7 +637,8 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
         turnID: turnID,
         task: Task<ExternalSurfaceRunBinding, Error> {
           throw ExternalSurfaceAuthorityError(code: "owner_boundary_begin_receipt_lost")
-        })
+        },
+        answer: RealtimeExternalRunAnswerAccumulator())
       ownerBoundaryExternalRunCompletion = nil
     }
 

--- a/desktop/macos/Desktop/Tests/ExternalSurfaceRunAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ExternalSurfaceRunAuthorityTests.swift
@@ -114,6 +114,59 @@ final class ExternalSurfaceRunAuthorityTests: XCTestCase {
         completion, finalText: "A replayed answer"))
   }
 
+  func testWhitespaceOnlyAnswerIsNotTreatedAsAnAnswer() {
+    // The wire guard and the validator used to disagree about blank text: the wire
+    // sent "   " because it is not `isEmpty`, the kernel trimmed it to nothing and
+    // reported nothing persisted, and this validator then threw on a run that had
+    // terminalized perfectly well. Both now normalize the same way.
+    let completion = ExternalSurfaceRunCompletion(
+      runID: binding.runID,
+      attemptID: binding.attemptID,
+      terminalStatus: .completed,
+      duplicate: false,
+      finalTextPersisted: false,
+      journalMaterialized: false
+    )
+
+    XCTAssertNoThrow(
+      try RealtimeHubController.validateExternalRunCompletion(
+        completion, finalText: "   \n\t "),
+      "whitespace is not an answer, so it must not demand a persistence receipt")
+
+    XCTAssertThrowsError(
+      try RealtimeHubController.validateExternalRunCompletion(
+        completion, finalText: "  A real answer  "),
+      "a real answer still demands one, whatever surrounds it"
+    ) { error in
+      XCTAssertEqual(
+        (error as? ExternalSurfaceAuthorityError)?.code,
+        "external_surface_final_text_not_persisted")
+    }
+  }
+
+  // The accumulator is @MainActor-isolated, like the controller that owns it.
+  @MainActor
+  func testTheAnswerAccumulatorKeepsTextStreamedBeforeTheToolCall() {
+    // An external tool can be requested mid-answer. Starting the accumulator empty
+    // dropped everything said before it -- invisible on the success path, where the
+    // final reply replaces the whole text, but a failed or cancelled turn reads the
+    // snapshot directly and came back empty exactly when the text was wanted.
+    let seeded = RealtimeExternalRunAnswerAccumulator(seed: "Half an answer")
+    XCTAssertEqual(seeded.snapshot, "Half an answer")
+
+    seeded.append(" and the rest")
+    XCTAssertEqual(seeded.snapshot, "Half an answer and the rest")
+
+    seeded.replace(with: "The provider's final reply")
+    XCTAssertEqual(
+      seeded.snapshot, "The provider's final reply",
+      "a final reply still replaces the whole answer rather than appending to it")
+
+    XCTAssertNil(
+      RealtimeExternalRunAnswerAccumulator(seed: "   ").snapshot,
+      "a whitespace seed is still no answer")
+  }
+
   func testStructuredErrorUsesCodeWithoutTrustingDisplayMessage() {
     let error = ExternalSurfaceAuthorityError.from(
       [

--- a/desktop/macos/Desktop/Tests/ExternalSurfaceRunAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ExternalSurfaceRunAuthorityTests.swift
@@ -56,12 +56,62 @@ final class ExternalSurfaceRunAuthorityTests: XCTestCase {
       requestId: "request-3",
       binding: binding,
       terminalStatus: .failed,
+      finalText: "Partial answer before disconnect.",
       errorCode: "provider_disconnected"
     )
 
     XCTAssertEqual(message["type"] as? String, "external_surface_run_complete")
     XCTAssertEqual(message["terminalStatus"] as? String, "failed")
+    XCTAssertEqual(message["finalText"] as? String, "Partial answer before disconnect.")
     XCTAssertEqual(message["errorCode"] as? String, "provider_disconnected")
+  }
+
+  func testCompleteWireOmitsEmptyFinalText() {
+    let message = AgentRuntimeProcess.externalSurfaceRunCompleteWireMessage(
+      clientId: "realtime",
+      requestId: "request-empty",
+      binding: binding,
+      terminalStatus: .completed,
+      finalText: "",
+      errorCode: nil
+    )
+
+    XCTAssertNil(message["finalText"])
+  }
+
+  func testCompletionValidationRejectsAContentFreeKernelReceipt() {
+    let completion = ExternalSurfaceRunCompletion(
+      runID: binding.runID,
+      attemptID: binding.attemptID,
+      terminalStatus: .completed,
+      duplicate: false,
+      finalTextPersisted: true,
+      journalMaterialized: false
+    )
+
+    XCTAssertThrowsError(
+      try RealtimeHubController.validateExternalRunCompletion(
+        completion, finalText: "A real answer")
+    ) { error in
+      XCTAssertEqual(
+        (error as? ExternalSurfaceAuthorityError)?.code,
+        "external_surface_journal_not_materialized")
+    }
+  }
+
+  func testDuplicateCompletionMayReuseTheFirstPersistedAnswer() {
+    let completion = ExternalSurfaceRunCompletion(
+      runID: binding.runID,
+      attemptID: binding.attemptID,
+      terminalStatus: .completed,
+      duplicate: true,
+      finalTextPersisted: false,
+      journalMaterialized: true
+    )
+
+    XCTAssertNoThrow(
+      try RealtimeHubController.validateExternalRunCompletion(
+        completion, finalText: "A replayed answer"))
   }
 
   func testStructuredErrorUsesCodeWithoutTrustingDisplayMessage() {

--- a/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift
@@ -9,12 +9,14 @@ private actor OwnerBoundaryExternalRunProbe {
   private var closed = false
   private var observedOwnerID: String?
   private var observedStatus: ExternalSurfaceRunTerminalStatus?
+  private var observedFinalText: String?
   private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
   private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
   func terminalize(
     binding: ExternalSurfaceRunBinding,
     status: ExternalSurfaceRunTerminalStatus,
+    finalText: String?,
     capability: RuntimeOwnerTransitionCleanupCapability?
   ) async throws {
     guard let capability,
@@ -26,6 +28,7 @@ private actor OwnerBoundaryExternalRunProbe {
     }
     observedOwnerID = binding.ownerID
     observedStatus = status
+    observedFinalText = finalText
     entered = true
     let waiters = enteredWaiters
     enteredWaiters.removeAll()
@@ -59,8 +62,10 @@ private actor OwnerBoundaryExternalRunProbe {
     waiters.forEach { $0.resume() }
   }
 
-  func snapshot() -> (closed: Bool, ownerID: String?, status: ExternalSurfaceRunTerminalStatus?) {
-    (closed, observedOwnerID, observedStatus)
+  func snapshot() -> (
+    closed: Bool, ownerID: String?, status: ExternalSurfaceRunTerminalStatus?, finalText: String?
+  ) {
+    (closed, observedOwnerID, observedStatus, observedFinalText)
   }
 }
 
@@ -265,11 +270,13 @@ final class PushToTalkStateMachineTests: XCTestCase {
           captureID: VoiceCaptureID(manager.ownerBoundarySnapshot.captureGeneration)))
       hub.installOwnerBoundaryExternalRunFixture(
         ownerID: "owner-a",
-        turnID: turnID
-      ) { binding, status, _, capability in
+        turnID: turnID,
+        finalText: "Answer captured before UI cleanup."
+      ) { binding, status, finalText, _, capability in
         try await probe.terminalize(
           binding: binding,
           status: status,
+          finalText: finalText,
           capability: capability)
       }
 
@@ -293,6 +300,7 @@ final class PushToTalkStateMachineTests: XCTestCase {
       XCTAssertTrue(terminal.closed)
       XCTAssertEqual(terminal.ownerID, "owner-a")
       XCTAssertEqual(terminal.status, .cancelled)
+      XCTAssertEqual(terminal.finalText, "Answer captured before UI cleanup.")
       XCTAssertEqual(defaults.string(forKey: .authUserId), "owner-b")
       XCTAssertEqual(VoiceTurnCoordinator.shared.model.lastTerminal?.reason, .ownerChanged)
       assertHubOwnerBoundaryIsEmpty(hub.ownerBoundarySnapshot)

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -2479,7 +2479,27 @@ async function main(): Promise<void> {
             terminalStatus: result.terminalStatus,
             duplicate: result.duplicate,
             finalTextPersisted: result.finalTextPersisted,
+            journalMaterialized: result.journalMaterialized,
           });
+          for (const change of result.journalChanges) {
+            const range = listJournalTurns(store, {
+              ownerId: change.ownerId,
+              conversationId: change.conversationId,
+              afterTurnSeq: Math.max(0, change.turn.turnSeq - 1),
+              limit: 1,
+            });
+            send({
+              type: "journal_turn_changed",
+              ownerId: change.ownerId,
+              conversationGeneration: range.generation,
+              generationBaseTurnSeq: range.generationBaseTurnSeq,
+              surfaceKind: change.surfaceKind,
+              externalRefKind: change.externalRefKind,
+              externalRefId: change.externalRefId,
+              turn: journalTurnProjection(change.turn),
+            });
+          }
+          if (result.journalChanges.length > 0) pumpJournalOutbox();
         } catch (error) {
           send({
             type: "external_surface_run_complete_result",

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -814,6 +814,8 @@ export interface ExternalSurfaceRunCompleteResultMessage extends OutboundEnvelop
    * trusting a silent no-op (#12731).
    */
   finalTextPersisted?: boolean;
+  /** Whether completion left a canonical assistant row for this voice turn. */
+  journalMaterialized?: boolean;
   error?: ExternalAuthorityError;
 }
 

--- a/desktop/macos/agent/src/runtime/external-surface-journal.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-journal.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+
+import { conversationTurnFromRow } from "./conversation-turns.js";
+import { recordJournalExchange, updateJournalTurn } from "./conversation-journal.js";
+import type { AgentRun, AgentStore, ConversationTurn, RunAttempt } from "./types.js";
+
+export interface ExternalSurfaceJournalChange {
+  ownerId: string;
+  conversationId: string;
+  surfaceKind: string;
+  externalRefKind: string;
+  externalRefId: string;
+  turn: ConversationTurn;
+}
+
+export interface ExternalSurfaceJournalMaterialization {
+  materialized: boolean;
+  changes: ExternalSurfaceJournalChange[];
+}
+
+/**
+ * Repairs the canonical voice exchange from a successfully completed external
+ * realtime run. The normal Swift journal funnel may already have committed the
+ * same stable turn IDs; in that case those rows stay authoritative. This path
+ * only fills the crash/restart gap where the run terminalized but the journal
+ * exchange never landed (#12731).
+ */
+export function materializeExternalSurfaceRunJournal(
+  store: AgentStore,
+  input: {
+    ownerId: string;
+    run: AgentRun;
+    attempt: RunAttempt;
+    finalText: string | null;
+    nowMs?: number;
+  },
+): ExternalSurfaceJournalMaterialization {
+  const runInput = parseObject(input.run.inputJson);
+  const metadata = objectValue(runInput.metadata);
+  const external = objectValue(metadata?.externalSurface);
+  if (external?.authority !== "swift_realtime") {
+    throw new Error("External surface journal materialization requires Swift realtime authority");
+  }
+  const rawTurnId = typeof external.turnId === "string" ? external.turnId.trim() : "";
+  if (!rawTurnId) throw new Error("External surface journal materialization is missing turn identity");
+
+  const surface = store.getOptionalRow(
+    `SELECT conversation_id, surface_kind, external_ref_kind, external_ref_id
+     FROM surface_conversations
+     WHERE owner_id = ? AND agent_session_id = ?
+       AND surface_kind IN ('main_chat', 'floating_chat', 'realtime_voice', 'realtime')
+     ORDER BY CASE surface_kind
+       WHEN 'main_chat' THEN 0
+       WHEN 'floating_chat' THEN 1
+       WHEN 'realtime_voice' THEN 2
+       ELSE 3
+     END, last_active_at_ms DESC
+     LIMIT 1`,
+    [input.ownerId, input.run.sessionId],
+  );
+  if (!surface) throw new Error("External surface run has no canonical journal surface");
+
+  const conversationId = String(surface.conversation_id);
+  const surfaceKind = String(surface.surface_kind);
+  const externalRefKind = String(surface.external_ref_kind);
+  const externalRefId = String(surface.external_ref_id);
+  const continuityKey = `voice:${rawTurnId.toLowerCase()}`;
+  const userTurnId = stableTurnId(continuityKey, "user");
+  const assistantTurnId = stableTurnId(continuityKey, "assistant");
+  const existingUser = optionalTurn(store, conversationId, userTurnId);
+  const existingAssistant = optionalTurn(store, conversationId, assistantTurnId);
+
+  if (existingUser) assertCanonicalIdentity(existingUser, conversationId, "user", continuityKey);
+  if (existingAssistant) {
+    assertCanonicalIdentity(existingAssistant, conversationId, "assistant", continuityKey);
+    // A spawn receipt can own this continuity key with different assistant
+    // prose and run provenance. Stable canonical ownership wins over this
+    // repair path; never overwrite it with provider narration.
+    if (existingAssistant.status === "completed" || existingAssistant.status === "failed") {
+      return { materialized: true, changes: [] };
+    }
+  }
+
+  const finalText = input.finalText?.trim() ?? "";
+  if (!finalText) return { materialized: false, changes: [] };
+
+  const now = input.nowMs ?? Date.now();
+  const changes: ExternalSurfaceJournalChange[] = [];
+  const change = (turn: ConversationTurn): ExternalSurfaceJournalChange => ({
+    ownerId: input.ownerId,
+    conversationId,
+    surfaceKind,
+    externalRefKind,
+    externalRefId,
+    turn,
+  });
+
+  if (existingAssistant) {
+    const updated = updateJournalTurn(store, {
+      ownerId: input.ownerId,
+      conversationId,
+      turnId: assistantTurnId,
+      status: "completed",
+      content: finalText,
+      producingRunId: existingAssistant.producingRunId ?? input.run.runId,
+      producingAttemptId: existingAssistant.producingAttemptId ?? input.attempt.attemptId,
+      nowMs: now,
+    });
+    changes.push(change(updated));
+    return { materialized: true, changes };
+  }
+
+  const promptIsSynthetic = external.promptIsSynthetic === true;
+  const prompt = typeof runInput.prompt === "string" ? runInput.prompt.trim() : "";
+  const metadataJson = JSON.stringify({ continuityKey });
+  const turns = [];
+  if (!existingUser && !promptIsSynthetic && prompt) {
+    turns.push({
+      turnId: userTurnId,
+      role: "user" as const,
+      surfaceKind,
+      origin: "realtime_voice" as const,
+      status: "completed" as const,
+      content: prompt,
+      contentBlocks: [],
+      resources: [],
+      metadataJson,
+      createdAtMs: Math.min(now, Number.MAX_SAFE_INTEGER - 1),
+    });
+  }
+  turns.push({
+    turnId: assistantTurnId,
+    role: "assistant" as const,
+    surfaceKind,
+    origin: "realtime_voice" as const,
+    status: "completed" as const,
+    content: finalText,
+    contentBlocks: [],
+    resources: [],
+    producingRunId: input.run.runId,
+    producingAttemptId: input.attempt.attemptId,
+    metadataJson,
+    createdAtMs: promptIsSynthetic || !prompt ? now : Math.min(now, Number.MAX_SAFE_INTEGER - 1) + 1,
+  });
+  const recorded = recordJournalExchange(store, {
+    ownerId: input.ownerId,
+    conversationId,
+    turns,
+  });
+  for (const turn of recorded.createdTurns) changes.push(change(turn));
+  return { materialized: true, changes };
+}
+
+function stableTurnId(continuityKey: string, role: "user" | "assistant"): string {
+  return `turn_${createHash("sha256").update(`${continuityKey}\0${role}`).digest("hex").slice(0, 32)}`;
+}
+
+function optionalTurn(store: AgentStore, conversationId: string, turnId: string): ConversationTurn | null {
+  const row = store.getOptionalRow(
+    "SELECT * FROM conversation_turns WHERE conversation_id = ? AND turn_id = ?",
+    [conversationId, turnId],
+  );
+  return row ? conversationTurnFromRow(row) : null;
+}
+
+function assertCanonicalIdentity(
+  turn: ConversationTurn,
+  conversationId: string,
+  role: "user" | "assistant",
+  continuityKey: string,
+): void {
+  const metadata = parseObject(turn.metadataJson);
+  if (
+    turn.conversationId !== conversationId
+    || turn.role !== role
+    || (metadata.continuityKey !== undefined && metadata.continuityKey !== continuityKey)
+  ) {
+    throw new Error("External surface journal stable identity collides with another canonical turn");
+  }
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return objectValue(parsed) ?? {};
+    } catch {
+      return {};
+    }
+  }
+  return objectValue(value) ?? {};
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}

--- a/desktop/macos/agent/src/runtime/external-surface-journal.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-journal.ts
@@ -49,10 +49,14 @@ export function materializeExternalSurfaceRunJournal(
      FROM surface_conversations
      WHERE owner_id = ? AND agent_session_id = ?
        AND surface_kind IN ('main_chat', 'floating_chat', 'realtime_voice', 'realtime')
+     -- This repair belongs to a realtime voice run, so a realtime surface wins.
+     -- Ordering main_chat first labelled the repaired voice turns main_chat
+     -- whenever the session also had a main-chat alias, and emitted the change
+     -- on that surface, so the voice projection never saw its own turn.
      ORDER BY CASE surface_kind
-       WHEN 'main_chat' THEN 0
-       WHEN 'floating_chat' THEN 1
-       WHEN 'realtime_voice' THEN 2
+       WHEN 'realtime_voice' THEN 0
+       WHEN 'realtime' THEN 1
+       WHEN 'floating_chat' THEN 2
        ELSE 3
      END, last_active_at_ms DESC
      LIMIT 1`,
@@ -76,8 +80,16 @@ export function materializeExternalSurfaceRunJournal(
     // A spawn receipt can own this continuity key with different assistant
     // prose and run provenance. Stable canonical ownership wins over this
     // repair path; never overwrite it with provider narration.
-    if (existingAssistant.status === "completed" || existingAssistant.status === "failed") {
+    if (existingAssistant.status === "completed") {
       return { materialized: true, changes: [] };
+    }
+    // A failed canonical row is not ownership, it is a conflict: the successful
+    // answer is nowhere in history and this path will not overwrite a failure to
+    // put it there. Reporting `materialized: true` here told Swift the answer had
+    // landed when it had not, which is exactly the silent loss this change exists
+    // to close -- so report the truth and let Swift fail closed.
+    if (existingAssistant.status === "failed") {
+      return { materialized: false, changes: [] };
     }
   }
 
@@ -85,6 +97,21 @@ export function materializeExternalSurfaceRunJournal(
   if (!finalText) return { materialized: false, changes: [] };
 
   const now = input.nowMs ?? Date.now();
+  const promptIsSynthetic = external.promptIsSynthetic === true;
+  const prompt = typeof runInput.prompt === "string" ? runInput.prompt.trim() : "";
+  const metadataJson = JSON.stringify({ continuityKey });
+  const userTurn = (createdAtMs: number) => ({
+    turnId: userTurnId,
+    role: "user" as const,
+    surfaceKind,
+    origin: "realtime_voice" as const,
+    status: "completed" as const,
+    content: prompt,
+    contentBlocks: [],
+    resources: [],
+    metadataJson,
+    createdAtMs: Math.min(createdAtMs, Number.MAX_SAFE_INTEGER - 1),
+  });
   const changes: ExternalSurfaceJournalChange[] = [];
   const change = (turn: ConversationTurn): ExternalSurfaceJournalChange => ({
     ownerId: input.ownerId,
@@ -96,6 +123,20 @@ export function materializeExternalSurfaceRunJournal(
   });
 
   if (existingAssistant) {
+    // The user turn can be absent even when the assistant row exists -- a crash
+    // between the two writes leaves exactly that. Restore it first, or the
+    // repaired exchange is an answer with no question.
+    if (!existingUser && !promptIsSynthetic && prompt) {
+      // Placed just before the assistant row, not at `now`. The answer already
+      // exists and carries an older timestamp, so a restored question stamped now
+      // sorts after it and history reads as a reply with no question.
+      const restored = recordJournalExchange(store, {
+        ownerId: input.ownerId,
+        conversationId,
+        turns: [userTurn(Math.max(0, existingAssistant.createdAtMs - 1))],
+      });
+      for (const turn of restored.createdTurns) changes.push(change(turn));
+    }
     const updated = updateJournalTurn(store, {
       ownerId: input.ownerId,
       conversationId,
@@ -110,24 +151,8 @@ export function materializeExternalSurfaceRunJournal(
     return { materialized: true, changes };
   }
 
-  const promptIsSynthetic = external.promptIsSynthetic === true;
-  const prompt = typeof runInput.prompt === "string" ? runInput.prompt.trim() : "";
-  const metadataJson = JSON.stringify({ continuityKey });
   const turns = [];
-  if (!existingUser && !promptIsSynthetic && prompt) {
-    turns.push({
-      turnId: userTurnId,
-      role: "user" as const,
-      surfaceKind,
-      origin: "realtime_voice" as const,
-      status: "completed" as const,
-      content: prompt,
-      contentBlocks: [],
-      resources: [],
-      metadataJson,
-      createdAtMs: Math.min(now, Number.MAX_SAFE_INTEGER - 1),
-    });
-  }
+  if (!existingUser && !promptIsSynthetic && prompt) turns.push(userTurn(now));
   turns.push({
     turnId: assistantTurnId,
     role: "assistant" as const,

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -30,6 +30,10 @@ import {
 } from "./context-snapshot.js";
 import { repairPersistedAgentSpawnJournals } from "./agent-spawn-journal.js";
 import {
+  materializeExternalSurfaceRunJournal,
+  type ExternalSurfaceJournalChange,
+} from "./external-surface-journal.js";
+import {
   bindProducingJournalTurn,
   searchJournalConversation,
   validateProducingJournalTurnAdmission,
@@ -665,10 +669,24 @@ export class KernelCore {
     const persistedStatus = input.terminalStatus === "completed" ? "succeeded" : input.terminalStatus;
     if (TERMINAL_STATUSES.includes(run.status) || TERMINAL_STATUSES.includes(attempt.status)) {
       if (run.status === persistedStatus && attempt.status === persistedStatus) {
+        const journal = run.status === "succeeded"
+          ? materializeExternalSurfaceRunJournal(this.store, {
+            ownerId: input.ownerId,
+            run,
+            attempt,
+            finalText: run.finalText,
+          })
+          : { materialized: false, changes: [] as ExternalSurfaceJournalChange[] };
         // First write wins, so a replayed frame's text is deliberately not
         // stored. Say so rather than letting the surface read ok and assume it
         // landed — that silence is the shape of #12731 itself.
-        return { ...input, duplicate: true, finalTextPersisted: false };
+        return {
+          ...input,
+          duplicate: true,
+          finalTextPersisted: false,
+          journalMaterialized: journal.materialized,
+          journalChanges: journal.changes,
+        };
       }
       throw new ExternalSurfaceAuthorityError("run_terminal", "External surface run already has a different terminal state");
     }
@@ -699,7 +717,7 @@ export class KernelCore {
     // or sent "" (#12731).
     const trimmed = input.finalText?.trim();
     const finalText = trimmed ? trimmed : null;
-    this.withTransaction(() => {
+    const journal = this.withTransaction(() => {
       this.finishAttemptAndRun({
         sessionId: input.sessionId,
         runId: input.runId,
@@ -709,8 +727,22 @@ export class KernelCore {
         errorCode: persistedStatus === "failed" ? errorCode ?? "external_surface_failed" : null,
         errorMessage: persistedStatus === "failed" ? "External surface execution failed" : null,
       });
+      return persistedStatus === "succeeded"
+        ? materializeExternalSurfaceRunJournal(this.store, {
+          ownerId: input.ownerId,
+          run: { ...run, status: persistedStatus, finalText },
+          attempt: { ...attempt, status: persistedStatus },
+          finalText,
+        })
+        : { materialized: false, changes: [] as ExternalSurfaceJournalChange[] };
     });
-    return { ...input, duplicate: false, finalTextPersisted: finalText !== null };
+    return {
+      ...input,
+      duplicate: false,
+      finalTextPersisted: finalText !== null,
+      journalMaterialized: journal.materialized,
+      journalChanges: journal.changes,
+    };
   }
 
   private assertExternalRunIdentity(

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -669,13 +669,22 @@ export class KernelCore {
     const persistedStatus = input.terminalStatus === "completed" ? "succeeded" : input.terminalStatus;
     if (TERMINAL_STATUSES.includes(run.status) || TERMINAL_STATUSES.includes(attempt.status)) {
       if (run.status === persistedStatus && attempt.status === persistedStatus) {
+        // Wrapped, like the first-completion path below. Until the missing-user-turn
+        // repair landed this branch made a single write, so atomicity was free; it now
+        // restores the question and updates the answer, and a partial failure between
+        // them would leave a half-repaired exchange until some later replay finished
+        // the job. Re-entrancy makes that recoverable rather than corrupting, but
+        // recoverable-by-retry is a weaker property than the first write already has,
+        // and there is no reason for the two paths to differ. `withTransaction` tracks
+        // nesting depth, so this composes with the transactions the journal helpers
+        // open themselves.
         const journal = run.status === "succeeded"
-          ? materializeExternalSurfaceRunJournal(this.store, {
+          ? this.withTransaction(() => materializeExternalSurfaceRunJournal(this.store, {
             ownerId: input.ownerId,
             run,
             attempt,
             finalText: run.finalText,
-          })
+          }))
           : { materialized: false, changes: [] as ExternalSurfaceJournalChange[] };
         // First write wins, so a replayed frame's text is deliberately not
         // stored. Say so rather than letting the surface read ok and assume it

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -144,6 +144,10 @@ export interface CompleteExternalSurfaceRunResult {
   duplicate: boolean;
   /** Whether this call wrote `finalText`, so an older kernel is detectable by its absence. */
   finalTextPersisted: boolean;
+  /** Whether the canonical assistant journal row exists after completion. */
+  journalMaterialized: boolean;
+  /** Internal daemon projection events; omitted from the completion wire receipt. */
+  journalChanges: import("./external-surface-journal.js").ExternalSurfaceJournalChange[];
 }
 
 export type ExternalSurfaceAuthorityErrorCode =

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1547,6 +1547,154 @@ describe("external realtime surface authority", () => {
     fixture.store.close();
   });
 
+  it("materializes a missing completed external exchange into the canonical journal", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "I saved the corrected hopper ratio.",
+    });
+
+    expect(completion.journalMaterialized).toBe(true);
+    expect(completion.journalChanges).toHaveLength(2);
+    const rows = fixture.store.allRows(
+      `SELECT turn_id, role, content, status, producing_run_id, producing_attempt_id
+       FROM conversation_turns ORDER BY created_at_ms, turn_seq`,
+    );
+    const continuityKey = "voice:voice-turn-1";
+    expect(rows).toEqual([
+      {
+        turn_id: stableAgentSpawnTurnId(continuityKey, "user"),
+        role: "user",
+        content: "Remember my latest request",
+        status: "completed",
+        producing_run_id: null,
+        producing_attempt_id: null,
+      },
+      {
+        turn_id: stableAgentSpawnTurnId(continuityKey, "assistant"),
+        role: "assistant",
+        content: "I saved the corrected hopper ratio.",
+        status: "completed",
+        producing_run_id: run.runId,
+        producing_attempt_id: run.attemptId,
+      },
+    ]);
+    expect(fixture.store.getRow(
+      "SELECT COUNT(*) AS count FROM backend_turn_outbox",
+    ).count).toBe(2);
+    fixture.store.close();
+  });
+
+  it("defers to an already completed canonical voice exchange", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const conversationId = String(fixture.store.getRow(
+      "SELECT conversation_id FROM surface_conversations WHERE agent_session_id = ? LIMIT 1",
+      [fixture.sessionId],
+    ).conversation_id);
+    const continuityKey = "voice:voice-turn-1";
+    recordJournalTurn(fixture.store, {
+      ownerId: "owner",
+      conversationId,
+      turnId: stableAgentSpawnTurnId(continuityKey, "assistant"),
+      role: "assistant",
+      surfaceKind: "realtime_voice",
+      origin: "agent_runtime",
+      status: "completed",
+      content: "The accepted spawn receipt owns this turn.",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: JSON.stringify({ continuityKey }),
+    });
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "Provider narration must not replace the receipt.",
+    });
+
+    expect(completion.journalMaterialized).toBe(true);
+    expect(completion.journalChanges).toHaveLength(0);
+    expect(fixture.store.getRow(
+      "SELECT content FROM conversation_turns WHERE turn_id = ?",
+      [stableAgentSpawnTurnId(continuityKey, "assistant")],
+    ).content).toBe("The accepted spawn receipt owns this turn.");
+    fixture.store.close();
+  });
+
+  it("preserves a corrected canonical user transcript while repairing its missing answer", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const conversationId = String(fixture.store.getRow(
+      "SELECT conversation_id FROM surface_conversations WHERE agent_session_id = ? LIMIT 1",
+      [fixture.sessionId],
+    ).conversation_id);
+    const continuityKey = "voice:voice-turn-1";
+    recordJournalTurn(fixture.store, {
+      ownerId: "owner",
+      conversationId,
+      turnId: stableAgentSpawnTurnId(continuityKey, "user"),
+      role: "user",
+      surfaceKind: "realtime_voice",
+      origin: "realtime_voice",
+      status: "completed",
+      content: "Actually, remember the corrected request.",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: JSON.stringify({ continuityKey, transcriptSource: "local_lid" }),
+    });
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "I kept the corrected request.",
+    });
+
+    expect(completion.journalMaterialized).toBe(true);
+    expect(fixture.store.allRows(
+      "SELECT role, content FROM conversation_turns ORDER BY created_at_ms, turn_seq",
+    )).toEqual([
+      { role: "user", content: "Actually, remember the corrected request." },
+      { role: "assistant", content: "I kept the corrected request." },
+    ]);
+    fixture.store.close();
+  });
+
+  it("does not attribute a synthetic external authorization prompt to the user", () => {
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun({
+      ...beginInput(fixture.sessionId),
+      prompt: "Authorize the provider tool call without a final transcript",
+      promptIsSynthetic: true,
+    });
+
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "The tool call completed.",
+    });
+
+    expect(fixture.store.allRows(
+      "SELECT role, content FROM conversation_turns ORDER BY turn_seq",
+    )).toEqual([{ role: "assistant", content: "The tool call completed." }]);
+    fixture.store.close();
+  });
+
   it("puts the streamed text on the message.completed event, not an empty payload", () => {
     // The trace in #12731 shows these events carrying literally {"text":""}. The
     // event is emitted from finishAttemptAndRun off the same finalText the run row
@@ -1757,6 +1905,48 @@ describe("external realtime surface authority", () => {
       "SELECT final_text FROM runs WHERE run_id = ?",
       [run.runId],
     ).final_text).toBe("Three parts sand to one part clay.");
+    fixture.store.close();
+  });
+
+  it("repairs a missing journal from the first persisted answer on a completion replay", () => {
+    // A crash can commit the terminal run before the canonical journal exchange
+    // is visible. The idempotent Swift retry must repair from persisted truth,
+    // never from a different payload carried by the replayed frame.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "The first answer is canonical.",
+    });
+    fixture.store.execute("DELETE FROM backend_turn_outbox");
+    fixture.store.execute("DELETE FROM conversation_turn_revisions");
+    fixture.store.execute("DELETE FROM conversation_turns");
+
+    const replay = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "A later replay must not replace it.",
+    });
+
+    expect(replay).toMatchObject({
+      duplicate: true,
+      finalTextPersisted: false,
+      journalMaterialized: true,
+    });
+    expect(replay.journalChanges).toHaveLength(2);
+    expect(fixture.store.allRows(
+      "SELECT role, content FROM conversation_turns ORDER BY created_at_ms, turn_seq",
+    )).toEqual([
+      { role: "user", content: "Remember my latest request" },
+      { role: "assistant", content: "The first answer is canonical." },
+    ]);
     fixture.store.close();
   });
 

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1672,6 +1672,122 @@ describe("external realtime surface authority", () => {
     fixture.store.close();
   });
 
+  it("reports a conflicting failed canonical answer as unmaterialized", () => {
+    // A failed canonical row is not ownership, it is a conflict: the successful answer
+    // is nowhere in history and this path will not overwrite a failure to put it there.
+    // Reporting materialized here told Swift the answer had landed when it had not --
+    // the silent loss this whole change exists to close.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const conversationId = String(fixture.store.getRow(
+      "SELECT conversation_id FROM surface_conversations WHERE agent_session_id = ? LIMIT 1",
+      [fixture.sessionId],
+    ).conversation_id);
+    const continuityKey = "voice:voice-turn-1";
+    recordJournalTurn(fixture.store, {
+      ownerId: "owner",
+      conversationId,
+      turnId: stableAgentSpawnTurnId(continuityKey, "assistant"),
+      role: "assistant",
+      surfaceKind: "realtime_voice",
+      origin: "agent_runtime",
+      status: "failed",
+      content: "",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: JSON.stringify({ continuityKey }),
+    });
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "The answer that must not be reported as landed.",
+    });
+
+    expect(completion.journalMaterialized).toBe(false);
+    expect(completion.journalChanges).toHaveLength(0);
+    fixture.store.close();
+  });
+
+  it("restores a missing user turn when repairing an in-progress assistant row", () => {
+    // A crash between the two journal writes leaves the assistant row without its
+    // question. Repairing only the answer left an exchange that reads as an assistant
+    // talking to nobody.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const conversationId = String(fixture.store.getRow(
+      "SELECT conversation_id FROM surface_conversations WHERE agent_session_id = ? LIMIT 1",
+      [fixture.sessionId],
+    ).conversation_id);
+    const continuityKey = "voice:voice-turn-1";
+    recordJournalTurn(fixture.store, {
+      ownerId: "owner",
+      conversationId,
+      turnId: stableAgentSpawnTurnId(continuityKey, "assistant"),
+      role: "assistant",
+      surfaceKind: "realtime_voice",
+      origin: "agent_runtime",
+      status: "streaming",
+      content: "",
+      contentBlocks: [],
+      resources: [],
+      metadataJson: JSON.stringify({ continuityKey }),
+    });
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "The repaired answer.",
+    });
+
+    expect(completion.journalMaterialized).toBe(true);
+    expect(fixture.store.allRows(
+      "SELECT role, content FROM conversation_turns ORDER BY created_at_ms, turn_seq",
+    )).toEqual([
+      { role: "user", content: "Remember my latest request" },
+      { role: "assistant", content: "The repaired answer." },
+    ]);
+    fixture.store.close();
+  });
+
+  it("repairs onto the realtime surface even when a main-chat alias exists", () => {
+    // Ordering main_chat first labelled the repaired voice turns main_chat and emitted
+    // the change on that surface, so the voice projection never saw its own turn.
+    const fixture = createFixture();
+    const run = fixture.kernel.beginExternalSurfaceRun(beginInput(fixture.sessionId));
+    const realtime = fixture.store.getRow(
+      "SELECT conversation_id FROM surface_conversations WHERE agent_session_id = ? LIMIT 1",
+      [fixture.sessionId],
+    );
+    fixture.store.execute(
+      `INSERT INTO surface_conversations
+         (owner_id, agent_session_id, conversation_id, surface_kind, external_ref_kind, external_ref_id, created_at_ms, last_active_at_ms)
+       VALUES (?, ?, ?, 'main_chat', 'chat', 'main-chat-alias', ?, ?)`,
+      ["owner", fixture.sessionId, String(realtime.conversation_id), Date.now(), Date.now() + 1000],
+    );
+
+    const completion = fixture.kernel.completeExternalSurfaceRun({
+      ownerId: "owner",
+      sessionId: fixture.sessionId,
+      runId: run.runId,
+      attemptId: run.attemptId,
+      terminalStatus: "completed",
+      finalText: "Answered on the surface that asked.",
+    });
+
+    expect(completion.journalMaterialized).toBe(true);
+    for (const change of completion.journalChanges ?? []) {
+      expect(["realtime_voice", "realtime"]).toContain(change.surfaceKind);
+    }
+    fixture.store.close();
+  });
+
   it("does not attribute a synthetic external authorization prompt to the user", () => {
     const fixture = createFixture();
     const run = fixture.kernel.beginExternalSurfaceRun({

--- a/desktop/macos/agent/tests/protocol-v2.test.ts
+++ b/desktop/macos/agent/tests/protocol-v2.test.ts
@@ -408,6 +408,7 @@ describe("protocol v2", () => {
       terminalStatus: "completed",
       duplicate: false,
       finalTextPersisted: true,
+      journalMaterialized: true,
     };
     expect([begin, invoke, complete] satisfies InboundMessage[]).toHaveLength(3);
     expect([began, invoked, completed] satisfies OutboundMessage[]).toHaveLength(3);

--- a/desktop/macos/changelog/unreleased/20260906-external-realtime-final-text.json
+++ b/desktop/macos/changelog/unreleased/20260906-external-realtime-final-text.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed completed realtime voice tool calls losing their final answer from conversation history"
+  "change": "Completed realtime voice conversations now keep their final answer in conversation history"
 }

--- a/desktop/macos/changelog/unreleased/20260906-external-realtime-final-text.json
+++ b/desktop/macos/changelog/unreleased/20260906-external-realtime-final-text.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed completed realtime voice tool calls losing their final answer from conversation history"
+}


### PR DESCRIPTION
## Summary

Fixes #12731.

External realtime voice runs could finish successfully while `runs.final_text`, the completion event, and the canonical conversation journal remained empty. Swift rendered the provider answer, but terminalization sent only status/error metadata; clearing the realtime UI state then discarded the only complete copy.

This change makes the answer part of the terminal authority contract:

- accumulates the turn-scoped authoritative answer across streamed text, accepted spawn receipts, local fallback text, and the final provider reply;
- sends non-empty `finalText` through the Swift/kernel completion wire and returns explicit persistence/materialization receipts;
- persists the first accepted answer on the run and atomically materializes a missing successful exchange into the canonical journal;
- preserves stable voice-turn IDs, corrected user transcripts, synthetic-prompt behavior, and existing spawn-receipt ownership;
- repairs a missing journal during an idempotent completion replay from the first persisted answer, never the retry payload;
- keeps partial text on failed/cancelled run records without presenting it as a completed chat exchange.

The accumulator is ephemeral terminalization state, not a second durable transcript store. The kernel journal remains canonical, and the repair path is a no-op when a completed canonical assistant turn already owns the continuity key.

## Root cause

The external-run protocol accepted `finalText`, but the Swift realtime producer never supplied it. The kernel therefore sealed a valid run with `final_text = NULL` and emitted `message.completed` with an empty payload. The ordinary Swift journal usually masked the missing kernel materialization, but owner transitions, restart timing, or terminal retries could leave the successful answer absent from conversation history.

## Failure semantics

- Non-empty successful answers must be both persisted and materialized; Swift fails closed if the kernel receipt cannot prove either property.
- Completion is first-write-wins. A duplicate retry can repair from persisted run truth but cannot replace that truth.
- Failed/cancelled runs retain diagnostic partial text on the run and do not create a successful journal exchange.
- Existing terminal canonical turns remain authoritative and are never overwritten.

## Verification

- `npm test` — full macOS agent suite
- `npm run build` — TypeScript production build
- `swift test --filter 'ExternalSurfaceRunAuthorityTests|PushToTalkStateMachineTests.testOwnerTransitionAwaitsExternalVoiceRunTerminalizationBeforeOwnerBAdmission'` — 8 passed
- `desktop/macos/scripts/agent-logic-harness.sh --cross-surface-smoke --verbose` — 72 Swift and 311 agent tests passed
- Regression coverage proves run persistence, non-empty completion events, stable journal IDs, outbox creation, corrected transcript preservation, synthetic prompt omission, existing receipt ownership, blank/failed/cancelled behavior, and replay repair from first-write truth.

## Manual verification

Built and launched isolated bundle `omi-12731-final-text` (`com.omi.omi-12731-final-text`) against the development backend. Health confirmed authenticated app state, running packaged agent runtime, and negotiated protocol v2. The live continuity gauntlet passed typed → realtime PTT provider path → canonical journal → blind typed recall at commit `56ed9b0d72`.

Evidence: `desktop/macos/.harness/agent-continuity-gauntlet/20260906T122459Z/manifest.json`

The deterministic gauntlet uses a forced transcript to make provider/journal continuity reproducible. A natural microphone PTT turn remains the final physical QA item; no production bundle was touched.

## Product invariants

- INV-AGENT-*
- INV-CHAT-1
- INV-VOICE-1

Failure-Class: FC-decoded-outcome-discarded-before-canonical-record

Line-Count-Exception: desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift | 4396 -> 4403 | Threads the answer and persistence receipts through the existing single runtime protocol boundary; extracting the signature/decoder lines would split one wire contract. The shared non-blank-answer definition the wire and the validator now agree on lives in ExternalSurfaceRunAuthority.swift beside the binding and completion types, not here.
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1572 -> 1582 | Feeds the turn-scoped accumulator at the three existing authoritative answer transitions; extracting these call sites would hide rather than reduce the ownership boundary.
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift | 1656 -> 1683 | Captures and validates final text at the existing terminalization owner boundary; the reusable answer accumulator and kernel journal policy are already extracted.
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift | 1539 -> 1578 | Defines the small turn-scoped accumulator beside the external-run state it protects; it has no independent lifecycle or reusable API worth a separate package surface. Now seedable, so an external tool requested mid-answer does not discard the text already streamed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



