### PR TITLE
S19: desktop Pendant BLE STT is plan-aware for basic

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -80,14 +80,20 @@ extension AppState {
       // Desktop transcribes on-device with Parakeet by default on Apple Silicon — no Deepgram.
       // Intel Macs (no Neural Engine) fall back to the cloud path. Force cloud for debugging with
       // OMI_FORCE_CLOUD_STT=1 or `defaults write <bundle> forceCloudSTT -bool true`.
+      // Pendant BLE used to force cloud; identified basic now matches mic (local, unnamed).
+      // Cache miss / unknown plan fail open to the previous BLE→cloud path; prefetch warms the next start.
       let debugForceCloud = STTSessionState.debugForceCloudSTT(
         environmentForceCloud: ProcessInfo.processInfo.environment["OMI_FORCE_CLOUD_STT"] == "1",
         userDefaultsForceCloud: UserDefaults.standard.bool(forKey: "forceCloudSTT")
       )
+      let preferLocalOnBasic =
+        SubscriptionEntitlementService.shared.cachedDecisionForManagedProactivity() == .planGated
+      Task { _ = await SubscriptionEntitlementService.shared.snapshot() }
       sttSession.beginRecording(
         audioSource: effectiveSource,
         isAppleSilicon: Self.isAppleSilicon,
-        debugForceCloud: debugForceCloud
+        debugForceCloud: debugForceCloud,
+        preferLocalOnBasic: preferLocalOnBasic
       )
       let clientConversationId = UUID().uuidString.lowercased()
       currentClientConversationId = sttSession.useLocalSTT ? nil : clientConversationId

--- a/desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
+++ b/desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
@@ -36,13 +36,21 @@ struct STTSessionState: Equatable {
   }
 
   /// Resolve which STT path to use for a new recording.
+  ///
+  /// Pendant BLE used to force cloud for named speaker-ID. Identified basic
+  /// (non-BYOK) on Apple Silicon now matches mic: local, unnamed. Paid,
+  /// unknown, and cache-miss stay on the previous BLE→cloud path.
   func resolveMode(
     audioSource: AudioSource,
     isAppleSilicon: Bool,
-    debugForceCloud: Bool
+    debugForceCloud: Bool,
+    preferLocalOnBasic: Bool = false
   ) -> ResolvedMode {
     let forceCloud = !sessionForceLocal && (debugForceCloud || appRunForceCloud)
-    if audioSource == .bleDevice || !isAppleSilicon || forceCloud {
+    if !isAppleSilicon || forceCloud {
+      return .cloud
+    }
+    if audioSource == .bleDevice && !preferLocalOnBasic {
       return .cloud
     }
     return .local
@@ -51,12 +59,14 @@ struct STTSessionState: Equatable {
   mutating func beginRecording(
     audioSource: AudioSource,
     isAppleSilicon: Bool,
-    debugForceCloud: Bool
+    debugForceCloud: Bool,
+    preferLocalOnBasic: Bool = false
   ) {
     activeMode = resolveMode(
       audioSource: audioSource,
       isAppleSilicon: isAppleSilicon,
-      debugForceCloud: debugForceCloud
+      debugForceCloud: debugForceCloud,
+      preferLocalOnBasic: preferLocalOnBasic
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
+++ b/desktop/macos/Desktop/Sources/Services/SubscriptionEntitlementService.swift
@@ -109,6 +109,16 @@ final class SubscriptionEntitlementService: @unchecked Sendable {
     withLock { cached?.response }
   }
 
+  /// Sync peek for call sites that cannot await (recording start). Empty or
+  /// expired cache is unknown plan and fails open.
+  func cachedDecisionForManagedProactivity() -> SubscriptionEntitlementDecision {
+    let info = cachedSnapshot?.subscription
+    return SubscriptionEntitlement.decision(
+      plan: info?.plan,
+      features: info?.features ?? [],
+      isByokActive: isByokActive())
+  }
+
   func decisionForManagedProactivity() async -> SubscriptionEntitlementDecision {
     let info = await snapshot()?.subscription
     return SubscriptionEntitlement.decision(

--- a/desktop/macos/Desktop/Tests/STTSessionStateTests.swift
+++ b/desktop/macos/Desktop/Tests/STTSessionStateTests.swift
@@ -23,6 +23,39 @@ final class STTSessionStateTests: XCTestCase {
     XCTAssertEqual(mode, .cloud)
   }
 
+  func testResolveMode_bleDevice_basicAppleSilicon_isLocal() {
+    let session = STTSessionState()
+    let mode = session.resolveMode(
+      audioSource: .bleDevice,
+      isAppleSilicon: true,
+      debugForceCloud: false,
+      preferLocalOnBasic: true
+    )
+    XCTAssertEqual(mode, .local)
+  }
+
+  func testResolveMode_bleDevice_basicIntel_isCloud() {
+    let session = STTSessionState()
+    let mode = session.resolveMode(
+      audioSource: .bleDevice,
+      isAppleSilicon: false,
+      debugForceCloud: false,
+      preferLocalOnBasic: true
+    )
+    XCTAssertEqual(mode, .cloud)
+  }
+
+  func testResolveMode_bleDevice_basicDebugForceCloud_isCloud() {
+    let session = STTSessionState()
+    let mode = session.resolveMode(
+      audioSource: .bleDevice,
+      isAppleSilicon: true,
+      debugForceCloud: true,
+      preferLocalOnBasic: true
+    )
+    XCTAssertEqual(mode, .cloud)
+  }
+
   func testResolveMode_intelMac_isCloud() {
     let session = STTSessionState()
     let mode = session.resolveMode(

--- a/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/SubscriptionEntitlementServiceTests.swift
@@ -79,6 +79,17 @@ final class SubscriptionEntitlementServiceTests: XCTestCase {
     XCTAssertEqual(fetches.value, 1)
   }
 
+  func testCachedDecisionFailsOpenUntilSnapshotLands() async throws {
+    let service = SubscriptionEntitlementService(
+      observeAuthChanges: false,
+      fetchSubscription: { try Self.decodeSubscription(plan: "basic") },
+      isByokActive: { false })
+    XCTAssertEqual(service.cachedDecisionForManagedProactivity(), .allowManagedProactivity)
+    let fetched = await service.decisionForManagedProactivity()
+    XCTAssertEqual(fetched, .planGated)
+    XCTAssertEqual(service.cachedDecisionForManagedProactivity(), .planGated)
+  }
+
   func testServiceFetchFailureFailsOpen() async {
     let service = SubscriptionEntitlementService(
       observeAuthChanges: false,

--- a/desktop/macos/changelog/unreleased/20260906-s19-ble-local-basic.json
+++ b/desktop/macos/changelog/unreleased/20260906-s19-ble-local-basic.json
@@ -1,0 +1,3 @@
+{
+  "change": "Free-plan Pendant recording on Apple Silicon now uses on-device transcription instead of forcing the cloud STT path."
+}


### PR DESCRIPTION
## S19 desktop — Pendant BLE `resolveMode` is plan-aware

Shard S19's **desktop one-liner** from the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S19; spec `40-mobile-pendant-port.md` §4.2). Mobile pendant-local and S19's mobile half stay with S17/S18 — not this PR.

Premise re-verified on `origin/main` `63bbcec7b1` (S13 just landed): `STTSessionState.resolveMode` still does `audioSource == .bleDevice || !isAppleSilicon || forceCloud → .cloud`. Mic on Apple Silicon is already local. S13's cached entitlement service is now on `main`; this PR consumes the sync cache peek so recording start stays synchronous.

### What changed

- `resolveMode` / `beginRecording` take `preferLocalOnBasic`. Identified basic + Apple Silicon + BLE → `.local` (unnamed, matching mic). Paid, unknown, cache-miss, Intel, and debug/app-run force-cloud stay `.cloud`.
- `startTranscription` reads `SubscriptionEntitlementService.cachedDecisionForManagedProactivity()` (empty cache fails open to the previous BLE→cloud path) and prefetches the snapshot for the next start.
- Named speaker-ID is still paid: this PR does not enable diarization on the local BLE path.

### Automatic-or-dead check

- BLE + Apple Silicon + `preferLocalOnBasic=false` → `.cloud` (paid / unknown / cache miss).
- BLE + Apple Silicon + `preferLocalOnBasic=true` → `.local`.
- BLE + Intel + `preferLocalOnBasic=true` → `.cloud`.
- BLE + Apple Silicon + debugForceCloud + `preferLocalOnBasic=true` → `.cloud`.
- Empty entitlement cache → `cachedDecisionForManagedProactivity() == .allowManagedProactivity`; after a basic snapshot it is `.planGated`.

Red-proof: restore the unconditional `audioSource == .bleDevice` short-circuit and `testResolveMode_bleDevice_basicAppleSilicon_isLocal` fails.

### Proof

Hermetic `STTSessionStateTests` + `SubscriptionEntitlementServiceTests`. Local Xcode 16.4 is not installed on this Mac; GitHub `macos-15` Desktop Swift jobs are the compile+test proof.

Dest: desktop-only. Merging does not deploy Cloud Run. Hourly desktop beta train may pick the merge up; no flag flip.

### Line-count ratchet

Line-Count-Exception: desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift | 1768 -> 1774 | S19: pass cached basic-plan decision into BLE resolveMode without making startTranscription async

### Cut list

- Mobile pendant-local / S19 mobile half (needs S17).
- Named speaker-ID on free.
- Making `startTranscription` await a fresh subscription fetch (first post-launch BLE start may still be cloud until the cache warms).
- S17 `SttModeResolver` (PR #11681 still open; last updated 2026-08-19).
- S21 mobile segment store.

## How it was verified

- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — run at preflight
- New/updated XCTest cases listed under Automatic-or-dead
- Did not run `run-swift-ci.sh` locally (requires Xcode 16.4; this host is 26.6)

## Tests

- `STTSessionStateTests` — BLE paid stays cloud; BLE basic Apple Silicon is local; Intel and debug-force stay cloud
- `SubscriptionEntitlementServiceTests` — sync cache peek fails open until a basic snapshot lands

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

