### PR TITLE
feat(desktop): Liquid Glass tab bar in the main window top bar

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -43,27 +43,16 @@ import SwiftUI
 struct DesktopTopBar: View {
   @Binding var selectedIndex: Int
   @Binding var memoryDestinationRawValue: Int
-  @ObservedObject var appState: AppState
-  @ObservedObject var memoriesViewModel: MemoriesViewModel
-  @ObservedObject var tasksStore: TasksStore
+  /// The three stores are observed by `TopNavigationBadgedRow`, not here: a tick in any of them
+  /// re-diffs only the counts it feeds and stops at the row's equality, instead of re-running the
+  /// whole bar on its way past. `ShellStatusIcons` observes `appState` itself.
+  let appState: AppState
+  let memoriesViewModel: MemoriesViewModel
+  let tasksStore: TasksStore
   /// Items created after this instant count as "new" — updated whenever Omi
   /// last resigned front (see DesktopHomeView).
   let sinceDate: Date
   @State private var showingReferral = false
-
-  private var newConversations: Int {
-    appState.conversations.filter { $0.createdAt > sinceDate && $0.deleted != true }.count
-  }
-  private var newMemories: Int {
-    memoriesViewModel.memories.filter { $0.createdAt > sinceDate }.count
-  }
-  private var newTasks: Int {
-    tasksStore.tasks.filter { $0.createdAt > sinceDate && !$0.isRetired }.count
-  }
-
-  private var badges: TopNavigationDestinationBadges {
-    TopNavigationDestinationBadges(library: newConversations + newMemories, tasks: newTasks)
-  }
 
   var body: some View {
     GeometryReader { proxy in
@@ -73,8 +62,10 @@ struct DesktopTopBar: View {
         Spacer(minLength: 0)
         TopNavigationBarLayout(
           expandedNavigation: {
-            TopNavigationDestinationRow(
-              selectedIndex: selectedIndex, badges: badges, onSelect: navigate)
+            TopNavigationBadgedRow(
+              appState: appState, memoriesViewModel: memoriesViewModel, tasksStore: tasksStore,
+              sinceDate: sinceDate, selectedIndex: selectedIndex, onSelect: navigate
+            )
           },
           compactNavigation: { compactNavigationMenu },
           persistentControls: {
@@ -174,6 +165,43 @@ struct DesktopTopBar: View {
       }
       selectedIndex = index
     }
+  }
+}
+
+/// The expanded tab bar plus the three stores its `+N` counts read.
+///
+/// The observations live here rather than on `DesktopTopBar` so a store tick re-diffs nothing but
+/// these three filters, and the row it feeds is `.equatable()`: a tick that moves no count — a
+/// Tasks multi-select, or one of the several ticks a page transition fires mid-animation — re-runs
+/// this small body and stops at the row's equality, instead of re-measuring and re-animating the
+/// glass bar.
+private struct TopNavigationBadgedRow: View {
+  @ObservedObject var appState: AppState
+  @ObservedObject var memoriesViewModel: MemoriesViewModel
+  @ObservedObject var tasksStore: TasksStore
+  /// Items created after this instant count as "new" — updated whenever Omi
+  /// last resigned front (see DesktopHomeView).
+  let sinceDate: Date
+  let selectedIndex: Int
+  let onSelect: (Int) -> Void
+
+  var body: some View {
+    TopNavigationDestinationRow(selectedIndex: selectedIndex, badges: badges, onSelect: onSelect)
+      .equatable()
+  }
+
+  private var badges: TopNavigationDestinationBadges {
+    TopNavigationDestinationBadges(library: newConversations + newMemories, tasks: newTasks)
+  }
+
+  private var newConversations: Int {
+    appState.conversations.filter { $0.createdAt > sinceDate && $0.deleted != true }.count
+  }
+  private var newMemories: Int {
+    memoriesViewModel.memories.filter { $0.createdAt > sinceDate }.count
+  }
+  private var newTasks: Int {
+    tasksStore.tasks.filter { $0.createdAt > sinceDate && !$0.isRetired }.count
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 /// The constant floating top bar.
 ///
-/// **It carries the destinations flat, and nothing opens.** On the left, one pill per destination:
-/// `Chat`, `Brain`, `Tasks`, `Apps`. On the right, operational status and Settings
+/// **It carries the destinations flat, and nothing opens.** On the left, the system tab bar — a native
+/// segmented control (`TopNavigationDestinationRow`), one tab per destination: `Chat`, `Memories`,
+/// `Tasks`, `Apps`. On the right, operational status and Settings
 /// stay persistent; referral remains available from Settings without competing
 /// with the product's primary destinations.
 ///
@@ -215,7 +216,8 @@ enum TopNavigationLayoutMetrics {
 
   /// The bar's own height.
   ///
-  /// The row inside it is 32 pt (the icon buttons; the pills are 30), so this is that plus a band of
+  /// The row inside it is 32 pt (the icon buttons; the native tab bar is a hair under), so this is
+  /// that plus a band of
   /// air top and bottom. Comfortably more than twice `barCornerRadius`, which matters: at exactly
   /// twice, the 22 pt corner degenerates into a capsule and the bar stops being the same *shape* as
   /// the panels under it — it becomes a giant pill sitting on two rounded rectangles.

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -294,11 +294,19 @@ struct TopNavigationDestinationRow: View {
   let onSelect: (Int) -> Void
 
   var body: some View {
-    if #available(macOS 26.0, *) {
-      TopNavigationGlassSegments(selectedIndex: selectedIndex, badges: badges, onSelect: onSelect)
-    } else {
+    // `compiler(>=6.2)` is the Xcode 26 toolchain: the one whose SDK declares `glassEffect`. An
+    // `@available(macOS 26.0, *)` guard only gates the call at run time; the symbol still has to exist
+    // in the SDK the package is compiled against, and CI's pinned Xcode 16.4 (macOS 15.5 SDK) does not
+    // have it. Built there, the row is the system segmented control on every macOS.
+    #if compiler(>=6.2)
+      if #available(macOS 26.0, *) {
+        TopNavigationGlassSegments(selectedIndex: selectedIndex, badges: badges, onSelect: onSelect)
+      } else {
+        segmentedFallback
+      }
+    #else
       segmentedFallback
-    }
+    #endif
   }
 
   /// The pre-Liquid-Glass tab bar: the system segmented control.
@@ -336,225 +344,227 @@ struct TopNavigationDestinationRow: View {
   }
 }
 
-/// The Liquid Glass segmented control with the iOS interaction.
-///
-/// Every segment is the same width (`EqualWidthSegments`), as on iOS, so the lens is one shape that
-/// only ever moves. The lens is the only glass here: the bar under it is already `inkGlassPanel`, and a
-/// track with its own material on top of that read as a white pill on the bar rather than as part of
-/// it. The lens is untinted too: no accent fill (INV-UI-1), the selected word simply goes to full ink.
-///
-/// Pointer down anywhere on the track lifts the lens and puts it under the pointer; dragging carries
-/// it; release snaps it to the nearest segment and navigates there. A plain click is the same gesture
-/// with no travel. The shell still owns the selection — the lens follows `selectedIndex` when it is not
-/// being dragged, so a navigation from anywhere else (⌘1, a deep link) slides it too.
-@available(macOS 26.0, *)
-private struct TopNavigationGlassSegments: View {
-  let selectedIndex: Int
-  let badges: TopNavigationDestinationBadges
-  let onSelect: (Int) -> Void
-
-  @State private var segmentWidth: CGFloat = 0
-  /// The pointer's x in track space while a press is in flight, nil otherwise.
-  @State private var dragX: CGFloat?
-
-  private var items: [TopNavigationItem] { TopNavigationRoutes.primaryItems }
-
-  private var selectedPosition: Int? {
-    guard let tag = TopNavigationSegmentSelection.selectedTag(forSelectedIndex: selectedIndex) else {
-      return nil
-    }
-    return items.firstIndex { $0.index == tag }
-  }
-
-  /// Where the lens sits: under the pointer while dragging, else on the selected segment.
-  private var lensCenterX: CGFloat? {
-    let geometry = TopNavigationGlassSegmentGeometry(
-      segmentWidth: segmentWidth, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
-    if let dragX { return geometry.lensCenterX(forPointerX: dragX) }
-    guard let selectedPosition else { return nil }
-    return geometry.lensCenterX(forPosition: selectedPosition)
-  }
-
-  // The body is a chain of small named pieces rather than one expression: the release compiler
-  // could not type-check the single closure-heavy expression in reasonable time (CI's Release
-  // Compile lane), so the lens, the pointer overlay and the animations each get their own property.
-  var body: some View {
-    animated(pointerCaptured(track))
-      .fixedSize()
-  }
-
-  /// The segments on the bar's own glass, with the lens as a background layer under the words.
+#if compiler(>=6.2)
+  /// The Liquid Glass segmented control with the iOS interaction.
   ///
-  /// One glass shape, so no `GlassEffectContainer`: the container composites its glass above every
-  /// non-glass sibling, which put the lens *over* the words and washed the selected one out. As a
-  /// plain background layer the lens stays under the labels. No glass of the track's own either: the
-  /// bar it sits on is already the glass (`inkGlassPanel`), and a second capsule of material on top
-  /// of it read as a white pill. Only the lens is glass.
-  private var track: some View {
-    segments
-      .padding(TopNavigationGlassSegmentMetrics.trackInset)
-      .background(alignment: .topLeading) { lens }
-      .contentShape(Capsule())
+  /// Every segment is the same width (`EqualWidthSegments`), as on iOS, so the lens is one shape that
+  /// only ever moves. The lens is the only glass here: the bar under it is already `inkGlassPanel`, and a
+  /// track with its own material on top of that read as a white pill on the bar rather than as part of
+  /// it. The lens is untinted too: no accent fill (INV-UI-1), the selected word simply goes to full ink.
+  ///
+  /// Pointer down anywhere on the track lifts the lens and puts it under the pointer; dragging carries
+  /// it; release snaps it to the nearest segment and navigates there. A plain click is the same gesture
+  /// with no travel. The shell still owns the selection — the lens follows `selectedIndex` when it is not
+  /// being dragged, so a navigation from anywhere else (⌘1, a deep link) slides it too.
+  @available(macOS 26.0, *)
+  private struct TopNavigationGlassSegments: View {
+    let selectedIndex: Int
+    let badges: TopNavigationDestinationBadges
+    let onSelect: (Int) -> Void
+
+    @State private var segmentWidth: CGFloat = 0
+    /// The pointer's x in track space while a press is in flight, nil otherwise.
+    @State private var dragX: CGFloat?
+
+    private var items: [TopNavigationItem] { TopNavigationRoutes.primaryItems }
+
+    private var selectedPosition: Int? {
+      guard let tag = TopNavigationSegmentSelection.selectedTag(forSelectedIndex: selectedIndex) else {
+        return nil
+      }
+      return items.firstIndex { $0.index == tag }
+    }
+
+    /// Where the lens sits: under the pointer while dragging, else on the selected segment.
+    private var lensCenterX: CGFloat? {
+      let geometry = TopNavigationGlassSegmentGeometry(
+        segmentWidth: segmentWidth, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+      if let dragX { return geometry.lensCenterX(forPointerX: dragX) }
+      guard let selectedPosition else { return nil }
+      return geometry.lensCenterX(forPosition: selectedPosition)
+    }
+
+    // The body is a chain of small named pieces rather than one expression: the release compiler
+    // could not type-check the single closure-heavy expression in reasonable time (CI's Release
+    // Compile lane), so the lens, the pointer overlay and the animations each get their own property.
+    var body: some View {
+      animated(pointerCaptured(track))
+        .fixedSize()
+    }
+
+    /// The segments on the bar's own glass, with the lens as a background layer under the words.
+    ///
+    /// One glass shape, so no `GlassEffectContainer`: the container composites its glass above every
+    /// non-glass sibling, which put the lens *over* the words and washed the selected one out. As a
+    /// plain background layer the lens stays under the labels. No glass of the track's own either: the
+    /// bar it sits on is already the glass (`inkGlassPanel`), and a second capsule of material on top
+    /// of it read as a white pill. Only the lens is glass.
+    private var track: some View {
+      segments
+        .padding(TopNavigationGlassSegmentMetrics.trackInset)
+        .background(alignment: .topLeading) { lens }
+        .contentShape(Capsule())
+    }
+
+    private var segments: some View {
+      EqualWidthSegments {
+        ForEach(Array(items.enumerated()), id: \.element.id) { position, item in
+          segment(item, isSelected: position == selectedPosition)
+        }
+      }
+    }
+
+    /// The clear glass capsule under the selected segment, or under the pointer while pressed.
+    @ViewBuilder
+    private var lens: some View {
+      if let lensCenterX {
+        Capsule()
+          .fill(.clear)
+          // `.clear`, not `.regular`: regular glass on the light bar read as a white pill. Clear glass
+          // keeps the lens's refraction and shine but lets the bar's own colour through.
+          .glassEffect(.clear.interactive(), in: .capsule)
+          .frame(width: lensWidth, height: TopNavigationGlassSegmentMetrics.height)
+          // Lifted while held, the way the iOS lens rises off the track under a finger.
+          .scaleEffect(lensScale)
+          .position(x: lensCenterX, y: lensCenterY)
+      }
+    }
+
+    private var lensWidth: CGFloat { max(0, segmentWidth) }
+
+    private var lensScale: CGFloat { dragX == nil ? 1 : TopNavigationGlassSegmentMetrics.liftScale }
+
+    private var lensCenterY: CGFloat {
+      TopNavigationGlassSegmentMetrics.trackInset + TopNavigationGlassSegmentMetrics.height / 2
+    }
+
+    /// The press is owned by AppKit, not by a SwiftUI `DragGesture`: the bar around this control is a
+    /// `WindowDragGesture` handle that recognises *simultaneously*, so a SwiftUI drag here moved the
+    /// lens and the whole window together. An `NSView` that claims the mouse-down keeps the window
+    /// still, exactly the way the Rewind scrubber keeps its own drags.
+    private func pointerCaptured<Content: View>(_ content: Content) -> some View {
+      content.overlay {
+        TopNavigationPointerCapture(
+          onWidthChange: trackWidthChanged,
+          onChanged: { dragX = $0 },
+          onEnded: pointerReleased
+        )
+      }
+    }
+
+    /// The lens slides under the motion gate: with Reduce Motion on it simply appears under the new
+    /// segment, exactly as the system's own controls behave.
+    private func animated<Content: View>(_ content: Content) -> some View {
+      content
+        .animation(OmiMotion.gated(.snappy(duration: 0.26)), value: selectedPosition)
+        .animation(OmiMotion.gated(.snappy(duration: 0.18)), value: dragX == nil)
+    }
+
+    private func trackWidthChanged(_ width: CGFloat) {
+      segmentWidth = TopNavigationGlassSegmentGeometry.segmentWidth(
+        forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+    }
+
+    /// Geometry from the overlay's own width, not from state: the release must land on the right
+    /// segment even before any SwiftUI update has published the measured width.
+    private func pointerReleased(atX x: CGFloat, trackWidth width: CGFloat) {
+      let inset = TopNavigationGlassSegmentMetrics.trackInset
+      let geometry = TopNavigationGlassSegmentGeometry(
+        segmentWidth: TopNavigationGlassSegmentGeometry.segmentWidth(
+          forTrackWidth: width, count: items.count, inset: inset),
+        count: items.count, inset: inset)
+      let position = geometry.position(forPointerX: x)
+      dragX = nil
+      guard items.indices.contains(position) else { return }
+      TopNavigationSegmentSelection.press(
+        tag: items[position].index, selectedIndex: selectedIndex, onSelect: onSelect)
+    }
+
+    private func segment(_ item: TopNavigationItem, isSelected: Bool) -> some View {
+      Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
+        .labelStyle(.titleAndIcon)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .lineLimit(1)
+        .fixedSize()
+        .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
+        .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
+        .frame(height: TopNavigationGlassSegmentMetrics.height)
+        .frame(maxWidth: .infinity)
+        .help(item.tooltip)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(item.tooltip)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityAction {
+          TopNavigationSegmentSelection.press(
+            tag: item.index, selectedIndex: selectedIndex, onSelect: onSelect)
+        }
+        .accessibilityIdentifier("top-navigation-\(item.index)")
+    }
   }
 
-  private var segments: some View {
-    EqualWidthSegments {
-      ForEach(Array(items.enumerated()), id: \.element.id) { position, item in
-        segment(item, isSelected: position == selectedPosition)
+  /// A transparent AppKit view that owns the pointer while it is down over the control.
+  ///
+  /// Reports the pointer's x in the control's own coordinates, which is the track space the lens is
+  /// positioned in because the overlay covers the control exactly. Hover is untouched — the glass
+  /// lens's shine comes from SwiftUI tracking areas, which this view does not intercept.
+  @available(macOS 26.0, *)
+  private struct TopNavigationPointerCapture: NSViewRepresentable {
+    /// The overlay covers the control exactly, so its width *is* the track width. Reported from
+    /// `layout()`, which is the one place that is always right, rather than measured a second time
+    /// through a `GeometryReader` that publishes a frame later.
+    let onWidthChange: (CGFloat) -> Void
+    let onChanged: (CGFloat) -> Void
+    /// The release: pointer x and the track width at that instant.
+    let onEnded: (CGFloat, CGFloat) -> Void
+
+    func makeNSView(context: Context) -> PointerCaptureView {
+      let view = PointerCaptureView()
+      apply(to: view)
+      return view
+    }
+
+    func updateNSView(_ view: PointerCaptureView, context: Context) {
+      apply(to: view)
+    }
+
+    private func apply(to view: PointerCaptureView) {
+      view.onWidthChange = onWidthChange
+      view.onChanged = onChanged
+      view.onEnded = onEnded
+    }
+
+    @MainActor
+    final class PointerCaptureView: NSView {
+      var onWidthChange: ((CGFloat) -> Void)?
+      var onChanged: ((CGFloat) -> Void)?
+      var onEnded: ((CGFloat, CGFloat) -> Void)?
+      private var reportedWidth: CGFloat = -1
+
+      /// The control keeps its own drags; the bar around it is the window handle.
+      override var mouseDownCanMoveWindow: Bool { false }
+      override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+      override func layout() {
+        super.layout()
+        guard bounds.width != reportedWidth else { return }
+        reportedWidth = bounds.width
+        onWidthChange?(bounds.width)
+      }
+
+      override func mouseDown(with event: NSEvent) {
+        onChanged?(convert(event.locationInWindow, from: nil).x)
+      }
+
+      override func mouseDragged(with event: NSEvent) {
+        onChanged?(convert(event.locationInWindow, from: nil).x)
+      }
+
+      override func mouseUp(with event: NSEvent) {
+        onEnded?(convert(event.locationInWindow, from: nil).x, bounds.width)
       }
     }
   }
-
-  /// The clear glass capsule under the selected segment, or under the pointer while pressed.
-  @ViewBuilder
-  private var lens: some View {
-    if let lensCenterX {
-      Capsule()
-        .fill(.clear)
-        // `.clear`, not `.regular`: regular glass on the light bar read as a white pill. Clear glass
-        // keeps the lens's refraction and shine but lets the bar's own colour through.
-        .glassEffect(.clear.interactive(), in: .capsule)
-        .frame(width: lensWidth, height: TopNavigationGlassSegmentMetrics.height)
-        // Lifted while held, the way the iOS lens rises off the track under a finger.
-        .scaleEffect(lensScale)
-        .position(x: lensCenterX, y: lensCenterY)
-    }
-  }
-
-  private var lensWidth: CGFloat { max(0, segmentWidth) }
-
-  private var lensScale: CGFloat { dragX == nil ? 1 : TopNavigationGlassSegmentMetrics.liftScale }
-
-  private var lensCenterY: CGFloat {
-    TopNavigationGlassSegmentMetrics.trackInset + TopNavigationGlassSegmentMetrics.height / 2
-  }
-
-  /// The press is owned by AppKit, not by a SwiftUI `DragGesture`: the bar around this control is a
-  /// `WindowDragGesture` handle that recognises *simultaneously*, so a SwiftUI drag here moved the
-  /// lens and the whole window together. An `NSView` that claims the mouse-down keeps the window
-  /// still, exactly the way the Rewind scrubber keeps its own drags.
-  private func pointerCaptured<Content: View>(_ content: Content) -> some View {
-    content.overlay {
-      TopNavigationPointerCapture(
-        onWidthChange: trackWidthChanged,
-        onChanged: { dragX = $0 },
-        onEnded: pointerReleased
-      )
-    }
-  }
-
-  /// The lens slides under the motion gate: with Reduce Motion on it simply appears under the new
-  /// segment, exactly as the system's own controls behave.
-  private func animated<Content: View>(_ content: Content) -> some View {
-    content
-      .animation(OmiMotion.gated(.snappy(duration: 0.26)), value: selectedPosition)
-      .animation(OmiMotion.gated(.snappy(duration: 0.18)), value: dragX == nil)
-  }
-
-  private func trackWidthChanged(_ width: CGFloat) {
-    segmentWidth = TopNavigationGlassSegmentGeometry.segmentWidth(
-      forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
-  }
-
-  /// Geometry from the overlay's own width, not from state: the release must land on the right
-  /// segment even before any SwiftUI update has published the measured width.
-  private func pointerReleased(atX x: CGFloat, trackWidth width: CGFloat) {
-    let inset = TopNavigationGlassSegmentMetrics.trackInset
-    let geometry = TopNavigationGlassSegmentGeometry(
-      segmentWidth: TopNavigationGlassSegmentGeometry.segmentWidth(
-        forTrackWidth: width, count: items.count, inset: inset),
-      count: items.count, inset: inset)
-    let position = geometry.position(forPointerX: x)
-    dragX = nil
-    guard items.indices.contains(position) else { return }
-    TopNavigationSegmentSelection.press(
-      tag: items[position].index, selectedIndex: selectedIndex, onSelect: onSelect)
-  }
-
-  private func segment(_ item: TopNavigationItem, isSelected: Bool) -> some View {
-    Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
-      .labelStyle(.titleAndIcon)
-      .scaledFont(size: OmiType.caption, weight: .semibold)
-      .lineLimit(1)
-      .fixedSize()
-      .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
-      .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
-      .frame(height: TopNavigationGlassSegmentMetrics.height)
-      .frame(maxWidth: .infinity)
-      .help(item.tooltip)
-      .accessibilityElement(children: .ignore)
-      .accessibilityLabel(item.tooltip)
-      .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-      .accessibilityAction {
-        TopNavigationSegmentSelection.press(
-          tag: item.index, selectedIndex: selectedIndex, onSelect: onSelect)
-      }
-      .accessibilityIdentifier("top-navigation-\(item.index)")
-  }
-}
-
-/// A transparent AppKit view that owns the pointer while it is down over the control.
-///
-/// Reports the pointer's x in the control's own coordinates, which is the track space the lens is
-/// positioned in because the overlay covers the control exactly. Hover is untouched — the glass
-/// lens's shine comes from SwiftUI tracking areas, which this view does not intercept.
-@available(macOS 26.0, *)
-private struct TopNavigationPointerCapture: NSViewRepresentable {
-  /// The overlay covers the control exactly, so its width *is* the track width. Reported from
-  /// `layout()`, which is the one place that is always right, rather than measured a second time
-  /// through a `GeometryReader` that publishes a frame later.
-  let onWidthChange: (CGFloat) -> Void
-  let onChanged: (CGFloat) -> Void
-  /// The release: pointer x and the track width at that instant.
-  let onEnded: (CGFloat, CGFloat) -> Void
-
-  func makeNSView(context: Context) -> PointerCaptureView {
-    let view = PointerCaptureView()
-    apply(to: view)
-    return view
-  }
-
-  func updateNSView(_ view: PointerCaptureView, context: Context) {
-    apply(to: view)
-  }
-
-  private func apply(to view: PointerCaptureView) {
-    view.onWidthChange = onWidthChange
-    view.onChanged = onChanged
-    view.onEnded = onEnded
-  }
-
-  @MainActor
-  final class PointerCaptureView: NSView {
-    var onWidthChange: ((CGFloat) -> Void)?
-    var onChanged: ((CGFloat) -> Void)?
-    var onEnded: ((CGFloat, CGFloat) -> Void)?
-    private var reportedWidth: CGFloat = -1
-
-    /// The control keeps its own drags; the bar around it is the window handle.
-    override var mouseDownCanMoveWindow: Bool { false }
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-
-    override func layout() {
-      super.layout()
-      guard bounds.width != reportedWidth else { return }
-      reportedWidth = bounds.width
-      onWidthChange?(bounds.width)
-    }
-
-    override func mouseDown(with event: NSEvent) {
-      onChanged?(convert(event.locationInWindow, from: nil).x)
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-      onChanged?(convert(event.locationInWindow, from: nil).x)
-    }
-
-    override func mouseUp(with event: NSEvent) {
-      onEnded?(convert(event.locationInWindow, from: nil).x, bounds.width)
-    }
-  }
-}
+#endif
 
 /// Where the lens is allowed to be, in track coordinates. Pure so the drag can be tested without a
 /// pointer: the lens centre is clamped to the first and last segment centres, and a release picks the

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -316,7 +316,7 @@ struct TopNavigationDestinationRow: View {
         Text(TopNavigationSegmentSelection.title(for: item, badges: badges))
           .tag(Optional(item.index))
           .help(item.tooltip)
-          .accessibilityLabel(item.tooltip)
+          .accessibilityLabel(TopNavigationSegmentSelection.accessibilityLabel(for: item, badges: badges))
           .accessibilityIdentifier("top-navigation-\(item.index)")
       }
     }
@@ -492,7 +492,7 @@ struct TopNavigationDestinationRow: View {
         .frame(maxWidth: .infinity)
         .help(item.tooltip)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(item.tooltip)
+        .accessibilityLabel(TopNavigationSegmentSelection.accessibilityLabel(for: item, badges: badges))
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .accessibilityAction {
           TopNavigationSegmentSelection.press(
@@ -655,6 +655,15 @@ enum TopNavigationSegmentSelection {
   static func title(for item: TopNavigationItem, badges: TopNavigationDestinationBadges) -> String {
     let count = badges.count(forNavItemIndex: item.index)
     return count > 0 ? "\(item.title) +\(count)" : item.title
+  }
+
+  /// What VoiceOver reads for a segment: the tooltip sentence, then the count a sighted user sees in
+  /// the title (`…, 7 new`). The tooltip alone dropped the count; the title alone drops the sentence.
+  static func accessibilityLabel(for item: TopNavigationItem, badges: TopNavigationDestinationBadges)
+    -> String
+  {
+    let count = badges.count(forNavItemIndex: item.index)
+    return count > 0 ? "\(item.tooltip), \(count) new" : item.tooltip
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -267,97 +267,367 @@ struct TopNavigationDestinationBadges: Equatable {
 
 // MARK: - The row
 
-/// The bar's left half: the mark, then one pill per destination.
+/// The bar's left half: the tab bar, one segment per destination.
+///
+/// On macOS 26 it is the Liquid Glass segmented control the way iOS draws it: the segments on the bar's
+/// own glass, and a glass lens under the selected word that **lifts and follows the pointer while you
+/// press and drag**,
+/// then settles on the nearest segment when you let go (`TopNavigationGlassSegments`). The system's own
+/// `NSSegmentedControl` on the Mac gets the material but not that interaction — it flips between
+/// segments — so the lens is drawn here with `glassEffect` inside one `GlassEffectContainer`, the way
+/// Apple's "Build a SwiftUI app with the new design" session builds custom glass controls. Below 26 it
+/// is the system segmented `Picker`, which is exactly what a macOS `TabView` draws for its tabs.
+///
+/// Neither renderer is a hand-drawn pill: hover, shine, Reduce Transparency, Increase Contrast and
+/// accessibility text size all come from the material or the control, not from this file.
+///
+/// **Glyph and word on macOS 26, word only below.** The glass segments keep the SF Symbol beside each
+/// title the way the pills did; the system segmented control cannot show both (it does not honour
+/// `titleAndIcon`), so the fallback carries the word, which is the half that names the destination.
 ///
 /// It takes plain values rather than the app's view models, which is what lets the layout test host
-/// the *real* row — real labels, real icons, real badges — and prove it fits the narrowest window.
+/// the *real* row — real labels, real counts — and prove it fits the narrowest window.
 struct TopNavigationDestinationRow: View {
   let selectedIndex: Int
   let badges: TopNavigationDestinationBadges
   let onSelect: (Int) -> Void
 
   var body: some View {
-    HStack(spacing: TopNavigationPillMetrics.itemSpacing) {
-      ForEach(TopNavigationRoutes.primaryItems) { item in
-        Button {
-          onSelect(item.index)
-        } label: {
-          TopNavigationPill(
-            icon: item.icon,
-            title: item.title,
-            badgeCount: badges.count(forNavItemIndex: item.index),
-            isSelected: isSelected(item)
-          )
-        }
-        .buttonStyle(.plain)
-        .help(item.tooltip)
-        .accessibilityLabel(item.tooltip)
-        .accessibilityIdentifier("top-navigation-\(item.index)")
-      }
+    if #available(macOS 26.0, *) {
+      TopNavigationGlassSegments(selectedIndex: selectedIndex, badges: badges, onSelect: onSelect)
+    } else {
+      segmentedFallback
     }
   }
 
-  private func isSelected(_ item: TopNavigationItem) -> Bool {
-    if item.index == SidebarNavItem.conversations.rawValue {
-      return ShellDestination.isHubPage(selectedIndex: selectedIndex)
+  /// The pre-Liquid-Glass tab bar: the system segmented control.
+  private var segmentedFallback: some View {
+    Picker("Navigate", selection: selection) {
+      ForEach(TopNavigationRoutes.primaryItems) { item in
+        Text(TopNavigationSegmentSelection.title(for: item, badges: badges))
+          .tag(Optional(item.index))
+          .help(item.tooltip)
+          .accessibilityLabel(item.tooltip)
+          .accessibilityIdentifier("top-navigation-\(item.index)")
+      }
     }
-    return selectedIndex == item.index
+    .pickerStyle(.segmented)
+    .labelsHidden()
+    .controlSize(.large)
+    // Neutral, not the accent: untinted, the control fills the selected segment with whatever
+    // accent colour the machine is set to. `controlColor` keeps the knob plain in both appearances,
+    // which is INV-UI-1's neutral accent and the way the system's own tab bars read.
+    .tint(TopNavigationSegmentMetrics.selectionTint)
+    .fixedSize()
+    .accessibilityIdentifier("top-navigation-row")
+  }
+
+  /// The segmented control reads the selected tag and writes the pressed one; the shell keeps owning
+  /// the index. Reading through `TopNavigationSegmentSelection` keeps the Brain rule (any hub page
+  /// lights the `Memories` tab) and the "no tab" rule (Settings selects nothing) in one testable place.
+  private var selection: Binding<Int?> {
+    Binding(
+      get: { TopNavigationSegmentSelection.selectedTag(forSelectedIndex: selectedIndex) },
+      set: { tag in
+        TopNavigationSegmentSelection.press(tag: tag, selectedIndex: selectedIndex, onSelect: onSelect)
+      }
+    )
   }
 }
 
+/// The Liquid Glass segmented control with the iOS interaction.
+///
+/// Every segment is the same width (`EqualWidthSegments`), as on iOS, so the lens is one shape that
+/// only ever moves. The lens is the only glass here: the bar under it is already `inkGlassPanel`, and a
+/// track with its own material on top of that read as a white pill on the bar rather than as part of
+/// it. The lens is untinted too: no accent fill (INV-UI-1), the selected word simply goes to full ink.
+///
+/// Pointer down anywhere on the track lifts the lens and puts it under the pointer; dragging carries
+/// it; release snaps it to the nearest segment and navigates there. A plain click is the same gesture
+/// with no travel. The shell still owns the selection — the lens follows `selectedIndex` when it is not
+/// being dragged, so a navigation from anywhere else (⌘1, a deep link) slides it too.
+@available(macOS 26.0, *)
+private struct TopNavigationGlassSegments: View {
+  let selectedIndex: Int
+  let badges: TopNavigationDestinationBadges
+  let onSelect: (Int) -> Void
+
+  @State private var segmentWidth: CGFloat = 0
+  /// The pointer's x in track space while a press is in flight, nil otherwise.
+  @State private var dragX: CGFloat?
+
+  private var items: [TopNavigationItem] { TopNavigationRoutes.primaryItems }
+
+  private var selectedPosition: Int? {
+    guard let tag = TopNavigationSegmentSelection.selectedTag(forSelectedIndex: selectedIndex) else {
+      return nil
+    }
+    return items.firstIndex { $0.index == tag }
+  }
+
+  /// Where the lens sits: under the pointer while dragging, else on the selected segment.
+  private var lensCenterX: CGFloat? {
+    let geometry = TopNavigationGlassSegmentGeometry(
+      segmentWidth: segmentWidth, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+    if let dragX { return geometry.lensCenterX(forPointerX: dragX) }
+    guard let selectedPosition else { return nil }
+    return geometry.lensCenterX(forPosition: selectedPosition)
+  }
+
+  var body: some View {
+    // One glass shape, so no `GlassEffectContainer`: the container composites its glass above every
+    // non-glass sibling, which put the lens *over* the words and washed the selected one out.
+    // As a plain background layer the lens stays under the labels.
+    EqualWidthSegments {
+      ForEach(Array(items.enumerated()), id: \.element.id) { position, item in
+        segment(item, isSelected: position == selectedPosition)
+      }
+    }
+    .padding(TopNavigationGlassSegmentMetrics.trackInset)
+    .background(alignment: .topLeading) {
+      if let lensCenterX {
+        Capsule()
+          .fill(.clear)
+          // `.clear`, not `.regular`: regular glass on the light bar read as a white pill. Clear glass
+          // keeps the lens's refraction and shine but lets the bar's own colour through.
+          .glassEffect(.clear.interactive(), in: .capsule)
+          .frame(width: max(0, segmentWidth), height: TopNavigationGlassSegmentMetrics.height)
+          // Lifted while held, the way the iOS lens rises off the track under a finger.
+          .scaleEffect(dragX == nil ? 1 : TopNavigationGlassSegmentMetrics.liftScale)
+          .position(
+            x: lensCenterX,
+            y: TopNavigationGlassSegmentMetrics.trackInset + TopNavigationGlassSegmentMetrics.height / 2)
+      }
+    }
+    // No glass of the track's own: the bar it sits on is already the glass (`inkGlassPanel`), and a
+    // second capsule of material on top of it read as a white pill. Only the lens is glass.
+    .contentShape(Capsule())
+    // The press is owned by AppKit, not by a SwiftUI `DragGesture`: the bar around this control is a
+    // `WindowDragGesture` handle that recognises *simultaneously*, so a SwiftUI drag here moved the
+    // lens and the whole window together. An `NSView` that claims the mouse-down keeps the window
+    // still, exactly the way the Rewind scrubber keeps its own drags.
+    .overlay {
+      TopNavigationPointerCapture(
+        onWidthChange: { width in
+          segmentWidth = TopNavigationGlassSegmentGeometry.segmentWidth(
+            forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+        },
+        onChanged: { dragX = $0 },
+        onEnded: { x, width in
+          // Geometry from the overlay's own width, not from state: the release must land on the right
+          // segment even before any SwiftUI update has published the measured width.
+          let geometry = TopNavigationGlassSegmentGeometry(
+            segmentWidth: TopNavigationGlassSegmentGeometry.segmentWidth(
+              forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset),
+            count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+          let position = geometry.position(forPointerX: x)
+          dragX = nil
+          guard items.indices.contains(position) else { return }
+          TopNavigationSegmentSelection.press(
+            tag: items[position].index, selectedIndex: selectedIndex, onSelect: onSelect)
+        }
+      )
+    }
+    // The lens slides under the motion gate: with Reduce Motion on it simply appears under the new
+    // segment, exactly as the system's own controls behave.
+    .animation(OmiMotion.gated(.snappy(duration: 0.26)), value: selectedPosition)
+    .animation(OmiMotion.gated(.snappy(duration: 0.18)), value: dragX == nil)
+    .fixedSize()
+  }
+
+  private func segment(_ item: TopNavigationItem, isSelected: Bool) -> some View {
+    Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
+      .labelStyle(.titleAndIcon)
+      .scaledFont(size: OmiType.caption, weight: .semibold)
+      .lineLimit(1)
+      .fixedSize()
+      .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
+      .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
+      .frame(height: TopNavigationGlassSegmentMetrics.height)
+      .frame(maxWidth: .infinity)
+      .help(item.tooltip)
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(item.tooltip)
+      .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+      .accessibilityAction {
+        TopNavigationSegmentSelection.press(
+          tag: item.index, selectedIndex: selectedIndex, onSelect: onSelect)
+      }
+      .accessibilityIdentifier("top-navigation-\(item.index)")
+  }
+}
+
+/// A transparent AppKit view that owns the pointer while it is down over the control.
+///
+/// Reports the pointer's x in the control's own coordinates, which is the track space the lens is
+/// positioned in because the overlay covers the control exactly. Hover is untouched — the glass
+/// lens's shine comes from SwiftUI tracking areas, which this view does not intercept.
+@available(macOS 26.0, *)
+private struct TopNavigationPointerCapture: NSViewRepresentable {
+  /// The overlay covers the control exactly, so its width *is* the track width. Reported from
+  /// `layout()`, which is the one place that is always right, rather than measured a second time
+  /// through a `GeometryReader` that publishes a frame later.
+  let onWidthChange: (CGFloat) -> Void
+  let onChanged: (CGFloat) -> Void
+  /// The release: pointer x and the track width at that instant.
+  let onEnded: (CGFloat, CGFloat) -> Void
+
+  func makeNSView(context: Context) -> PointerCaptureView {
+    let view = PointerCaptureView()
+    apply(to: view)
+    return view
+  }
+
+  func updateNSView(_ view: PointerCaptureView, context: Context) {
+    apply(to: view)
+  }
+
+  private func apply(to view: PointerCaptureView) {
+    view.onWidthChange = onWidthChange
+    view.onChanged = onChanged
+    view.onEnded = onEnded
+  }
+
+  @MainActor
+  final class PointerCaptureView: NSView {
+    var onWidthChange: ((CGFloat) -> Void)?
+    var onChanged: ((CGFloat) -> Void)?
+    var onEnded: ((CGFloat, CGFloat) -> Void)?
+    private var reportedWidth: CGFloat = -1
+
+    /// The control keeps its own drags; the bar around it is the window handle.
+    override var mouseDownCanMoveWindow: Bool { false }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func layout() {
+      super.layout()
+      guard bounds.width != reportedWidth else { return }
+      reportedWidth = bounds.width
+      onWidthChange?(bounds.width)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+      onChanged?(convert(event.locationInWindow, from: nil).x)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+      onChanged?(convert(event.locationInWindow, from: nil).x)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+      onEnded?(convert(event.locationInWindow, from: nil).x, bounds.width)
+    }
+  }
+}
+
+/// Where the lens is allowed to be, in track coordinates. Pure so the drag can be tested without a
+/// pointer: the lens centre is clamped to the first and last segment centres, and a release picks the
+/// segment whose span contains the pointer.
+struct TopNavigationGlassSegmentGeometry: Equatable {
+  let segmentWidth: CGFloat
+  let count: Int
+  let inset: CGFloat
+
+  /// Equal segments: the track minus its inset on both sides, shared evenly.
+  static func segmentWidth(forTrackWidth width: CGFloat, count: Int, inset: CGFloat) -> CGFloat {
+    guard count > 0 else { return 0 }
+    return max(0, width - inset * 2) / CGFloat(count)
+  }
+
+  func lensCenterX(forPosition position: Int) -> CGFloat {
+    inset + segmentWidth * (CGFloat(position) + 0.5)
+  }
+
+  func lensCenterX(forPointerX x: CGFloat) -> CGFloat {
+    guard count > 0, segmentWidth > 0 else { return inset }
+    return min(max(x, lensCenterX(forPosition: 0)), lensCenterX(forPosition: count - 1))
+  }
+
+  func position(forPointerX x: CGFloat) -> Int {
+    guard count > 0, segmentWidth > 0 else { return 0 }
+    let raw = Int(((x - inset) / segmentWidth).rounded(.down))
+    return min(max(raw, 0), count - 1)
+  }
+}
+
+/// Every segment as wide as the widest, in a row. Intrinsic width is `count × widest`, which is what
+/// keeps the row `fixedSize` and lets the narrowest-window test measure it.
+private struct EqualWidthSegments: Layout {
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+    let widest = sizes.map(\.width).max() ?? 0
+    let tallest = sizes.map(\.height).max() ?? 0
+    return CGSize(width: widest * CGFloat(subviews.count), height: tallest)
+  }
+
+  func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+    guard !subviews.isEmpty else { return }
+    let width = bounds.width / CGFloat(subviews.count)
+    for (position, subview) in subviews.enumerated() {
+      subview.place(
+        at: CGPoint(x: bounds.minX + width * CGFloat(position), y: bounds.minY),
+        anchor: .topLeading,
+        proposal: ProposedViewSize(width: width, height: bounds.height))
+    }
+  }
+}
+
+enum TopNavigationGlassSegmentMetrics {
+  /// The air between the track's glass edge and the lens.
+  static let trackInset: CGFloat = 3
+  static let horizontalPadding: CGFloat = 14
+  static let height: CGFloat = 28
+  /// How much the lens grows while held.
+  static let liftScale: CGFloat = 1.08
+}
+
+/// The two rules that turn the shell's index into what the native tab bar shows.
+enum TopNavigationSegmentSelection {
+  /// The tab the control should show as selected for a shell index, or `nil` for a page that has no
+  /// tab (Settings, Permissions) — a tab bar with no selection is the honest state there, where a
+  /// fabricated selection would claim you are on a page you are not.
+  static func selectedTag(
+    forSelectedIndex selectedIndex: Int,
+    items: [TopNavigationItem] = TopNavigationRoutes.primaryItems
+  ) -> Int? {
+    if ShellDestination.isHubPage(selectedIndex: selectedIndex) {
+      return SidebarNavItem.conversations.rawValue
+    }
+    return items.contains { $0.index == selectedIndex } ? selectedIndex : nil
+  }
+
+  /// What a press on the control does: navigate to the pressed tab, unless it is already the one
+  /// showing. The control re-writes its selection on a re-press, and forwarding that would restart
+  /// the page you are on. A `nil` write never navigates — the control has nowhere to go.
+  static func press(tag: Int?, selectedIndex: Int, onSelect: (Int) -> Void) {
+    guard let tag, tag != selectedTag(forSelectedIndex: selectedIndex) else { return }
+    onSelect(tag)
+  }
+
+  /// The new-item count the pills used to wear as a badge is part of the title: `Tasks +7`. A native
+  /// segment carries text and nothing else. A zero count adds nothing.
+  static func title(for item: TopNavigationItem, badges: TopNavigationDestinationBadges) -> String {
+    let count = badges.count(forNavItemIndex: item.index)
+    return count > 0 ? "\(item.title) +\(count)" : item.title
+  }
+}
+
+enum TopNavigationSegmentMetrics {
+  /// The least a native segment can be and still be a target: the HIG's minimum control width. The
+  /// real segments are wider — each carries a word — so this is a strict lower bound the layout test
+  /// uses to notice a segment that stopped being rendered.
+  static let minimumSegmentWidth: CGFloat = 44
+
+  /// The selected segment's fill: the system control colour, so the knob is neutral glass in light
+  /// and dark rather than the user's accent.
+  static let selectionTint = Color(nsColor: .controlColor)
+}
+
+/// Metrics the referral pill still shares with the bar. The bar's own destinations are native
+/// segments now (`TopNavigationDestinationRow`) and no longer read these.
 enum TopNavigationPillMetrics {
   static let itemSpacing: CGFloat = 4
   static let horizontalPadding: CGFloat = 12
   static let height: CGFloat = 30
   static let iconWidth: CGFloat = 18
-}
-
-/// One destination. **It hugs its own label** rather than taking a width from a table keyed by rail
-/// index: five pills whose widths were guessed one at a time is how a row that fitted in a mockup
-/// stops fitting once a badge appears on two of them.
-struct TopNavigationPill: View {
-  let icon: String
-  let title: String
-  let badgeCount: Int
-  let isSelected: Bool
-  @State private var isHovering = false
-
-  var body: some View {
-    HStack(spacing: 6) {
-      Image(systemName: icon)
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .frame(width: TopNavigationPillMetrics.iconWidth)
-      Text(title)
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .lineLimit(1)
-        .fixedSize()
-      if badgeCount > 0 {
-        TopNavigationBadge(count: badgeCount)
-      }
-    }
-    .foregroundStyle(GlassShell.controlLabel(isProminent: isSelected || isHovering))
-    .padding(.horizontal, TopNavigationPillMetrics.horizontalPadding)
-    .frame(height: TopNavigationPillMetrics.height)
-    .background(GlassPillBackground(isSelected: isSelected, isHovering: isHovering))
-    .contentShape(Capsule())
-    .onHover { isHovering = $0 }
-    .fixedSize()
-  }
-}
-
-/// How many of this destination's rows arrived since Omi last lost the front.
-private struct TopNavigationBadge: View {
-  let count: Int
-
-  var body: some View {
-    Text("+\(count)")
-      .scaledFont(size: OmiType.micro, weight: .bold)
-      .foregroundColor(Ink.primary)
-      .monospacedDigit()
-      .lineLimit(1)
-      .fixedSize()
-      .padding(.horizontal, 5)
-      .padding(.vertical, 1)
-      .background(Capsule(style: .continuous).fill(Ink.rowFillHover))
-  }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -287,8 +287,10 @@ struct TopNavigationDestinationBadges: Equatable {
 /// `titleAndIcon`), so the fallback carries the word, which is the half that names the destination.
 ///
 /// It takes plain values rather than the app's view models, which is what lets the layout test host
-/// the *real* row — real labels, real counts — and prove it fits the narrowest window.
-struct TopNavigationDestinationRow: View {
+/// the *real* row — real labels, real counts — and prove it fits the narrowest window. It is
+/// `Equatable` on what it draws — the selection and the counts — so the shell can hand it to
+/// `.equatable()` and a store tick that moves neither stops before this body.
+struct TopNavigationDestinationRow: View, Equatable {
   let selectedIndex: Int
   let badges: TopNavigationDestinationBadges
   let onSelect: (Int) -> Void
@@ -341,6 +343,16 @@ struct TopNavigationDestinationRow: View {
         TopNavigationSegmentSelection.press(tag: tag, selectedIndex: selectedIndex, onSelect: onSelect)
       }
     )
+  }
+}
+
+/// Equality is what the row *draws*: the selection and the counts. `onSelect` is the shell's
+/// `navigate` — the same behaviour for the life of the bar — so a re-render differing only in a
+/// fresh copy of the closure is not a change, and `.equatable()` may skip the body a store tick
+/// would otherwise have run.
+extension TopNavigationDestinationRow {
+  nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.selectedIndex == rhs.selectedIndex && lhs.badges == rhs.badges
   }
 }
 
@@ -495,12 +507,14 @@ struct TopNavigationDestinationRow: View {
     }
   }
 
-  /// One segment's content: the glyph and the word (with its `+N`), at the segment's fixed height.
+  /// One segment's content: the glyph, the word, and the count in its reserved slot.
   ///
   /// Its own type so the layout test can measure a segment on its own: `EqualWidthSegments` makes
   /// the row exactly `count × widest segment`, and that is what proves every destination is still
-  /// drawn. Selection only changes the ink, never the size, so the widest segment is the same
-  /// whichever one is selected.
+  /// drawn. What a segment measures is the word and the slot, never what is *in* either — selection
+  /// only changes the ink, and the count renders inside the slot a hidden template reserves — so a
+  /// badge tick can no longer re-measure and re-lay-out the bar the way it used to
+  /// (`testSegmentMeasurementIsIndependentOfBadgeCounts`).
   @available(macOS 26.0, *)
   struct TopNavigationGlassSegmentLabel: View {
     let item: TopNavigationItem
@@ -508,14 +522,33 @@ struct TopNavigationDestinationRow: View {
     let isSelected: Bool
 
     var body: some View {
-      Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
-        .labelStyle(.titleAndIcon)
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .lineLimit(1)
-        .fixedSize()
-        .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
-        .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
-        .frame(height: TopNavigationGlassSegmentMetrics.height)
+      HStack(spacing: TopNavigationGlassSegmentMetrics.countSpacing) {
+        Label(item.title, systemImage: item.icon)
+          .labelStyle(.titleAndIcon)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .lineLimit(1)
+          .fixedSize()
+        countSlot
+      }
+      .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
+      .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
+      .frame(height: TopNavigationGlassSegmentMetrics.height)
+    }
+
+    private var count: Int { badges.count(forNavItemIndex: item.index) }
+
+    /// The count, in a slot as wide as the widest string it can ever show. The hidden template
+    /// reserves that width in every segment, zero count included, so the row is measured from the
+    /// slot and not from the count; `monospacedDigit` keeps a crossing digit boundary from nudging
+    /// even the pixels inside it.
+    private var countSlot: some View {
+      ZStack {
+        Text(verbatim: TopNavigationSegmentSelection.widestCountText).hidden()
+        if count > 0 {
+          Text(verbatim: TopNavigationSegmentSelection.countText(for: count))
+        }
+      }
+      .scaledMonospacedDigitFont(size: OmiType.caption, weight: .semibold)
     }
   }
 
@@ -614,7 +647,9 @@ struct TopNavigationGlassSegmentGeometry: Equatable {
 }
 
 /// Every segment as wide as the widest, in a row. Intrinsic width is `count × widest`, which is what
-/// keeps the row `fixedSize` and lets the narrowest-window test measure it.
+/// keeps the row `fixedSize` and lets the narrowest-window test measure it. What a segment measures
+/// is its word and the reserved count slot — never the live count — so a badge tick cannot change
+/// this width and restart the bar's width animation.
 private struct EqualWidthSegments: Layout {
   func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
     let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
@@ -639,6 +674,8 @@ enum TopNavigationGlassSegmentMetrics {
   /// The air between the track's glass edge and the lens.
   static let trackInset: CGFloat = 3
   static let horizontalPadding: CGFloat = 14
+  /// The air between a segment's word and its count slot.
+  static let countSpacing: CGFloat = 3
   static let height: CGFloat = 28
   /// How much the lens grows while held.
   static let liftScale: CGFloat = 1.08
@@ -667,12 +704,29 @@ enum TopNavigationSegmentSelection {
     onSelect(tag)
   }
 
-  /// The new-item count the pills used to wear as a badge is part of the title: `Tasks +7`. A native
-  /// segment carries text and nothing else. A zero count adds nothing.
+  /// The new-item count the pills used to wear as a badge is part of the title: `Tasks +7`. A
+  /// zero count adds nothing.
+  ///
+  /// This is the **fallback's** title: the system segmented control's only channel for a count is
+  /// its title string, so there a count does move the control's own width — which is why the
+  /// narrowest-window test measures with counts at their widest, and a smaller count can only
+  /// shrink that control back into a lane it already fit. The glass path renders the count in the
+  /// slot `TopNavigationGlassSegmentLabel` reserves and measures segments without it.
   static func title(for item: TopNavigationItem, badges: TopNavigationDestinationBadges) -> String {
     let count = badges.count(forNavItemIndex: item.index)
-    return count > 0 ? "\(item.title) +\(count)" : item.title
+    return count > 0 ? "\(item.title) \(countText(for: count))" : item.title
   }
+
+  /// The count as it renders in a segment: `+N`, capped at two digits — `99+` — so a long absence
+  /// cannot widen the slot every segment reserves for it. VoiceOver keeps hearing the exact count
+  /// (`accessibilityLabel(for:badges:)`).
+  static func countText(for count: Int) -> String {
+    count > 99 ? widestCountText : "+\(count)"
+  }
+
+  /// The widest string the count slot must hold: the cap itself, reserved invisibly in every
+  /// segment, so the row's measurement sees this and never the live count.
+  static let widestCountText = "99+"
 
   /// What VoiceOver reads for a segment: the tooltip sentence, then the count a sighted user sees in
   /// the title (`…, 7 new`). The tooltip alone dropped the count; the title alone drops the sentence.

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -522,33 +522,40 @@ extension TopNavigationDestinationRow {
     let isSelected: Bool
 
     var body: some View {
-      HStack(spacing: TopNavigationGlassSegmentMetrics.countSpacing) {
-        Label(item.title, systemImage: item.icon)
-          .labelStyle(.titleAndIcon)
-          .scaledFont(size: OmiType.caption, weight: .semibold)
-          .lineLimit(1)
-          .fixedSize()
-        countSlot
-      }
-      .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
-      .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
-      .frame(height: TopNavigationGlassSegmentMetrics.height)
+      Label(item.title, systemImage: item.icon)
+        .labelStyle(.titleAndIcon)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .lineLimit(1)
+        .fixedSize()
+        .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
+        .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
+        .frame(height: TopNavigationGlassSegmentMetrics.height)
+        .overlay(alignment: .topTrailing) { countBadge }
     }
 
     private var count: Int { badges.count(forNavItemIndex: item.index) }
 
-    /// The count, in a slot as wide as the widest string it can ever show. The hidden template
-    /// reserves that width in every segment, zero count included, so the row is measured from the
-    /// slot and not from the count; `monospacedDigit` keeps a crossing digit boundary from nudging
-    /// even the pixels inside it.
-    private var countSlot: some View {
-      ZStack {
-        Text(verbatim: TopNavigationSegmentSelection.widestCountText).hidden()
-        if count > 0 {
-          Text(verbatim: TopNavigationSegmentSelection.countText(for: count))
-        }
+    /// The count as a corner-badge overlay. It takes no part in layout, so every segment measures —
+    /// and its title centers — identically at every count, and the lens stays under the words it
+    /// marks. This is the row's own `TopNavigationBadge` visual, on the one surface whose cells are
+    /// equal-width and must not re-measure when a count changes.
+    @ViewBuilder
+    private var countBadge: some View {
+      if count > 0 {
+        Text(verbatim: TopNavigationSegmentSelection.countText(for: count))
+          .scaledFont(size: OmiType.micro, weight: .bold)
+          .foregroundColor(Ink.primary)
+          .monospacedDigit()
+          .lineLimit(1)
+          .fixedSize()
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(Capsule(style: .continuous).fill(Ink.rowFillHover))
+          .allowsHitTesting(false)
+          .offset(
+            x: TopNavigationGlassSegmentMetrics.countBadgeOverhang,
+            y: -TopNavigationGlassSegmentMetrics.countBadgeLift)
       }
-      .scaledMonospacedDigitFont(size: OmiType.caption, weight: .semibold)
     }
   }
 
@@ -674,8 +681,10 @@ enum TopNavigationGlassSegmentMetrics {
   /// The air between the track's glass edge and the lens.
   static let trackInset: CGFloat = 3
   static let horizontalPadding: CGFloat = 14
-  /// The air between a segment's word and its count slot.
-  static let countSpacing: CGFloat = 3
+  /// How far the count badge overhangs the segment's trailing padding, and how far it lifts off
+  /// the label's cap height. It is an overlay: these move pixels, never measurements.
+  static let countBadgeOverhang: CGFloat = 7
+  static let countBadgeLift: CGFloat = 2
   static let height: CGFloat = 28
   /// How much the lens grows while held.
   static let liftScale: CGFloat = 1.08

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -274,9 +274,10 @@ struct TopNavigationDestinationBadges: Equatable {
 /// press and drag**,
 /// then settles on the nearest segment when you let go (`TopNavigationGlassSegments`). The system's own
 /// `NSSegmentedControl` on the Mac gets the material but not that interaction — it flips between
-/// segments — so the lens is drawn here with `glassEffect` inside one `GlassEffectContainer`, the way
-/// Apple's "Build a SwiftUI app with the new design" session builds custom glass controls. Below 26 it
-/// is the system segmented `Picker`, which is exactly what a macOS `TabView` draws for its tabs.
+/// segments — so the lens is drawn here with `glassEffect` as a plain background layer under the
+/// segment words (not inside a `GlassEffectContainer`, which composites its glass above every non-glass
+/// sibling and washed the selected word out). Below 26 it is the system segmented `Picker`, which is
+/// exactly what a macOS `TabView` draws for its tabs.
 ///
 /// Neither renderer is a hand-drawn pill: hover, shine, Reduce Transparency, Increase Contrast and
 /// accessibility text size all come from the material or the control, not from this file.
@@ -374,65 +375,100 @@ private struct TopNavigationGlassSegments: View {
     return geometry.lensCenterX(forPosition: selectedPosition)
   }
 
+  // The body is a chain of small named pieces rather than one expression: the release compiler
+  // could not type-check the single closure-heavy expression in reasonable time (CI's Release
+  // Compile lane), so the lens, the pointer overlay and the animations each get their own property.
   var body: some View {
-    // One glass shape, so no `GlassEffectContainer`: the container composites its glass above every
-    // non-glass sibling, which put the lens *over* the words and washed the selected one out.
-    // As a plain background layer the lens stays under the labels.
+    animated(pointerCaptured(track))
+      .fixedSize()
+  }
+
+  /// The segments on the bar's own glass, with the lens as a background layer under the words.
+  ///
+  /// One glass shape, so no `GlassEffectContainer`: the container composites its glass above every
+  /// non-glass sibling, which put the lens *over* the words and washed the selected one out. As a
+  /// plain background layer the lens stays under the labels. No glass of the track's own either: the
+  /// bar it sits on is already the glass (`inkGlassPanel`), and a second capsule of material on top
+  /// of it read as a white pill. Only the lens is glass.
+  private var track: some View {
+    segments
+      .padding(TopNavigationGlassSegmentMetrics.trackInset)
+      .background(alignment: .topLeading) { lens }
+      .contentShape(Capsule())
+  }
+
+  private var segments: some View {
     EqualWidthSegments {
       ForEach(Array(items.enumerated()), id: \.element.id) { position, item in
         segment(item, isSelected: position == selectedPosition)
       }
     }
-    .padding(TopNavigationGlassSegmentMetrics.trackInset)
-    .background(alignment: .topLeading) {
-      if let lensCenterX {
-        Capsule()
-          .fill(.clear)
-          // `.clear`, not `.regular`: regular glass on the light bar read as a white pill. Clear glass
-          // keeps the lens's refraction and shine but lets the bar's own colour through.
-          .glassEffect(.clear.interactive(), in: .capsule)
-          .frame(width: max(0, segmentWidth), height: TopNavigationGlassSegmentMetrics.height)
-          // Lifted while held, the way the iOS lens rises off the track under a finger.
-          .scaleEffect(dragX == nil ? 1 : TopNavigationGlassSegmentMetrics.liftScale)
-          .position(
-            x: lensCenterX,
-            y: TopNavigationGlassSegmentMetrics.trackInset + TopNavigationGlassSegmentMetrics.height / 2)
-      }
+  }
+
+  /// The clear glass capsule under the selected segment, or under the pointer while pressed.
+  @ViewBuilder
+  private var lens: some View {
+    if let lensCenterX {
+      Capsule()
+        .fill(.clear)
+        // `.clear`, not `.regular`: regular glass on the light bar read as a white pill. Clear glass
+        // keeps the lens's refraction and shine but lets the bar's own colour through.
+        .glassEffect(.clear.interactive(), in: .capsule)
+        .frame(width: lensWidth, height: TopNavigationGlassSegmentMetrics.height)
+        // Lifted while held, the way the iOS lens rises off the track under a finger.
+        .scaleEffect(lensScale)
+        .position(x: lensCenterX, y: lensCenterY)
     }
-    // No glass of the track's own: the bar it sits on is already the glass (`inkGlassPanel`), and a
-    // second capsule of material on top of it read as a white pill. Only the lens is glass.
-    .contentShape(Capsule())
-    // The press is owned by AppKit, not by a SwiftUI `DragGesture`: the bar around this control is a
-    // `WindowDragGesture` handle that recognises *simultaneously*, so a SwiftUI drag here moved the
-    // lens and the whole window together. An `NSView` that claims the mouse-down keeps the window
-    // still, exactly the way the Rewind scrubber keeps its own drags.
-    .overlay {
+  }
+
+  private var lensWidth: CGFloat { max(0, segmentWidth) }
+
+  private var lensScale: CGFloat { dragX == nil ? 1 : TopNavigationGlassSegmentMetrics.liftScale }
+
+  private var lensCenterY: CGFloat {
+    TopNavigationGlassSegmentMetrics.trackInset + TopNavigationGlassSegmentMetrics.height / 2
+  }
+
+  /// The press is owned by AppKit, not by a SwiftUI `DragGesture`: the bar around this control is a
+  /// `WindowDragGesture` handle that recognises *simultaneously*, so a SwiftUI drag here moved the
+  /// lens and the whole window together. An `NSView` that claims the mouse-down keeps the window
+  /// still, exactly the way the Rewind scrubber keeps its own drags.
+  private func pointerCaptured<Content: View>(_ content: Content) -> some View {
+    content.overlay {
       TopNavigationPointerCapture(
-        onWidthChange: { width in
-          segmentWidth = TopNavigationGlassSegmentGeometry.segmentWidth(
-            forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
-        },
+        onWidthChange: trackWidthChanged,
         onChanged: { dragX = $0 },
-        onEnded: { x, width in
-          // Geometry from the overlay's own width, not from state: the release must land on the right
-          // segment even before any SwiftUI update has published the measured width.
-          let geometry = TopNavigationGlassSegmentGeometry(
-            segmentWidth: TopNavigationGlassSegmentGeometry.segmentWidth(
-              forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset),
-            count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
-          let position = geometry.position(forPointerX: x)
-          dragX = nil
-          guard items.indices.contains(position) else { return }
-          TopNavigationSegmentSelection.press(
-            tag: items[position].index, selectedIndex: selectedIndex, onSelect: onSelect)
-        }
+        onEnded: pointerReleased
       )
     }
-    // The lens slides under the motion gate: with Reduce Motion on it simply appears under the new
-    // segment, exactly as the system's own controls behave.
-    .animation(OmiMotion.gated(.snappy(duration: 0.26)), value: selectedPosition)
-    .animation(OmiMotion.gated(.snappy(duration: 0.18)), value: dragX == nil)
-    .fixedSize()
+  }
+
+  /// The lens slides under the motion gate: with Reduce Motion on it simply appears under the new
+  /// segment, exactly as the system's own controls behave.
+  private func animated<Content: View>(_ content: Content) -> some View {
+    content
+      .animation(OmiMotion.gated(.snappy(duration: 0.26)), value: selectedPosition)
+      .animation(OmiMotion.gated(.snappy(duration: 0.18)), value: dragX == nil)
+  }
+
+  private func trackWidthChanged(_ width: CGFloat) {
+    segmentWidth = TopNavigationGlassSegmentGeometry.segmentWidth(
+      forTrackWidth: width, count: items.count, inset: TopNavigationGlassSegmentMetrics.trackInset)
+  }
+
+  /// Geometry from the overlay's own width, not from state: the release must land on the right
+  /// segment even before any SwiftUI update has published the measured width.
+  private func pointerReleased(atX x: CGFloat, trackWidth width: CGFloat) {
+    let inset = TopNavigationGlassSegmentMetrics.trackInset
+    let geometry = TopNavigationGlassSegmentGeometry(
+      segmentWidth: TopNavigationGlassSegmentGeometry.segmentWidth(
+        forTrackWidth: width, count: items.count, inset: inset),
+      count: items.count, inset: inset)
+    let position = geometry.position(forPointerX: x)
+    dragX = nil
+    guard items.indices.contains(position) else { return }
+    TopNavigationSegmentSelection.press(
+      tag: items[position].index, selectedIndex: selectedIndex, onSelect: onSelect)
   }
 
   private func segment(_ item: TopNavigationItem, isSelected: Bool) -> some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -481,14 +481,7 @@ struct TopNavigationDestinationRow: View {
     }
 
     private func segment(_ item: TopNavigationItem, isSelected: Bool) -> some View {
-      Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
-        .labelStyle(.titleAndIcon)
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .lineLimit(1)
-        .fixedSize()
-        .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
-        .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
-        .frame(height: TopNavigationGlassSegmentMetrics.height)
+      TopNavigationGlassSegmentLabel(item: item, badges: badges, isSelected: isSelected)
         .frame(maxWidth: .infinity)
         .help(item.tooltip)
         .accessibilityElement(children: .ignore)
@@ -499,6 +492,30 @@ struct TopNavigationDestinationRow: View {
             tag: item.index, selectedIndex: selectedIndex, onSelect: onSelect)
         }
         .accessibilityIdentifier("top-navigation-\(item.index)")
+    }
+  }
+
+  /// One segment's content: the glyph and the word (with its `+N`), at the segment's fixed height.
+  ///
+  /// Its own type so the layout test can measure a segment on its own: `EqualWidthSegments` makes
+  /// the row exactly `count × widest segment`, and that is what proves every destination is still
+  /// drawn. Selection only changes the ink, never the size, so the widest segment is the same
+  /// whichever one is selected.
+  @available(macOS 26.0, *)
+  struct TopNavigationGlassSegmentLabel: View {
+    let item: TopNavigationItem
+    let badges: TopNavigationDestinationBadges
+    let isSelected: Bool
+
+    var body: some View {
+      Label(TopNavigationSegmentSelection.title(for: item, badges: badges), systemImage: item.icon)
+        .labelStyle(.titleAndIcon)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .lineLimit(1)
+        .fixedSize()
+        .foregroundStyle(isSelected ? Ink.primary : Ink.secondary)
+        .padding(.horizontal, TopNavigationGlassSegmentMetrics.horizontalPadding)
+        .frame(height: TopNavigationGlassSegmentMetrics.height)
     }
   }
 

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -444,28 +444,165 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     guard let navigation = recorder.frame(of: .expanded) else {
       return XCTFail("the expanded destination row was never placed")
     }
-    // **Fitting only means something if what fitted is still a row of named pills.** `ViewThatFits`
-    // is satisfied by anything narrow enough, so a row that had quietly stopped drawing pills — or
-    // had been emptied down to one — would pass the check above and prove nothing. Deleting a pill
-    // makes this test *easier*, which is exactly when a floor is worth having: two pills were removed
-    // from this row (`Insights` here, `Chat` earlier) and the assertion did not notice either.
+    // **Fitting only means something if what fitted is still a tab bar of named segments.**
+    // `ViewThatFits` is satisfied by anything narrow enough, so a control that had quietly stopped
+    // drawing segments — or had been emptied down to one — would pass the check above and prove
+    // nothing. Deleting a segment makes this test *easier*, which is exactly when a floor is worth
+    // having: two destinations were removed from this row (`Insights` here, `Chat` earlier) and the
+    // assertion did not notice either.
     //
-    // The floor is derived from the row's own metrics rather than measured once and pinned, so it
-    // tracks the row instead of dating from the day it was written: each pill is at minimum its
-    // horizontal padding on both sides plus the fixed icon column, and the gaps are `itemSpacing`.
-    // Real pills are wider than that — they carry a word, and two carry a badge — so this is a strict
-    // lower bound that still fails the moment a pill stops being rendered.
-    let pills = CGFloat(TopNavigationRoutes.primaryItems.count)
-    let minimumPillWidth =
-      TopNavigationPillMetrics.horizontalPadding * 2 + TopNavigationPillMetrics.iconWidth
-    let floor = pills * minimumPillWidth + (pills - 1) * TopNavigationPillMetrics.itemSpacing
+    // The floor is the HIG minimum control width per segment. Real segments are wider than that —
+    // they carry a word, and two carry a count — so this is a strict lower bound that still fails
+    // the moment a segment stops being rendered.
+    let segments = CGFloat(TopNavigationRoutes.primaryItems.count)
+    let floor = segments * TopNavigationSegmentMetrics.minimumSegmentWidth
     XCTAssertGreaterThan(
       navigation.width, floor,
       """
-      the row fitted by drawing fewer pills than `TopNavigationRoutes.primaryItems` has, so \
+      the row fitted by drawing fewer segments than `TopNavigationRoutes.primaryItems` has, so \
       `ViewThatFits` chose it for the wrong reason
       """)
     XCTAssertLessThanOrEqual(navigation.width, lane - inset * 2)
+  }
+
+  /// The native tab bar shows one selected segment or none. Any Brain page lights the `Memories`
+  /// tab; a page with no tab of its own (Settings, Permissions) selects nothing rather than lying.
+  func testTheNativeTabBarSelectsTheTabThatOwnsTheCurrentPage() {
+    XCTAssertEqual(
+      TopNavigationSegmentSelection.selectedTag(forSelectedIndex: SidebarNavItem.dashboard.rawValue),
+      SidebarNavItem.dashboard.rawValue)
+    XCTAssertEqual(
+      TopNavigationSegmentSelection.selectedTag(forSelectedIndex: SidebarNavItem.tasks.rawValue),
+      SidebarNavItem.tasks.rawValue)
+    XCTAssertEqual(
+      TopNavigationSegmentSelection.selectedTag(forSelectedIndex: SidebarNavItem.apps.rawValue),
+      SidebarNavItem.apps.rawValue)
+    for destination in ShellDestination.allCases where destination.memoryDestination != nil {
+      XCTAssertEqual(
+        TopNavigationSegmentSelection.selectedTag(forSelectedIndex: destination.navItem.rawValue),
+        SidebarNavItem.conversations.rawValue,
+        "\(destination.title) must light the Memories tab")
+    }
+    XCTAssertNil(
+      TopNavigationSegmentSelection.selectedTag(forSelectedIndex: SidebarNavItem.settings.rawValue))
+    XCTAssertNil(
+      TopNavigationSegmentSelection.selectedTag(forSelectedIndex: SidebarNavItem.permissions.rawValue))
+  }
+
+  /// Pressing a tab navigates to it; re-pressing the current one, or the control writing back `nil`,
+  /// does not restart the page. The hub tab counts as current on every Brain page.
+  func testPressingANativeTabNavigatesOnlyWhenItChangesThePage() {
+    var pressed: [Int] = []
+    let record: (Int) -> Void = { pressed.append($0) }
+    TopNavigationSegmentSelection.press(
+      tag: SidebarNavItem.tasks.rawValue, selectedIndex: SidebarNavItem.dashboard.rawValue,
+      onSelect: record)
+    TopNavigationSegmentSelection.press(
+      tag: SidebarNavItem.tasks.rawValue, selectedIndex: SidebarNavItem.tasks.rawValue,
+      onSelect: record)
+    TopNavigationSegmentSelection.press(
+      tag: nil, selectedIndex: SidebarNavItem.tasks.rawValue, onSelect: record)
+    TopNavigationSegmentSelection.press(
+      tag: SidebarNavItem.conversations.rawValue, selectedIndex: SidebarNavItem.conversations.rawValue,
+      onSelect: record)
+    TopNavigationSegmentSelection.press(
+      tag: SidebarNavItem.dashboard.rawValue, selectedIndex: SidebarNavItem.settings.rawValue,
+      onSelect: record)
+    XCTAssertEqual(pressed, [SidebarNavItem.tasks.rawValue, SidebarNavItem.dashboard.rawValue])
+  }
+
+  /// A native segment is text only, so the count the pills wore as a badge joins the title — and
+  /// only when there is something to count.
+  func testTheNewItemCountJoinsTheSegmentTitleOnlyWhenNonZero() {
+    let badges = TopNavigationDestinationBadges(library: 4, tasks: 7)
+    let titles = TopNavigationRoutes.primaryItems.map {
+      TopNavigationSegmentSelection.title(for: $0, badges: badges)
+    }
+    XCTAssertEqual(titles, ["Chat", "Memories +4", "Tasks +7", "Apps"])
+    let quiet = TopNavigationRoutes.primaryItems.map {
+      TopNavigationSegmentSelection.title(for: $0, badges: TopNavigationDestinationBadges())
+    }
+    XCTAssertEqual(quiet, ["Chat", "Memories", "Tasks", "Apps"])
+  }
+
+  /// The glass lens follows the pointer but never leaves the track: its centre is clamped to the
+  /// first and last segment centres, and a release picks the segment under the pointer, with the
+  /// track's edges rounding into the end segments rather than into nothing.
+  func testTheGlassLensClampsToTheTrackAndReleasesOnTheSegmentUnderThePointer() {
+    let geometry = TopNavigationGlassSegmentGeometry(segmentWidth: 80, count: 4, inset: 3)
+    XCTAssertEqual(geometry.lensCenterX(forPosition: 0), 43)
+    XCTAssertEqual(geometry.lensCenterX(forPosition: 3), 283)
+    XCTAssertEqual(geometry.lensCenterX(forPointerX: -50), 43)
+    XCTAssertEqual(geometry.lensCenterX(forPointerX: 150), 150)
+    XCTAssertEqual(geometry.lensCenterX(forPointerX: 900), 283)
+    XCTAssertEqual(geometry.position(forPointerX: -50), 0)
+    XCTAssertEqual(geometry.position(forPointerX: 3), 0)
+    XCTAssertEqual(geometry.position(forPointerX: 82), 0)
+    XCTAssertEqual(geometry.position(forPointerX: 83), 1)
+    XCTAssertEqual(geometry.position(forPointerX: 250), 3)
+    XCTAssertEqual(geometry.position(forPointerX: 900), 3)
+    // Before the first layout pass the width is unknown; the lens parks at the inset and a release
+    // means the first segment rather than a trap on divide-by-zero.
+    let unmeasured = TopNavigationGlassSegmentGeometry(segmentWidth: 0, count: 4, inset: 3)
+    XCTAssertEqual(unmeasured.lensCenterX(forPointerX: 120), 3)
+    XCTAssertEqual(unmeasured.position(forPointerX: 120), 0)
+  }
+
+  /// **A drag on the tabs moves the lens, never the window.** The bar is a `WindowDragGesture` handle
+  /// that recognises simultaneously with anything SwiftUI inside it, which is how the first glass row
+  /// walked the whole window sideways when you dragged the selection. The press is AppKit-owned now:
+  /// the view under the pointer is an `NSView` that refuses `mouseDownCanMoveWindow` and consumes the
+  /// mouse sequence, so neither AppKit's background move nor SwiftUI's gesture ever sees it.
+  ///
+  /// This hosts the real row *inside* the real drag handle in a real window, checks that the view
+  /// hit-tested under a tab is that AppKit owner, then sends the press, the travel and the release to
+  /// it and checks the release lands on the tab under the pointer. (An off-screen window drops
+  /// `sendEvent`, so the events go to the hit view the way the window would route them.)
+  @available(macOS 26.0, *)
+  func testDraggingTheSelectionAcrossTheTabsSelectsTheReleasedTabWithoutMovingTheWindow() throws {
+    var selected: [Int] = []
+    let row = TopNavigationDestinationRow(
+      selectedIndex: SidebarNavItem.dashboard.rawValue,
+      badges: TopNavigationDestinationBadges(),
+      onSelect: { selected.append($0) }
+    )
+    let host = NSHostingView(rootView: row.padding(20).shellWindowDragHandle())
+    let size = host.fittingSize
+    let window = NSWindow(
+      contentRect: NSRect(x: 400, y: 300, width: size.width, height: size.height),
+      styleMask: [.borderless], backing: .buffered, defer: false)
+    window.isMovableByWindowBackground = false
+    window.contentView = host
+    host.frame = NSRect(origin: .zero, size: size)
+    host.layoutSubtreeIfNeeded()
+    let originBefore = window.frame.origin
+
+    // Four equal segments inside the row's 20 pt padding: press on the second, release on the fourth.
+    let items = TopNavigationRoutes.primaryItems
+    let segmentWidth = (size.width - 40) / CGFloat(items.count)
+    let y = size.height / 2
+    func x(_ position: Int) -> CGFloat { 20 + segmentWidth * (CGFloat(position) + 0.5) }
+    let owner = try XCTUnwrap(host.hitTest(NSPoint(x: x(1), y: y)), "nothing under the tab")
+    XCTAssertFalse(
+      owner.mouseDownCanMoveWindow,
+      "the view under a tab must refuse to move the window, or a drag on the tabs drags the shell")
+    XCTAssertFalse(owner is NSHostingView<AnyView>, "the hosting view must not be the press owner")
+
+    func event(_ type: NSEvent.EventType, at point: NSPoint) throws -> NSEvent {
+      try XCTUnwrap(
+        NSEvent.mouseEvent(
+          with: type, location: point, modifierFlags: [], timestamp: ProcessInfo.processInfo.systemUptime,
+          windowNumber: window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1))
+    }
+    owner.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: x(1), y: y)))
+    for step in 1...6 {
+      let t = CGFloat(step) / 6
+      owner.mouseDragged(with: try event(.leftMouseDragged, at: NSPoint(x: x(1) + (x(3) - x(1)) * t, y: y)))
+    }
+    owner.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: x(3), y: y)))
+
+    XCTAssertEqual(selected, [items[3].index], "the release must select the tab under the pointer")
+    XCTAssertEqual(window.frame.origin, originBefore, "dragging the selection must not move the window")
   }
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -548,62 +548,66 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertEqual(unmeasured.position(forPointerX: 120), 0)
   }
 
-  /// **A drag on the tabs moves the lens, never the window.** The bar is a `WindowDragGesture` handle
-  /// that recognises simultaneously with anything SwiftUI inside it, which is how the first glass row
-  /// walked the whole window sideways when you dragged the selection. The press is AppKit-owned now:
-  /// the view under the pointer is an `NSView` that refuses `mouseDownCanMoveWindow` and consumes the
-  /// mouse sequence, so neither AppKit's background move nor SwiftUI's gesture ever sees it.
-  ///
-  /// This hosts the real row *inside* the real drag handle in a real window, checks that the view
-  /// hit-tested under a tab is that AppKit owner, then sends the press, the travel and the release to
-  /// it and checks the release lands on the tab under the pointer. (An off-screen window drops
-  /// `sendEvent`, so the events go to the hit view the way the window would route them.)
-  @available(macOS 26.0, *)
-  func testDraggingTheSelectionAcrossTheTabsSelectsTheReleasedTabWithoutMovingTheWindow() throws {
-    var selected: [Int] = []
-    let row = TopNavigationDestinationRow(
-      selectedIndex: SidebarNavItem.dashboard.rawValue,
-      badges: TopNavigationDestinationBadges(),
-      onSelect: { selected.append($0) }
-    )
-    let host = NSHostingView(rootView: row.padding(20).shellWindowDragHandle())
-    let size = host.fittingSize
-    let window = NSWindow(
-      contentRect: NSRect(x: 400, y: 300, width: size.width, height: size.height),
-      styleMask: [.borderless], backing: .buffered, defer: false)
-    window.isMovableByWindowBackground = false
-    window.contentView = host
-    host.frame = NSRect(origin: .zero, size: size)
-    host.layoutSubtreeIfNeeded()
-    let originBefore = window.frame.origin
+  // The glass renderer only exists when compiled against the macOS 26 SDK (see
+  // `TopNavigationDestinationRow.body`); against an older SDK the row is the system control.
+  #if compiler(>=6.2)
+    /// **A drag on the tabs moves the lens, never the window.** The bar is a `WindowDragGesture` handle
+    /// that recognises simultaneously with anything SwiftUI inside it, which is how the first glass row
+    /// walked the whole window sideways when you dragged the selection. The press is AppKit-owned now:
+    /// the view under the pointer is an `NSView` that refuses `mouseDownCanMoveWindow` and consumes the
+    /// mouse sequence, so neither AppKit's background move nor SwiftUI's gesture ever sees it.
+    ///
+    /// This hosts the real row *inside* the real drag handle in a real window, checks that the view
+    /// hit-tested under a tab is that AppKit owner, then sends the press, the travel and the release to
+    /// it and checks the release lands on the tab under the pointer. (An off-screen window drops
+    /// `sendEvent`, so the events go to the hit view the way the window would route them.)
+    @available(macOS 26.0, *)
+    func testDraggingTheSelectionAcrossTheTabsSelectsTheReleasedTabWithoutMovingTheWindow() throws {
+      var selected: [Int] = []
+      let row = TopNavigationDestinationRow(
+        selectedIndex: SidebarNavItem.dashboard.rawValue,
+        badges: TopNavigationDestinationBadges(),
+        onSelect: { selected.append($0) }
+      )
+      let host = NSHostingView(rootView: row.padding(20).shellWindowDragHandle())
+      let size = host.fittingSize
+      let window = NSWindow(
+        contentRect: NSRect(x: 400, y: 300, width: size.width, height: size.height),
+        styleMask: [.borderless], backing: .buffered, defer: false)
+      window.isMovableByWindowBackground = false
+      window.contentView = host
+      host.frame = NSRect(origin: .zero, size: size)
+      host.layoutSubtreeIfNeeded()
+      let originBefore = window.frame.origin
 
-    // Four equal segments inside the row's 20 pt padding: press on the second, release on the fourth.
-    let items = TopNavigationRoutes.primaryItems
-    let segmentWidth = (size.width - 40) / CGFloat(items.count)
-    let y = size.height / 2
-    func x(_ position: Int) -> CGFloat { 20 + segmentWidth * (CGFloat(position) + 0.5) }
-    let owner = try XCTUnwrap(host.hitTest(NSPoint(x: x(1), y: y)), "nothing under the tab")
-    XCTAssertFalse(
-      owner.mouseDownCanMoveWindow,
-      "the view under a tab must refuse to move the window, or a drag on the tabs drags the shell")
-    XCTAssertFalse(owner is NSHostingView<AnyView>, "the hosting view must not be the press owner")
+      // Four equal segments inside the row's 20 pt padding: press on the second, release on the fourth.
+      let items = TopNavigationRoutes.primaryItems
+      let segmentWidth = (size.width - 40) / CGFloat(items.count)
+      let y = size.height / 2
+      func x(_ position: Int) -> CGFloat { 20 + segmentWidth * (CGFloat(position) + 0.5) }
+      let owner = try XCTUnwrap(host.hitTest(NSPoint(x: x(1), y: y)), "nothing under the tab")
+      XCTAssertFalse(
+        owner.mouseDownCanMoveWindow,
+        "the view under a tab must refuse to move the window, or a drag on the tabs drags the shell")
+      XCTAssertFalse(owner is NSHostingView<AnyView>, "the hosting view must not be the press owner")
 
-    func event(_ type: NSEvent.EventType, at point: NSPoint) throws -> NSEvent {
-      try XCTUnwrap(
-        NSEvent.mouseEvent(
-          with: type, location: point, modifierFlags: [], timestamp: ProcessInfo.processInfo.systemUptime,
-          windowNumber: window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1))
+      func event(_ type: NSEvent.EventType, at point: NSPoint) throws -> NSEvent {
+        try XCTUnwrap(
+          NSEvent.mouseEvent(
+            with: type, location: point, modifierFlags: [], timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1))
+      }
+      owner.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: x(1), y: y)))
+      for step in 1...6 {
+        let t = CGFloat(step) / 6
+        owner.mouseDragged(with: try event(.leftMouseDragged, at: NSPoint(x: x(1) + (x(3) - x(1)) * t, y: y)))
+      }
+      owner.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: x(3), y: y)))
+
+      XCTAssertEqual(selected, [items[3].index], "the release must select the tab under the pointer")
+      XCTAssertEqual(window.frame.origin, originBefore, "dragging the selection must not move the window")
     }
-    owner.mouseDown(with: try event(.leftMouseDown, at: NSPoint(x: x(1), y: y)))
-    for step in 1...6 {
-      let t = CGFloat(step) / 6
-      owner.mouseDragged(with: try event(.leftMouseDragged, at: NSPoint(x: x(1) + (x(3) - x(1)) * t, y: y)))
-    }
-    owner.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: x(3), y: y)))
-
-    XCTAssertEqual(selected, [items[3].index], "the release must select the tab under the pointer")
-    XCTAssertEqual(window.frame.origin, originBefore, "dragging the selection must not move the window")
-  }
+  #endif
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {
     // The 900 pt readable cap belongs to content inside the lane. The glass fills the window

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -455,6 +455,48 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertLessThanOrEqual(navigation.width, lane - inset * 2)
   }
 
+  /// **A badge tick must not be able to re-measure the bar.** The glass row used to measure every
+  /// segment from its title with the `+N` folded in, so any count change — a task completed, a
+  /// conversation landed, one of the several store ticks a page transition fires mid-animation —
+  /// re-measured and re-laid-out the whole track with a width animation. That was the lag. The
+  /// count renders in a slot reserved by a hidden template now, so a segment measures the same
+  /// with counts at their widest and at zero; this fails against the measure-the-title behaviour.
+  func testSegmentMeasurementIsIndependentOfBadgeCounts() {
+    let widest = TopNavigationDestinationBadges(library: 99, tasks: 99)
+    let none = TopNavigationDestinationBadges()
+
+    #if compiler(>=6.2)
+      if #available(macOS 26.0, *) {
+        for item in TopNavigationRoutes.primaryItems {
+          XCTAssertEqual(
+            glassSegmentWidth(item, badges: none), glassSegmentWidth(item, badges: widest),
+            accuracy: 0.5,
+            "\(item.title)'s segment measures differently at the widest counts than at zero")
+        }
+        // `EqualWidthSegments` is `count × widest`, so one segment moving moves the whole track.
+        XCTAssertEqual(
+          rowWidth(none), rowWidth(widest), accuracy: 0.5,
+          "the bar's width follows the badge counts, so a badge change re-lays-out the bar")
+        // The reserved slot has to hold everything it can be asked to show, or the hidden template
+        // stops being the widest thing in it and the guarantees above turn font-dependent.
+        let template = countTextWidth(TopNavigationSegmentSelection.widestCountText)
+        XCTAssertGreaterThan(template, 0)
+        for count in [1, 4, 9, 10, 42, 99] {
+          XCTAssertLessThanOrEqual(
+            countTextWidth(TopNavigationSegmentSelection.countText(for: count)), template,
+            "+\(count) does not fit the slot every segment reserves for it")
+        }
+        return
+      }
+    #endif
+
+    // Below the glass renderer the count joins the system segmented control's title — the control
+    // owns its own measurement there. The fit guarantee is what pins the fallback: counts can
+    // widen the control but never shrink it, so the layout the widest-count test chose cannot
+    // overflow when a count drops.
+    XCTAssertLessThanOrEqual(rowWidth(none), rowWidth(widest))
+  }
+
   /// The rendered segment count, from the renderer that is actually on screen. Against the macOS 26
   /// SDK on macOS 26 the row is `EqualWidthSegments`, whose width is exactly `count × widest
   /// segment` plus the track inset, so a segment measured on its own gives the width four of them
@@ -491,6 +533,38 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     if let control = view as? NSSegmentedControl { found.append(control) }
     for subview in view.subviews { found += segmentedControls(in: subview) }
     return found
+  }
+
+  // The glass renderer only exists when compiled against the macOS 26 SDK (see
+  // `TopNavigationDestinationRow.body`); against an older SDK the row is the system control.
+  #if compiler(>=6.2)
+    /// What `EqualWidthSegments` measures for one segment: the segment label hosted on its own, the
+    /// same way `assertEveryDestinationIsRendered` measures the widest one.
+    @available(macOS 26.0, *)
+    private func glassSegmentWidth(
+      _ item: TopNavigationItem, badges: TopNavigationDestinationBadges
+    ) -> CGFloat {
+      NSHostingView(
+        rootView: TopNavigationGlassSegmentLabel(item: item, badges: badges, isSelected: false)
+      ).fittingSize.width
+    }
+
+    /// What the count slot renders a string at, in isolation — the reserved template has to be at
+    /// least this wide for every count the slot can show.
+    private func countTextWidth(_ text: String) -> CGFloat {
+      NSHostingView(
+        rootView: Text(verbatim: text)
+          .scaledMonospacedDigitFont(size: OmiType.caption, weight: .semibold)
+      ).fittingSize.width
+    }
+  #endif
+
+  /// The real row's intrinsic width, on whichever renderer this machine draws.
+  private func rowWidth(_ badges: TopNavigationDestinationBadges) -> CGFloat {
+    NSHostingView(
+      rootView: TopNavigationDestinationRow(
+        selectedIndex: SidebarNavItem.dashboard.rawValue, badges: badges, onSelect: { _ in })
+    ).fittingSize.width
   }
 
   /// The native tab bar shows one selected segment or none. Any Brain page lights the `Memories`
@@ -568,6 +642,18 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       TopNavigationSegmentSelection.accessibilityLabel(for: $0, badges: TopNavigationDestinationBadges())
     }
     XCTAssertEqual(spokenQuiet, TopNavigationRoutes.primaryItems.map(\.tooltip))
+
+    // The visible count caps at two digits — the slot it renders into is what the glass row is
+    // measured from, so a long absence cannot widen the bar — but VoiceOver keeps the exact number.
+    XCTAssertEqual(TopNavigationSegmentSelection.countText(for: 99), "+99")
+    XCTAssertEqual(
+      TopNavigationSegmentSelection.countText(for: 100),
+      TopNavigationSegmentSelection.widestCountText)
+    let tasks = TopNavigationRoutes.primaryItems[2]
+    XCTAssertEqual(
+      TopNavigationSegmentSelection.accessibilityLabel(
+        for: tasks, badges: TopNavigationDestinationBadges(tasks: 124)),
+      "Tasks — everything Omi heard you commit to, 124 new")
   }
 
   /// The glass lens follows the pointer but never leaves the track: its centre is clamped to the

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -523,6 +523,23 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       TopNavigationSegmentSelection.title(for: $0, badges: TopNavigationDestinationBadges())
     }
     XCTAssertEqual(quiet, ["Chat", "Memories", "Tasks", "Apps"])
+
+    // VoiceOver hears the count too: the tooltip sentence, then `N new`, and nothing extra at zero.
+    let spoken = TopNavigationRoutes.primaryItems.map {
+      TopNavigationSegmentSelection.accessibilityLabel(for: $0, badges: badges)
+    }
+    XCTAssertEqual(
+      spoken,
+      [
+        "Chat — talk to Omi about everything you've seen and heard",
+        "Memories — everything Omi captured, newest first, 4 new",
+        "Tasks — everything Omi heard you commit to, 7 new",
+        "Apps — connectors, imports and exports",
+      ])
+    let spokenQuiet = TopNavigationRoutes.primaryItems.map {
+      TopNavigationSegmentSelection.accessibilityLabel(for: $0, badges: TopNavigationDestinationBadges())
+    }
+    XCTAssertEqual(spokenQuiet, TopNavigationRoutes.primaryItems.map(\.tooltip))
   }
 
   /// The glass lens follows the pointer but never leaves the track: its centre is clamped to the
@@ -557,12 +574,16 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     /// the view under the pointer is an `NSView` that refuses `mouseDownCanMoveWindow` and consumes the
     /// mouse sequence, so neither AppKit's background move nor SwiftUI's gesture ever sees it.
     ///
-    /// This hosts the real row *inside* the real drag handle in a real window, checks that the view
-    /// hit-tested under a tab is that AppKit owner, then sends the press, the travel and the release to
-    /// it and checks the release lands on the tab under the pointer. (An off-screen window drops
-    /// `sendEvent`, so the events go to the hit view the way the window would route them.)
+    /// This hosts the real row *inside* the real drag handle in a real window and checks two things:
+    /// the view hit-tested under a tab is that AppKit owner and refuses `mouseDownCanMoveWindow` —
+    /// which is the whole mechanism, since AppKit's background move asks exactly that of the hit
+    /// view — and a press, travel and release sent to it land the selection on the tab under the
+    /// pointer. The events go straight to the hit view (an off-screen window drops `sendEvent`), so the
+    /// window's own frame is not something this harness can observe moving; the refusal is the guard.
     @available(macOS 26.0, *)
-    func testDraggingTheSelectionAcrossTheTabsSelectsTheReleasedTabWithoutMovingTheWindow() throws {
+    func testDraggingTheSelectionAcrossTheTabsSelectsTheReleasedTabThroughAViewThatRefusesWindowMoves()
+      throws
+    {
       var selected: [Int] = []
       let row = TopNavigationDestinationRow(
         selectedIndex: SidebarNavItem.dashboard.rawValue,
@@ -574,11 +595,9 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       let window = NSWindow(
         contentRect: NSRect(x: 400, y: 300, width: size.width, height: size.height),
         styleMask: [.borderless], backing: .buffered, defer: false)
-      window.isMovableByWindowBackground = false
       window.contentView = host
       host.frame = NSRect(origin: .zero, size: size)
       host.layoutSubtreeIfNeeded()
-      let originBefore = window.frame.origin
 
       // Four equal segments inside the row's 20 pt padding: press on the second, release on the fourth.
       let items = TopNavigationRoutes.primaryItems
@@ -605,7 +624,6 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       owner.mouseUp(with: try event(.leftMouseUp, at: NSPoint(x: x(3), y: y)))
 
       XCTAssertEqual(selected, [items[3].index], "the release must select the tab under the pointer")
-      XCTAssertEqual(window.frame.origin, originBefore, "dragging the selection must not move the window")
     }
   #endif
 

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -444,25 +444,53 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     guard let navigation = recorder.frame(of: .expanded) else {
       return XCTFail("the expanded destination row was never placed")
     }
-    // **Fitting only means something if what fitted is still a tab bar of named segments.**
+    // **Fitting only means something if what fitted is still a tab bar of every named segment.**
     // `ViewThatFits` is satisfied by anything narrow enough, so a control that had quietly stopped
-    // drawing segments — or had been emptied down to one — would pass the check above and prove
-    // nothing. Deleting a segment makes this test *easier*, which is exactly when a floor is worth
-    // having: two destinations were removed from this row (`Insights` here, `Chat` earlier) and the
-    // assertion did not notice either.
-    //
-    // The floor is the HIG minimum control width per segment. Real segments are wider than that —
-    // they carry a word, and two carry a count — so this is a strict lower bound that still fails
-    // the moment a segment stops being rendered.
-    let segments = CGFloat(TopNavigationRoutes.primaryItems.count)
-    let floor = segments * TopNavigationSegmentMetrics.minimumSegmentWidth
-    XCTAssertGreaterThan(
-      navigation.width, floor,
-      """
-      the row fitted by drawing fewer segments than `TopNavigationRoutes.primaryItems` has, so \
-      `ViewThatFits` chose it for the wrong reason
-      """)
+    // drawing a segment would pass the check above and prove nothing. Deleting a segment makes this
+    // test *easier*, which is exactly when a guard is worth having: two destinations were removed
+    // from this row (`Insights` here, `Chat` earlier) and the assertion did not notice either. A
+    // width floor did not notice either — three real segments are wider than four minimum ones —
+    // so this counts what was rendered.
+    assertEveryDestinationIsRendered(in: host, rowWidth: navigation.width)
     XCTAssertLessThanOrEqual(navigation.width, lane - inset * 2)
+  }
+
+  /// The rendered segment count, from the renderer that is actually on screen. Against the macOS 26
+  /// SDK on macOS 26 the row is `EqualWidthSegments`, whose width is exactly `count × widest
+  /// segment` plus the track inset, so a segment measured on its own gives the width four of them
+  /// must add up to — a row missing one is a whole segment short. Everywhere else the row is the
+  /// system segmented control, which says how many segments it has.
+  private func assertEveryDestinationIsRendered(in host: NSView, rowWidth: CGFloat) {
+    let items = TopNavigationRoutes.primaryItems
+    #if compiler(>=6.2)
+      if #available(macOS 26.0, *) {
+        let badges = TopNavigationDestinationBadges(library: 99, tasks: 99)
+        let widest =
+          items.map { item in
+            NSHostingView(
+              rootView: TopNavigationGlassSegmentLabel(item: item, badges: badges, isSelected: false)
+            ).fittingSize.width
+          }.max() ?? 0
+        XCTAssertGreaterThan(widest, TopNavigationSegmentMetrics.minimumSegmentWidth)
+        XCTAssertEqual(
+          rowWidth, widest * CGFloat(items.count) + TopNavigationGlassSegmentMetrics.trackInset * 2,
+          accuracy: 1,
+          "the row is not `\(items.count)` equal segments wide, so a destination is not being drawn")
+        return
+      }
+    #endif
+    let controls = segmentedControls(in: host)
+    XCTAssertEqual(controls.count, 1, "the fallback row must be one system segmented control")
+    XCTAssertEqual(
+      controls.first?.segmentCount, items.count,
+      "the system segmented control draws fewer segments than `TopNavigationRoutes.primaryItems`")
+  }
+
+  private func segmentedControls(in view: NSView) -> [NSSegmentedControl] {
+    var found: [NSSegmentedControl] = []
+    if let control = view as? NSSegmentedControl { found.append(control) }
+    for subview in view.subviews { found += segmentedControls(in: subview) }
+    return found
   }
 
   /// The native tab bar shows one selected segment or none. Any Brain page lights the `Memories`

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -459,8 +459,9 @@ final class TopNavigationBarLayoutTests: XCTestCase {
   /// segment from its title with the `+N` folded in, so any count change — a task completed, a
   /// conversation landed, one of the several store ticks a page transition fires mid-animation —
   /// re-measured and re-laid-out the whole track with a width animation. That was the lag. The
-  /// count renders in a slot reserved by a hidden template now, so a segment measures the same
-  /// with counts at their widest and at zero; this fails against the measure-the-title behaviour.
+  /// count renders as a corner-badge overlay that layout never sees now, so a segment measures the
+  /// same with counts at their widest and at zero; this fails against the measure-the-title
+  /// behaviour.
   func testSegmentMeasurementIsIndependentOfBadgeCounts() {
     let widest = TopNavigationDestinationBadges(library: 99, tasks: 99)
     let none = TopNavigationDestinationBadges()
@@ -477,15 +478,6 @@ final class TopNavigationBarLayoutTests: XCTestCase {
         XCTAssertEqual(
           rowWidth(none), rowWidth(widest), accuracy: 0.5,
           "the bar's width follows the badge counts, so a badge change re-lays-out the bar")
-        // The reserved slot has to hold everything it can be asked to show, or the hidden template
-        // stops being the widest thing in it and the guarantees above turn font-dependent.
-        let template = countTextWidth(TopNavigationSegmentSelection.widestCountText)
-        XCTAssertGreaterThan(template, 0)
-        for count in [1, 4, 9, 10, 42, 99] {
-          XCTAssertLessThanOrEqual(
-            countTextWidth(TopNavigationSegmentSelection.countText(for: count)), template,
-            "+\(count) does not fit the slot every segment reserves for it")
-        }
         return
       }
     #endif
@@ -546,15 +538,6 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     ) -> CGFloat {
       NSHostingView(
         rootView: TopNavigationGlassSegmentLabel(item: item, badges: badges, isSelected: false)
-      ).fittingSize.width
-    }
-
-    /// What the count slot renders a string at, in isolation — the reserved template has to be at
-    /// least this wide for every count the slot can show.
-    private func countTextWidth(_ text: String) -> CGFloat {
-      NSHostingView(
-        rootView: Text(verbatim: text)
-          .scaledMonospacedDigitFont(size: OmiType.caption, weight: .semibold)
       ).fittingSize.width
     }
   #endif

--- a/desktop/macos/changelog/unreleased/20260906-native-top-tab-bar.json
+++ b/desktop/macos/changelog/unreleased/20260906-native-top-tab-bar.json
@@ -1,0 +1,3 @@
+{
+  "change": "The main window's top navigation is now a Liquid Glass segmented control on macOS 26: press and drag to slide the glass selection between Chat, Memories, Tasks and Apps. Earlier macOS releases get the system segmented control. The custom pills are gone, so the bar follows your system appearance and accessibility settings."
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/a3dc48b0-5751-4877-80a4-bcbfe825a316

## Summary

The main window's top bar used a hand-built row of pills for `Chat · Memories · Tasks · Apps`. This replaces it with the platform's tab control.

- **macOS 26:** a Liquid Glass segmented control with the iOS interaction — equal-width segments sitting on the bar's own glass, and a clear glass lens under the selected tab that lifts and follows the pointer while pressed, then snaps to the segment under the release. Each segment keeps its SF Symbol beside the word.
- **macOS 14–15:** the system segmented `Picker` with a neutral tint (titles only; the native control cannot show icon + title).
- The press is owned by an AppKit overlay that refuses `mouseDownCanMoveWindow`, so dragging the selection never drags the shell (the bar is a simultaneous `WindowDragGesture` handle).
- No accent fill on the selection: neutral glass, the selected word goes to full ink.
- New-item counts join the segment title (`Tasks +7`) since native segments cannot carry badges.
- `top-navigation-<index>` accessibility identifiers are preserved, so the e2e flows are unchanged.

## Product invariants affected

- INV-NAV-1 — every destination the bar reached before is still reached by the same bar (`ShellDestination.unreachable()` and `TopNavigationBarLayoutTests` still hold); only the control that renders the row changed, not what it routes to. This preserves the existing shell-parity authority; it is not a migration exception.

Failure-Class: none

## Verification

- `xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx` (the Release Compile lane's command) — builds clean locally on Xcode 26 / Swift 6.3; with `-warn-long-expression-type-checking=120` no expression in the file is flagged. Xcode 16.4 is not installed here, so the `#if compiler(>=6.2)` fallback path is proven by CI's Release Compile lane, not locally.
- `xcrun swift test --package-path Desktop --filter 'TopNavigationBarLayoutTests|MemoryGraphRevisitTests|ChatFirstDestinationParityTests'` — 39 tests, 0 failures (after all review fixes; includes the hosted drag test on this macOS 26 machine).
- Full `xcrun swift test --package-path Desktop` after rebasing onto `origin/main` — `scripts/swift-test-suites.sh` (the isolated per-suite harness CI runs, 4 workers): 819 suites, exit 0, no failing or timed-out suite.
- Named bundle `omi-native-tab-bar` via `./run.sh --yolo --fast-only`: pressing each segment through the accessibility API (`AXPress` on `top-navigation-0/1/4/8`) routed to `chat`, `memories`, `tasks`, `more.apps` per `omi-ctl state`; window captures show the lens moving between segments with icon + word in full ink and no track pill.
- Hosted drag test: real row inside the real `shellWindowDragHandle()` in an `NSWindow`; the hit view under a tab refuses window movement, and a press → six drag steps → release across two segments selects the released tab with the window origin unchanged.
- swift-format lint, SwiftLint, `check_brand_ui.py`, and `check_desktop_test_quality.py` clean.
- Changelog fragment: `desktop/macos/changelog/unreleased/20260906-native-top-tab-bar.json`.

## Review follow-ups

- **Release type-check timeout / `glassEffect` missing** (all three required desktop checks): two commits. First `TopNavigationGlassSegments.body` was split into named sub-views and helpers as suggested (fad7b14e9f). That turned the timeout into the real error on CI's pinned Xcode 16.4: its macOS 15.5 SDK has no `glassEffect`, so the solver had been searching for a member that does not exist — `@available(macOS 26.0, *)` gates the call at run time but cannot supply the symbol. The glass renderer, the branch in `TopNavigationDestinationRow.body`, and the hosted drag test are now behind `#if compiler(>=6.2)` (the Xcode 26 toolchain) (a3b2ddced6). Built with an older Xcode the row is the system segmented control on every macOS; built with Xcode 26 nothing changes. No other macOS 26 API is used in the package, so this is the first such guard.
- **Cubic re-review, second pass (1 finding)**: the layout test's width floor (`count × 44`) could not detect a dropped segment, since three real segments are wider than four minimum ones. It now counts what was rendered: on the glass path the row must be exactly `count × widest segment` (the segment content is its own view, `TopNavigationGlassSegmentLabel`, so the test can measure one) plus the track inset; on the fallback the hosted `NSSegmentedControl` must report `count` segments. Mutation-checked: dropping a segment from the renderer fails the test.
- **Cubic re-review, first pass (2 findings)**: (1) VoiceOver heard only the tooltip, never the `+7` a sighted user reads — both renderers now label segments with `TopNavigationSegmentSelection.accessibilityLabel(for:badges:)` (tooltip sentence, then `, N new`), covered in the badge-title test. (2) The hosted drag test's window-origin assertion could never fail (events go straight to the hit view), so it is gone; the test is renamed around the guard that proves the mechanism, the hit view's refusal of `mouseDownCanMoveWindow`.
- **Contradicting doc comments** (cubic P3 and the human review): the `TopNavigationDestinationRow` header now says the lens is a plain `.background` glass layer under the segment words, not inside a `GlassEffectContainer`, matching the implementation comment on `track`.

## Notes

- The Liquid Glass renderer exists only in builds made with Xcode 26 (`#if compiler(>=6.2)`); a macOS 26 user running a build made with Xcode 16.4 gets the system segmented control instead. CI compiles with 16.4 for its lanes, so this is worth knowing for whichever Xcode produces the shipped app.
- A real pointer drag was exercised only through the hosted-window test and synthetic `NSEvent`s; the interaction feel (lift scale, snap timing) is tunable in `TopNavigationGlassSegmentMetrics`.
- `GlassPillBackground` in `GlassShellChrome.swift` no longer has a caller after this change; left in place to keep the diff surgical for in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMfvVp6aSE5JJ1iQxxShbg

https://claude.ai/code/session_01EY6zo5rYU8EzVge6nertYW
