### PR TITLE
fix(desktop): move every Rewind stage control under the picture

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -729,7 +729,8 @@ struct RewindPage: View {
       frameDisplay
         .frame(maxHeight: .infinity)
 
-      // Timeline and controls at bottom
+      // The picture's own controls, then the track
+      stageControls
       bottomControls
     }
   }
@@ -854,7 +855,8 @@ struct RewindPage: View {
       frameDisplay
         .frame(maxHeight: .infinity)
 
-      // Timeline and controls
+      // The picture's own controls, then the track
+      stageControls
       bottomControls
     }
   }
@@ -1019,9 +1021,11 @@ struct RewindPage: View {
               }
             }
             .clipShape(frameShape)
-            // A border keyed to the app the frame belongs to, so the picture and its segment on the
-            // track are visibly the same stretch of the day.
-            .overlay(frameShape.strokeBorder(frameBorderColor, lineWidth: 2))
+            // A neutral hairline, never the app's palette colour: the track segment already says which
+            // app this is, and a coloured ring around a photograph of a screen reads as a selection
+            // state rather than as a frame. The hairline only keeps a white capture from dissolving
+            // into the light glass under it.
+            .overlay(frameShape.strokeBorder(Ink.hairline, lineWidth: 1))
             .shadow(color: .black.opacity(0.08), radius: 8)
             // **The stage is a preview, not the frame.** It is fit to whatever the pane happens to
             // be, which on a half-width window is a fraction of a 5120pt capture — enough to
@@ -1063,11 +1067,18 @@ struct RewindPage: View {
         // The overlay lands on the *padded* stage, so the chrome re-derives the picture's rect in
         // that space. It needs the frame's shape to do it.
         imageSize: currentImage?.size,
-        window: trackWindow,
-        onSelect: { seekToIndex($0) },
-        showsDatePicker: $showDatePicker,
-        datePicker: AnyView(dayPicker))
+        onSelect: { seekToIndex($0) })
     }
+  }
+
+  /// The date pill and the zoom cluster, on the glass directly under the picture rather than on it.
+  private var stageControls: some View {
+    RewindStageControlBar(
+      screenshots: activeScreenshots,
+      currentIndex: currentIndex,
+      window: trackWindow,
+      showsDatePicker: $showDatePicker,
+      datePicker: AnyView(dayPicker))
   }
 
   private var frameShape: RoundedRectangle {
@@ -1085,13 +1096,6 @@ struct RewindPage: View {
     let frames = screenshots.map { QuickLookFrame(screenshot: $0) }
     ScreenFrameQuickLook.shared.present(
       frames, startingAt: frames[currentIndex].id)
-  }
-
-  /// Nil is an honest outcome: with no frame resolved the border is a neutral hairline rather than an
-  /// invented colour.
-  private var frameBorderColor: Color {
-    guard activeScreenshots.indices.contains(currentIndex) else { return Ink.hairline }
-    return RewindPalette.color(forApp: activeScreenshots[currentIndex].appName)
   }
 
   // MARK: - Bottom Controls

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -1060,25 +1060,18 @@ struct RewindPage: View {
     }
     .padding(.horizontal, RewindStageFit.horizontalInset)
     .padding(.vertical, RewindStageFit.verticalInset)
-    .overlay {
-      RewindStageChrome(
-        screenshots: activeScreenshots,
-        currentIndex: currentIndex,
-        // The overlay lands on the *padded* stage, so the chrome re-derives the picture's rect in
-        // that space. It needs the frame's shape to do it.
-        imageSize: currentImage?.size,
-        onSelect: { seekToIndex($0) })
-    }
   }
 
-  /// The date pill and the zoom cluster, on the glass directly under the picture rather than on it.
+  /// Every control the picture owns — the date pill, the previous/next app circles and the zoom
+  /// cluster — on the glass directly under it. Nothing is overlaid on the picture itself.
   private var stageControls: some View {
     RewindStageControlBar(
       screenshots: activeScreenshots,
       currentIndex: currentIndex,
       window: trackWindow,
       showsDatePicker: $showDatePicker,
-      datePicker: AnyView(dayPicker))
+      datePicker: AnyView(dayPicker),
+      onSelect: { seekToIndex($0) })
   }
 
   private var frameShape: RoundedRectangle {

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
@@ -204,95 +204,17 @@ struct RewindTrackBar: View {
   nonisolated static let topPadding: CGFloat = 4
 }
 
-// MARK: - Stage chrome
+// MARK: - App steps
 
-/// The controls that sit **on** the frame: the segment chevrons on its left and right edges, and
-/// nothing else.
-///
-/// **They pin to the photograph, not to the stage, and that is the whole point of the type.** The
-/// chrome is an overlay on the stage, so it used to take the stage's edges — right only while the
-/// picture fills the stage, which it does not. Measured on the running app at its default 1450 pt
-/// window the stage is 2.55 wide against a capture's 1.81, so the picture is height-bound and there
-/// is a wide band of empty glass down each side of it. The left chevron therefore sat about 200 pt
-/// away from the frame it steps through, reading as a control floating on nothing rather than as the
-/// frame's own edge. `RewindStageFit` answers where the picture actually is and everything here is
-/// laid out inside that rectangle.
-///
-/// **The date pill and the zoom cluster are not here any more.** They used to sit in the picture's
-/// bottom corners, over whatever the capture happened to show there — a menu bar, a status line, the
-/// very text someone scrubbed to — and a control over the content it hides is a control in the wrong
-/// place. They live in `RewindStageControlBar`, on the glass directly under the picture.
-///
-/// **The chevrons carry a material, and that is not the banned second material.**
-/// `GlassContentChromeTests` holds content pages to "InkGlass is the only material in this app",
-/// because a material stacked *inside* the panel reads as a muddy patch of the same glass. These
-/// controls are not on the panel — they are on a photograph of somebody's screen, which can be any
-/// colour at all, and a flat fill legible over a dark editor disappears over a white document. It is
-/// the same exemption `glassMediaMat` already carves out for the player, for the same reason: a
-/// viewport onto rendered media is not a glass surface.
-struct RewindStageChrome: View {
-  let screenshots: [Screenshot]
-  let currentIndex: Int
-  /// The decoded frame's own size, or nil before one has arrived. The chrome belongs to the picture,
-  /// so it cannot place itself without the picture's shape.
-  let imageSize: CGSize?
-  let onSelect: (Int) -> Void
-
-  var body: some View {
-    GeometryReader { proxy in
-      // The overlay is applied after the stage's padding, so `proxy` is the *outer* stage and the
-      // fit has to cross both spaces. `pictureRectInStage` is that composition, so this cannot get
-      // half-applied.
-      let picture = RewindStageFit.pictureRectInStage(image: imageSize ?? .zero, stage: proxy.size)
-      controls
-        .frame(width: picture.width, height: picture.height)
-        .offset(x: picture.minX, y: picture.minY)
-        // Nothing to belong to yet. Hidden rather than parked somewhere plausible: chrome that
-        // shows up in a corner and then jumps onto the picture reads as a glitch.
-        .opacity(picture.isEmpty ? 0 : 1)
-        .accessibilityHidden(picture.isEmpty)
-    }
-  }
-
-  private var controls: some View {
-    // Chevrons sit on the frame's own left and right edges.
-    HStack {
-      chevron(forward: false)
-      Spacer(minLength: 0)
-      chevron(forward: true)
-    }
-    .padding(.horizontal, 10)
-  }
-
-  // MARK: Edges: one app stretch at a time
-
-  private func chevron(forward: Bool) -> some View {
-    let target = adjacentSegmentIndex(forward: forward)
-    return Button {
-      if let target { onSelect(target) }
-    } label: {
-      Image(systemName: forward ? "chevron.right" : "chevron.left")
-        .font(.system(size: 13, weight: .semibold))
-        .foregroundStyle(Ink.primary)
-        .frame(width: 30, height: 44)
-        .background(
-          RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(.regularMaterial)
-            .overlay(
-              RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Ink.hairline, lineWidth: 1)))
-    }
-    .buttonStyle(.plain)
-    // Vanishes rather than greying out: a disabled control still advertises a step that does not
-    // exist, and over a photograph a dimmed chip reads as part of the picture.
-    .opacity(target == nil ? 0 : 1)
-    .disabled(target == nil)
-    .keyboardShortcut(forward ? .rightArrow : .leftArrow, modifiers: [.option])
-    .help(forward ? "Next app" : "Previous app")
-  }
-
-  /// The first capture of the next (or previous) app stretch, or nil at either end.
-  private func adjacentSegmentIndex(forward: Bool) -> Int? {
+/// One app stretch at a time: where the previous and the next stretch begin, as a pure function so
+/// the stepping is a test rather than a click.
+enum RewindAppStep {
+  /// The first capture of the next (or previous) app stretch, or nil at either end. Backward lands on
+  /// the *start* of the previous stretch, not its last frame, so two presses walk two apps back
+  /// rather than one press per frame.
+  static func adjacentSegmentIndex(in screenshots: [Screenshot], from currentIndex: Int, forward: Bool)
+    -> Int?
+  {
     guard screenshots.indices.contains(currentIndex) else { return nil }
     let app = screenshots[currentIndex].appName
     if forward {
@@ -307,7 +229,6 @@ struct RewindStageChrome: View {
     while index > 0, screenshots[index - 1].appName == previousApp { index -= 1 }
     return index
   }
-
 }
 
 // MARK: - Stage control bar
@@ -322,9 +243,12 @@ enum RewindStageControlBarLayout {
   /// Delegated to the stage, never restated: the picture and its controls keep one margin.
   static var horizontalInset: CGFloat { RewindStageFit.horizontalInset }
 
-  /// The control height. The pill and the zoom buttons are the same height so the row has one
-  /// baseline, and it matches the stage chrome's circle buttons so the two families read as one.
+  /// The control height. The pill, the app-step circles and the zoom circles are all this tall so
+  /// the row has one baseline and the three families read as one.
   static let controlHeight: CGFloat = 30
+
+  /// The air between two circles that belong together — the previous/next pair, the zoom pair.
+  static let pairSpacing: CGFloat = 8
 
   /// The air under the row, before the track's own top padding. The stage already carries its
   /// `verticalInset` above the row, so the row sits the same distance from the picture as it does
@@ -332,20 +256,28 @@ enum RewindStageControlBarLayout {
   static var bottomGap: CGFloat { RewindStageFit.verticalInset - RewindTrackBar.topPadding }
 }
 
-/// The date pill and the zoom cluster, in a row on the glass directly under the picture.
+/// The row on the glass directly under the picture: the date pill at the leading edge, the
+/// previous/next app circles in the centre, the zoom cluster at the trailing edge.
 ///
-/// **On the panel, so on the panel's fills.** These controls used to sit on the photograph, where a
-/// flat fill could vanish against whatever the capture showed and `.regularMaterial` was the
-/// exemption that kept them legible. Under the picture they are on `InkGlass` like every other
-/// control on a content page, and a material stacked inside the panel is exactly the muddy second
-/// glass `GlassContentChromeTests` forbids — so they take `Ink.rowFill` and a hairline, the same
-/// dress as the rest of the page's chrome.
+/// **Nothing sits on the photograph any more.** The pill and the zoom cluster used to live in the
+/// picture's bottom corners and the app-step chevrons on its left and right edges — all of them
+/// over whatever the capture happened to show there, a menu bar, a status line, the very text
+/// someone scrubbed to. A control over the content it hides is a control in the wrong place, so
+/// the whole set is one row beneath the picture, and the picture is only the picture.
+///
+/// **On the panel, so on the panel's fills.** Over a photograph these controls needed a system
+/// material to stay legible against any colour a capture could show. Under the picture they are on
+/// `InkGlass` like every other control on a content page, and a material stacked inside the panel
+/// is exactly the muddy second glass `GlassContentChromeTests` forbids — so every control here is
+/// `Ink.rowFill` under a hairline, the same dress as the rest of the page's chrome. The app-step
+/// buttons are the same circle as the zoom buttons, not a taller chip: one shape for one row.
 struct RewindStageControlBar: View {
   let screenshots: [Screenshot]
   let currentIndex: Int
   @ObservedObject var window: RewindTrackWindowModel
   @Binding var showsDatePicker: Bool
   let datePicker: AnyView
+  let onSelect: (Int) -> Void
 
   var body: some View {
     HStack(alignment: .center) {
@@ -353,6 +285,9 @@ struct RewindStageControlBar: View {
       Spacer(minLength: 0)
       controlCluster
     }
+    // Centred on the row, not between the pill and the zoom cluster: the pill's width changes with
+    // the date, and a pair that drifted with it would never sit under the picture's middle.
+    .overlay { appSteps }
     .padding(.horizontal, RewindStageControlBarLayout.horizontalInset)
     .padding(.bottom, RewindStageControlBarLayout.bottomGap)
   }
@@ -392,10 +327,31 @@ struct RewindStageControlBar: View {
     return screenshots[currentIndex].formattedDateCompact
   }
 
+  // MARK: Centre: one app stretch at a time
+
+  private var appSteps: some View {
+    HStack(spacing: RewindStageControlBarLayout.pairSpacing) {
+      appStep(forward: false)
+      appStep(forward: true)
+    }
+  }
+
+  private func appStep(forward: Bool) -> some View {
+    let target = RewindAppStep.adjacentSegmentIndex(in: screenshots, from: currentIndex, forward: forward)
+    return circleButton(
+      systemName: forward ? "chevron.right" : "chevron.left",
+      help: forward ? "Next app" : "Previous app",
+      enabled: target != nil
+    ) {
+      if let target { onSelect(target) }
+    }
+    .keyboardShortcut(forward ? .rightArrow : .leftArrow, modifiers: [.option])
+  }
+
   // MARK: Trailing: the zoom cluster
 
   private var controlCluster: some View {
-    HStack(spacing: 8) {
+    HStack(spacing: RewindStageControlBarLayout.pairSpacing) {
       circleButton(
         systemName: "minus.magnifyingglass",
         help: "Zoom the timeline out — or pinch in on the track",
@@ -409,6 +365,7 @@ struct RewindStageControlBar: View {
     }
   }
 
+  /// The row's one button shape: a glass circle, `controlHeight` across.
   private func circleButton(
     systemName: String,
     help: String,
@@ -429,8 +386,8 @@ struct RewindStageControlBar: View {
             .overlay(Circle().strokeBorder(Ink.hairline, lineWidth: 1)))
     }
     .buttonStyle(.plain)
-    // Dimmed rather than removed: unlike a step that does not exist, zoom is always a feature of the
-    // track — the dimming reports that it has run out of range, not that it is absent.
+    // Dimmed rather than removed. On the glass a missing circle leaves a hole in a pair, and the
+    // dimming reports that the step or the zoom has run out of range, not that it is absent.
     .opacity(enabled ? 1 : 0.45)
     .disabled(!enabled)
     .help(help)

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPlaybackChrome.swift
@@ -195,15 +195,19 @@ struct RewindTrackBar: View {
       onScroll: onScroll
     )
     .frame(height: RewindTrackNSView.height)
-    .padding(.horizontal, 18)
-    .padding(.top, 4)
+    .padding(.horizontal, RewindStageFit.horizontalInset)
+    .padding(.top, Self.topPadding)
   }
+
+  /// The air above the track. Published so the control bar above it can close the gap to the same
+  /// distance the stage keeps on its other side.
+  nonisolated static let topPadding: CGFloat = 4
 }
 
 // MARK: - Stage chrome
 
-/// The controls that sit **on** the frame: the segment chevrons on its edges, the timestamp pill at
-/// bottom-left and the zoom cluster at bottom-right.
+/// The controls that sit **on** the frame: the segment chevrons on its left and right edges, and
+/// nothing else.
 ///
 /// **They pin to the photograph, not to the stage, and that is the whole point of the type.** The
 /// chrome is an overlay on the stage, so it used to take the stage's edges — right only while the
@@ -214,25 +218,25 @@ struct RewindTrackBar: View {
 /// frame's own edge. `RewindStageFit` answers where the picture actually is and everything here is
 /// laid out inside that rectangle.
 ///
-/// **The pill and the zoom buttons carry a material, and that is not the banned second material.**
+/// **The date pill and the zoom cluster are not here any more.** They used to sit in the picture's
+/// bottom corners, over whatever the capture happened to show there — a menu bar, a status line, the
+/// very text someone scrubbed to — and a control over the content it hides is a control in the wrong
+/// place. They live in `RewindStageControlBar`, on the glass directly under the picture.
+///
+/// **The chevrons carry a material, and that is not the banned second material.**
 /// `GlassContentChromeTests` holds content pages to "InkGlass is the only material in this app",
 /// because a material stacked *inside* the panel reads as a muddy patch of the same glass. These
 /// controls are not on the panel — they are on a photograph of somebody's screen, which can be any
 /// colour at all, and a flat fill legible over a dark editor disappears over a white document. It is
 /// the same exemption `glassMediaMat` already carves out for the player, for the same reason: a
-/// viewport onto rendered media is not a glass surface. The chevrons take the material too now, for
-/// exactly that reason — they used to sit out on the stage's margin, where `Ink.rowFill` was correct,
-/// and they now sit on the picture, where it would not be.
+/// viewport onto rendered media is not a glass surface.
 struct RewindStageChrome: View {
   let screenshots: [Screenshot]
   let currentIndex: Int
   /// The decoded frame's own size, or nil before one has arrived. The chrome belongs to the picture,
   /// so it cannot place itself without the picture's shape.
   let imageSize: CGSize?
-  @ObservedObject var window: RewindTrackWindowModel
   let onSelect: (Int) -> Void
-  @Binding var showsDatePicker: Bool
-  let datePicker: AnyView
 
   var body: some View {
     GeometryReader { proxy in
@@ -251,58 +255,13 @@ struct RewindStageChrome: View {
   }
 
   private var controls: some View {
-    ZStack {
-      // Chevrons sit on the frame's own left and right edges.
-      HStack {
-        chevron(forward: false)
-        Spacer(minLength: 0)
-        chevron(forward: true)
-      }
-      .padding(.horizontal, 10)
-
-      VStack {
-        Spacer(minLength: 0)
-        HStack(alignment: .bottom) {
-          timestampPill
-          Spacer(minLength: 0)
-          controlCluster
-        }
-      }
-      .padding(14)
+    // Chevrons sit on the frame's own left and right edges.
+    HStack {
+      chevron(forward: false)
+      Spacer(minLength: 0)
+      chevron(forward: true)
     }
-  }
-
-  // MARK: Bottom-left: the date/time pill
-
-  private var timestampPill: some View {
-    Button {
-      showsDatePicker.toggle()
-    } label: {
-      HStack(spacing: 6) {
-        Image(systemName: "calendar")
-          .font(.system(size: 11, weight: .medium))
-        Text(timestampLabel)
-          .font(.system(size: 12, weight: .medium))
-        Image(systemName: "chevron.down")
-          .font(.system(size: 8, weight: .bold))
-          .foregroundStyle(Ink.secondary)
-      }
-      .foregroundStyle(Ink.primary)
-      .padding(.horizontal, 11)
-      .padding(.vertical, 6)
-      .background(
-        Capsule(style: .continuous)
-          .fill(.regularMaterial)
-          .overlay(Capsule(style: .continuous).strokeBorder(Ink.hairline, lineWidth: 1)))
-    }
-    .buttonStyle(.plain)
-    .popover(isPresented: $showsDatePicker, arrowEdge: .bottom) { datePicker }
-    .help("Jump to a day")
-  }
-
-  private var timestampLabel: String {
-    guard screenshots.indices.contains(currentIndex) else { return "—" }
-    return screenshots[currentIndex].formattedDateCompact
+    .padding(.horizontal, 10)
   }
 
   // MARK: Edges: one app stretch at a time
@@ -349,7 +308,91 @@ struct RewindStageChrome: View {
     return index
   }
 
-  // MARK: Bottom-right: the zoom cluster
+}
+
+// MARK: - Stage control bar
+
+/// Where the row of controls under the picture sits, as values a test can hold rather than literals
+/// inside a `body`.
+///
+/// The row shares the stage's horizontal inset and the track's, so the pill's leading edge, the
+/// stage's leading edge and the track's leading edge are one line down the panel. A row inset
+/// differently from the objects above and below it reads as belonging to neither.
+enum RewindStageControlBarLayout {
+  /// Delegated to the stage, never restated: the picture and its controls keep one margin.
+  static var horizontalInset: CGFloat { RewindStageFit.horizontalInset }
+
+  /// The control height. The pill and the zoom buttons are the same height so the row has one
+  /// baseline, and it matches the stage chrome's circle buttons so the two families read as one.
+  static let controlHeight: CGFloat = 30
+
+  /// The air under the row, before the track's own top padding. The stage already carries its
+  /// `verticalInset` above the row, so the row sits the same distance from the picture as it does
+  /// from the track.
+  static var bottomGap: CGFloat { RewindStageFit.verticalInset - RewindTrackBar.topPadding }
+}
+
+/// The date pill and the zoom cluster, in a row on the glass directly under the picture.
+///
+/// **On the panel, so on the panel's fills.** These controls used to sit on the photograph, where a
+/// flat fill could vanish against whatever the capture showed and `.regularMaterial` was the
+/// exemption that kept them legible. Under the picture they are on `InkGlass` like every other
+/// control on a content page, and a material stacked inside the panel is exactly the muddy second
+/// glass `GlassContentChromeTests` forbids — so they take `Ink.rowFill` and a hairline, the same
+/// dress as the rest of the page's chrome.
+struct RewindStageControlBar: View {
+  let screenshots: [Screenshot]
+  let currentIndex: Int
+  @ObservedObject var window: RewindTrackWindowModel
+  @Binding var showsDatePicker: Bool
+  let datePicker: AnyView
+
+  var body: some View {
+    HStack(alignment: .center) {
+      timestampPill
+      Spacer(minLength: 0)
+      controlCluster
+    }
+    .padding(.horizontal, RewindStageControlBarLayout.horizontalInset)
+    .padding(.bottom, RewindStageControlBarLayout.bottomGap)
+  }
+
+  // MARK: Leading: the date/time pill
+
+  private var timestampPill: some View {
+    Button {
+      showsDatePicker.toggle()
+    } label: {
+      HStack(spacing: 6) {
+        Image(systemName: "calendar")
+          .font(.system(size: 11, weight: .medium))
+        Text(timestampLabel)
+          .font(.system(size: 12, weight: .medium))
+        Image(systemName: "chevron.down")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(Ink.secondary)
+      }
+      .foregroundStyle(Ink.primary)
+      .padding(.horizontal, 11)
+      .frame(height: RewindStageControlBarLayout.controlHeight)
+      .background(
+        Capsule(style: .continuous)
+          .fill(Ink.rowFill)
+          .overlay(Capsule(style: .continuous).strokeBorder(Ink.hairline, lineWidth: 1)))
+    }
+    .buttonStyle(.plain)
+    // Opens upward, over the picture: the track under the row is what the user is about to scrub,
+    // and a popover that lands on it hides the thing the date it picks will move.
+    .popover(isPresented: $showsDatePicker, arrowEdge: .top) { datePicker }
+    .help("Jump to a day")
+  }
+
+  private var timestampLabel: String {
+    guard screenshots.indices.contains(currentIndex) else { return "—" }
+    return screenshots[currentIndex].formattedDateCompact
+  }
+
+  // MARK: Trailing: the zoom cluster
 
   private var controlCluster: some View {
     HStack(spacing: 8) {
@@ -376,10 +419,13 @@ struct RewindStageChrome: View {
       Image(systemName: systemName)
         .font(.system(size: 12, weight: .medium))
         .foregroundStyle(Ink.primary)
-        .frame(width: 30, height: 30)
+        .frame(
+          width: RewindStageControlBarLayout.controlHeight,
+          height: RewindStageControlBarLayout.controlHeight
+        )
         .background(
           Circle()
-            .fill(.regularMaterial)
+            .fill(Ink.rowFill)
             .overlay(Circle().strokeBorder(Ink.hairline, lineWidth: 1)))
     }
     .buttonStyle(.plain)

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindSurfaceLayout.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindSurfaceLayout.swift
@@ -77,16 +77,11 @@ enum RewindSurfaceLayout {
 
 /// The stage inside the player panel, and where a picture of a given shape lands on it.
 ///
-/// **This exists because the chrome was pinned to the wrong rectangle.** The two segment chevrons
-/// are an `.overlay` on the stage, so they pinned to the *stage's* edges. That is correct only while the photograph fills the stage. It does not: a screen
-/// capture is around 1.8 wide, and at the app's default 1450 pt window the stage is 2.55 — so the
-/// picture is height-bound and there are roughly 200 pt of empty glass down each side of it. The
-/// chevron then sits 200 pt away from the frame it steps through, floating on nothing, which is what
-/// "the controls are scattered" describes.
-///
-/// The fit is a value rather than arithmetic inside a `body` so the behaviour is a test rather than a
-/// screenshot: at any aspect ratio the picture keeps its shape, stays inside the stage, sits centred,
-/// and touches the edge that binds it.
+/// **The fit is a value rather than arithmetic inside a `body`** so the behaviour is a test rather
+/// than a screenshot: at any aspect ratio the picture keeps its shape, stays inside the stage, sits
+/// centred, and touches the edge that binds it. `RewindPage` asks it for the picture's display size;
+/// the controls that belong to the picture are not overlaid on it any more — they sit in
+/// `RewindStageControlBar` on the glass beneath it — so nothing else needs the picture's rect.
 enum RewindStageFit {
 
   /// The air between the player panel's edge and the photograph's stage. The picture is a picture,
@@ -94,25 +89,11 @@ enum RewindStageFit {
   static let horizontalInset: CGFloat = 18
   static let verticalInset: CGFloat = 12
 
-  /// The stage, inside an outer rect of `size`.
-  ///
-  /// The overlay that carries the chrome is applied *after* the stage's padding, so it spans the
-  /// outer rect while the picture is fitted into the inner one. Two coordinate spaces one inset
-  /// apart is exactly the kind of difference that is invisible in a `body`, so it is stated here
-  /// once and both callers ask for it.
-  static func stageRect(in size: CGSize) -> CGRect {
-    CGRect(
-      x: horizontalInset,
-      y: verticalInset,
-      width: max(0, size.width - horizontalInset * 2),
-      height: max(0, size.height - verticalInset * 2))
-  }
-
   /// Where a picture of `image` lands inside `container` — aspect-fit and centred.
   ///
-  /// Empty on any degenerate input, positioned at the container's centre rather than its origin: a
-  /// zero-size rect at the origin would fling the chrome into the top-left corner for the frame or
-  /// two before the first image decodes, and a control that jumps is worse than one that is absent.
+  /// Empty on any degenerate input, positioned at the container's centre rather than its origin, so
+  /// a caller that reads the rect before the first image decodes gets "nothing, in the middle"
+  /// rather than "nothing, in the top-left corner".
   static func pictureRect(image: CGSize, in container: CGSize) -> CGRect {
     guard image.width > 0, image.height > 0, container.width > 0, container.height > 0 else {
       return CGRect(x: container.width / 2, y: container.height / 2, width: 0, height: 0)
@@ -136,14 +117,6 @@ enum RewindStageFit {
       y: (container.height - height) / 2,
       width: width,
       height: height)
-  }
-
-  /// Where the picture lands in the **outer** stage's coordinates — the space the chrome overlay is
-  /// laid out in. The composition of the two above, so a caller cannot apply one and forget the
-  /// other.
-  static func pictureRectInStage(image: CGSize, stage size: CGSize) -> CGRect {
-    let stage = stageRect(in: size)
-    return pictureRect(image: image, in: stage.size).offsetBy(dx: stage.minX, dy: stage.minY)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindSurfaceLayout.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindSurfaceLayout.swift
@@ -77,9 +77,8 @@ enum RewindSurfaceLayout {
 
 /// The stage inside the player panel, and where a picture of a given shape lands on it.
 ///
-/// **This exists because the chrome was pinned to the wrong rectangle.** The timestamp pill, the
-/// zoom cluster and the two segment chevrons are an `.overlay` on the stage, so they pinned to the
-/// *stage's* edges. That is correct only while the photograph fills the stage. It does not: a screen
+/// **This exists because the chrome was pinned to the wrong rectangle.** The two segment chevrons
+/// are an `.overlay` on the stage, so they pinned to the *stage's* edges. That is correct only while the photograph fills the stage. It does not: a screen
 /// capture is around 1.8 wide, and at the app's default 1450 pt window the stage is 2.55 — so the
 /// picture is height-bound and there are roughly 200 pt of empty glass down each side of it. The
 /// chevron then sits 200 pt away from the frame it steps through, floating on nothing, which is what

--- a/desktop/macos/Desktop/Tests/GlassContentChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassContentChromeTests.swift
@@ -119,6 +119,7 @@ final class GlassContentChromeTests: XCTestCase {
     "MainWindow/Components/SpeakerBubbleView.swift",
     "MainWindow/Components/TranscriptDetailView.swift",
     "Rewind/UI/RewindPage.swift",
+    "Rewind/UI/RewindPlaybackChrome.swift",
     "Rewind/UI/RewindSurfaceLayout.swift",
     "Rewind/UI/RewindTimelineView.swift",
     "Rewind/UI/SearchResultsFilmstrip.swift",

--- a/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
@@ -3,15 +3,17 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// The row of controls under Rewind's picture — the date pill and the zoom cluster — and the two
-/// things the move asserts: the row shares its margins with the objects above and below it, and
-/// nothing about the picture's own frame is keyed to the app's palette colour any more.
+/// The row of controls under Rewind's picture — the date pill, the previous/next app circles and
+/// the zoom cluster — and the things the move asserts: the row shares its margins with the objects
+/// above and below it, nothing is overlaid on the picture any more, and the app stepping lands where
+/// it says it does.
 ///
 /// **The defect this holds shut.** The pill and the zoom buttons used to sit *on* the photograph, in
-/// its bottom corners, over whatever the capture showed there; and the picture wore a 2 pt ring in
-/// the app's palette colour, which read as a selection state rather than as a frame. Both are layout
-/// facts a screenshot would show and a `body` would silently lose, so they are stated here as values
-/// and as a narrow static tripwire.
+/// its bottom corners, and the app-step chevrons on its left and right edges, over whatever the
+/// capture showed there; and the picture wore a 2 pt ring in the app's palette colour, which read as
+/// a selection state rather than as a frame. Those are layout facts a screenshot would show and a
+/// `body` would silently lose, so they are stated here as values and as a narrow static tripwire.
+/// The stepping itself is a pure function, so it is a behavioural test.
 final class RewindStageControlBarTests: XCTestCase {
 
   // MARK: - One margin down the panel
@@ -36,11 +38,44 @@ final class RewindStageControlBarTests: XCTestCase {
       RewindStageControlBarLayout.controlHeight, 28, "below 28 pt a circle button is under the click target floor")
   }
 
-  // MARK: - The picture is not keyed to the app colour, and the pill is not on it
+  // MARK: - One app stretch at a time
 
-  // Which view owns the pill and what the frame's border is drawn with are SwiftUI `body` facts with
-  // no inspectable runtime value; see the reasoned annotation on `source(_:)`.
-  func testStaticCheckerTheFrameBorderIsNeutralAndThePillIsUnderThePictureNotOnIt() throws {
+  private func frames(_ apps: [String]) -> [Screenshot] {
+    apps.enumerated().map { offset, app in
+      Screenshot(id: Int64(offset), timestamp: Date(timeIntervalSince1970: Double(offset)), appName: app)
+    }
+  }
+
+  func testForwardLandsOnTheFirstFrameOfTheNextApp() {
+    let frames = frames(["Editor", "Editor", "Browser", "Browser", "Terminal"])
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 0, forward: true), 2)
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 1, forward: true), 2)
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 3, forward: true), 4)
+  }
+
+  func testBackwardLandsOnTheFirstFrameOfThePreviousAppNotItsLast() {
+    // Two presses walk two apps back. Landing on the previous stretch's *last* frame would make the
+    // next press step within the same app.
+    let frames = frames(["Editor", "Editor", "Browser", "Browser", "Terminal"])
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 4, forward: false), 2)
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 3, forward: false), 0)
+    XCTAssertEqual(RewindAppStep.adjacentSegmentIndex(in: frames, from: 2, forward: false), 0)
+  }
+
+  func testTheStepIsNilAtEitherEndAndOffTheList() {
+    let frames = frames(["Editor", "Editor", "Browser"])
+    XCTAssertNil(RewindAppStep.adjacentSegmentIndex(in: frames, from: 2, forward: true), "no app after the last")
+    XCTAssertNil(RewindAppStep.adjacentSegmentIndex(in: frames, from: 0, forward: false), "no app before the first")
+    XCTAssertNil(RewindAppStep.adjacentSegmentIndex(in: frames, from: 1, forward: false), "still inside the first app")
+    XCTAssertNil(RewindAppStep.adjacentSegmentIndex(in: frames, from: 7, forward: true))
+    XCTAssertNil(RewindAppStep.adjacentSegmentIndex(in: [], from: 0, forward: true))
+  }
+
+  // MARK: - The picture is not keyed to the app colour, and nothing sits on it
+
+  // Which view owns each control and what the frame's border is drawn with are SwiftUI `body` facts
+  // with no inspectable runtime value; see the reasoned annotation on `source(_:)`.
+  func testStaticCheckerTheFrameBorderIsNeutralAndEveryControlIsUnderThePictureNotOnIt() throws {
     let page = try source("Rewind/UI/RewindPage.swift")
     XCTAssertFalse(
       page.contains("strokeBorder(frameBorderColor"),
@@ -51,14 +86,18 @@ final class RewindStageControlBarTests: XCTestCase {
     XCTAssertTrue(
       page.contains("RewindStageControlBar("),
       "RewindPage no longer places the control bar under the picture")
+    XCTAssertFalse(
+      page.contains("RewindStageChrome"),
+      "RewindPage overlays chrome on the picture again — every control belongs in the row beneath it")
 
     let chrome = try source("Rewind/UI/RewindPlaybackChrome.swift")
-    let stageChrome = try body(ofType: "RewindStageChrome", in: chrome)
-    for banished in ["timestampPill", "controlCluster", "showsDatePicker", "magnifyingglass"] {
-      XCTAssertFalse(
-        stageChrome.contains(banished),
-        "RewindStageChrome carries `\(banished)` again — the pill and zoom cluster belong under the picture, not on it")
+    let bar = try body(ofType: "RewindStageControlBar", in: chrome)
+    for expected in ["chevron.left", "chevron.right", "magnifyingglass", "showsDatePicker"] {
+      XCTAssertTrue(bar.contains(expected), "RewindStageControlBar lost `\(expected)`")
     }
+    XCTAssertFalse(
+      bar.contains("RoundedRectangle"),
+      "the app-step buttons are the same glass circle as the zoom buttons, not a taller chip")
   }
 
   // MARK: - Helpers

--- a/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
@@ -24,13 +24,29 @@ final class RewindStageControlBarTests: XCTestCase {
       "the pill's leading edge and the stage's leading edge are one line")
   }
 
-  func testTheControlRowSitsAsFarFromTheTrackAsItDoesFromThePicture() {
-    // Above the row: the stage's own vertical inset. Below it: the row's bottom gap plus the track's
-    // top padding. The two must agree or the row reads as belonging to one neighbour and not the other.
-    let above = RewindStageFit.verticalInset
-    let below = RewindStageControlBarLayout.bottomGap + RewindTrackBar.topPadding
-    XCTAssertEqual(above, below, accuracy: 0.001)
+  /// Above the row: the stage's own vertical inset. Below it: the row's bottom gap plus the track's
+  /// top padding. `bottomGap` is *defined* as the difference, so asserting the sum would hold by
+  /// construction; what can actually regress is which view applies which constant. Each of the
+  /// three paddings is a `body` fact, so this reads the sources for the wiring and checks the one
+  /// value that is not settled by the definition: the gap must not have gone negative.
+  func testTheControlRowSitsAsFarFromTheTrackAsItDoesFromThePicture() throws {
     XCTAssertGreaterThanOrEqual(RewindStageControlBarLayout.bottomGap, 0, "a negative gap overlaps the track")
+
+    let page = try source("Rewind/UI/RewindPage.swift")
+    let frameDisplay = try body(ofProperty: "frameDisplay", in: page)
+    XCTAssertTrue(
+      frameDisplay.contains(".padding(.vertical, RewindStageFit.verticalInset)"),
+      "the picture no longer keeps `RewindStageFit.verticalInset` above the row")
+
+    let chrome = try source("Rewind/UI/RewindPlaybackChrome.swift")
+    let bar = try body(ofType: "RewindStageControlBar", in: chrome)
+    XCTAssertTrue(
+      bar.contains(".padding(.bottom, RewindStageControlBarLayout.bottomGap)"),
+      "the row no longer closes its bottom gap with `RewindStageControlBarLayout.bottomGap`")
+    let track = try body(ofType: "RewindTrackBar", in: chrome)
+    XCTAssertTrue(
+      track.contains(".padding(.top, Self.topPadding)"),
+      "the track no longer pads its top with the `topPadding` the gap is computed against")
   }
 
   func testTheControlsAreOneHeightSoTheRowHasOneBaseline() {
@@ -110,6 +126,17 @@ final class RewindStageControlBarTests: XCTestCase {
       .appendingPathComponent(relativePath)
     // omi-test-quality: source-inspection -- static contract: the frame's border colour and the pill's owner are SwiftUI body facts with no runtime value
     return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// The text of `private var <name>: some View {` up to the next property or function at the
+  /// same indentation, so a padding asserted on one view cannot be satisfied by a neighbour.
+  private func body(ofProperty name: String, in source: String) throws -> Substring {
+    guard let start = source.range(of: "private var \(name): some View {") else {
+      throw XCTSkip("`private var \(name): some View` not found — the property was renamed; update this test")
+    }
+    let rest = source[start.upperBound...]
+    guard let end = rest.range(of: "\n  }\n") else { return rest }
+    return rest[..<end.lowerBound]
   }
 
   /// The text from `struct <name>` to the next top-level `// MARK: -`, which is how this file is

--- a/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStageControlBarTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// The row of controls under Rewind's picture — the date pill and the zoom cluster — and the two
+/// things the move asserts: the row shares its margins with the objects above and below it, and
+/// nothing about the picture's own frame is keyed to the app's palette colour any more.
+///
+/// **The defect this holds shut.** The pill and the zoom buttons used to sit *on* the photograph, in
+/// its bottom corners, over whatever the capture showed there; and the picture wore a 2 pt ring in
+/// the app's palette colour, which read as a selection state rather than as a frame. Both are layout
+/// facts a screenshot would show and a `body` would silently lose, so they are stated here as values
+/// and as a narrow static tripwire.
+final class RewindStageControlBarTests: XCTestCase {
+
+  // MARK: - One margin down the panel
+
+  func testTheControlRowSharesTheStagesHorizontalInset() {
+    XCTAssertEqual(
+      RewindStageControlBarLayout.horizontalInset, RewindStageFit.horizontalInset, accuracy: 0.001,
+      "the pill's leading edge and the stage's leading edge are one line")
+  }
+
+  func testTheControlRowSitsAsFarFromTheTrackAsItDoesFromThePicture() {
+    // Above the row: the stage's own vertical inset. Below it: the row's bottom gap plus the track's
+    // top padding. The two must agree or the row reads as belonging to one neighbour and not the other.
+    let above = RewindStageFit.verticalInset
+    let below = RewindStageControlBarLayout.bottomGap + RewindTrackBar.topPadding
+    XCTAssertEqual(above, below, accuracy: 0.001)
+    XCTAssertGreaterThanOrEqual(RewindStageControlBarLayout.bottomGap, 0, "a negative gap overlaps the track")
+  }
+
+  func testTheControlsAreOneHeightSoTheRowHasOneBaseline() {
+    XCTAssertGreaterThanOrEqual(
+      RewindStageControlBarLayout.controlHeight, 28, "below 28 pt a circle button is under the click target floor")
+  }
+
+  // MARK: - The picture is not keyed to the app colour, and the pill is not on it
+
+  // Which view owns the pill and what the frame's border is drawn with are SwiftUI `body` facts with
+  // no inspectable runtime value; see the reasoned annotation on `source(_:)`.
+  func testStaticCheckerTheFrameBorderIsNeutralAndThePillIsUnderThePictureNotOnIt() throws {
+    let page = try source("Rewind/UI/RewindPage.swift")
+    XCTAssertFalse(
+      page.contains("strokeBorder(frameBorderColor"),
+      "RewindPage strokes the frame in the app's palette colour again; the ring reads as a selection state")
+    XCTAssertFalse(
+      page.contains("RewindPalette.color(forApp"),
+      "RewindPage keys the picture to the app's palette colour; the track segment already says which app it is")
+    XCTAssertTrue(
+      page.contains("RewindStageControlBar("),
+      "RewindPage no longer places the control bar under the picture")
+
+    let chrome = try source("Rewind/UI/RewindPlaybackChrome.swift")
+    let stageChrome = try body(ofType: "RewindStageChrome", in: chrome)
+    for banished in ["timestampPill", "controlCluster", "showsDatePicker", "magnifyingglass"] {
+      XCTAssertFalse(
+        stageChrome.contains(banished),
+        "RewindStageChrome carries `\(banished)` again — the pill and zoom cluster belong under the picture, not on it")
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func source(_ relativePath: String) throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+      .appendingPathComponent(relativePath)
+    // omi-test-quality: source-inspection -- static contract: the frame's border colour and the pill's owner are SwiftUI body facts with no runtime value
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// The text from `struct <name>` to the next top-level `// MARK: -`, which is how this file is
+  /// sectioned. Fails loudly if the type or the section break moves.
+  private func body(ofType name: String, in source: String) throws -> Substring {
+    guard let start = source.range(of: "struct \(name): View") else {
+      throw XCTSkip("`struct \(name): View` not found — the type was renamed; update this test")
+    }
+    let rest = source[start.lowerBound...]
+    guard let end = rest.range(of: "\n// MARK: -") else { return rest }
+    return rest[..<end.lowerBound]
+  }
+}

--- a/desktop/macos/Desktop/Tests/RewindStageFitTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStageFitTests.swift
@@ -6,8 +6,8 @@ import XCTest
 /// Where Rewind's photograph lands on its stage, and therefore where the controls that belong to it
 /// have to be.
 ///
-/// **The defect this holds shut.** The timestamp pill, the zoom cluster and the two segment chevrons
-/// are an overlay on the stage, so they used to pin to the *stage's* edges. That is right only while
+/// **The defect this holds shut.** The two segment chevrons are an overlay on the stage, so they used
+/// to pin to the *stage's* edges. That is right only while
 /// the picture fills the stage, and it does not: a screen capture is around 1.8 wide while the stage
 /// at the app's own default window width is around 2.55, so the picture is height-bound with a wide
 /// band of empty glass down each side. The chevron then sat a long way from the frame it steps

--- a/desktop/macos/Desktop/Tests/RewindStageFitTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindStageFitTests.swift
@@ -3,16 +3,15 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// Where Rewind's photograph lands on its stage, and therefore where the controls that belong to it
-/// have to be.
+/// Where Rewind's photograph lands on its stage.
 ///
-/// **The defect this holds shut.** The two segment chevrons are an overlay on the stage, so they used
-/// to pin to the *stage's* edges. That is right only while
-/// the picture fills the stage, and it does not: a screen capture is around 1.8 wide while the stage
-/// at the app's own default window width is around 2.55, so the picture is height-bound with a wide
-/// band of empty glass down each side. The chevron then sat a long way from the frame it steps
-/// through. Everything below is stated as a ratio or a relation rather than a measured point, so it
-/// survives the next padding change and still fails if the fit stops being a fit.
+/// **The defect this holds shut.** The picture is aspect-fit into a stage that is almost never its
+/// own shape: a screen capture is around 1.8 wide while the stage at the app's own default window
+/// width is around 2.55, so the picture is height-bound with a wide band of empty glass down each
+/// side. `RewindPage` sizes the frame from this fit, and a fit that drifted would stretch, crop or
+/// off-centre the picture. Everything below is stated as a ratio or a relation rather than a
+/// measured point, so it survives the next padding change and still fails if the fit stops being a
+/// fit.
 final class RewindStageFitTests: XCTestCase {
 
   /// Shapes worth fitting: taller than wide, square, 4:3, 16:10, 16:9, the stage's own measured
@@ -116,58 +115,10 @@ final class RewindStageFitTests: XCTestCase {
       "the two bands of glass are the same width")
   }
 
-  /// The same claim in the coordinate space the chrome is actually laid out in.
-  func testThePicturesEdgeIsNotTheStagesEdgeWhenTheShapesDisagree() {
-    let stageSize = CGSize(width: 1_418, height: 565)
-    let stage = RewindStageFit.stageRect(in: stageSize)
-    let picture = RewindStageFit.pictureRectInStage(image: image(ratio: 16.0 / 9.0), stage: stageSize)
-
-    XCTAssertGreaterThan(
-      picture.minX - stage.minX, RewindStageFit.horizontalInset,
-      "pinning a chevron to the stage would put it further from the frame than the stage's own inset")
-    XCTAssertTrue(stage.contains(picture), "the picture still lives inside the stage")
-  }
-
-  // MARK: - The two coordinate spaces
-
-  func testTheStageIsTheOuterRectLessItsOwnInsets() {
-    let outer = CGSize(width: 1_000, height: 600)
-    let stage = RewindStageFit.stageRect(in: outer)
-
-    XCTAssertEqual(stage.minX, RewindStageFit.horizontalInset, accuracy: 0.001)
-    XCTAssertEqual(stage.minY, RewindStageFit.verticalInset, accuracy: 0.001)
-    XCTAssertEqual(stage.width, outer.width - RewindStageFit.horizontalInset * 2, accuracy: 0.001)
-    XCTAssertEqual(stage.height, outer.height - RewindStageFit.verticalInset * 2, accuracy: 0.001)
-  }
-
-  func testTheStageNeverInvertsOnAWindowSmallerThanItsOwnInsets() {
-    let stage = RewindStageFit.stageRect(in: CGSize(width: 4, height: 4))
-
-    XCTAssertGreaterThanOrEqual(stage.width, 0)
-    XCTAssertGreaterThanOrEqual(stage.height, 0)
-  }
-
-  /// `pictureRectInStage` is the composition of the two, and a caller cannot apply one and forget
-  /// the other.
-  func testThePictureInTheStageIsThePictureOffsetByTheInsets() {
-    let outer = CGSize(width: 1_418, height: 565)
-    for ratio in Self.ratios {
-      let stage = RewindStageFit.stageRect(in: outer)
-      let inner = RewindStageFit.pictureRect(image: image(ratio: ratio), in: stage.size)
-      let composed = RewindStageFit.pictureRectInStage(image: image(ratio: ratio), stage: outer)
-
-      XCTAssertEqual(composed.minX, inner.minX + stage.minX, accuracy: 0.001)
-      XCTAssertEqual(composed.minY, inner.minY + stage.minY, accuracy: 0.001)
-      XCTAssertEqual(composed.size.width, inner.size.width, accuracy: 0.001)
-      XCTAssertEqual(composed.size.height, inner.size.height, accuracy: 0.001)
-    }
-  }
-
   // MARK: - Nothing degenerate escapes
 
   /// An empty rect at the stage's centre, not at its origin: before the first frame decodes there is
-  /// no picture, and chrome that parks in the top-left corner for a frame and then jumps is worse
-  /// than chrome that is simply not there yet.
+  /// no picture, and "nothing, in the middle" is the answer a caller can place without jumping.
   func testAnUndecodedImageIsAnEmptyRectAtTheCentre() {
     let container = CGSize(width: 800, height: 400)
     let rect = RewindStageFit.pictureRect(image: .zero, in: container)

--- a/desktop/macos/changelog/unreleased/20260906-rewind-stage-controls.json
+++ b/desktop/macos/changelog/unreleased/20260906-rewind-stage-controls.json
@@ -1,3 +1,3 @@
 {
-  "change": "Rewind's screenshot no longer wears the app-coloured outline, and the date pill and zoom buttons moved off the picture into their own row directly beneath it, aligned with the timeline"
+  "change": "Rewind's screenshot no longer wears the app-coloured outline, and every control that used to sit on the picture — the date pill, the previous/next app buttons and the zoom buttons — moved into one row directly beneath it, with the app buttons centred as simple glass circles"
 }

--- a/desktop/macos/changelog/unreleased/20260906-rewind-stage-controls.json
+++ b/desktop/macos/changelog/unreleased/20260906-rewind-stage-controls.json
@@ -1,0 +1,3 @@
+{
+  "change": "Rewind's screenshot no longer wears the app-coloured outline, and the date pill and zoom buttons moved off the picture into their own row directly beneath it, aligned with the timeline"
+}


### PR DESCRIPTION
<img width="809" height="690" alt="Screenshot 2026-09-06 at 10 44 08 AM" src="https://github.com/user-attachments/assets/d228fcff-dab4-4a72-b71c-1d08e546d0e6" />

## Summary

Rewind's picture used to carry every control: a 2 pt ring in the app's palette colour, the date pill and the zoom cluster in its bottom corners, and the previous/next app chevrons as tall chips on its left and right edges — all over whatever the capture showed there. This PR makes the picture only the picture.

- The frame's ring is a neutral hairline; the track segment already says which app the frame belongs to.
- The date pill, the previous/next app buttons and the zoom buttons live in one row (`RewindStageControlBar`) on the glass directly beneath the picture, sharing the stage's and the track's horizontal inset so all three keep one leading edge.
- The app-step buttons are simple glass circles — the same `Ink.rowFill` + hairline circle as the zoom buttons — centred on the row so they stay under the picture's middle whatever width the date takes.
- The on-picture chrome view and the stage-fit helpers only it used are removed; the app stepping is the pure `RewindAppStep.adjacentSegmentIndex` with behavioural tests. `RewindPlaybackChrome.swift` no longer holds any system material, so it joins the `GlassContentChromeTests` ratchet.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

## Verification

- `DEVELOPER_DIR=Xcode xcrun swift build -c debug` clean on the rebased tree.
- `xcrun swift test --filter 'RewindStageControlBarTests|RewindStageFitTests|GlassContentChromeTests|RewindSurfaceLayoutTests|RewindPaletteTests|RewindTrackTests'` → 67 tests, 0 failures. New tests: forward lands on the first frame of the next app, backward on the *first* frame of the previous app, nil at either end; the control row shares the stage's inset and equal air above and below; a reasoned static tripwire holds that RewindPage overlays nothing on the picture, the frame is not stroked in the palette colour, and the bar's buttons are circles.
- Built `OMI_APP_NAME=omi-rewind-reorg ./run.sh --yolo`, seeded Rewind history, `omi-ctl navigate rewind`, captured the window: no outline or controls on the picture; the date pill (left), two centred app-step circles, and the zoom circles (right) sit in one row between the picture and the track, aligned with both.
- `make preflight` with this body: all selected manifest checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfHDsYkrfscMkmZ5os1e6z


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

