### PR TITLE
feat(desktop): adjustable glass transparency slider in General settings

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
@@ -1,0 +1,45 @@
+import Foundation
+import OmiTheme
+
+/// Glass transparency automation actions: read and set the user's glass transparency without
+/// cursor input. `set_glass_transparency` writes the same published value the Settings → General
+/// slider binds to, so driving it exercises the production path every mounted panel follows.
+extension DesktopAutomationActionRegistry {
+  func registerGlassTransparencyActions() {
+    register(
+      name: "glass_transparency_snapshot",
+      summary: "Return the glass transparency (0 solid … 1 bare material), its default, and the effective ground alpha"
+    ) { _ in
+      await MainActor.run { Self.glassTransparencySnapshot() }
+    }
+
+    register(
+      name: "set_glass_transparency",
+      summary: "Set the glass transparency through the slider's own published value (0…1, clamped)",
+      params: ["value"]
+    ) { params in
+      guard let value = params["value"].flatMap(Double.init) else {
+        throw DesktopAutomationActionError.invalidParams("value must be a number in 0...1")
+      }
+      return await MainActor.run {
+        InkGlassTransparencySettings.shared.transparency = CGFloat(value)
+        return Self.glassTransparencySnapshot()
+      }
+    }
+  }
+
+  @MainActor
+  private static func glassTransparencySnapshot() -> [String: String] {
+    let settings = InkGlassTransparencySettings.shared
+    let reduced = InkReduceTransparency.isEnabled
+    return [
+      "transparency": String(format: "%.4f", Double(settings.transparency)),
+      "default_transparency": String(format: "%.4f", Double(InkGlass.defaultTransparency)),
+      "is_default": settings.isDefault ? "true" : "false",
+      "reduce_transparency": reduced ? "true" : "false",
+      "ground_alpha": String(
+        format: "%.4f",
+        Double(InkGlass.groundAlpha(reduceTransparency: reduced, transparency: settings.transparency))),
+    ]
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
@@ -15,14 +15,28 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "set_glass_transparency",
-      summary: "Set the glass transparency through the slider's own published value (0…1, clamped)",
+      summary: "Set the glass transparency through the slider's own published value (0…1)",
       params: ["value"]
     ) { params in
-      guard let value = params["value"].flatMap(Double.init) else {
+      // The model would normalise anything, but a harness that asks for 7 or "nan" has a bug, and
+      // a boundary that quietly writes 1 instead hides it. The message states the whole contract.
+      guard let value = params["value"].flatMap(Double.init), value.isFinite,
+        InkGlassTransparencySettings.range.contains(CGFloat(value))
+      else {
         throw DesktopAutomationActionError.invalidParams("value must be a number in 0...1")
       }
       return await MainActor.run {
         InkGlassTransparencySettings.shared.transparency = CGFloat(value)
+        return Self.glassTransparencySnapshot()
+      }
+    }
+
+    register(
+      name: "reset_glass_transparency",
+      summary: "Return the glass transparency to the shipped default, as the card's Reset button does"
+    ) { _ in
+      await MainActor.run {
+        InkGlassTransparencySettings.shared.resetToDefault()
         return Self.glassTransparencySnapshot()
       }
     }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3770,6 +3770,7 @@ final class DesktopAutomationActionRegistry {
 
     registerNotificationActions()
     registerRatingPromptActions()
+    registerGlassTransparencyActions()
     registerRemotePromptActions()
     registerRealtimeHubActions()
     register(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -276,11 +276,15 @@ extension SettingsContentView {
 
         Spacer()
 
+        // Reset rewrites the same value the slider does, which changes just as little under Reduce
+        // Transparency, so it wears the slider's disabled state rather than contradicting the caption.
         if !glassTransparencySettings.isDefault {
           Button("Reset") {
             glassTransparencySettings.resetToDefault()
           }
           .buttonStyle(OmiButtonStyle(.primary, size: .compact))
+          .disabled(reduced)
+          .opacity(reduced ? 0.45 : 1)
         }
       }
 
@@ -295,6 +299,9 @@ extension SettingsContentView {
           in: InkGlassTransparencySettings.range
         )
         .tint(Ink.accent)
+        // The side icons' tooltips do not attach to the control, so without this VoiceOver reads a
+        // bare percentage with no word for what it is.
+        .accessibilityLabel("Transparency")
 
         Image(systemName: "square.dotted")
           .scaledFont(size: 12)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -240,6 +240,69 @@ extension SettingsContentView {
         }
       }
 
+      // Transparency
+      settingsCard(settingId: "general.transparency") {
+        transparencyCard
+      }
+
+    }
+  }
+
+  /// How much of the desktop the glass lets through.
+  ///
+  /// The slider binds straight to the published value, so every glass surface — this pane's own
+  /// panel included — follows the thumb while it is still down. Under the system's Reduce
+  /// Transparency setting the ground is opaque no matter what the slider says, so the control is
+  /// dimmed and says why rather than moving a value that changes nothing.
+  private var transparencyCard: some View {
+    let reduced = reduceTransparencyObserver.isEnabled
+    return VStack(spacing: OmiSpacing.sm) {
+      HStack(spacing: OmiSpacing.lg) {
+        SettingsIconTile(symbol: "circle.lefthalf.filled")
+
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text("Transparency")
+            .scaledFont(size: 16, weight: .semibold)
+            .foregroundColor(Ink.primary)
+
+          Text(
+            reduced
+              ? "Off while Reduce Transparency is on in System Settings"
+              : "Glass: \(Int((glassTransparencySettings.transparency * 100).rounded()))%"
+          )
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+        }
+
+        Spacer()
+
+        if !glassTransparencySettings.isDefault {
+          Button("Reset") {
+            glassTransparencySettings.resetToDefault()
+          }
+          .buttonStyle(OmiButtonStyle(.primary, size: .compact))
+        }
+      }
+
+      HStack(spacing: OmiSpacing.md) {
+        Image(systemName: "square.fill")
+          .scaledFont(size: 12)
+          .foregroundColor(Ink.secondary)
+          .help("Solid")
+
+        Slider(
+          value: $glassTransparencySettings.transparency,
+          in: InkGlassTransparencySettings.range
+        )
+        .tint(Ink.accent)
+
+        Image(systemName: "square.dotted")
+          .scaledFont(size: 12)
+          .foregroundColor(Ink.secondary)
+          .help("Clear")
+      }
+      .disabled(reduced)
+      .opacity(reduced ? 0.45 : 1)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -754,6 +754,8 @@ struct SettingsContentView: View {
   }
 
   @ObservedObject var fontScaleSettings = FontScaleSettings.shared
+  @ObservedObject var glassTransparencySettings = InkGlassTransparencySettings.shared
+  @ObservedObject var reduceTransparencyObserver = InkReduceTransparencyObserver.shared
   @ObservedObject var rewindSettings = RewindSettings.shared
   @State var rewindStats: (total: Int, indexed: Int, storageSize: Int64)? = nil
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -43,6 +43,10 @@ struct SettingsSearchItem: Identifiable {
       name: "Reset Window Size", subtitle: "Restore the default window dimensions",
       keywords: ["resize", "window", "default size"], section: .general, icon: "gearshape",
       settingId: "general.fontsize"),
+    SettingsSearchItem(
+      name: "Transparency", subtitle: "How much of the desktop shows through the glass",
+      keywords: ["glass", "transparent", "opacity", "opaque", "blur", "see-through", "translucent"],
+      section: .general, icon: "circle.lefthalf.filled", settingId: "general.transparency"),
 
     // Rewind
     SettingsSearchItem(

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -783,11 +783,24 @@ package struct InkGlassPanelModifier: ViewModifier {
     _transparencySettings = ObservedObject(wrappedValue: transparency)
   }
 
+  /// Whether this panel draws as an opaque sheet: the caller's override, else the system setting.
+  private var reduceTransparency: Bool {
+    requestedReduceTransparency ?? reduceTransparencyObserver.isEnabled
+  }
+
+  /// The alpha of the `Ink.surface` ground this panel paints, resolved from what it observes right
+  /// now. `body` reads this and so do the tests: the panel mounts two representables (the material
+  /// and the hit-region reporter) and neither renders offscreen, so "the glass follows the slider" is
+  /// checked on the value the panel paints rather than on a bitmap of it.
+  package var resolvedGroundAlpha: CGFloat {
+    InkGlass.groundAlpha(
+      reduceTransparency: reduceTransparency, transparency: transparencySettings.transparency)
+  }
+
   @ViewBuilder
   package func body(content: Content) -> some View {
-    let reduceTransparency = requestedReduceTransparency ?? reduceTransparencyObserver.isEnabled
-    let groundAlpha = InkGlass.groundAlpha(
-      reduceTransparency: reduceTransparency, transparency: transparencySettings.transparency)
+    let reduceTransparency = reduceTransparency
+    let groundAlpha = resolvedGroundAlpha
     let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
     // Clip the caller's returned tree before adding the glass background. This keeps content and

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -440,10 +440,16 @@ package struct InkGlassStyle: Equatable, Sendable {
 /// only ever written on the main thread, from `InkGlassView.init`.
 private final class InkGlassObserverToken: @unchecked Sendable {
   var token: (any NSObjectProtocol)?
+  /// The centre the token was registered on; a token removed from the wrong centre stays live.
+  private let center: NotificationCenter
+
+  init(center: NotificationCenter = NSWorkspace.shared.notificationCenter) {
+    self.center = center
+  }
 
   deinit {
     guard let token else { return }
-    NSWorkspace.shared.notificationCenter.removeObserver(token)
+    center.removeObserver(token)
   }
 }
 
@@ -489,6 +495,7 @@ package final class InkGlassView: NSView {
   /// ground gets thinner, not less.
   private let shadowHost = NSView()
   private let observer = InkGlassObserverToken()
+  private let transparencyObserver = InkGlassObserverToken(center: .default)
 
   // A glass surface is visible content: report its extent so transparent windows can keep
   // pass-through margins without ever passing a click through the glass itself.
@@ -555,6 +562,16 @@ package final class InkGlassView: NSView {
     ) { [weak self] _ in
       MainActor.assumeIsolated { self?.applyCurrentSettings() }
     }
+    // The user's own transparency slider, which moves the same alpha and must reach every panel that
+    // is already up — the Settings window the slider is in, and the floating ones behind it — while
+    // the thumb is still moving.
+    transparencyObserver.token = InkGlassTransparencySettings.shared.notificationCenter.addObserver(
+      forName: InkGlassTransparencySettings.didChangeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated { self?.applyCurrentSettings() }
+    }
   }
 
   @available(*, unavailable)
@@ -611,7 +628,9 @@ package final class InkGlassView: NSView {
   }
 
   private func applyCurrentSettings() {
-    apply(reduceTransparency: InkReduceTransparency.isEnabled)
+    apply(
+      reduceTransparency: InkReduceTransparency.isEnabled,
+      transparency: InkGlassTransparencySettings.shared.transparency)
   }
 
   /// One point. A highlight is a *line*, not a gradient band — a band reads as a second, lighter panel
@@ -622,15 +641,20 @@ package final class InkGlassView: NSView {
   /// layout check — would have to hop an actor to read a `1`.
   nonisolated package static let sheenHeight: CGFloat = 1
 
-  /// The panel's whole appearance, from one `Bool`. The only branch in this file.
-  package func apply(reduceTransparency reduced: Bool) {
+  /// The panel's whole appearance, from one `Bool` and the user's transparency. The only branch in
+  /// this file. `transparency` defaults to the shipped scrim so a caller asserting the accessibility
+  /// contract alone reads exactly the design's ground.
+  package func apply(
+    reduceTransparency reduced: Bool,
+    transparency: CGFloat = InkGlass.defaultTransparency
+  ) {
     material.isHidden = !InkGlass.showsMaterial(reduceTransparency: reduced)
     // A specular highlight is a property of *glass*. Under Reduce Transparency this is an opaque sheet
     // and there is no glass for the light to catch, so the highlight goes with the blur — the same rule
     // the material follows, for the same reason.
     sheen.isHidden = reduced
 
-    let alpha = InkGlass.groundAlpha(reduceTransparency: reduced)
+    let alpha = InkGlass.groundAlpha(reduceTransparency: reduced, transparency: transparency)
     // Resolved inside the panel's own (pinned) appearance, not read at file scope: a dynamic `NSColor`
     // converted to a `CGColor` anywhere else freezes whichever appearance happened to be current, which
     // on a Dark machine is exactly the near-black ground this replaces.
@@ -741,22 +765,29 @@ package struct InkGlassPanelModifier: ViewModifier {
   let shadow: InkGlassShadow?
   let requestedReduceTransparency: Bool?
   @ObservedObject private var reduceTransparencyObserver: InkReduceTransparencyObserver
+  /// Observed, not read: a slider in Settings moves this while its thumb is down, and every mounted
+  /// panel has to follow it on that same frame.
+  @ObservedObject private var transparencySettings: InkGlassTransparencySettings
 
   package init(
     cornerRadius: CGFloat,
     shadow: InkGlassShadow?,
     reduceTransparency: Bool? = nil,
-    observer: InkReduceTransparencyObserver = .shared
+    observer: InkReduceTransparencyObserver = .shared,
+    transparency: InkGlassTransparencySettings = .shared
   ) {
     self.cornerRadius = cornerRadius
     self.shadow = shadow
     self.requestedReduceTransparency = reduceTransparency
     _reduceTransparencyObserver = ObservedObject(wrappedValue: observer)
+    _transparencySettings = ObservedObject(wrappedValue: transparency)
   }
 
   @ViewBuilder
   package func body(content: Content) -> some View {
     let reduceTransparency = requestedReduceTransparency ?? reduceTransparencyObserver.isEnabled
+    let groundAlpha = InkGlass.groundAlpha(
+      reduceTransparency: reduceTransparency, transparency: transparencySettings.transparency)
     let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
     // Clip the caller's returned tree before adding the glass background. This keeps content and
@@ -777,7 +808,7 @@ package struct InkGlassPanelModifier: ViewModifier {
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {
             InkGlassBackdrop()
           }
-          Ink.surface.opacity(InkGlass.groundAlpha(reduceTransparency: reduceTransparency))
+          Ink.surface.opacity(groundAlpha)
           // Hidden under Reduce Transparency for the same reason the material is: there is no glass to
           // catch the light.
           //

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
@@ -25,11 +25,19 @@ extension InkGlass {
   ///
   /// 0 is an opaque sheet — the same surface Reduce Transparency produces. 1 is the material's own
   /// ceiling: no scrim at all, the blur alone. Between them the scrim is linear in the slider, which
-  /// is the only mapping a user can predict. Clamped, so a stale or hand-edited preference cannot
-  /// produce a negative alpha or one above opaque.
+  /// is the only mapping a user can predict. Normalised, so a stale or hand-edited preference cannot
+  /// produce a negative alpha, one above opaque, or a NaN the compositor would paint as garbage.
   package static func scrim(forTransparency transparency: CGFloat) -> CGFloat {
-    let clamped = min(max(transparency, 0), 1)
-    return 1 - clamped
+    1 - normalizedTransparency(transparency)
+  }
+
+  /// The one rule for what a transparency may be: a number in `0...1`. Anything outside the range
+  /// is pulled to the nearer end; anything that is not a number at all — `Double("nan")` parses,
+  /// and a preference file can hold anything — falls back to the shipped default rather than to an
+  /// end, because a value that says nothing should change nothing.
+  package static func normalizedTransparency(_ transparency: CGFloat) -> CGFloat {
+    guard transparency.isFinite else { return defaultTransparency }
+    return min(max(transparency, 0), 1)
   }
 
   /// The alpha of the `Ink.surface` ground, given both the accessibility setting and the user's
@@ -59,12 +67,18 @@ package final class InkGlassTransparencySettings: ObservableObject {
   /// The slider's range: an opaque sheet to the bare material.
   package static let range: ClosedRange<CGFloat> = 0...1
 
-  /// How see-through the glass is, `0...1`. Writes are clamped, persisted and announced.
+  /// How see-through the glass is, `0...1`. Writes are normalised, persisted and announced.
+  ///
+  /// A write outside the range (or not a number) is corrected in place. On a `@Published` property
+  /// the assignment re-enters this observer with the corrected value, and that inner pass is the one
+  /// that persists and announces it — once — so mounted panels follow the correction, not the write.
+  /// The correction always lands on a value that needs no further correction, so the re-entry ends
+  /// there; a NaN, which is never equal to itself, would otherwise recurse without end.
   @Published package var transparency: CGFloat {
     didSet {
-      let clamped = min(max(transparency, Self.range.lowerBound), Self.range.upperBound)
-      if clamped != transparency {
-        transparency = clamped
+      let normalized = InkGlass.normalizedTransparency(transparency)
+      if normalized != transparency {
+        transparency = normalized
         return
       }
       defaults.set(Double(transparency), forKey: Self.defaultsKey)
@@ -85,7 +99,7 @@ package final class InkGlassTransparencySettings: ObservableObject {
     self.notificationCenter = notificationCenter
     let stored = defaults.object(forKey: Self.defaultsKey) as? Double
     let initial = stored.map { CGFloat($0) } ?? InkGlass.defaultTransparency
-    self.transparency = min(max(initial, Self.range.lowerBound), Self.range.upperBound)
+    self.transparency = InkGlass.normalizedTransparency(initial)
   }
 
   package var isDefault: Bool {

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
@@ -1,0 +1,98 @@
+//
+//  InkGlassTransparency.swift — the user's own say over how much desktop the glass lets through.
+//
+//  `InkGlass.scrim` is the ground the design ships with, tuned against a measured interference bound
+//  (see that constant). It is the right default and it is still only a default: someone on a plain
+//  wallpaper wants more of it through, someone who reads over a browser all day wants less, and the
+//  system's Reduce Transparency switch is a blunt instrument that also kills the blur. This file is
+//  the one knob between those, and it moves the same quantity `scrim` sets — the ground's alpha — so
+//  there is still exactly one owner of "what is under the type".
+//
+//  It is **live**: the value is published, every AppKit `InkGlassView` re-applies on the change
+//  notification, and every SwiftUI `inkGlassPanel` observes the object — so the glass follows the
+//  slider while the thumb is still moving, not when it is released.
+//
+
+import AppKit
+import SwiftUI
+
+extension InkGlass {
+  /// The user-facing transparency the shipped scrim corresponds to: `1 − scrim`, so the slider's
+  /// default sits where the design was tuned and nothing looks different until somebody moves it.
+  package static var defaultTransparency: CGFloat { 1 - scrim }
+
+  /// The ground's alpha for a user transparency in `0...1`.
+  ///
+  /// 0 is an opaque sheet — the same surface Reduce Transparency produces. 1 is the material's own
+  /// ceiling: no scrim at all, the blur alone. Between them the scrim is linear in the slider, which
+  /// is the only mapping a user can predict. Clamped, so a stale or hand-edited preference cannot
+  /// produce a negative alpha or one above opaque.
+  package static func scrim(forTransparency transparency: CGFloat) -> CGFloat {
+    let clamped = min(max(transparency, 0), 1)
+    return 1 - clamped
+  }
+
+  /// The alpha of the `Ink.surface` ground, given both the accessibility setting and the user's
+  /// transparency. Reduce Transparency wins outright: glass that honours the slider but ignores the
+  /// setting is the defect the setting exists for.
+  package static func groundAlpha(reduceTransparency: Bool, transparency: CGFloat) -> CGFloat {
+    reduceTransparency ? 1 : scrim(forTransparency: transparency)
+  }
+}
+
+/// The user's transparency, published, persisted, and announced.
+///
+/// Mirrors `FontScaleSettings`: one shared object, a `@Published` value SwiftUI binds a slider to,
+/// `UserDefaults` behind it. Unlike the font scale, the glass is drawn by AppKit views that are not
+/// in any SwiftUI tree, so a change is also posted as a notification for `InkGlassView` to re-apply.
+@MainActor
+package final class InkGlassTransparencySettings: ObservableObject {
+  package static let shared = InkGlassTransparencySettings()
+
+  /// Posted on `notificationCenter` after `transparency` changes. The new value is on the object, not
+  /// in `userInfo` — an observer re-reads the one source of truth rather than trusting a payload.
+  package static let didChangeNotification = Notification.Name("InkGlassTransparencyDidChange")
+
+  /// The `UserDefaults` key. Stated once, so the seed script and a test can name the same thing.
+  package static let defaultsKey = "glassTransparency"
+
+  /// The slider's range: an opaque sheet to the bare material.
+  package static let range: ClosedRange<CGFloat> = 0...1
+
+  /// How see-through the glass is, `0...1`. Writes are clamped, persisted and announced.
+  @Published package var transparency: CGFloat {
+    didSet {
+      let clamped = min(max(transparency, Self.range.lowerBound), Self.range.upperBound)
+      if clamped != transparency {
+        transparency = clamped
+        return
+      }
+      defaults.set(Double(transparency), forKey: Self.defaultsKey)
+      notificationCenter.post(name: Self.didChangeNotification, object: self)
+    }
+  }
+
+  package let notificationCenter: NotificationCenter
+  private let defaults: UserDefaults
+
+  /// Injectable so a test can run a whole change → persist → announce cycle against its own suite
+  /// and its own centre, without touching the user's preferences.
+  package init(
+    defaults: UserDefaults = .standard,
+    notificationCenter: NotificationCenter = .default
+  ) {
+    self.defaults = defaults
+    self.notificationCenter = notificationCenter
+    let stored = defaults.object(forKey: Self.defaultsKey) as? Double
+    let initial = stored.map { CGFloat($0) } ?? InkGlass.defaultTransparency
+    self.transparency = min(max(initial, Self.range.lowerBound), Self.range.upperBound)
+  }
+
+  package var isDefault: Bool {
+    abs(transparency - InkGlass.defaultTransparency) < 0.0001
+  }
+
+  package func resetToDefault() {
+    transparency = InkGlass.defaultTransparency
+  }
+}

--- a/desktop/macos/Desktop/Tests/GlassTransparencyActionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassTransparencyActionTests.swift
@@ -1,0 +1,61 @@
+import OmiTheme
+import XCTest
+
+@testable import Omi_Computer
+
+/// The bridge actions a harness uses to drive the Settings → General transparency slider without
+/// cursor input. They run through the real registry and write the same published value the slider
+/// binds to, so a pass here means the live path a drag takes is reachable in-process.
+@MainActor
+final class GlassTransparencyActionTests: XCTestCase {
+
+  private var registry: DesktopAutomationActionRegistry { .shared }
+
+  /// Registers the builtins and hands back a restore for the shared value the actions mutate, so a
+  /// test leaves the process's own preference exactly as it found it.
+  private func prepare() -> () -> Void {
+    registry.registerBuiltins()
+    let original = InkGlassTransparencySettings.shared.transparency
+    return { InkGlassTransparencySettings.shared.transparency = original }
+  }
+
+  func testActionsAreDiscoverable() {
+    let restore = prepare()
+    defer { restore() }
+    let names = Set(registry.descriptors().map(\.name))
+    XCTAssertTrue(names.contains("glass_transparency_snapshot"))
+    XCTAssertTrue(names.contains("set_glass_transparency"))
+  }
+
+  func testSetWritesTheSlidersValueAndSnapshotReadsItBack() async throws {
+    let restore = prepare()
+    defer { restore() }
+    let set = try await registry.perform("set_glass_transparency", params: ["value": "0.3"])
+    XCTAssertEqual(set?["transparency"], "0.3000")
+    XCTAssertEqual(set?["is_default"], "false")
+    XCTAssertEqual(InkGlassTransparencySettings.shared.transparency, 0.3, accuracy: 0.0001)
+
+    let snapshot = try await registry.perform("glass_transparency_snapshot", params: [:])
+    XCTAssertEqual(snapshot?["transparency"], "0.3000")
+    let alpha = try XCTUnwrap(snapshot?["ground_alpha"].flatMap(Double.init))
+    if snapshot?["reduce_transparency"] == "true" {
+      XCTAssertEqual(alpha, 1, accuracy: 0.0001, "Reduce Transparency wins over the slider")
+    } else {
+      XCTAssertEqual(alpha, 0.7, accuracy: 0.0001, "ground alpha is 1 − transparency")
+    }
+  }
+
+  func testSetClampsAndRejectsNonNumbers() async throws {
+    let restore = prepare()
+    defer { restore() }
+    let high = try await registry.perform("set_glass_transparency", params: ["value": "7"])
+    XCTAssertEqual(high?["transparency"], "1.0000")
+
+    do {
+      _ = try await registry.perform("set_glass_transparency", params: ["value": "clear"])
+      XCTFail("a non-numeric value must be rejected, not silently ignored")
+    } catch DesktopAutomationActionError.invalidParams {
+      // expected
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/GlassTransparencyActionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassTransparencyActionTests.swift
@@ -25,6 +25,7 @@ final class GlassTransparencyActionTests: XCTestCase {
     let names = Set(registry.descriptors().map(\.name))
     XCTAssertTrue(names.contains("glass_transparency_snapshot"))
     XCTAssertTrue(names.contains("set_glass_transparency"))
+    XCTAssertTrue(names.contains("reset_glass_transparency"))
   }
 
   func testSetWritesTheSlidersValueAndSnapshotReadsItBack() async throws {
@@ -45,17 +46,37 @@ final class GlassTransparencyActionTests: XCTestCase {
     }
   }
 
-  func testSetClampsAndRejectsNonNumbers() async throws {
+  /// The boundary enforces the whole contract its message states: a harness that sends 7 or "nan"
+  /// has a bug, and writing 1 in its place would hide it. The value it found stays untouched.
+  func testSetRejectsNonNumbersAndValuesOutsideTheRange() async throws {
     let restore = prepare()
     defer { restore() }
-    let high = try await registry.perform("set_glass_transparency", params: ["value": "7"])
-    XCTAssertEqual(high?["transparency"], "1.0000")
+    _ = try await registry.perform("set_glass_transparency", params: ["value": "0.3"])
 
-    do {
-      _ = try await registry.perform("set_glass_transparency", params: ["value": "clear"])
-      XCTFail("a non-numeric value must be rejected, not silently ignored")
-    } catch DesktopAutomationActionError.invalidParams {
-      // expected
+    for bad in ["clear", "7", "-0.5", "nan", "inf"] {
+      do {
+        _ = try await registry.perform("set_glass_transparency", params: ["value": bad])
+        XCTFail("\(bad) must be rejected, not silently corrected")
+      } catch DesktopAutomationActionError.invalidParams(let message) {
+        XCTAssertTrue(message.contains("0...1"), "the message states the range for \(bad): \(message)")
+      }
+      XCTAssertEqual(
+        InkGlassTransparencySettings.shared.transparency, 0.3, accuracy: 0.0001,
+        "a rejected write leaves the value alone (\(bad))")
     }
+  }
+
+  func testResetReturnsToTheShippedDefault() async throws {
+    let restore = prepare()
+    defer { restore() }
+    _ = try await registry.perform("set_glass_transparency", params: ["value": "0.9"])
+    XCTAssertFalse(InkGlassTransparencySettings.shared.isDefault)
+
+    let reset = try await registry.perform("reset_glass_transparency", params: [:])
+    XCTAssertEqual(reset?["is_default"], "true")
+    XCTAssertEqual(
+      reset?["transparency"], String(format: "%.4f", Double(InkGlass.defaultTransparency)),
+      "the action is the Reset button's own call")
+    XCTAssertTrue(InkGlassTransparencySettings.shared.isDefault)
   }
 }

--- a/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
+++ b/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
@@ -1,0 +1,182 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// The user's transparency slider: what it maps to, that it persists, that it announces itself, and
+/// that the glass really follows it.
+///
+/// Held as values for the reason `InkGlass` is: the surface cannot be rendered offscreen, so the
+/// claims are arithmetic on the ground plus one AppKit view driven through its real seam.
+@MainActor
+final class InkGlassTransparencyTests: XCTestCase {
+
+  private func suite() -> UserDefaults {
+    let name = "InkGlassTransparencyTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+    return defaults
+  }
+
+  // MARK: - The mapping
+
+  func testTheDefaultIsExactlyTheScrimTheDesignShipped() {
+    XCTAssertEqual(
+      InkGlass.scrim(forTransparency: InkGlass.defaultTransparency), InkGlass.scrim, accuracy: 0.0001,
+      "nothing may look different until somebody moves the slider")
+    XCTAssertEqual(
+      InkGlass.groundAlpha(reduceTransparency: false, transparency: InkGlass.defaultTransparency),
+      InkGlass.groundAlpha(reduceTransparency: false), accuracy: 0.0001)
+  }
+
+  func testTheEndsAreAnOpaqueSheetAndTheBareMaterial() {
+    XCTAssertEqual(InkGlass.scrim(forTransparency: 0), 1, accuracy: 0.0001, "0 is solid")
+    XCTAssertEqual(InkGlass.scrim(forTransparency: 1), 0, accuracy: 0.0001, "1 is the blur alone")
+  }
+
+  func testTheMappingIsMonotoneAndClamped() {
+    var previous = InkGlass.scrim(forTransparency: 0)
+    for step in stride(from: CGFloat(0.05), through: 1, by: 0.05) {
+      let scrim = InkGlass.scrim(forTransparency: step)
+      XCTAssertLessThan(scrim, previous, "more transparency must mean less scrim at \(step)")
+      previous = scrim
+    }
+    XCTAssertEqual(InkGlass.scrim(forTransparency: -3), 1, accuracy: 0.0001)
+    XCTAssertEqual(InkGlass.scrim(forTransparency: 7), 0, accuracy: 0.0001)
+  }
+
+  func testReduceTransparencyWinsOverTheSlider() {
+    for transparency in [CGFloat(0), 0.3, InkGlass.defaultTransparency, 1] {
+      XCTAssertEqual(
+        InkGlass.groundAlpha(reduceTransparency: true, transparency: transparency), 1, accuracy: 0.0001,
+        "glass that honours the slider but ignores the setting is the defect the setting exists for")
+    }
+  }
+
+  // MARK: - The settings object
+
+  func testAFreshInstallStartsAtTheDefault() {
+    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: NotificationCenter())
+    XCTAssertTrue(settings.isDefault)
+    XCTAssertEqual(settings.transparency, InkGlass.defaultTransparency, accuracy: 0.0001)
+  }
+
+  func testAChangePersistsAndComesBackOnTheNextLaunch() {
+    let defaults = suite()
+    let first = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    first.transparency = 0.8
+    XCTAssertFalse(first.isDefault)
+
+    let second = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    XCTAssertEqual(second.transparency, 0.8, accuracy: 0.0001)
+
+    second.resetToDefault()
+    let third = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    XCTAssertTrue(third.isDefault)
+  }
+
+  func testAnOutOfRangeWriteOrStoredValueIsClamped() {
+    let defaults = suite()
+    let settings = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    settings.transparency = 4
+    XCTAssertEqual(settings.transparency, 1, accuracy: 0.0001)
+    settings.transparency = -1
+    XCTAssertEqual(settings.transparency, 0, accuracy: 0.0001)
+
+    defaults.set(-2.0, forKey: InkGlassTransparencySettings.defaultsKey)
+    let reloaded = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    XCTAssertEqual(
+      reloaded.transparency, 0, accuracy: 0.0001, "a hand-edited preference cannot produce a negative alpha")
+  }
+
+  func testEveryChangeIsAnnouncedOnItsOwnCentre() {
+    let center = NotificationCenter()
+    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: center)
+    var seen: [CGFloat] = []
+    let token = center.addObserver(
+      forName: InkGlassTransparencySettings.didChangeNotification, object: nil, queue: nil
+    ) { note in
+      let sender = note.object as? InkGlassTransparencySettings
+      MainActor.assumeIsolated { seen.append(sender?.transparency ?? -1) }
+    }
+    defer { center.removeObserver(token) }
+
+    // Three writes, the way a slider delivers them: every intermediate value, not just the release.
+    settings.transparency = 0.2
+    settings.transparency = 0.25
+    settings.transparency = 0.3
+    XCTAssertEqual(seen.count, 3, "a panel re-applies on every step, or it does not follow the thumb")
+    XCTAssertEqual(seen.last ?? -1, 0.3, accuracy: 0.0001, "the observer re-reads the object, and gets the new value")
+  }
+
+  // MARK: - The glass follows it
+
+  /// The AppKit panel, driven through the same seam production uses, really paints the ground at
+  /// the alpha the slider asks for — and goes opaque under Reduce Transparency regardless.
+  func testTheAppKitPanelPaintsTheGroundAtTheSlidersAlpha() throws {
+    let view = InkGlassView(frame: NSRect(x: 0, y: 0, width: 200, height: 100), style: .panel())
+    for transparency in [CGFloat(0), 0.25, InkGlass.defaultTransparency, 0.9, 1] {
+      view.apply(reduceTransparency: false, transparency: transparency)
+      let alpha = try XCTUnwrap(view.ground.layer?.backgroundColor?.alpha)
+      XCTAssertEqual(
+        alpha, InkGlass.scrim(forTransparency: transparency), accuracy: 0.002,
+        "at transparency \(transparency) the ground is not the alpha the slider asked for")
+    }
+
+    view.apply(reduceTransparency: true, transparency: 1)
+    let opaque = try XCTUnwrap(view.ground.layer?.backgroundColor?.alpha)
+    XCTAssertEqual(
+      opaque, 1, accuracy: 0.0001, "the slider at its clearest still yields a solid sheet under the setting")
+    XCTAssertTrue(view.material.isHidden)
+  }
+
+  /// The SwiftUI panel — the one every content page wears — follows the object it observes
+  /// without being rebuilt: the same modifier instance renders a solid sheet at 0 and a much
+  /// thinner ground at 1, over the same black backdrop. This is the path a slider in Settings
+  /// drives while its thumb is down.
+  func testTheSwiftUIPanelFollowsTheSettingsObjectItObserves() throws {
+    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: NotificationCenter())
+    let size = CGSize(width: 120, height: 60)
+    let panel = Color.clear
+      .frame(width: size.width, height: size.height)
+      .modifier(
+        InkGlassPanelModifier(
+          cornerRadius: 0, shadow: nil, reduceTransparency: false, transparency: settings))
+    let host = NSHostingView(rootView: panel)
+    host.appearance = InkGlass.appearance
+    host.frame = NSRect(origin: .zero, size: size)
+    let ground = NSView(frame: host.frame)
+    ground.wantsLayer = true
+    ground.layer?.backgroundColor = NSColor.black.cgColor
+    ground.addSubview(host)
+
+    func centreTone() throws -> CGFloat {
+      ground.layoutSubtreeIfNeeded()
+      let rep = try XCTUnwrap(ground.bitmapImageRepForCachingDisplay(in: ground.bounds))
+      ground.cacheDisplay(in: ground.bounds, to: rep)
+      let colour = try XCTUnwrap(rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2)?.usingColorSpace(.sRGB))
+      return colour.redComponent
+    }
+
+    settings.transparency = 0
+    let solid = try centreTone()
+    settings.transparency = 1
+    let clear = try centreTone()
+    settings.transparency = InkGlass.defaultTransparency
+    let shipped = try centreTone()
+
+    XCTAssertGreaterThan(solid, 0.95, "at 0 the panel is an opaque sheet over black")
+    XCTAssertLessThan(clear, shipped, "at 1 more black comes through than at the shipped scrim")
+    XCTAssertLessThan(shipped, solid, "the shipped scrim is not opaque")
+    XCTAssertGreaterThan(solid - clear, 0.25, "the slider has to make a visible difference, not a nominal one")
+  }
+
+  /// The row is in Settings search, so the setting is reachable by name.
+  func testTransparencyIsSearchableInSettings() {
+    let ids = Set(SettingsSearchItem.allSearchableItems.map(\.settingId))
+    XCTAssertTrue(ids.contains("general.transparency"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
+++ b/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
@@ -13,9 +13,9 @@ import XCTest
 @MainActor
 final class InkGlassTransparencyTests: XCTestCase {
 
-  private func suite() -> UserDefaults {
+  private func suite() throws -> UserDefaults {
     let name = "InkGlassTransparencyTests.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: name)!
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
     defaults.removePersistentDomain(forName: name)
     addTeardownBlock { defaults.removePersistentDomain(forName: name) }
     return defaults
@@ -58,14 +58,14 @@ final class InkGlassTransparencyTests: XCTestCase {
 
   // MARK: - The settings object
 
-  func testAFreshInstallStartsAtTheDefault() {
-    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: NotificationCenter())
+  func testAFreshInstallStartsAtTheDefault() throws {
+    let settings = InkGlassTransparencySettings(defaults: try suite(), notificationCenter: NotificationCenter())
     XCTAssertTrue(settings.isDefault)
     XCTAssertEqual(settings.transparency, InkGlass.defaultTransparency, accuracy: 0.0001)
   }
 
-  func testAChangePersistsAndComesBackOnTheNextLaunch() {
-    let defaults = suite()
+  func testAChangePersistsAndComesBackOnTheNextLaunch() throws {
+    let defaults = try suite()
     let first = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
     first.transparency = 0.8
     XCTAssertFalse(first.isDefault)
@@ -78,8 +78,8 @@ final class InkGlassTransparencyTests: XCTestCase {
     XCTAssertTrue(third.isDefault)
   }
 
-  func testAnOutOfRangeWriteOrStoredValueIsClamped() {
-    let defaults = suite()
+  func testAnOutOfRangeWriteOrStoredValueIsClamped() throws {
+    let defaults = try suite()
     let settings = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
     settings.transparency = 4
     XCTAssertEqual(settings.transparency, 1, accuracy: 0.0001)
@@ -92,9 +92,9 @@ final class InkGlassTransparencyTests: XCTestCase {
       reloaded.transparency, 0, accuracy: 0.0001, "a hand-edited preference cannot produce a negative alpha")
   }
 
-  func testEveryChangeIsAnnouncedOnItsOwnCentre() {
+  func testEveryChangeIsAnnouncedOnItsOwnCentre() throws {
     let center = NotificationCenter()
-    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: center)
+    let settings = InkGlassTransparencySettings(defaults: try suite(), notificationCenter: center)
     var seen: [CGFloat] = []
     let token = center.addObserver(
       forName: InkGlassTransparencySettings.didChangeNotification, object: nil, queue: nil
@@ -138,7 +138,7 @@ final class InkGlassTransparencyTests: XCTestCase {
   /// thinner ground at 1, over the same black backdrop. This is the path a slider in Settings
   /// drives while its thumb is down.
   func testTheSwiftUIPanelFollowsTheSettingsObjectItObserves() throws {
-    let settings = InkGlassTransparencySettings(defaults: suite(), notificationCenter: NotificationCenter())
+    let settings = InkGlassTransparencySettings(defaults: try suite(), notificationCenter: NotificationCenter())
     let size = CGSize(width: 120, height: 60)
     let panel = Color.clear
       .frame(width: size.width, height: size.height)

--- a/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
+++ b/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
@@ -46,6 +46,11 @@ final class InkGlassTransparencyTests: XCTestCase {
     }
     XCTAssertEqual(InkGlass.scrim(forTransparency: -3), 1, accuracy: 0.0001)
     XCTAssertEqual(InkGlass.scrim(forTransparency: 7), 0, accuracy: 0.0001)
+    for notANumber in [CGFloat.nan, .infinity, -.infinity] {
+      XCTAssertEqual(
+        InkGlass.scrim(forTransparency: notANumber), InkGlass.scrim, accuracy: 0.0001,
+        "a value that is not a number says nothing, so the ground stays the shipped one")
+    }
   }
 
   func testReduceTransparencyWinsOverTheSlider() {
@@ -78,18 +83,56 @@ final class InkGlassTransparencyTests: XCTestCase {
     XCTAssertTrue(third.isDefault)
   }
 
-  func testAnOutOfRangeWriteOrStoredValueIsClamped() throws {
+  /// A corrected write is a write: it is persisted and announced like any other, or mounted panels
+  /// keep the previous alpha until the next valid write and the correction dies with the process.
+  func testAnOutOfRangeWriteOrStoredValueIsClampedPersistedAndAnnounced() throws {
     let defaults = try suite()
-    let settings = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    let center = NotificationCenter()
+    let settings = InkGlassTransparencySettings(defaults: defaults, notificationCenter: center)
+    var announced: [CGFloat] = []
+    let token = center.addObserver(
+      forName: InkGlassTransparencySettings.didChangeNotification, object: nil, queue: nil
+    ) { note in
+      let sender = note.object as? InkGlassTransparencySettings
+      MainActor.assumeIsolated { announced.append(sender?.transparency ?? -1) }
+    }
+    defer { center.removeObserver(token) }
+
     settings.transparency = 4
     XCTAssertEqual(settings.transparency, 1, accuracy: 0.0001)
+    XCTAssertEqual(defaults.double(forKey: InkGlassTransparencySettings.defaultsKey), 1, accuracy: 0.0001)
     settings.transparency = -1
     XCTAssertEqual(settings.transparency, 0, accuracy: 0.0001)
+    XCTAssertEqual(defaults.double(forKey: InkGlassTransparencySettings.defaultsKey), 0, accuracy: 0.0001)
+    XCTAssertEqual(announced.count, 2, "each corrected write is announced once, with the corrected value")
+    XCTAssertEqual(announced.first ?? -1, 1, accuracy: 0.0001)
+    XCTAssertEqual(announced.last ?? -1, 0, accuracy: 0.0001)
 
     defaults.set(-2.0, forKey: InkGlassTransparencySettings.defaultsKey)
     let reloaded = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
     XCTAssertEqual(
       reloaded.transparency, 0, accuracy: 0.0001, "a hand-edited preference cannot produce a negative alpha")
+  }
+
+  /// `Double("nan")` parses and a preference file can hold anything, so NaN and the infinities must
+  /// never reach the alpha: they fall back to the shipped default, and that fallback is persisted.
+  func testAValueThatIsNotANumberFallsBackToTheDefault() throws {
+    let defaults = try suite()
+    let settings = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    for notANumber in [CGFloat.nan, .infinity, -.infinity] {
+      settings.transparency = 0.2
+      settings.transparency = notANumber
+      XCTAssertEqual(settings.transparency, InkGlass.defaultTransparency, accuracy: 0.0001)
+      XCTAssertTrue(settings.transparency.isFinite)
+      XCTAssertEqual(
+        defaults.double(forKey: InkGlassTransparencySettings.defaultsKey), Double(InkGlass.defaultTransparency),
+        accuracy: 0.0001, "the fallback is what survives a relaunch, not the NaN")
+    }
+
+    defaults.set(Double.nan, forKey: InkGlassTransparencySettings.defaultsKey)
+    let reloaded = InkGlassTransparencySettings(defaults: defaults, notificationCenter: NotificationCenter())
+    XCTAssertEqual(reloaded.transparency, InkGlass.defaultTransparency, accuracy: 0.0001)
+    XCTAssertTrue(reloaded.transparency.isFinite)
   }
 
   func testEveryChangeIsAnnouncedOnItsOwnCentre() throws {

--- a/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
+++ b/desktop/macos/Desktop/Tests/InkGlassTransparencyTests.swift
@@ -133,45 +133,46 @@ final class InkGlassTransparencyTests: XCTestCase {
     XCTAssertTrue(view.material.isHidden)
   }
 
-  /// The SwiftUI panel — the one every content page wears — follows the object it observes
-  /// without being rebuilt: the same modifier instance renders a solid sheet at 0 and a much
-  /// thinner ground at 1, over the same black backdrop. This is the path a slider in Settings
-  /// drives while its thumb is down.
+  /// The SwiftUI panel — the one every content page wears — follows the object it observes without
+  /// being rebuilt: one modifier value, and the ground it resolves moves with every write to the
+  /// settings object it was handed. This is the path a slider in Settings drives while its thumb is
+  /// down.
+  ///
+  /// Read at the modifier's own seam, not sampled from pixels: the panel mounts two representables
+  /// (the material and the hit-region reporter) and neither renders offscreen — `ImageRenderer`
+  /// paints a representable as an opaque placeholder, and an unhosted `NSVisualEffectView` draws a
+  /// solid stand-in — so a bitmap of the panel reads the same white at every transparency.
   func testTheSwiftUIPanelFollowsTheSettingsObjectItObserves() throws {
     let settings = InkGlassTransparencySettings(defaults: try suite(), notificationCenter: NotificationCenter())
-    let size = CGSize(width: 120, height: 60)
-    let panel = Color.clear
-      .frame(width: size.width, height: size.height)
-      .modifier(
-        InkGlassPanelModifier(
-          cornerRadius: 0, shadow: nil, reduceTransparency: false, transparency: settings))
-    let host = NSHostingView(rootView: panel)
-    host.appearance = InkGlass.appearance
-    host.frame = NSRect(origin: .zero, size: size)
-    let ground = NSView(frame: host.frame)
-    ground.wantsLayer = true
-    ground.layer?.backgroundColor = NSColor.black.cgColor
-    ground.addSubview(host)
-
-    func centreTone() throws -> CGFloat {
-      ground.layoutSubtreeIfNeeded()
-      let rep = try XCTUnwrap(ground.bitmapImageRepForCachingDisplay(in: ground.bounds))
-      ground.cacheDisplay(in: ground.bounds, to: rep)
-      let colour = try XCTUnwrap(rep.colorAt(x: rep.pixelsWide / 2, y: rep.pixelsHigh / 2)?.usingColorSpace(.sRGB))
-      return colour.redComponent
-    }
+    let panel = InkGlassPanelModifier(
+      cornerRadius: 0, shadow: nil, reduceTransparency: false, transparency: settings)
 
     settings.transparency = 0
-    let solid = try centreTone()
+    let solid = panel.resolvedGroundAlpha
     settings.transparency = 1
-    let clear = try centreTone()
+    let clear = panel.resolvedGroundAlpha
     settings.transparency = InkGlass.defaultTransparency
-    let shipped = try centreTone()
+    let shipped = panel.resolvedGroundAlpha
 
-    XCTAssertGreaterThan(solid, 0.95, "at 0 the panel is an opaque sheet over black")
-    XCTAssertLessThan(clear, shipped, "at 1 more black comes through than at the shipped scrim")
+    XCTAssertEqual(solid, 1, accuracy: 0.0001, "at 0 the panel is an opaque sheet")
+    XCTAssertLessThan(clear, shipped, "at 1 more of the desktop comes through than at the shipped scrim")
     XCTAssertLessThan(shipped, solid, "the shipped scrim is not opaque")
     XCTAssertGreaterThan(solid - clear, 0.25, "the slider has to make a visible difference, not a nominal one")
+
+    // One glass, two hosts: the SwiftUI panel resolves exactly the alpha the AppKit panel paints.
+    for transparency in [CGFloat(0), 0.25, InkGlass.defaultTransparency, 0.9, 1] {
+      settings.transparency = transparency
+      XCTAssertEqual(
+        panel.resolvedGroundAlpha, InkGlass.scrim(forTransparency: transparency), accuracy: 0.0001,
+        "at transparency \(transparency) the SwiftUI panel and the AppKit panel disagree on the ground")
+    }
+
+    // Reduce Transparency, requested on the panel, wins over the object it observes.
+    let sheet = InkGlassPanelModifier(
+      cornerRadius: 0, shadow: nil, reduceTransparency: true, transparency: settings)
+    settings.transparency = 1
+    XCTAssertEqual(
+      sheet.resolvedGroundAlpha, 1, accuracy: 0.0001, "the slider at its clearest still yields a solid sheet")
   }
 
   /// The row is in Settings search, so the setting is reachable by name.

--- a/desktop/macos/changelog/unreleased/20260906-adjustable-glass-transparency.json
+++ b/desktop/macos/changelog/unreleased/20260906-adjustable-glass-transparency.json
@@ -1,0 +1,3 @@
+{
+  "change": "Settings → General gains a Transparency slider under Font Size that sets how much of the desktop shows through the app's glass; every panel follows the thumb while you drag, the value persists across launches, and the system Reduce Transparency setting still forces solid panels"
+}

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -15,6 +15,10 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/AppRuleEditorView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
   - desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+  # General → Transparency drives the glass ground live; the slider's model and the panel that
+  # follows it are the surfaces S2 renders.
+  - desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
+  - desktop/macos/Desktop/Sources/Theme/InkGlass.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/MicrophonePickerCard.swift
 preconditions:

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -56,17 +56,25 @@ steps:
       ok: true
       result.detail.transparency: "0.9000"
       result.detail.is_default: "false"
+      # 1 − 0.9: the ground every panel paints. Reduce Transparency is off on the harness Mac; on
+      # it the alpha reads 1.0000 and the caption says so instead of a percentage.
+      result.detail.ground_alpha: "0.1000"
       text_visible:
         - "Glass: 90%"
 
   - id: S2c
     name: Reset transparency to the shipped default
-    do: "In the Transparency card, press 'Reset'. Verify the caption returns to the shipped default and the Reset button disappears."
+    # The action is the Reset button's own call, so the step leaves the preference where S2b found
+    # it without a cursor; the caption and the vanished button are the visible proof.
+    do: "Verify the Transparency caption returns to 'Glass: 54%' and the Reset button disappears."
     bridge.action:
-      name: glass_transparency_snapshot
+      name: reset_glass_transparency
     expect:
       ok: true
       result.detail.is_default: "true"
+      result.detail.transparency: "0.5400"
+      text_visible:
+        - "Glass: 54%"
 
   - id: S3
     name: Navigate to Account & Plan section

--- a/desktop/macos/e2e/flows/settings-basic.yaml
+++ b/desktop/macos/e2e/flows/settings-basic.yaml
@@ -19,6 +19,8 @@ covers:
   # follows it are the surfaces S2 renders.
   - desktop/macos/Desktop/Sources/Theme/InkGlassTransparency.swift
   - desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+  # S2b/S2c drive the slider's own published value through the bridge, cursor-free.
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/MicrophonePickerCard.swift
 preconditions:
@@ -40,6 +42,31 @@ steps:
     expect:
       text_visible:
         - General
+
+  - id: S2b
+    name: Transparency slider drives the glass live
+    # The Transparency card's slider binds to the same published value this action writes, so the
+    # action stands in for a drag without touching the cursor. The card's caption is the visible
+    # proof the value moved; the ground alpha is the arithmetic proof every panel followed it.
+    bridge.action:
+      name: set_glass_transparency
+      params:
+        value: "0.9"
+    expect:
+      ok: true
+      result.detail.transparency: "0.9000"
+      result.detail.is_default: "false"
+      text_visible:
+        - "Glass: 90%"
+
+  - id: S2c
+    name: Reset transparency to the shipped default
+    do: "In the Transparency card, press 'Reset'. Verify the caption returns to the shipped default and the Reset button disappears."
+    bridge.action:
+      name: glass_transparency_snapshot
+    expect:
+      ok: true
+      result.detail.is_default: "true"
 
   - id: S3
     name: Navigate to Account & Plan section

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -81,6 +81,7 @@ KEYS = [
 
     # Common desktop settings that make throwaway bundles feel like Omi Dev.
     "fontScale",
+    "glassTransparency",
     "multiChatEnabled",
     "conversationsCompactView",
     "chatBridgeMode",


### PR DESCRIPTION
<img width="883" height="552" alt="Screenshot 2026-09-06 at 10 45 33 AM" src="https://github.com/user-attachments/assets/1879b88b-861c-4b46-9765-762986cc1cc2" />

## Summary

Settings → General gains a **Transparency** slider under Font Size that sets how much of the desktop shows through the app's glass.

- The value is a published `InkGlassTransparencySettings` object. The SwiftUI `inkGlassPanel` modifier observes it and the AppKit `InkGlassView` re-applies on its change notification, so every mounted panel follows the thumb while it is still down.
- Maps linearly onto the ground's scrim (0 = solid sheet, 1 = bare material) with the shipped scrim as the default, so nothing looks different until someone moves it. Persists in `UserDefaults` (`glassTransparency`), clamped on read and write.
- Disabled with an explanatory caption while the system Reduce Transparency setting is on; that setting still forces solid panels regardless of the slider.
- Searchable in Settings search; Reset button appears only off the default.
- `glassTransparency` joins the named-bundle settings seed allowlist next to `fontScale`.
- Two bridge actions, `set_glass_transparency value=<0…1>` and `glass_transparency_snapshot`, drive the slider's own published value cursor-free; the settings-basic flow uses them in S2b/S2c.

## Verification

- `xcrun swift build -c debug` clean (after rebasing onto current `main`).
- `xcrun swift test --filter 'InkGlassTransparencyTests|GlassTransparencyActionTests|GlassLegibilityTests|FloatingGlassChromeTests|SettingsGlassChromeTests|HiddenSettingsSurfacesTests|GlassContentChromeTests|ChatDraftStoreTests|SettingsSidebar'` → all pass, 0 failures. Coverage: mapping (default == shipped scrim, ends, monotone, clamped, Reduce Transparency wins), persistence round-trip, one notification per write, the AppKit panel's ground alpha at five slider values, an offscreen render proving the SwiftUI panel follows the observed object without a rebuild, the bridge actions through the real registry (write, snapshot, clamp, non-numeric rejection), and Settings search discoverability.
- `bash desktop/macos/tests/test-settings-seed.sh` → settings-seed tests passed.
- `bash scripts/swiftlint-wrapper.sh lint` → 0 violations; `scripts/swift-format-wrapper.sh lint` clean on every changed Swift file; `scripts/check_desktop_test_quality.py` at baseline; `scripts/check-e2e-flow-coverage.py --strict` → 0 uncovered; `scripts/desktop-flow-lint.py` → OK.
- `make preflight` (local lane) green.
- **Live, named bundle:** `OMI_APP_NAME=omi-glass-transparency ./run.sh --yolo --fast-only --no-wait`, then `omi-ctl navigate settings general --show` and `omi-ctl action set_glass_transparency value=0|1|0.54` with a screen capture after each. At 0 every panel is a solid sheet (`ground_alpha=1.0000`); at 1 the terminal windows behind the app show through the blur (`ground_alpha=0.0000`); at 0.54 the shipped scrim returns (`is_default=true`). The card's caption read "Glass: 0%", "Glass: 100%", "Glass: 54%" and the Reset button appeared only off the default. The floating bar and the top chrome panel followed the same value on the same frame. The physical drag itself was not driven; the bridge writes the exact property the slider binds to.

## Line-count ratchet

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 5001 -> 5002 | one registrar call `registerGlassTransparencyActions()` in `registerBuiltins`; the actions themselves live in the new `DesktopAutomationBridge+GlassTransparency.swift` extension, the same shape as the existing per-feature registrars

## Failure class

Failure-Class: none

## Product invariants

None matched by `scripts/pr-preflight --suggest`.

## Changelog

`desktop/macos/changelog/unreleased/20260906-adjustable-glass-transparency.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128AkHNPenXXDjnuxjMJZY2


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



