### PR TITLE
S21: mobile local segment store (no capture_controller collision)

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -49,6 +49,7 @@ import 'package:omi/providers/announcement_provider.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/auth_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/services/capture/local_segment_store.dart';
 import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/providers/device_provider.dart';
@@ -363,7 +364,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         ),
         ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
             CaptureProvider>(
-          create: (context) => CaptureProvider(),
+          create: (context) => CaptureProvider(localSegmentStore: LocalSegmentStore.appSupport()),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) {
             final externalActions = ProviderCaptureExternalActions(
               conversationProvider: conversation,
@@ -372,7 +373,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               usageProvider: usage,
             );
             return (previous?..updateExternalActions(externalActions)) ??
-                CaptureProvider(externalActions: externalActions);
+                CaptureProvider(
+                  externalActions: externalActions,
+                  localSegmentStore: LocalSegmentStore.appSupport(),
+                );
           },
         ),
         ChangeNotifierProxyProvider<ConversationProvider, LocalRecordingsProvider>(

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:omi/services/capture/capture_controller.dart';
+import 'package:omi/services/capture/local_segment_store.dart';
 
 class CaptureProvider extends CaptureController {
   CaptureProvider({
@@ -9,5 +12,30 @@ class CaptureProvider extends CaptureController {
     super.microphonePermissionRequester,
     super.phoneMicBatchRecorder,
     super.recordingTelemetry,
-  });
+    LocalSegmentStore? localSegmentStore,
+  }) : localSegmentStore = localSegmentStore ?? LocalSegmentStore.disabled() {
+    addListener(_persistLiveSegments);
+  }
+
+  final LocalSegmentStore localSegmentStore;
+  String? _lastPersistedFingerprint;
+
+  void _persistLiveSegments() {
+    if (!localSegmentStore.enabled) return;
+    final sessionId = activeCaptureSessionId ?? activeRecordingId;
+    if (sessionId == null) return;
+    final fingerprint = segments
+        .map((segment) =>
+            '${segment.id}:${segment.speaker}:${segment.speakerId}:${segment.isUser}:${segment.personId ?? ''}:${segment.text}')
+        .join('\n');
+    if (fingerprint == _lastPersistedFingerprint) return;
+    _lastPersistedFingerprint = fingerprint;
+    unawaited(localSegmentStore.replaceSession(sessionId, List.of(segments)));
+  }
+
+  @override
+  void dispose() {
+    removeListener(_persistLiveSegments);
+    super.dispose();
+  }
 }

--- a/app/lib/services/capture/local_segment_store.dart
+++ b/app/lib/services/capture/local_segment_store.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/utils/transcript_hash.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Durable live-caption segments for S21 / S22.
+///
+/// File-backed JSON under application-support `local_segments/`, not
+/// sqflite/Drift — `app/` has no SQLite plugin today and this shard must
+/// not add a native dependency. The bytes on disk are the v5 hash payload
+/// (speaker, speaker_id, is_user, person_id, text) plus timings/ids S22
+/// will need. [release] deletes a session after the projection is accepted.
+class LocalSegmentStore {
+  LocalSegmentStore._({required this.enabled, Directory? directory}) : _directory = directory;
+
+  factory LocalSegmentStore.disabled() => LocalSegmentStore._(enabled: false);
+
+  factory LocalSegmentStore.at(Directory directory) => LocalSegmentStore._(enabled: true, directory: directory);
+
+  /// Lazy application-support directory. Safe to construct off the first write.
+  factory LocalSegmentStore.appSupport() => LocalSegmentStore._(enabled: true);
+
+  static const folderName = 'local_segments';
+
+  final bool enabled;
+  Directory? _directory;
+
+  Future<Directory> resolveDirectory() async {
+    if (_directory != null) return _directory!;
+    final root = await getApplicationSupportDirectory();
+    final dir = Directory('${root.path}/$folderName');
+    await dir.create(recursive: true);
+    _directory = dir;
+    return dir;
+  }
+
+  File _fileFor(Directory dir, String sessionId) {
+    final safe = sessionId.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '_');
+    return File('${dir.path}/$safe.json');
+  }
+
+  Future<void> replaceSession(String sessionId, List<TranscriptSegment> segments) async {
+    if (!enabled) return;
+    final dir = await resolveDirectory();
+    await dir.create(recursive: true);
+    final file = _fileFor(dir, sessionId);
+    final tmp = File('${file.path}.tmp');
+    final payload = <String, Object?>{
+      'encoding_version': transcriptHashEncodingVersion,
+      'session_id': sessionId,
+      'transcript_sha256': transcriptSha256(segments),
+      'segments': segments.map(_segmentToJson).toList(),
+    };
+    await tmp.writeAsString(jsonEncode(payload));
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await tmp.rename(file.path);
+  }
+
+  Future<List<TranscriptSegment>> loadSession(String sessionId) async {
+    if (!enabled) return const [];
+    final dir = await resolveDirectory();
+    final file = _fileFor(dir, sessionId);
+    if (!await file.exists()) return const [];
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map<String, dynamic>) return const [];
+    final raw = decoded['segments'];
+    if (raw is! List) return const [];
+    return raw.whereType<Map<String, dynamic>>().map(_segmentFromJson).toList();
+  }
+
+  Future<String?> loadDigest(String sessionId) async {
+    if (!enabled) return null;
+    final dir = await resolveDirectory();
+    final file = _fileFor(dir, sessionId);
+    if (!await file.exists()) return null;
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map<String, dynamic>) return null;
+    final digest = decoded['transcript_sha256'];
+    return digest is String ? digest : null;
+  }
+
+  Future<void> release(String sessionId) async {
+    if (!enabled) return;
+    final dir = await resolveDirectory();
+    final file = _fileFor(dir, sessionId);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  static Map<String, Object?> _segmentToJson(TranscriptSegment segment) {
+    final kept = canonicalizeTranscriptSegment(segment);
+    return {
+      'id': segment.id,
+      'speaker': kept.speaker,
+      'speaker_id': kept.speakerId,
+      'is_user': kept.isUser,
+      'person_id': kept.personId,
+      'text': kept.text,
+      'start': segment.start,
+      'end': segment.end,
+    };
+  }
+
+  static TranscriptSegment _segmentFromJson(Map<String, dynamic> json) {
+    final kept = canonicalizeSegment(
+      speaker: json['speaker'] as String?,
+      speakerId: json['speaker_id'] as int?,
+      isUser: json['is_user'] as bool?,
+      personId: json['person_id'] as String?,
+      text: json['text'] as String?,
+    );
+    final segment = TranscriptSegment(
+      id: json['id'] as String? ?? '',
+      text: kept.text,
+      speaker: kept.speaker,
+      isUser: kept.isUser,
+      personId: kept.personId,
+      start: (json['start'] as num?)?.toDouble() ?? 0,
+      end: (json['end'] as num?)?.toDouble() ?? 0,
+      translations: const [],
+    );
+    // Constructor re-derives speakerId from the label; restore the stored id
+    // so SPEAKER_00 + speaker_id 7 (v5) survives a reload.
+    segment.speakerId = kept.speakerId;
+    return segment;
+  }
+}

--- a/app/lib/utils/transcript_hash.dart
+++ b/app/lib/utils/transcript_hash.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+
+/// Client copy of `omi:backend/utils/conversations/transcript_hash.py` encoding v5.
+///
+/// The digest is a wire contract. Bump [transcriptHashEncodingVersion] when
+/// the framing changes. The version is not mixed into the digest bytes.
+const int transcriptHashEncodingVersion = 5;
+
+const String defaultSpeaker = 'SPEAKER_00';
+const int defaultSpeakerId = 0;
+const String isUserToken = 'Y';
+const String notUserToken = 'N';
+
+class CanonicalTranscriptSegment {
+  const CanonicalTranscriptSegment({
+    required this.speaker,
+    required this.speakerId,
+    required this.isUser,
+    required this.personId,
+    required this.text,
+  });
+
+  final String speaker;
+  final int speakerId;
+  final bool isUser;
+  final String? personId;
+  final String text;
+}
+
+String _stripOrDefault(String? raw, [String defaultValue = '']) {
+  if (raw == null) return defaultValue;
+  final stripped = raw.trim();
+  if (stripped.isEmpty) return defaultValue;
+  return stripped;
+}
+
+int derivedSpeakerId(String canonicalSpeaker) {
+  final parts = canonicalSpeaker.split('_');
+  if (parts.length < 2) return defaultSpeakerId;
+  return int.tryParse(parts[1]) ?? defaultSpeakerId;
+}
+
+CanonicalTranscriptSegment canonicalizeSegment({
+  String? speaker,
+  int? speakerId,
+  bool? isUser,
+  String? personId,
+  String? text,
+}) {
+  final canonicalSpeaker = _stripOrDefault(speaker, defaultSpeaker);
+  final canonicalPerson = _stripOrDefault(personId);
+  return CanonicalTranscriptSegment(
+    speaker: canonicalSpeaker,
+    speakerId: speakerId ?? derivedSpeakerId(canonicalSpeaker),
+    isUser: isUser == true,
+    personId: canonicalPerson.isEmpty ? null : canonicalPerson,
+    text: _stripOrDefault(text),
+  );
+}
+
+CanonicalTranscriptSegment canonicalizeTranscriptSegment(TranscriptSegment segment) {
+  return canonicalizeSegment(
+    speaker: segment.speaker,
+    speakerId: segment.speakerId,
+    isUser: segment.isUser,
+    personId: segment.personId,
+    text: segment.text,
+  );
+}
+
+List<int> _frame(String value) {
+  final encoded = utf8.encode(value);
+  return [...ascii.encode('${encoded.length}\n'), ...encoded];
+}
+
+List<int> canonicalTranscriptBytes(Iterable<CanonicalTranscriptSegment> parts) {
+  final out = <int>[];
+  for (final part in parts) {
+    out
+      ..addAll(_frame(part.speaker))
+      ..addAll(_frame('${part.speakerId}'))
+      ..addAll(_frame(part.isUser ? isUserToken : notUserToken))
+      ..addAll(_frame(part.personId ?? ''))
+      ..addAll(_frame(part.text));
+  }
+  return out;
+}
+
+String transcriptSha256FromCanonical(Iterable<CanonicalTranscriptSegment> parts) {
+  return sha256.convert(canonicalTranscriptBytes(parts)).toString();
+}
+
+String transcriptSha256(Iterable<TranscriptSegment> segments) {
+  return transcriptSha256FromCanonical(segments.map(canonicalizeTranscriptSegment));
+}
+
+String transcriptSha256FromMaps(Iterable<Map<String, Object?>> segments) {
+  return transcriptSha256FromCanonical(
+    segments.map(
+      (segment) => canonicalizeSegment(
+        speaker: segment['speaker'] as String?,
+        speakerId: segment['speaker_id'] as int?,
+        isUser: segment['is_user'] as bool?,
+        personId: segment['person_id'] as String?,
+        text: segment['text'] as String?,
+      ),
+    ),
+  );
+}

--- a/app/test/unit/local_segment_store_test.dart
+++ b/app/test/unit/local_segment_store_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/services/capture/local_segment_store.dart';
+import 'package:omi/utils/transcript_hash.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+
+TranscriptSegment _seg(String id, String text, {String speaker = 'Alice'}) {
+  return TranscriptSegment(
+    id: id,
+    text: text,
+    speaker: speaker,
+    isUser: false,
+    personId: null,
+    start: 0,
+    end: 1,
+    translations: const [],
+  );
+}
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('s21-segments-');
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  test('disabled store writes nothing', () async {
+    final store = LocalSegmentStore.disabled();
+    await store.replaceSession('live-1', [_seg('a', 'hello')]);
+    expect(await store.loadSession('live-1'), isEmpty);
+    expect(dir.listSync(), isEmpty);
+  });
+
+  test('replace + new store instance reloads the exact hash payload', () async {
+    const sessionId = 'live-1700000000';
+    final first = LocalSegmentStore.at(dir);
+    final segments = [_seg('a', 'I agree', speaker: 'Alice'), _seg('b', 'I refuse', speaker: 'Bob')];
+    await first.replaceSession(sessionId, segments);
+
+    final killed = LocalSegmentStore.at(dir);
+    final loaded = await killed.loadSession(sessionId);
+    expect(loaded, hasLength(2));
+    expect(transcriptSha256(loaded), '6698e08ad93c92100b75e3ab279d15bfa3a70288b1693377841759a26e588d40');
+    expect(await killed.loadDigest(sessionId), transcriptSha256(loaded));
+  });
+
+  test('reload preserves an explicit speaker_id that the label does not name', () async {
+    const sessionId = 'live-7';
+    final original = _seg('a', 'I approved the transfer', speaker: 'SPEAKER_00');
+    original.speakerId = 7;
+    await LocalSegmentStore.at(dir).replaceSession(sessionId, [original]);
+
+    final loaded = await LocalSegmentStore.at(dir).loadSession(sessionId);
+    expect(loaded.single.speakerId, 7);
+    expect(transcriptSha256(loaded), 'd7dfcd646cda9e7d068693db981c82e11d144d376c800ba0640b611d3768ecdf');
+  });
+
+  test('release deletes the session file after projection acceptance', () async {
+    const sessionId = 'live-done';
+    final store = LocalSegmentStore.at(dir);
+    await store.replaceSession(sessionId, [_seg('a', 'hello')]);
+    expect(await store.loadSession(sessionId), isNotEmpty);
+    await store.release(sessionId);
+    expect(await store.loadSession(sessionId), isEmpty);
+    expect(await store.loadDigest(sessionId), isNull);
+  });
+
+  test('CaptureProvider listener persists when a live session is active', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final store = LocalSegmentStore.at(dir);
+    final provider = CaptureProvider(localSegmentStore: store);
+    addTearDown(provider.dispose);
+    provider.testSessionStartSeconds = 1700000000;
+    provider.segments = [_seg('a', 'I agree', speaker: 'Alice'), _seg('b', 'I refuse', speaker: 'Bob')];
+    provider.notifyListeners();
+    await pumpEventQueue();
+
+    final loaded = await LocalSegmentStore.at(dir).loadSession('live-1700000000');
+    expect(transcriptSha256(loaded), '6698e08ad93c92100b75e3ab279d15bfa3a70288b1693377841759a26e588d40');
+  });
+}

--- a/app/test/unit/transcript_hash_test.dart
+++ b/app/test/unit/transcript_hash_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/utils/transcript_hash.dart';
+
+TranscriptSegment _seg(
+  String text, {
+  String speaker = 'SPEAKER_00',
+  bool isUser = false,
+  String? personId,
+  String id = 's',
+}) {
+  return TranscriptSegment(
+    id: id,
+    text: text,
+    speaker: speaker,
+    isUser: isUser,
+    personId: personId,
+    start: 0,
+    end: 1,
+    translations: const [],
+  );
+}
+
+void main() {
+  test('encoding version is v5', () {
+    expect(transcriptHashEncodingVersion, 5);
+  });
+
+  test('known-answer vector pins Alice/Bob to the Python digest', () {
+    const digest = '6698e08ad93c92100b75e3ab279d15bfa3a70288b1693377841759a26e588d40';
+    expect(
+      transcriptSha256FromMaps([
+        {'speaker': 'Alice', 'text': 'I agree'},
+        {'speaker': 'Bob', 'text': 'I refuse'},
+      ]),
+      digest,
+    );
+    expect(
+      transcriptSha256([_seg('I agree', speaker: 'Alice'), _seg('I refuse', speaker: 'Bob')]),
+      digest,
+    );
+  });
+
+  test('empty list hashes the empty byte string', () {
+    expect(transcriptSha256FromMaps([]), 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+    expect(
+      transcriptSha256FromMaps([
+        {'text': ''},
+      ]),
+      '1f4edaaa8c0b550ed42040ed654a8bccfd34e121da991f1b986f9821e3d360a8',
+    );
+    expect(
+      transcriptSha256FromMaps([
+        {'text': ''},
+      ]),
+      isNot('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'),
+    );
+  });
+
+  test('hello/world and unicode match the Python fixtures', () {
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'hello'},
+        {'text': 'world'},
+      ]),
+      '8c07ee1d1a21bd1f1f319362b1435d6e875f8e24ef326dc08ecf113e226e3410',
+    );
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'café 你好'},
+      ]),
+      'de349219ac8122fb4f1bd000167d933ed6657dff1ad3835e1deb06a2bf79eef5',
+    );
+  });
+
+  test('attribution and speaker_id change the digest', () {
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'I approved the transfer', 'is_user': true},
+      ]),
+      '51d7fb6fb4e3cf863a1210d21280cbfb91e8dd16d818d9d6208af00470a5e3c9',
+    );
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'I approved the transfer', 'person_id': 'alice'},
+      ]),
+      '55629d482ae03ac3ca5f315ff39a6ac156e1ada4e4f6428b2a6fb9ec88b36a8d',
+    );
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'I approved the transfer', 'speaker_id': 0},
+      ]),
+      '863cf7938e692d22b06f5b757ad5330a517c87f60d115e5dd97a973fbc248d50',
+    );
+    expect(
+      transcriptSha256FromMaps([
+        {'text': 'I approved the transfer', 'speaker_id': 7},
+      ]),
+      'd7dfcd646cda9e7d068693db981c82e11d144d376c800ba0640b611d3768ecdf',
+    );
+  });
+
+  test('SPEAKER_07 without speaker_id derives 7', () {
+    expect(
+      transcriptSha256FromMaps([
+        {'speaker': 'SPEAKER_07', 'text': 'hello'},
+      ]),
+      transcriptSha256([_seg('hello', speaker: 'SPEAKER_07')]),
+    );
+  });
+
+  test('padded speaker and text strip to the same digest', () {
+    expect(
+      transcriptSha256FromMaps([
+        {'speaker': '  SPEAKER_07  ', 'text': '  hello  '},
+      ]),
+      transcriptSha256FromMaps([
+        {'speaker': 'SPEAKER_07', 'text': 'hello'},
+      ]),
+    );
+  });
+
+  test('swapped attribution is a different digest', () {
+    const original = '6698e08ad93c92100b75e3ab279d15bfa3a70288b1693377841759a26e588d40';
+    expect(
+      transcriptSha256FromMaps([
+        {'speaker': 'Bob', 'text': 'I agree'},
+        {'speaker': 'Alice', 'text': 'I refuse'},
+      ]),
+      isNot(original),
+    );
+  });
+}


### PR DESCRIPTION
## S21 — mobile local segment store

Shard S21 of the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S21; spec `40-mobile-pendant-port.md` §4.3). S22 will attach `client_processing`; this PR only persists the live-caption payload.

**#11681 recheck (2026-09-06):** still OPEN, last updated 2026-08-19. It rewrites `capture_controller.dart` and `transcription_service.dart`. This PR does **not** edit those files. The write hook lives on `CaptureProvider` (a file #11681 does not touch) and is wired from `main.dart`.

### Plan correction (dated 2026-09-06)

The row said sqflite/Drift. `app/` has no SQLite plugin in use for transcripts (WAL is audio-only). Adding a native plugin is not required for "survive app kill + exact hash payload." As built: dart:io JSON files under application-support `local_segments/`, injectable directory for tests.

### What changed

- Dart port of encoding-v5 `transcript_sha256` (speaker, speaker_id, is_user, person_id, text). Known-answer vectors copied from `backend/tests/unit/test_transcript_hash.py`.
- `LocalSegmentStore` replaces a session file atomically, reloads after a new instance (app-kill), and `release`s after projection acceptance (S22 will call it).
- `CaptureProvider` persists on `notifyListeners` when a live session id exists. Default store is disabled so existing tests stay hermetic. Production `main.dart` passes `LocalSegmentStore.appSupport()`.

### Automatic-or-dead check

- Alice/Bob known-answer digest `6698e08ad93c…` matches Python.
- Empty list hashes the empty byte string; empty-text rows still contribute identity frames.
- Store: write, construct a new store on the same directory, reload, digest unchanged. Explicit `speaker_id` 7 on `SPEAKER_00` survives reload.
- `CaptureProvider` with an injected store and `testSessionStartSeconds` writes `live-<ts>.json`.
- Disabled store writes nothing.

Red-proof: drop the `speaker_id` frame or restore an unconditional BLE-style skip of empty text, and `transcript_hash_test` fails against the Python fixtures.

### Proof

`flutter test test/unit/transcript_hash_test.dart test/unit/local_segment_store_test.dart` — 13 passed locally.

Dest: mobile client only. Merging does not deploy Cloud Run.

### Line-count ratchet

Line-Count-Exception: app/lib/main.dart | 552 -> 556 | S21: wire file-backed LocalSegmentStore into CaptureProvider without touching capture_controller.dart (#11681)

## Product invariants affected

- INV-DATA-1

Path overlap only: `main.dart` gained a `LocalSegmentStore.appSupport()` argument on `CaptureProvider`. No routing, env, Firebase, or API-base change.

### Cut list

- S22 Dart finalization / `client_processing` (consumes this store + hash).
- S17 / S19 mobile (blocked on #11681).
- Adding sqflite/Drift.
- Editing `capture_controller.dart` or `transcription_service.dart`.
- Calling `release` from the server-accept path (no projection yet).

## How it was verified

- `flutter test test/unit/transcript_hash_test.dart test/unit/local_segment_store_test.dart` — 13 passed
- Did not edit #11681 files

## Tests

- `transcript_hash_test.dart` — Python v5 fixtures
- `local_segment_store_test.dart` — kill/reload, speaker_id restore, release, CaptureProvider hook

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

