### PR TITLE
harden: fail pusher deploys on unexplained listen env drift

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -529,6 +529,11 @@ checks:
     triggers: ["backend/charts/pusher/**", "backend/scripts/verify_shared_config_migration.py", "backend/tests/unit/test_verify_shared_config_migration.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "SCA-39: static preflight that fails closed when pusher chart env/envFrom config references are structurally invalid (the 2026-07-22 REDIS_DB_HOST outage class)"
+  - id: pusher-cohost-env-diff
+    command: ["python3", "backend/scripts/verify_pusher_cohost_env_diff.py"]
+    triggers: ["backend/charts/pusher/**", "backend/charts/backend-listen/**", "backend/scripts/verify_pusher_cohost_env_diff.py", "backend/tests/unit/test_verify_pusher_cohost_env_diff.py", ".github/workflows/gcp_backend_pusher.yml", ".github/workflows/gcp_backend_pusher_auto_deploy.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "2026-08-30 pusher finalization outage: unexplained pusher vs backend-listen env divergence must fail the deploy path (decision 4 co-host env-diff)"
   - id: conversation-lifecycle-write-guard
     command: ["python3", "backend/scripts/check_conversation_lifecycle_writes.py"]
     triggers: ["backend/**/*.py", "backend/scripts/check_conversation_lifecycle_writes.py"]

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -323,6 +323,7 @@ jobs:
         run: |
           python3 backend/scripts/verify_pusher_rollout_budget.py
           python3 backend/scripts/verify_pusher_rollout_gate.py preflight
+          python3 backend/scripts/verify_pusher_cohost_env_diff.py
           python3 backend/scripts/verify_pusher_dev_observability.py
 
       - name: Get GKE credentials

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           python3 backend/scripts/verify_pusher_rollout_budget.py
           python3 backend/scripts/verify_pusher_rollout_gate.py preflight
+          python3 backend/scripts/verify_pusher_cohost_env_diff.py
           python3 backend/scripts/verify_pusher_dev_observability.py
 
       - name: Get GKE credentials

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -142,6 +142,14 @@ env:
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: MEMORY_ENABLED
     value: "on"
+  # Shared process_conversation rollout flags. Must match backend-listen in this
+  # environment — pusher hosts the same finalizer after 2026-08-30.
+  - name: CONVERSATION_NOTES_V2_ENABLED
+    value: "true"
+  - name: CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED
+    value: "true"
+  - name: CONVERSATION_OCR_CONTEXT_ENABLED
+    value: "true"
   - name: MEMORY_BELIEF_MODEL_ENABLED
     value: "true"
   - name: FAL_KEY

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -142,6 +142,14 @@ env:
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: MEMORY_ENABLED
     value: "on"
+  # Shared process_conversation rollout flags. Must match backend-listen in this
+  # environment — pusher hosts the same finalizer after 2026-08-30.
+  - name: CONVERSATION_NOTES_V2_ENABLED
+    value: "true"
+  - name: CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED
+    value: "false"
+  - name: CONVERSATION_OCR_CONTEXT_ENABLED
+    value: "false"
   - name: FAL_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -237,6 +237,15 @@ environments:
               key: OMI_LLM_GATEWAY_SERVICE_TOKEN
           MEMORY_ENABLED:
             value: 'on'
+          CONVERSATION_NOTES_V2_ENABLED:
+            value: 'true'
+            category: rollout
+          CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED:
+            value: 'true'
+            category: rollout
+          CONVERSATION_OCR_CONTEXT_ENABLED:
+            value: 'true'
+            category: rollout
           MEMORY_BELIEF_MODEL_ENABLED:
             value: 'true'
             category: rollout
@@ -1528,6 +1537,15 @@ environments:
         env:
           MEMORY_ENABLED:
             value: 'on'
+          CONVERSATION_NOTES_V2_ENABLED:
+            value: 'true'
+            category: rollout
+          CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED:
+            value: 'false'
+            category: rollout
+          CONVERSATION_OCR_CONTEXT_ENABLED:
+            value: 'false'
+            category: rollout
       config_map:
         name: prod-omi-backend-config
         entries:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -77,6 +77,15 @@ overlay:
             key: OMI_LLM_GATEWAY_SERVICE_TOKEN
         MEMORY_ENABLED:
           value: 'on'
+        CONVERSATION_NOTES_V2_ENABLED:
+          value: 'true'
+          category: rollout
+        CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED:
+          value: 'true'
+          category: rollout
+        CONVERSATION_OCR_CONTEXT_ENABLED:
+          value: 'true'
+          category: rollout
         MEMORY_BELIEF_MODEL_ENABLED:
           value: 'true'
           category: rollout

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -84,6 +84,15 @@ overlay:
       env:
         MEMORY_ENABLED:
           value: 'on'
+        CONVERSATION_NOTES_V2_ENABLED:
+          value: 'true'
+          category: rollout
+        CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED:
+          value: 'false'
+          category: rollout
+        CONVERSATION_OCR_CONTEXT_ENABLED:
+          value: 'false'
+          category: rollout
     config_map:
       name: prod-omi-backend-config
       entries:

--- a/backend/scripts/verify_pusher_cohost_env_diff.py
+++ b/backend/scripts/verify_pusher_cohost_env_diff.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Fail closed when pusher and backend-listen charts diverge without explanation.
+
+Decision 4 of pusher-production-hardening: a shared-config / shared-code-path
+host must be verified against its co-hosts, not against its own history. The
+2026-08-30 finalization outage shipped ``process_conversation`` onto pusher
+while ``MEMORY_ENABLED`` (and the conversation-notes rollout flags) existed
+only on backend-listen.
+
+This gate compares explicit ``env:`` key names in the Helm values files — the
+keys that actually ship. Shared ``envFrom`` ConfigMap names must also match.
+It never reads ConfigMap or Secret values.
+
+Unexplained listen-only or pusher-only keys fail. The current residuals are
+an explicit allowlist so a *new* flag cannot repeat the outage class. Growing
+the allowlist is a reviewed decision; shrinking it is required when a key
+lands on both hosts. Required-identical literals (the shared finalizer
+rollout flags) must exist on both hosts with the same value.
+
+Stdlib-only. Runs in pre-push/CI and in the pusher deploy workflows::
+
+  python3 backend/scripts/verify_pusher_cohost_env_diff.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENTS = ("dev", "prod")
+
+REQUIRED_IDENTICAL_LITERALS = (
+    "MEMORY_ENABLED",
+    "CONVERSATION_NOTES_V2_ENABLED",
+    "CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED",
+    "CONVERSATION_OCR_CONTEXT_ENABLED",
+)
+
+# Explained listen-only residuals. New listen-only keys fail until added here
+# *or* declared on pusher. Do not copy secret refs onto pusher from this list
+# without an ExternalSecret inventory (#12298).
+LISTEN_ONLY_ALLOWED: dict[str, frozenset[str]] = {
+    "dev": frozenset(
+        {
+            "ACCOUNT_CUTOVER_ENFORCEMENT",
+            "DEEPGRAM_API_KEY",
+            "DEEPGRAM_SELF_HOSTED_ENABLED",
+            "DESKTOP_UPDATE_POINTERS_MODE",
+            "DESKTOP_UPDATE_RECONCILE_SAMPLE_RATE",
+            "FAIR_USE_3DAY_SPEECH_MS",
+            "FAIR_USE_BUCKET_SECONDS",
+            "FAIR_USE_CHECK_INTERVAL_SECONDS",
+            "FAIR_USE_CLASSIFIER_ABUSE_SCORE_THRESHOLD",
+            "FAIR_USE_CLASSIFIER_COOLDOWN_SECONDS",
+            "FAIR_USE_CLASSIFIER_LOOKBACK_DAYS",
+            "FAIR_USE_CLASSIFIER_MODEL",
+            "FAIR_USE_DAILY_SPEECH_MS",
+            "FAIR_USE_ENABLED",
+            "FAIR_USE_EXEMPT_UIDS",
+            "FAIR_USE_KILL_SWITCH",
+            "FAIR_USE_REDIS_RETENTION_SECONDS",
+            "FAIR_USE_RESTRICT_DAILY_DG_MS",
+            "FAIR_USE_WEEKLY_SPEECH_MS",
+            "GCP_LOCATION",
+            "GEMINI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_CALENDAR_AUTO_LINK_ENABLED",
+            "GROQ_API_KEY",
+            "HOSTED_PUSHER_API_URL",
+            "HOSTED_TRANSLATION_API_URL",
+            "HOSTED_VAD_API_URL",
+            "LISTEN_FINALIZATION_BYOK_ABANDONMENT_ENABLED",
+            "LISTEN_FINALIZATION_ORPHAN_STALE_SECONDS",
+            "LLM_GATEWAY_ACCOUNTING_ENABLED",
+            "MCP_OAUTH_CHATGPT_CLIENT_SECRET",
+            "MEETING_RECEIPT_RECONCILER_ENABLED",
+            "MEMORY_CANONICAL_MAINTENANCE_ENABLED",
+            "MEMORY_TYPESENSE_COLLECTION",
+            "OMI_FIRESTORE_DATA_PLANE_PROJECT",
+            "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED",
+            "OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE",
+            "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_ENABLED",
+            "OMI_LLM_GATEWAY_CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE",
+            "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_ENABLED",
+            "OMI_LLM_GATEWAY_DEV_SHADOW_ALL_SAMPLE_RATE",
+            "OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED",
+            "OMI_PARITY_PACK_ALLOWED_PRINCIPALS",
+            "OMI_PARITY_PACK_CAPTURE",
+            "OMI_PARITY_PACK_EXPORT_INTERVAL_SECONDS",
+            "OMI_PARITY_PACK_GCS_URI",
+            "OMI_PARITY_PACK_ROOT",
+            "OPENROUTER_API_KEY",
+            "POSTHOG_PROJECT_API_KEY",
+            "PUBLIC_SHARED_CONVERSATION_CHAT_MODE",
+            "RAPID_API_KEY",
+            "REFERRAL_PUBLIC_BASE_URL",
+            "SONIOX_API_KEY",
+            "TRANSLATION_SERVICE_MODELS",
+            "TWILIO_API_KEY_SECRET",
+            "TWILIO_AUTH_TOKEN",
+            "USE_VERTEX_AI",
+            "VAD_GATE_MODE",
+            "WAKE_WORD_ADJUDICATION_ENABLED",
+            "X_OAUTH_CLIENT_SECRET",
+        }
+    ),
+    "prod": frozenset(
+        {
+            "ACCOUNT_CUTOVER_ENFORCEMENT",
+            "ACCOUNT_DELETION_DISPATCH_MODE",
+            "ACCOUNT_DELETION_TASKS_QUEUE",
+            "BETA_PROMOTION_TOKEN",
+            "DESKTOP_UPDATE_POINTERS_MODE",
+            "DESKTOP_UPDATE_RECONCILE_SAMPLE_RATE",
+            "FAIR_USE_3DAY_SPEECH_MS",
+            "FAIR_USE_BUCKET_SECONDS",
+            "FAIR_USE_CHECK_INTERVAL_SECONDS",
+            "FAIR_USE_CLASSIFIER_ABUSE_SCORE_THRESHOLD",
+            "FAIR_USE_CLASSIFIER_COOLDOWN_SECONDS",
+            "FAIR_USE_CLASSIFIER_LOOKBACK_DAYS",
+            "FAIR_USE_CLASSIFIER_MODEL",
+            "FAIR_USE_DAILY_SPEECH_MS",
+            "FAIR_USE_ENABLED",
+            "FAIR_USE_EXEMPT_UIDS",
+            "FAIR_USE_KILL_SWITCH",
+            "FAIR_USE_REDIS_RETENTION_SECONDS",
+            "FAIR_USE_RESTRICT_DAILY_DG_MS",
+            "FAIR_USE_WEEKLY_SPEECH_MS",
+            "GCP_LOCATION",
+            "GEMINI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "HOSTED_PUSHER_API_URL",
+            "HOSTED_TRANSLATION_API_URL",
+            "HOSTED_VAD_API_URL",
+            "LISTEN_FINALIZATION_BYOK_ABANDONMENT_ENABLED",
+            "LISTEN_FINALIZATION_ORPHAN_STALE_SECONDS",
+            "LLM_GATEWAY_ACCOUNTING_ENABLED",
+            "MCP_OAUTH_CHATGPT_CLIENT_SECRET",
+            "MCP_OAUTH_CLIENTS_JSON",
+            "MEETING_RECEIPT_RECONCILER_ENABLED",
+            "MEMORY_BELIEF_MODEL_ENABLED",
+            "MEMORY_CANONICAL_MAINTENANCE_ENABLED",
+            "MEMORY_TYPESENSE_COLLECTION",
+            "MEMORY_V3_CURSOR_SECRET",
+            "OMI_FIRESTORE_DATA_PLANE_PROJECT",
+            "OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED",
+            "POSTHOG_PROJECT_API_KEY",
+            "PUBLIC_SHARED_CONVERSATION_CHAT_MODE",
+            "REFERRAL_PUBLIC_BASE_URL",
+            "SONIOX_API_KEY",
+            "SYNC_TASKS_LOCATION",
+            "SYNC_TASKS_PROJECT",
+            "TRANSLATION_SERVICE_MODELS",
+            "TWILIO_API_KEY_SECRET",
+            "TWILIO_AUTH_TOKEN",
+            "USE_VERTEX_AI",
+            "VAD_GATE_MODE",
+            "WAKE_WORD_ADJUDICATION_ENABLED",
+            "X_OAUTH_CLIENT_SECRET",
+        }
+    ),
+}
+
+PUSHER_ONLY_ALLOWED: dict[str, frozenset[str]] = {
+    "dev": frozenset({"GOOGLE_CLIENT_ID", "REDIS_DB_HOST", "TYPESENSE_HOST"}),
+    "prod": frozenset({"DEEPGRAM_SELF_HOSTED_URL", "REDIS_DB_HOST", "TYPESENSE_HOST"}),
+}
+
+# Shared keys whose *literal* values are allowed to differ. Name-only diffs
+# belong in the only-allowed sets above, not here.
+SHARED_VALUE_DIFF_ALLOWED: dict[str, frozenset[str]] = {
+    "dev": frozenset({"DD_SERVICE", "STRIPE_ARCHITECT_MONTHLY_PRICE_ID"}),
+    "prod": frozenset({"BUCKET_SPEECH_PROFILES", "DD_SERVICE", "DEEPGRAM_SELF_HOSTED_ENABLED"}),
+}
+
+
+class DiffError(ValueError):
+    """Raised when chart inputs cannot be parsed for a co-host comparison."""
+
+
+@dataclass(frozen=True)
+class EnvEntry:
+    name: str
+    value: str | None
+    secret_key: str | None
+    config_map_key: str | None
+
+
+def _values_path(root: Path, service: str, env: str) -> Path:
+    if service == "pusher":
+        return root / "backend" / "charts" / "pusher" / f"{env}_omi_pusher_values.yaml"
+    if service == "listen":
+        return root / "backend" / "charts" / "backend-listen" / f"{env}_omi_backend_listen_values.yaml"
+    raise DiffError(f"unknown service {service!r}")
+
+
+def _env_block_lines(text: str) -> list[str]:
+    lines = text.splitlines()
+    started = False
+    block: list[str] = []
+    for line in lines:
+        if not started:
+            if re.match(r"^env:\s*$", line):
+                started = True
+            continue
+        if line and not line[0].isspace() and not line.startswith("#"):
+            break
+        block.append(line)
+    if not started:
+        raise DiffError("values file has no top-level env: list")
+    return block
+
+
+def parse_env_entries(text: str) -> dict[str, EnvEntry]:
+    """Parse explicit ``env:`` entries from a chart values file (stdlib)."""
+
+    entries: dict[str, EnvEntry] = {}
+    current: str | None = None
+    body: list[str] = []
+
+    def flush() -> None:
+        nonlocal current, body
+        if current is None:
+            return
+        blob = "\n".join(body)
+        value_match = re.search(r"^\s+value:\s*(.*)$", blob, re.MULTILINE)
+        value = value_match.group(1).strip().strip("\"'") if value_match else None
+        secret_match = re.search(
+            r"secretKeyRef:\s*\n\s*name:\s*(\S+)\s*\n\s*key:\s*(\S+)",
+            blob,
+        )
+        config_match = re.search(
+            r"configMapKeyRef:\s*\n\s*name:\s*(\S+)\s*\n\s*key:\s*(\S+)",
+            blob,
+        )
+        entries[current] = EnvEntry(
+            name=current,
+            value=value,
+            secret_key=secret_match.group(2) if secret_match else None,
+            config_map_key=config_match.group(2) if config_match else None,
+        )
+        current = None
+        body = []
+
+    for line in _env_block_lines(text):
+        match = re.match(r"^  - name:\s+(\S+)\s*$", line)
+        if match:
+            flush()
+            current = match.group(1)
+            body = []
+            continue
+        if current is not None:
+            body.append(line)
+    flush()
+    if not entries:
+        raise DiffError("values file env: list declared no names")
+    return entries
+
+
+def parse_envfrom_configmaps(text: str) -> set[str]:
+    return set(re.findall(r"configMapRef:\s*\n\s*name:\s*(\S+)", text))
+
+
+def _read_values(root: Path, service: str, env: str) -> tuple[dict[str, EnvEntry], set[str]]:
+    path = _values_path(root, service, env)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DiffError(f"could not read {path}: {exc}") from exc
+    return parse_env_entries(text), parse_envfrom_configmaps(text)
+
+
+def validate_preflight(root: Path = ROOT) -> list[str]:
+    """Return every unexplained pusher ↔ backend-listen env divergence."""
+
+    errors: list[str] = []
+    for env in ENVIRONMENTS:
+        try:
+            pusher_env, pusher_from = _read_values(root, "pusher", env)
+            listen_env, listen_from = _read_values(root, "listen", env)
+        except DiffError as exc:
+            errors.append(f"[{env}] {exc}")
+            continue
+
+        if pusher_from != listen_from:
+            errors.append(
+                f"[{env}] envFrom ConfigMap set differs: pusher={sorted(pusher_from)} "
+                f"listen={sorted(listen_from)} — co-hosts must share the same bulk source"
+            )
+
+        for flag in REQUIRED_IDENTICAL_LITERALS:
+            pusher_entry = pusher_env.get(flag)
+            listen_entry = listen_env.get(flag)
+            if pusher_entry is None or listen_entry is None:
+                missing = "pusher" if pusher_entry is None else "backend-listen"
+                errors.append(
+                    f"[{env}] required identical flag {flag} is missing on {missing} "
+                    "(shared process_conversation host)"
+                )
+                continue
+            if pusher_entry.value is None or listen_entry.value is None:
+                errors.append(f"[{env}] required identical flag {flag} must be a literal on both hosts")
+                continue
+            if pusher_entry.value != listen_entry.value:
+                errors.append(
+                    f"[{env}] required identical flag {flag} disagrees: "
+                    f"pusher={pusher_entry.value!r} listen={listen_entry.value!r}"
+                )
+
+        listen_only = set(listen_env) - set(pusher_env)
+        pusher_only = set(pusher_env) - set(listen_env)
+        allowed_listen = LISTEN_ONLY_ALLOWED[env]
+        allowed_pusher = PUSHER_ONLY_ALLOWED[env]
+        unexplained_listen = sorted(listen_only - allowed_listen)
+        unexplained_pusher = sorted(pusher_only - allowed_pusher)
+        stale_listen = sorted(allowed_listen - listen_only)
+        stale_pusher = sorted(allowed_pusher - pusher_only)
+
+        for name in unexplained_listen:
+            errors.append(
+                f"[{env}] unexplained listen-only env {name} — add it to pusher "
+                "or to LISTEN_ONLY_ALLOWED with a reason"
+            )
+        for name in unexplained_pusher:
+            errors.append(
+                f"[{env}] unexplained pusher-only env {name} — add it to backend-listen "
+                "or to PUSHER_ONLY_ALLOWED with a reason"
+            )
+        for name in stale_listen:
+            errors.append(f"[{env}] LISTEN_ONLY_ALLOWED entry {name} is no longer listen-only; remove it")
+        for name in stale_pusher:
+            errors.append(f"[{env}] PUSHER_ONLY_ALLOWED entry {name} is no longer pusher-only; remove it")
+
+        allowed_value_diff = SHARED_VALUE_DIFF_ALLOWED[env]
+        shared = set(pusher_env) & set(listen_env)
+        for name in sorted(shared):
+            pusher_value = pusher_env[name].value
+            listen_value = listen_env[name].value
+            if pusher_value is None or listen_value is None:
+                continue
+            if pusher_value == listen_value:
+                if name in allowed_value_diff:
+                    errors.append(f"[{env}] SHARED_VALUE_DIFF_ALLOWED entry {name} now matches; remove it")
+                continue
+            if name in REQUIRED_IDENTICAL_LITERALS:
+                continue
+            if name not in allowed_value_diff:
+                errors.append(
+                    f"[{env}] unexplained literal value diff for shared env {name}: "
+                    f"pusher={pusher_value!r} listen={listen_value!r}"
+                )
+        for name in sorted(allowed_value_diff - shared):
+            errors.append(f"[{env}] SHARED_VALUE_DIFF_ALLOWED entry {name} is not shared; remove it")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=ROOT,
+        help="Repository root (for hermetic fixture tests).",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    errors = validate_preflight(root)
+    if errors:
+        print("FAIL: pusher co-host env-diff gate", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("OK: pusher co-host env-diff gate passed.")
+    for env in ENVIRONMENTS:
+        try:
+            pusher_env, _ = _read_values(root, "pusher", env)
+            listen_env, _ = _read_values(root, "listen", env)
+        except DiffError:
+            continue
+        print(
+            f"- {env}: pusher={len(pusher_env)} listen={len(listen_env)} "
+            f"listen-only-allowed={len(LISTEN_ONLY_ALLOWED[env])} "
+            f"required-identical={len(REQUIRED_IDENTICAL_LITERALS)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/testing/workflow_contracts.json
+++ b/backend/testing/workflow_contracts.json
@@ -643,7 +643,8 @@
         "backend/testing/release_fixtures/transcription-release-probe.json",
         "backend/testing/release_fixtures/transcription-release-probe.wav",
         "backend/scripts/verify_pusher_dev_observability.py",
-        "backend/scripts/verify_pusher_source_closure.py"
+        "backend/scripts/verify_pusher_source_closure.py",
+        "backend/scripts/verify_pusher_cohost_env_diff.py"
       ],
       "tests": [
         "tests/unit/test_verify_pusher_rollout_budget.py",
@@ -655,7 +656,9 @@
         "tests/unit/test_pusher_semantic_probe.py",
         "tests/unit/test_verify_pusher_live_alert_route.py",
         "tests/unit/test_backend_runtime_env_validator.py",
-        "tests/unit/test_pusher_static_capability_admission.py"
+        "tests/unit/test_pusher_static_capability_admission.py",
+        "tests/unit/test_verify_pusher_cohost_env_diff.py",
+        "tests/unit/test_conversation_notes_v2_beta_rollout.py"
       ],
       "checks": [],
       "invariants": [
@@ -671,7 +674,8 @@
         "rollback remains absent until a complete image, config, schema, and protocol compatibility receipt exists; the workflow never blindly rolls back to the prior revision",
         "the live deployment gate rejects missing matching-node surge capacity before Helm can mutate the release",
         "the prod freshness check compares the full Dockerfile COPY source closure so a post-qualification change to any shared backend module cannot ship a stale digest",
-        "the live capacity gate has a confirm-and-reason break-glass hatch that records a tracking issue, matching the repo's gated-surface contract"
+        "the live capacity gate has a confirm-and-reason break-glass hatch that records a tracking issue, matching the repo's gated-surface contract",
+        "pusher and backend-listen explicit env key sets cannot gain an unexplained divergence; required process_conversation rollout flags must resolve identically"
       ]
     },
     {

--- a/backend/tests/unit/test_conversation_notes_v2_beta_rollout.py
+++ b/backend/tests/unit/test_conversation_notes_v2_beta_rollout.py
@@ -24,10 +24,11 @@ ROLLOUT_FLAGS = (
     'CONVERSATION_OCR_CONTEXT_ENABLED',
 )
 
-# backend-listen finalizes a live conversation; cloud_run/backend runs process_conversation
-# inline for POST /v1/conversations/{id}/reprocess. Both must agree or "regenerate" produces
-# a different summary pipeline than the one that captured the conversation.
-SUMMARY_PIPELINE_SCOPES = ('gke/backend-listen', 'cloud_run/backend')
+# backend-listen finalizes a live conversation; gke/pusher hosts the same
+# process_conversation path after 2026-08-30; cloud_run/backend runs it inline
+# for POST /v1/conversations/{id}/reprocess. All three must agree or a captured
+# conversation and a regenerate/pusher finalization produce different pipelines.
+SUMMARY_PIPELINE_SCOPES = ('gke/backend-listen', 'gke/pusher', 'cloud_run/backend')
 
 
 @functools.cache
@@ -38,6 +39,7 @@ def _composed() -> dict:
 def _env_maps(environment: dict) -> dict[str, dict]:
     return {
         'gke/backend-listen': environment['gke']['backend-listen']['env'],
+        'gke/pusher': environment['gke']['pusher']['env'],
         'cloud_run/backend': environment['cloud_run']['services']['backend']['env'],
     }
 
@@ -81,17 +83,20 @@ def test_reprocess_cannot_disagree_with_live_finalization():
             values = {scope: _value(env_maps[scope], flag) for scope in SUMMARY_PIPELINE_SCOPES}
             assert len(set(values.values())) == 1, f'{flag}: {values}'
             assert values['gke/backend-listen'] != '', flag
+            assert values['gke/pusher'] != '', flag
 
 
 def test_the_deployed_chart_values_match_the_composed_manifest():
     """Helm reads the values file, not runtime_env.yaml, so drift here is what actually ships."""
     composed = _composed()
-    for environment, chart in (
-        ('dev', 'dev_omi_backend_listen_values.yaml'),
-        ('prod', 'prod_omi_backend_listen_values.yaml'),
+    for environment, chart_dir, chart, scope in (
+        ('dev', 'backend-listen', 'dev_omi_backend_listen_values.yaml', 'gke/backend-listen'),
+        ('prod', 'backend-listen', 'prod_omi_backend_listen_values.yaml', 'gke/backend-listen'),
+        ('dev', 'pusher', 'dev_omi_pusher_values.yaml', 'gke/pusher'),
+        ('prod', 'pusher', 'prod_omi_pusher_values.yaml', 'gke/pusher'),
     ):
-        values = yaml.safe_load((BACKEND / 'charts/backend-listen' / chart).read_text(encoding='utf-8'))
+        values = yaml.safe_load((BACKEND / 'charts' / chart_dir / chart).read_text(encoding='utf-8'))
         rendered = {entry['name']: str(entry.get('value', '')).strip().lower() for entry in values['env']}
-        expected = _env_maps(composed['environments'][environment])['gke/backend-listen']
+        expected = _env_maps(composed['environments'][environment])[scope]
         for flag in ROLLOUT_FLAGS:
-            assert rendered.get(flag) == _value(expected, flag), f'{environment}:{flag}'
+            assert rendered.get(flag) == _value(expected, flag), f'{environment}:{scope}:{flag}'

--- a/backend/tests/unit/test_verify_pusher_cohost_env_diff.py
+++ b/backend/tests/unit/test_verify_pusher_cohost_env_diff.py
@@ -1,0 +1,117 @@
+"""Regression coverage for the pusher ↔ backend-listen co-host env-diff gate."""
+
+from __future__ import annotations
+
+import runpy
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "backend" / "scripts" / "verify_pusher_cohost_env_diff.py"
+WORKFLOWS = (
+    REPO_ROOT / ".github/workflows/gcp_backend_pusher.yml",
+    REPO_ROOT / ".github/workflows/gcp_backend_pusher_auto_deploy.yml",
+)
+
+FIXTURE_FILES = (
+    "backend/charts/pusher/dev_omi_pusher_values.yaml",
+    "backend/charts/pusher/prod_omi_pusher_values.yaml",
+    "backend/charts/backend-listen/dev_omi_backend_listen_values.yaml",
+    "backend/charts/backend-listen/prod_omi_backend_listen_values.yaml",
+)
+
+
+@pytest.fixture(scope="module")
+def gate() -> SimpleNamespace:
+    return SimpleNamespace(**runpy.run_path(str(SCRIPT)))
+
+
+@pytest.fixture
+def chart_fixture(tmp_path: Path) -> Path:
+    for relative in FIXTURE_FILES:
+        source = REPO_ROOT / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+    return tmp_path
+
+
+def replace_once(path: Path, before: str, after: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert text.count(before) == 1, f"expected exactly one {before!r} in {path}"
+    path.write_text(text.replace(before, after, 1), encoding="utf-8")
+
+
+def test_preflight_passes_on_repo_root(gate: SimpleNamespace) -> None:
+    assert gate.validate_preflight(REPO_ROOT) == []
+
+
+def test_preflight_passes_on_good_fixture(gate: SimpleNamespace, chart_fixture: Path) -> None:
+    assert gate.validate_preflight(chart_fixture) == []
+
+
+def test_cli_passes_on_repo_root(gate: SimpleNamespace) -> None:
+    assert gate.main(["--root", str(REPO_ROOT)]) == 0
+
+
+def test_new_listen_only_key_fails(gate: SimpleNamespace, chart_fixture: Path) -> None:
+    values = chart_fixture / "backend/charts/backend-listen/prod_omi_backend_listen_values.yaml"
+    replace_once(
+        values,
+        "env:\n  - name: REFERRAL_PUBLIC_BASE_URL\n",
+        "env:\n  - name: OMI_ENV_DIFF_PROBE\n    value: \"1\"\n  - name: REFERRAL_PUBLIC_BASE_URL\n",
+    )
+
+    errors = gate.validate_preflight(chart_fixture)
+
+    assert any("unexplained listen-only env OMI_ENV_DIFF_PROBE" in error for error in errors)
+
+
+def test_missing_required_flag_on_pusher_fails(gate: SimpleNamespace, chart_fixture: Path) -> None:
+    values = chart_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(
+        values,
+        '  - name: CONVERSATION_NOTES_V2_ENABLED\n    value: "true"\n',
+        "",
+    )
+
+    errors = gate.validate_preflight(chart_fixture)
+
+    assert any(
+        "required identical flag CONVERSATION_NOTES_V2_ENABLED is missing on pusher" in error for error in errors
+    )
+
+
+def test_required_flag_value_disagreement_fails(gate: SimpleNamespace, chart_fixture: Path) -> None:
+    values = chart_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(
+        values,
+        '  - name: CONVERSATION_NOTES_V2_ENABLED\n    value: "true"\n',
+        '  - name: CONVERSATION_NOTES_V2_ENABLED\n    value: "false"\n',
+    )
+
+    errors = gate.validate_preflight(chart_fixture)
+
+    assert any("required identical flag CONVERSATION_NOTES_V2_ENABLED disagrees" in error for error in errors)
+
+
+def test_stale_listen_only_allowlist_entry_fails(gate: SimpleNamespace, chart_fixture: Path) -> None:
+    values = chart_fixture / "backend/charts/pusher/prod_omi_pusher_values.yaml"
+    replace_once(
+        values,
+        '  - name: MEMORY_ENABLED\n    value: "on"\n',
+        '  - name: MEMORY_ENABLED\n    value: "on"\n  - name: USE_VERTEX_AI\n    value: "true"\n',
+    )
+
+    errors = gate.validate_preflight(chart_fixture)
+
+    assert any("LISTEN_ONLY_ALLOWED entry USE_VERTEX_AI is no longer listen-only" in error for error in errors)
+
+
+def test_deploy_workflows_invoke_the_gate() -> None:
+    for workflow in WORKFLOWS:
+        text = workflow.read_text(encoding="utf-8")
+        assert "backend/scripts/verify_pusher_cohost_env_diff.py" in text, workflow

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -179,6 +179,9 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
     assert preflight.direct_pusher_bindings(deployment) == expected
     assert {name: preflight.literal_pusher_values(deployment)[name] for name in literals} == literals
     assert literals == {
+        "CONVERSATION_CALENDAR_CONTEXT_READ_ENABLED": "true",
+        "CONVERSATION_NOTES_V2_ENABLED": "true",
+        "CONVERSATION_OCR_CONTEXT_ENABLED": "true",
         "GOOGLE_CLOUD_PROJECT": "based-hardware-dev",
         "HOSTED_PARAKEET_API_URL": "http://parakeet.omiapi.com",
         "MEMORY_BELIEF_MODEL_ENABLED": "true",


### PR DESCRIPTION
## What changed and why

Pusher-hardening decision 4 as an enforced deploy check. After 2026-08-30, `prod-omi-pusher` hosts `process_conversation` with backend-listen; an unexplained chart env gap is how `MEMORY_ENABLED` shipped missing. This PR does not copy the residual ~50 listen-only keys onto pusher (several are secret refs; widening them is the #12298 ExternalSecret class). It fails the pusher deploy path when a *new* unexplained key appears, and pins the shared notes-v2 rollout flags on pusher so they resolve identically with listen.

## Product invariants affected

- INV-DATA-1
- INV-MEM-4

## How it was verified

- `python3 backend/scripts/verify_pusher_cohost_env_diff.py` — OK; dev 67/124, prod 72/120 explicit env keys; 4 required-identical flags match.
- `python3 backend/scripts/validate-backend-runtime-env.py --env prod` and `--env dev` — passed.
- `pytest backend/tests/unit/test_verify_pusher_cohost_env_diff.py backend/tests/unit/test_conversation_notes_v2_beta_rollout.py backend/tests/unit/test_backend_runtime_env_validator.py backend/tests/unit/test_pusher_deployment_control_workflow.py` — 127 passed.

Dest-test after merge: dest pusher auto-deploy applies. Confirm dest pusher pods have `CONVERSATION_NOTES_V2_ENABLED=true` matching dest listen. No production dispatch.

## Tests

- `test_new_listen_only_key_fails` — a new listen-only key fails the gate (the MEMORY_ENABLED class).
- `test_missing_required_flag_on_pusher_fails` / `test_required_flag_value_disagreement_fails` — notes-v2 cannot be omitted or flipped on pusher alone.
- `test_stale_listen_only_allowlist_entry_fails` — allowlist shrinks when a residual lands on both hosts.
- `test_conversation_notes_v2_beta_rollout` now includes `gke/pusher` as a third summary-pipeline host.

## Automatic-or-dead

`test_new_listen_only_key_fails` plus `test_deploy_workflows_invoke_the_gate`. Adding `OMI_ENV_DIFF_PROBE` to listen only, or dropping the script from either pusher workflow, fails closed. Red-proof: delete the workflow line or allowlist the probe without a reason and CI fails.

## Proof

The four required-identical literals (`MEMORY_ENABLED` + the three notes-v2 flags) match on pusher and listen in both chart values and `runtime_env.yaml`. Residual listen-only keys stay allowlisted, not copied.

## Cut list

- Did not add `GEMINI_API_KEY` / `USE_VERTEX_AI` / `FAIR_USE_*` to pusher (secret-widening deferred).
- Did not flip any prod flag values; calendar/OCR stay dark on prod pusher, matching listen.
- Did not change the FC registry (canonical-prevention edits are a separate registry PR).
- Not S12 AFM, not S22, not S17/S19 mobile, not JIT, not prod memory-maintenance job create.

## New guards

Would have failed the 2026-08-30 pusher finalization outage when `MEMORY_ENABLED` was listen-only. This is a pusher↔listen chart env-diff, not a shared primitive: the residual set is host-pair-specific and must stay an explicit allowlist so secret-widening cannot sneak in.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

