### PR TITLE
fix(desktop): make voice typing dictate instead of asking Omi when Accessibility is denied (#12877)

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -24,7 +24,8 @@ final class VoiceTypeSession {
   private enum Latch {
     case none
     case typing
-    /// A type command that cannot be delivered (no Accessibility grant). Latched
+    /// A type command that cannot be pasted (no Accessibility grant), but still
+    /// belongs to voice typing — delivered by clipboard copy instead. Latched
     /// so one denied turn reports one fallback, not one per transcript.
     case blocked
   }
@@ -54,8 +55,10 @@ final class VoiceTypeSession {
   /// window forward and a dictation was typed into it instead of the document.
   private var releaseFocusTarget: String?
 
-  /// True once this turn has been recognised as a dictation.
-  var claimsTurn: Bool { latch == .typing }
+  /// True once this turn has been recognised as a dictation — whether or not
+  /// it can be pasted. A blocked turn still owns the turn: the words are
+  /// dictation, not a question, regardless of what delivers them.
+  var claimsTurn: Bool { latch == .typing || latch == .blocked }
 
   init(
     sink: TextInsertionSink = PasteboardTextInsertionSink(),
@@ -81,7 +84,7 @@ final class VoiceTypeSession {
   @discardableResult
   func claim(transcript: String, lenient: Bool = false) -> Bool {
     switch latch {
-    case .blocked: return false
+    case .blocked: return true
     case .typing: return true
     case .none: break
     }
@@ -121,11 +124,19 @@ final class VoiceTypeSession {
       latch = .none
       releaseFocusTarget = nil
     }
-    guard latch == .typing else { return .none }
+    let blocked = latch == .blocked
+    guard latch == .typing || blocked else { return .none }
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     // Nothing detected means nothing typed: not an empty paste, and not a
     // stray "." or "…" the recognizer produced from a breath.
     guard DictationPolisher.hasContent(trimmed) else { return .none }
+    // No Accessibility grant: a paste would not land, so go straight to the
+    // clipboard rather than trying and failing silently.
+    guard !blocked else {
+      log("VoiceTypeSession: Accessibility not granted — copied \(trimmed.count) chars instead of pasting")
+      sink.copy(trimmed)
+      return .copied(trimmed)
+    }
     if let aimed = releaseFocusTarget {
       let current = sink.focusTarget()
       if current == nil || current != aimed {
@@ -159,14 +170,16 @@ final class VoiceTypeSession {
   private func arm() -> Bool {
     guard isAccessibilityTrusted() else {
       latch = .blocked
-      log("VoiceTypeSession: Accessibility not granted — releasing turn to chat")
+      // Still owns the turn — see `claimsTurn` — so it never reaches the
+      // realtime model; only the delivery mechanism (copy, not paste) changes.
+      log("VoiceTypeSession: Accessibility not granted — will copy instead of paste")
       DesktopDiagnosticsManager.shared.recordFallback(
         area: "voice_typing",
         from: "paste_injection",
-        to: "chat_query",
+        to: "clipboard_copy",
         reason: "policy",
         outcome: .degraded)
-      return false
+      return true
     }
     latch = .typing
     log("VoiceTypeSession: typing turn armed")

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -187,12 +187,19 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertEqual(session.payload(from: "Type hello"), "Hello")
   }
 
-  func testWithoutAccessibilityTheTurnIsReleasedToChat() {
+  func testWithoutAccessibilityTheTurnStillDictatesButCopiesInsteadOfPasting() {
+    // Regression for #12877: a "type …" turn with no Accessibility grant used
+    // to release itself to the realtime model once blocked, which then acted
+    // on the words as an instruction (spawned an agent) instead of dictating
+    // them. The turn must still claim itself — never reach the model — and
+    // deliver by clipboard copy since a paste cannot land without the grant.
     let (session, sink) = makeSession(trusted: false)
-    XCTAssertFalse(session.claim(transcript: "Type hello"))
-    XCTAssertNil(session.payload(from: "Type hello again"), "one denied turn stays denied")
-    XCTAssertEqual(session.deliver("Hello"), .none)
-    XCTAssertTrue(sink.pasted.isEmpty)
+    XCTAssertTrue(session.claim(transcript: "Type hello"), "a blocked turn still claims itself")
+    XCTAssertEqual(session.payload(from: "Type hello again"), "Hello again", "one denied turn stays denied")
+    XCTAssertTrue(session.claimsTurn)
+    XCTAssertEqual(session.deliver("Hello again"), .copied("Hello again"))
+    XCTAssertTrue(sink.pasted.isEmpty, "no Accessibility grant means no paste is even attempted")
+    XCTAssertEqual(sink.copied, ["Hello again"])
   }
 
   func testADictationThatContinuesALineOpensWithASpace() {

--- a/desktop/macos/changelog/unreleased/20260906-voice-typing-accessibility-blocked.json
+++ b/desktop/macos/changelog/unreleased/20260906-voice-typing-accessibility-blocked.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice typing now always copies (or pastes) what you dictated instead of occasionally asking Omi to type it for you when Accessibility access hasn't been granted"
+}


### PR DESCRIPTION
fix(desktop): voice typing dictates instead of asking Omi when Accessibility is denied (#12877)

Bug: with no Accessibility grant, a push-to-talk turn opening with "type …"
was released to the realtime model as an ordinary question once
VoiceTypeSession latched to .blocked, because claim() then returned false to
every later caller (including the closing gate that decides whether a hub
commit is a dictation). The model heard "type why doesn't this work" and
spawned an agent to type it, instead of the turn ever owning its own words.

Root cause: VoiceTypeSession.claim() treated "blocked" (no Accessibility) the
same as "not a dictation", so the turn stopped claiming itself once denied.

Fix: a blocked turn still claims itself (claim()/claimsTurn now true for
.blocked, not just .typing) so it never reaches the hub/chat regardless of
permission state. deliver() skips the doomed paste attempt for a blocked turn
and copies straight to the clipboard, reusing the existing "Copied — press
⌘V to paste" hint path already wired through PushToTalkManager.

Root-caused and reported in detail by the issue author (nathanjcx); the
diagnostics/permission-signature part of that report (TCC row bound to a
stale code signature) and the separate run.sh signing note are out of scope
for this fix.

Tested: `./scripts/dev-feedback.py --once swift 'VoiceTypeSessionTests'` — 17
tests pass, including a new regression test for the denied-Accessibility
path (asserts the turn claims itself and copies rather than pasting or
falling through to chat). Also ran the rest of VoiceTypingTests.swift (51
tests) to confirm no other case regressed.

## Product invariants affected

- INV-CHAT-1 (path glob match only: `VoiceTypeSession.swift` is under
  `FloatingControlBar/**`; this change does not touch transcript storage,
  session identity, or continuity — it only changes when a turn claims
  itself and how it delivers text)

Failure-Class: none



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

