### PR TITLE
fix(desktop): compose every closed-surface resize with what is still showing (remaining scrunched-notch paths)

### DIFF
--- a/.github/failure-classes/FC-notch-resize-state-substitution.json
+++ b/.github/failure-classes/FC-notch-resize-state-substitution.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-notch-resize-state-substitution",
+  "violated_contract": "Every FloatingControlBarWindow resize must compose the closed surface from the state that is actually showing (mounted notification card, PTT status banner, listening/thinking island, open conversation); substituting the size of one transient state for the whole surface crushes the content that outlives it.",
+  "canonical_prevention": "Route every closed-surface resize through the composed sizing authorities (closedSurfaceSize / collapsedChromeSurfaceSize / notificationPreservingSurfaceSize) instead of re-deriving a bare state size at the call site, and behaviorally assert on the live resize paths that a mounted card and active voice state survive every surface transition.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift"
+  ],
+  "evidence_prs": [12630],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1475,7 +1475,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     // so the window center shifts — anchoring from center would land in the wrong spot).
     // Draggable + preChatCenter set: restore to where the bar was before chat opened.
     // Draggable + no preChatCenter: fall back to current center-anchor (best effort).
-    let surfaceSize = notchModeEnabled ? notchCollapsedSize : collapsedBarSize
+    // The close lands on the whole composed closed surface — the notification
+    // card, the status banner, and the listening/thinking island that may
+    // still be running underneath the conversation. Substituting the bare
+    // idle lobe here crushed a card that outlived the chat (agent chat opens
+    // over a mounted card without dismissing it) and scrunched a PTT hold
+    // still active at close time.
+    let surfaceSize = closedSurfaceSize(usesNotchIsland: notchModeEnabled)
     let size = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: surfaceSize)
     let restoreOrigin: NSPoint
     if !ShortcutSettings.shared.draggableBarEnabled || notchModeEnabled {
@@ -1506,6 +1512,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       // Without this guard, a rapid PTT query that fires while close settles gets collapsed
       // back to the pill position by this stale completion block.
       guard !self.state.showingAIConversation else { return }
+      // A card or voice presentation that surfaced during the settle window
+      // now owns the composed surface; snapping to the precomputed close frame
+      // would crush it (the same substitution the close target above stopped
+      // making). The arrival path already resized correctly.
+      let settledSize = self.responseGlowWindowSizeForCurrentScreen(
+        forSurfaceSize: self.closedSurfaceSize(usesNotchIsland: self.notchModeEnabled))
+      guard NSEqualSizes(size, settledSize) else { return }
       if !NSEqualRects(self.frame, targetFrame) {
         self.setFrame(targetFrame, display: true, animate: false)
       }
@@ -2203,15 +2216,23 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// island, grown to keep any mounted notification card whole.
   func pushToTalkSurfaceSize(expanded: Bool) -> NSSize {
     let usesNotchIsland = notchModeEnabled
+    if !expanded {
+      // The release edge lands on the *composed* closed surface: thinking or
+      // response-waiting keeps the wider island, and a mounted card and the
+      // status banner keep their budgets. Collapsing straight to the idle lobe
+      // here made the notch dip to hardware-lobe width between the release and
+      // the lifecycle-driven `syncActiveIsland` resize — two competing
+      // animated resizes in opposite directions.
+      return closedSurfaceSize(usesNotchIsland: usesNotchIsland)
+    }
     let voiceSize: NSSize
     if usesNotchIsland {
-      voiceSize = expanded ? notchSize(active: true) : notchCollapsedSize
+      voiceSize = notchSize(active: true)
     } else {
-      // On legacy displays, when the voice-response glow is still active
-      // (e.g. realtime audio received this turn), collapse to the glow-adjusted
-      // compact size so the white glow/stroke is not clipped until the idle
-      // timer clears it.
-      voiceSize = expanded ? Self.voiceBarSize : Self.minBarSize
+      // Legacy (non-notch) listening island. The collapse arm is handled
+      // above; resizeSurfaceTransition still applies the response-glow outset
+      // on top of whatever size lands.
+      voiceSize = Self.voiceBarSize
     }
     return FloatingControlBarGeometry.notificationPreservingSurfaceSize(
       transientSize: voiceSize,
@@ -2336,9 +2357,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     )
   }
 
-  func dismissNotification(animated: Bool = true) {
+  func dismissNotification(animated: Bool = true, resize: Bool = true) {
     guard state.currentNotification != nil else { return }
     state.currentNotification = nil
+
+    // The conversation surface owns the window frame while it is open: a card
+    // auto-dismissing (or being displaced) underneath an open chat must not
+    // drag that chat down to the closed island. closeAIConversation
+    // re-composes the surface from live state when the conversation actually
+    // closes. Callers that pass `resize: false` unmount a card ahead of a
+    // replacement and owe the window the replacement's single resize.
+    guard resize, !state.showingAIConversation else { return }
 
     let targetSize: NSSize
     if notchModeEnabled {
@@ -2347,12 +2376,27 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       // banner. Collapsing straight to the idle lobe is the same substitution
       // bug in the other direction.
       targetSize = closedSurfaceSize(usesNotchIsland: true)
+    } else if state.isNotchHoverMenuVisible {
+      targetSize = pillAgentListWindowSize(agentCount: AgentPillsManager.shared.pills.count)
     } else if state.isVoiceListening {
       targetSize = Self.voiceBarSize
     } else {
       targetSize = state.isHoveringBar ? Self.expandedBarSize : collapsedBarSize
     }
     resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
+  }
+
+  /// Resize to the composed closed surface without touching presentation
+  /// state. Escape hatch for callers that mutate notification or conversation
+  /// state directly (replacement swaps, owner resets) and must land the window
+  /// on the surface the new state implies.
+  func resizeToClosedSurface(animated: Bool = true) {
+    resizeAnchored(
+      to: closedSurfaceSize(usesNotchIsland: notchModeEnabled),
+      makeResizable: false,
+      animated: animated,
+      anchorTop: true
+    )
   }
 
   /// Restore the compact pill size when we temporarily surface the bar outside
@@ -2376,7 +2420,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     return !state.showingAIConversation
       && !suppressHoverResize
       && pendingRestoreFrame == nil
-      && NSEqualSizes(frame.size, settledSize)
+      // A mounted card is a settled close: the conversation surface finished
+      // collapsing into the card that outlived it, and the close no longer
+      // crushes that card to the bare island.
+      && (state.currentNotification != nil || NSEqualSizes(frame.size, settledSize))
   }
 
   private func resizeToResponseHeight(animated: Bool = false) {
@@ -3061,6 +3108,10 @@ class FloatingControlBarManager {
       window?.dismissNotification(animated: false)
     }
     window?.state.clearVisibleConversation()
+    // dismissNotification skips its resize while a conversation is open (the
+    // chat surface owns the frame until it closes). The conversation state is
+    // gone now, so land the window on the surface that is actually showing.
+    window?.resizeToClosedSurface(animated: false)
   }
   var notificationProjectionSnapshot: NotificationProjectionSnapshot {
     NotificationProjectionSnapshot(
@@ -3606,8 +3657,11 @@ class FloatingControlBarManager {
       // while it was visible presents before it returns — still awaiting its
       // Copy/Send/close decision. Its authorization snapshot stays registered
       // for the re-present, and no dismissal is tracked because the user
-      // never acted on it.
-      window.dismissNotification(animated: false)
+      // never acted on it. The unmount skips its resize so the replacement's
+      // presentation is the single transition — dismissing with a resize
+      // snapped the panel to the bare island before the newcomer animated
+      // back out, the visible scrunch pulse.
+      window.dismissNotification(animated: false, resize: false)
       pendingNotifications.insert(
         current,
         at: FloatingBarNotificationQueuePolicy.requeueIndex(queueCount: pendingNotifications.count))
@@ -3618,6 +3672,9 @@ class FloatingControlBarManager {
         )
       }
       guard presentNotification(notification, in: window) else {
+        // The replacement was rejected after its predecessor left the queue;
+        // land the window on the surface that is actually showing now.
+        window.resizeToClosedSurface(animated: false)
         return .rejectedOwnerChange
       }
       return .presented
@@ -4590,7 +4647,11 @@ class FloatingControlBarManager {
       )
       notificationPresentationCallbacks.removeValue(forKey: existing.id)?.onDropped()
       notificationAuthorizationSnapshots.removeValue(forKey: existing.id)
-      window.dismissNotification(animated: false)
+      // Skip the dismissal resize: the showNotification below mounts the
+      // replacement and performs the single composed resize. Snapping to the
+      // bare island in between made every card replacement pulse the notch
+      // down to lobe width and animate back out.
+      window.dismissNotification(animated: false, resize: false)
     }
 
     // A live voice session has no eyes. Hand it the card as silent context so a spoken

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2391,6 +2391,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// state directly (replacement swaps, owner resets) and must land the window
   /// on the surface the new state implies.
   func resizeToClosedSurface(animated: Bool = true) {
+    // A nonanimated landing must win over any in-flight animated resize: the
+    // old animation's completion still holds a matching frameAnimationToken
+    // and would restore its obsolete target after this resize. Invalidate it
+    // and drop the pending target so the direct setFrame below is final.
+    if !animated {
+      frameAnimationToken += 1
+      pendingFrameAnimationTarget = nil
+    }
     resizeAnchored(
       to: closedSurfaceSize(usesNotchIsland: notchModeEnabled),
       makeResizable: false,

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1585,9 +1585,12 @@ import XCTest
   func testPTTCollapsePreservesGlowPaddingOnLegacyDisplays() throws {
     let source = try floatingControlBarWindowSource()
 
-    // Legacy PTT collapse supplies the bare compact surface to the shared
-    // transition path, which applies the active response/agent glow exactly once.
-    XCTAssertTrue(source.contains("voiceSize = expanded ? Self.voiceBarSize : Self.minBarSize"))
+    // Legacy PTT collapse now lands on the composed closed surface (card ∪
+    // banner ∪ listening island) instead of substituting the bare compact
+    // bar; the shared transition path still applies the active response/agent
+    // glow exactly once on top of whatever size lands.
+    XCTAssertTrue(source.contains("return closedSurfaceSize(usesNotchIsland: usesNotchIsland)"))
+    XCTAssertFalse(source.contains("voiceSize = expanded ? Self.voiceBarSize : Self.minBarSize"))
     XCTAssertTrue(source.contains("let windowSize = responseGlowWindowSizeForCurrentScreen(forSurfaceSize: size)"))
     XCTAssertTrue(source.contains("guard state.isVoiceResponseGlowActive || collapsedPillAgentGlowActive else"))
   }

--- a/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
@@ -195,6 +195,114 @@ final class FloatingBarNotchCardSizingTests: XCTestCase {
     }
   }
 
+  // MARK: - Closing the conversation over a mounted card
+
+  /// Agent chat opens over a mounted card without dismissing it
+  /// (`openAgentInChat` never touches `currentNotification`), so the card
+  /// outlives the conversation by design. The close used to substitute the
+  /// bare idle lobe for whatever the surface was showing, leaving the card
+  /// mounted inside a scrunched panel — indefinitely, for persistent cards.
+  func testClosingTheConversationKeepsAMountedCardWhole() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      window.state.showingAIConversation = true
+      // The voice-handoff close is the live path that leaves listening and
+      // the mounted card untouched (`cancelsInFlightWork` is false).
+      window.closeAIConversation(intent: .voiceHandoff)
+
+      // The close animates and its settle snap lands one settle delay later.
+      let settled = expectation(description: "close settle snap")
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { settled.fulfill() }
+      wait(for: [settled], timeout: 2)
+
+      XCTAssertGreaterThanOrEqual(
+        window.frame.width, mounted.width,
+        "closing the conversation must not narrow the panel under a mounted card")
+      XCTAssertGreaterThanOrEqual(
+        window.frame.height, mounted.height,
+        "closing the conversation must not clip the card body")
+      XCTAssertNotNil(window.state.currentNotification, "the card must still be mounted")
+    }
+  }
+
+  // MARK: - Dismissal under an open conversation
+
+  /// A card auto-dismissing underneath an open conversation must leave the
+  /// chat's frame alone: the conversation surface owns the window until it
+  /// closes, and closeAIConversation recomposes from live state.
+  func testDismissingACardUnderAnOpenConversationLeavesTheChatFrameAlone() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      window.state.showingAIConversation = true
+      window.dismissNotification(animated: false)
+
+      XCTAssertNil(window.state.currentNotification)
+      XCTAssertEqual(
+        window.frame.width, mounted.width,
+        "the open conversation owns the frame; the dismissal must not crush it to the island")
+    }
+  }
+
+  /// Replacement swaps unmount the old card with `resize: false` so the
+  /// newcomer's presentation is the single transition — the old dismiss-then-
+  /// present sequence snapped the panel to the bare island before animating
+  /// back out, the visible scrunch pulse.
+  func testUnmountingForReplacementLeavesTheFrameToTheReplacement() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      window.dismissNotification(animated: false, resize: false)
+
+      XCTAssertNil(window.state.currentNotification)
+      XCTAssertEqual(window.frame.width, mounted.width)
+    }
+  }
+
+  // MARK: - The release edge
+
+  /// Releasing PTT lands on the *composed* closed surface: thinking or
+  /// response-waiting keeps the wider island. Collapsing to the bare idle
+  /// lobe dipped the notch below the thinking width between the release and
+  /// the lifecycle-driven syncActiveIsland resize.
+  func testPTTReleaseWhileThinkingKeepsTheWiderIsland() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.makeKeyAndOrderFront(nil)
+
+      let presenter = FloatingControlBarState.PTTBarPresenter(
+        barState: window.state,
+        resizeForPTT: { [weak window] in window?.resizeForPTTState(expanded: $0) }
+      )
+      presenter.apply(.idle)
+      let idle = window.pushToTalkSurfaceSize(expanded: false)
+
+      presenter.apply(VoiceTurnUIProjection(isThinking: true))
+      let thinking = window.pushToTalkSurfaceSize(expanded: false)
+
+      XCTAssertGreaterThan(
+        thinking.width, idle.width,
+        "the release edge must not dip the island below the thinking width")
+    }
+  }
+
   // MARK: - The pure rule
 
   func testNotificationPreservingSurfaceSizeKeepsTheCardWhole() {

--- a/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotchCardSizingTests.swift
@@ -217,6 +217,10 @@ final class FloatingBarNotchCardSizingTests: XCTestCase {
       window.closeAIConversation(intent: .voiceHandoff)
 
       // The close animates and its settle snap lands one settle delay later.
+      // omi-test-quality: wall-clock-wait -- the close settle is a real
+      // main-queue asyncAfter + NSAnimationContext completion on the window
+      // with no injectable clock; the 0.4s wait is enqueued after the 0.16s
+      // settle on the same main queue, so the signal is sequenced, not raced.
       let settled = expectation(description: "close settle snap")
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { settled.fulfill() }
       wait(for: [settled], timeout: 2)

--- a/desktop/macos/changelog/unreleased/20260906-notch-card-scrunch-composed-resize.json
+++ b/desktop/macos/changelog/unreleased/20260906-notch-card-scrunch-composed-resize.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the remaining scrunched-notch states: closing a conversation over a notification card, a card auto-dismissing under an open chat, card replacements, and the moment a voice hold releases no longer collapse the notch to its resting width while wider content is still showing."
+}


### PR DESCRIPTION
## Why the notch still scrunches after #12630

#12630 fixed one *shape* of bug at three call sites: a transient notch state was **substituted** for the closed surface instead of **composed** with it. A comprehensive scan of every resize path in `FloatingControlBarWindow` found three more substitutions that survived on other paths, plus one pulse with a different mechanism. Each is fixed here by routing through the same composed authority (`closedSurfaceSize`) that #12630 established.

### 1. `closeAIConversation` restored the bare idle lobe (persistent — the headline bug)

Agent chat opens over a mounted notification card **without dismissing it** (`openAgentInChat` never touches `currentNotification`; `showAIConversation` doesn't either — and `showNotification` refuses to mount cards *while* chat is open, so "card first, then chat" is the only coexistence and it happens on every agent-pill click over a card). Closing that chat — esc, click-away, voice handoff — substituted `notchCollapsedSize` for the surface, dropping a 508pt card into the ~270pt lobe. The settle-time snap re-asserted it. Nothing re-widens: hover/agent/island resizes are all card-guarded, so **persistent cards (meeting-summary share) stayed scrunched indefinitely**. A PTT hold active at close time was scrunched the same way until its next listening edge.

**Fix:** the close lands on `closedSurfaceSize` (card ∪ banner ∪ listening/thinking/idle), and the settle snap re-derives the target from live state so a card or voice presentation arriving during the settle window is not crushed by the stale precomputed frame.

### 2. `dismissNotification` crushed an open conversation (persistent)

The auto-dismiss timer fires `dismissNotificationAndAdvanceQueue` with no chat check: queue *advancement* is skipped while chat is open, but the dismissal itself still resized the window to the closed island — an open agent chat left scrunched until user action. The conversation surface owns the frame until it closes, so the dismissal now leaves it alone (card state still clears; queue bookkeeping unchanged). Same guard covers snooze and owner resets; `resetOwnerProjection` settles explicitly after clearing the conversation. The pill-mode arm also keeps an open agent list sized.

### 3. Card replacement pulsed the notch down and back (transient)

Displacing a persistent card (and the replacement branch in `presentNotification`) snapped the panel to the bare island and then animated the newcomer back out — a visible scrunch pulse on every replacement. The unmount now skips its resize (`dismissNotification(resize: false)`) so the replacement's presentation is the single composed transition, with a settle resize if the replacement is rejected.

### 4. PTT release dipped below the thinking width (transient)

`pushToTalkSurfaceSize(expanded: false)` collapsed to the bare idle lobe even while thinking/response-waiting should hold the wider island; the lifecycle-driven `syncActiveIsland` then animated back out — two competing animated resizes per release. The release edge now lands on the composed closed surface (thinking/waiting keep the island; card and banner keep their budgets; the no-card idle case is byte-identical to before).

`hasSettledClosedForAutomation` now accepts a mounted card as a settled close — it is one.

### Non-changes worth recording

`windowWillResize`'s card minimum does not floor programmatic `setFrame` — that is why the #12630 crush shipped despite the guard, and why every fix here is at the call site. The SwiftUI hosting view (`[.minSize, .maxSize]` inside a container) can only grow the window, so it is not a scrunch driver.

## Tests

Four new behavioural tests in `FloatingBarNotchCardSizingTests` assert the invariants on the live paths (the exact failure mode of #12630 — invariant tested only on the authority — is not repeated): close-over-card keeps the card whole through the settle snap; dismissal under an open conversation leaves the chat frame alone; the replacement unmount leaves the frame to the replacement; the thinking release edge stays wider than idle. Full `FloatingBarNotchCardSizingTests` (12) and `FloatingBarGeometryTests` (33) suites pass.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5827 -> 5896 | four call-site fixes composed with the existing closed-surface authorities carry their explanatory comments in place; splitting the 5.9k-line file is unrelated refactoring left to the ratchet's own follow-up

## Product invariants affected

- INV-CHAT-1 (presentation-geometry only: no transcript store, session-identity, or continuity change touches the kernel-owned transcript rule; the notch surface keeps rendering from the same state as before)

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


