### PR TITLE
fix(desktop): separate agent handoff text across tool-loop iterations

### DIFF
--- a/.github/failure-classes/FC-agent-iteration-text-runs-together.json
+++ b/.github/failure-classes/FC-agent-iteration-text-runs-together.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-agent-iteration-text-runs-together",
+  "violated_contract": "Answer text produced by separate provider tool-loop iterations must carry a separator at the iteration boundary; the pre-tool sentence and the post-tool continuation must never render as one run-on line in a chat transcript.",
+  "canonical_prevention": "The desktop chat adapter emits the same iteration separator the backend chat loop inserts — before a continuation's first text delta after a tool-pause turn and between tool-separated text blocks when extracting the terminal answer — and the desktop chat terminal overwrite applies the same sentence-spacing projection the streaming path applies.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/tests/pi-mono-adapter.test.ts",
+    "desktop/macos/Desktop/Tests/ChatCitationTests.swift"
+  ],
+  "evidence_prs": [5725],
+  "scope_hints": [
+    "desktop/macos/agent/src/adapters/pi-mono.ts",
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -182,12 +182,17 @@ extension ChatProvider {
     // The authoritative answer replaces every streamed projection, so the raw
     // accumulator this turn was built from has no further reader.
     streamingBuffer.finishStreaming(messageId: messageId)
-    messages[index].applyAuthoritativeTerminalAnswer(queryText)
+    // The streamed projection applied sentence spacing to every flush; the
+    // terminal answer must honor the same contract or a joined agent handoff
+    // ("…handle it.Capture the…") that was only ever visible as fixed would
+    // reappear the moment the turn settles — and be persisted that way.
+    let normalizedTerminalText = Self.normalizeAssistantSentenceSpacing(queryText)
+    messages[index].applyAuthoritativeTerminalAnswer(normalizedTerminalText)
     messages[index].applySelectedSourceFallback(
       selectedReferences: selectedReferences,
       requestedSources: requestedSources,
       retrievedReferences: turnReferences,
-      fallbackText: queryText)
+      fallbackText: normalizedTerminalText)
     messages[index].isStreaming = false
     // A number this turn never assigned is one the reader was shown a turn ago.
     let inheritedReferences = ChatCitationMarkup.inheritedReferences(

--- a/desktop/macos/Desktop/Tests/ChatCitationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatCitationTests.swift
@@ -769,6 +769,38 @@ final class ChatCitationTests: XCTestCase {
     XCTAssertFalse(provider.messages.first?.isStreaming ?? true)
   }
 
+  @MainActor
+  func testFinalizationAppliesSentenceSpacingToJoinedAgentHandoffTerminalAnswer() async {
+    // A think_deeper-style handoff: the provider's authoritative answer keeps
+    // the pre-tool sentence and the continuation joined with no space, which
+    // is exactly what the streamed projection was normalizing on every flush.
+    // The terminal overwrite must honor the same contract or the run-on join
+    // reappears the moment the turn settles — and is persisted that way.
+    let joined = "Let me think it through.Capture the context at the card."
+    let provider = ChatProvider()
+    provider.messages = [
+      ChatMessage(
+        id: "ai-terminal",
+        text: joined,
+        sender: .ai,
+        isStreaming: true,
+        contentBlocks: [.text(id: "answer", text: joined)])
+    ]
+
+    let accepted = await provider.finalizeAssistantMessageCitations(
+      messageId: "ai-terminal",
+      queryText: joined,
+      selectedReferences: [],
+      requestedSources: false,
+      terminalCitationReferences: [])
+
+    XCTAssertEqual(accepted, "Let me think it through. Capture the context at the card.")
+    XCTAssertEqual(
+      provider.messages.first?.text,
+      "Let me think it through. Capture the context at the card.")
+    XCTAssertFalse(provider.messages.first?.isStreaming ?? true)
+  }
+
   func testRequestedSourcesRailUsesTurnLedgerNotLookupCorpus() {
     var message = ChatMessage(
       id: "ai-1",

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -507,6 +507,15 @@ export class PiMonoAdapter implements HarnessAdapter {
   /** State for projecting gateway-owned public-web progress without waiting for
    * the terminal turn before forwarding model text. */
   private activePublicWebTurn: PublicWebTurnState | null = null;
+  /** Last character forwarded to the host as answer text this prompt, so an
+   *  iteration boundary can tell whether the two sides would render as one
+   *  run-on line. Null until this prompt has forwarded any answer text. */
+  private lastForwardedTextChar: string | null = null;
+  /** Set once the provider pauses on a tool mid-prompt. The next text delta
+   *  opens a new provider iteration; without a separator the host renders the
+   *  pre-tool sentence and the continuation joined together
+   *  ("…handle it.Capture the…"). */
+  private awaitingContinuationText = false;
   /** Served models observed on the in-flight prompt, deduplicated. Reported
    *  once per identity through the adapter event sink (`model_used`) so the
    *  Response Context popover can attribute the answer honestly. */
@@ -835,6 +844,8 @@ export class PiMonoAdapter implements HarnessAdapter {
 
     this.eventHandler = onEvent;
     this.reportedPromptModels.clear();
+    this.lastForwardedTextChar = null;
+    this.awaitingContinuationText = false;
     this.toolExecutor = onToolCall;
     this.requiredAgentControlFailures.clear();
     this.requiredControlInputs.clear();
@@ -1294,7 +1305,12 @@ export class PiMonoAdapter implements HarnessAdapter {
             this.activePublicWebTurn.bufferedText += msgEvent.delta;
             this.emitPublicWebText(this.activePublicWebTurn);
           } else {
-            this.eventHandler?.({ type: "text_delta", text: msgEvent.delta });
+            if (this.awaitingContinuationText) {
+              this.awaitingContinuationText = false;
+              const gap = this.iterationGapDelta(msgEvent.delta);
+              if (gap) this.forwardAnswerDelta(gap);
+            }
+            this.forwardAnswerDelta(msgEvent.delta);
           }
         }
         break;
@@ -1340,6 +1356,56 @@ export class PiMonoAdapter implements HarnessAdapter {
         // Handled by turn_end
         break;
     }
+  }
+
+  /** Forward answer text to the host, remembering the last character so a
+   *  later iteration boundary can tell whether the two sides run together. */
+  private forwardAnswerDelta(delta: string): void {
+    const last = delta[delta.length - 1];
+    if (last !== undefined) this.lastForwardedTextChar = last;
+    this.eventHandler?.({ type: "text_delta", text: delta });
+  }
+
+  /** The separator to emit before a continuation's first text delta, empty
+   *  when either side already carries whitespace so the provider's own line
+   *  breaks are never doubled. Same rule the backend chat agent loop applies
+   *  between its own tool-loop iterations. */
+  private iterationGapDelta(nextDelta: string): string {
+    const previous = this.lastForwardedTextChar;
+    const next = nextDelta[0];
+    if (!previous || !next) return "";
+    const carriesBreak = (c: string) => c === " " || c === "\n";
+    return carriesBreak(previous) || carriesBreak(next) ? "" : "\n\n";
+  }
+
+  /** Terminal answer text for the prompt result: every text block of the
+   *  provider's final message, with an iteration separator where a tool block
+   *  splits two text runs that would otherwise join into one line. */
+  static terminalText(content: PiContentBlock[] | undefined): string {
+    if (!content) return "";
+    let text = "";
+    let separated = false;
+    for (const block of content) {
+      if (block.type === "text") {
+        const blockText = block.text || "";
+        if (blockText) {
+          const carriesBreak = (c: string) => c === " " || c === "\n";
+          if (
+            separated &&
+            text &&
+            !carriesBreak(text[text.length - 1]) &&
+            !carriesBreak(blockText[0])
+          ) {
+            text += "\n\n";
+          }
+          text += blockText;
+        }
+        separated = false;
+      } else {
+        separated = true;
+      }
+    }
+    return text;
   }
 
   private handleToolStart(event: PiRpcEvent): void {
@@ -1586,6 +1652,10 @@ export class PiMonoAdapter implements HarnessAdapter {
         this.rejectJitAttemptBudget(generation, pending);
         return;
       }
+      // The continuation's text opens a new provider iteration. If text was
+      // already forwarded this prompt, the two sides must not render as one
+      // run-on line — the next text delta carries the separator.
+      this.awaitingContinuationText = true;
       process.stderr.write(
         `[pi-mono] intermediate turn_end (${stopReason}) — keeping prompt alive\n`
       );
@@ -1613,14 +1683,11 @@ export class PiMonoAdapter implements HarnessAdapter {
     const publicWebTurn = this.activePublicWebTurn;
     this.activePublicWebTurn = null;
 
-    // Extract text from content blocks
-    let text = "";
-    if (message?.content) {
-      text = message.content
-        .filter((b) => b.type === "text")
-        .map((b) => b.text || "")
-        .join("");
-    }
+    // Extract text from content blocks. A provider that keeps its whole loop
+    // in one message puts tool blocks between the text blocks; joining only
+    // the text runs the iterations together ("…handle it.Capture the…"), so
+    // the separator mirrors what the streamed deltas carry.
+    let text = PiMonoAdapter.terminalText(message?.content);
     if (publicWebTurn) {
       text = publicWebTurn.bufferedText || text;
       // A terminal public-web turn proves the gateway completed the required

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -1374,7 +1374,9 @@ export class PiMonoAdapter implements HarnessAdapter {
     const previous = this.lastForwardedTextChar;
     const next = nextDelta[0];
     if (!previous || !next) return "";
-    const carriesBreak = (c: string) => c === " " || c === "\n";
+    // Whitespace of any kind (\t, \r, …) counts as an existing break — the
+    // provider's own separator must never be doubled by a blank paragraph.
+    const carriesBreak = (c: string) => /\s/.test(c);
     return carriesBreak(previous) || carriesBreak(next) ? "" : "\n\n";
   }
 
@@ -1389,7 +1391,9 @@ export class PiMonoAdapter implements HarnessAdapter {
       if (block.type === "text") {
         const blockText = block.text || "";
         if (blockText) {
-          const carriesBreak = (c: string) => c === " " || c === "\n";
+          // Same whitespace contract as iterationGapDelta: any whitespace
+          // character counts as an existing break.
+          const carriesBreak = (c: string) => /\s/.test(c);
           if (
             separated &&
             text &&

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -1492,6 +1492,22 @@ describe("PiMonoAdapter iteration text separation", () => {
         { type: "text", text: "\n\nNext paragraph." },
       ])
     ).toBe("Ended with a break.\n\n\nNext paragraph.");
+    // Any whitespace character (\t, \r) counts as an existing break at a
+    // tool-separated boundary — no extra blank paragraph is inserted.
+    expect(
+      PiMonoAdapter.terminalText([
+        { type: "text", text: "Ended with a tab.\t" },
+        { type: "toolCall", id: "t", name: "x", arguments: {} },
+        { type: "text", text: "Continuation." },
+      ])
+    ).toBe("Ended with a tab.\tContinuation.");
+    expect(
+      PiMonoAdapter.terminalText([
+        { type: "text", text: "Ended with a carriage return.\r" },
+        { type: "toolCall", id: "t", name: "x", arguments: {} },
+        { type: "text", text: "Continuation." },
+      ])
+    ).toBe("Ended with a carriage return.\rContinuation.");
     expect(PiMonoAdapter.terminalText(undefined)).toBe("");
   });
 });

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -1344,3 +1344,154 @@ describe("PiMonoAdapter served-model attribution", () => {
     expect(modelEvents.every((e: any) => e.model === "gpt-5.6-luna")).toBe(true);
   });
 });
+
+describe("PiMonoAdapter iteration text separation", () => {
+  function makeIntermediateTurnEndEvent() {
+    return {
+      type: "turn_end",
+      message: {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [
+          { type: "text", text: "Got it." },
+          { type: "toolCall", id: "tool-1", name: "think_deeper", arguments: {} },
+        ],
+      },
+    };
+  }
+
+  function makeTextDeltaEvent(delta: string) {
+    return JSON.stringify({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta },
+    });
+  }
+
+  it("separates the continuation iteration from forwarded pre-tool text", async () => {
+    const { adapter, events } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "how should this work" }],
+      [],
+      "act",
+      (event) => events.push(event),
+      async () => "",
+    );
+
+    // The provider streams a sentence, pauses to run a tool, then continues.
+    (adapter as any).handleEvent(
+      makeTextDeltaEvent("Got it, that's a tricky detail — let me think it through.")
+    );
+    (adapter as any).handleEvent(JSON.stringify(makeIntermediateTurnEndEvent()));
+    (adapter as any).handleEvent(makeTextDeltaEvent("Capture the context first."));
+
+    const deltas = events
+      .filter((e: any) => e.type === "text_delta")
+      .map((e: any) => e.text as string);
+    // The joined pre-tool sentence and continuation must not render as one
+    // run-on line ("…think it through.Capture the…").
+    expect(deltas.join("")).toBe(
+      "Got it, that's a tricky detail — let me think it through.\n\nCapture the context first."
+    );
+
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("unused — deltas already streamed"));
+    await prompt;
+  });
+
+  it("does not double-separate when the continuation carries its own break", async () => {
+    const { adapter, events } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "q" }],
+      [],
+      "act",
+      (event) => events.push(event),
+      async () => "",
+    );
+
+    (adapter as any).handleEvent(makeTextDeltaEvent("First answer."));
+    (adapter as any).handleEvent(JSON.stringify(makeIntermediateTurnEndEvent()));
+    (adapter as any).handleEvent(makeTextDeltaEvent("\n\nContinuation."));
+
+    const deltas = events
+      .filter((e: any) => e.type === "text_delta")
+      .map((e: any) => e.text as string);
+    expect(deltas.join("")).toBe("First answer.\n\nContinuation.");
+
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("done"));
+    await prompt;
+  });
+
+  it("emits no separator after a tool-only iteration with no prior text", async () => {
+    const { adapter, events } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "q" }],
+      [],
+      "act",
+      (event) => events.push(event),
+      async () => "",
+    );
+
+    (adapter as any).handleEvent(JSON.stringify(makeIntermediateTurnEndEvent()));
+    (adapter as any).handleEvent(makeTextDeltaEvent("Now the answer."));
+
+    const deltas = events
+      .filter((e: any) => e.type === "text_delta")
+      .map((e: any) => e.text as string);
+    expect(deltas).toEqual(["Now the answer."]);
+
+    (adapter as any).handleTurnEnd(makeTurnEndEvent("done"));
+    await prompt;
+  });
+
+  it("joins the terminal message's tool-separated text blocks with the same separator", async () => {
+    const { adapter } = createAdapter();
+    seedSessions(adapter, "session-1");
+
+    const prompt = adapter.sendPrompt(
+      "session-1",
+      [{ type: "text", text: "q" }],
+      [],
+      "act",
+      () => {},
+      async () => "",
+    );
+
+    const turnEnd = makeTurnEndEvent("");
+    (turnEnd.message as any).content = [
+      { type: "text", text: "Let me think it through." },
+      { type: "toolCall", id: "tool-1", name: "think_deeper", arguments: {} },
+      { type: "text", text: "Capture the context first." },
+    ];
+    (adapter as any).handleTurnEnd(turnEnd);
+
+    await expect(prompt).resolves.toMatchObject({
+      text: "Let me think it through.\n\nCapture the context first.",
+    });
+  });
+
+  it("keeps adjacent text blocks without a tool between them joined verbatim", () => {
+    expect(
+      PiMonoAdapter.terminalText([
+        { type: "text", text: "Same line " },
+        { type: "text", text: "continues here." },
+      ])
+    ).toBe("Same line continues here.");
+    // A provider break of its own is never doubled.
+    expect(
+      PiMonoAdapter.terminalText([
+        { type: "text", text: "Ended with a break.\n" },
+        { type: "toolCall", id: "t", name: "x", arguments: {} },
+        { type: "text", text: "\n\nNext paragraph." },
+      ])
+    ).toBe("Ended with a break.\n\n\nNext paragraph.");
+    expect(PiMonoAdapter.terminalText(undefined)).toBe("");
+  });
+});

--- a/desktop/macos/changelog/unreleased/20260906-agent-handoff-spacing.json
+++ b/desktop/macos/changelog/unreleased/20260906-agent-handoff-spacing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat answers no longer run the pre-tool sentence and the post-tool continuation together when Omi pauses to think or search mid-turn (\"...handle it.Capture the context...\" now renders as two properly separated sentences)"
+}


### PR DESCRIPTION
## What & why

When the chat agent pauses to run a tool mid-turn (`think_deeper`, memory search, …), the text spoken before the pause and the continuation after the tool result were joined with no separator. The rendered answer read "…let me think through a clean way to handle it.Capture the context…" — one run-on line at the agent handoff (reported on macOS desktop chat).

The backend chat agent loop already guards this for mobile/web: #5725 inserts `\n\n` between its tool-loop iterations. The desktop chat path runs its tool loop inside the local agent runtime (pi-mono adapter), and the same join existed there in two places, plus one render-side gap:

1. **pi-mono adapter, streamed deltas** — text deltas from a continuation iteration were forwarded with no separator after the pre-tool text (visible live on Windows; masked on macOS by the streaming sentence-spacing normalizer).
2. **pi-mono adapter, terminal result text** — the adapter extracts the prompt's answer by joining the terminal message's text blocks; a provider that keeps its whole loop in one message puts tool blocks between the text runs, and the old `join("")` concatenated the iterations ("…handle it." + "Capture the context…"). That text is the authoritative answer both desktops overwrite the streamed transcript with, so the join won at turn end even where streaming had shown a space.
3. **macOS terminal overwrite** — `finalizeAssistantMessageCitations` wrote the authoritative answer via `applyAuthoritativeTerminalAnswer` without the sentence-spacing projection every streaming flush applies, so an un-normalized handoff reappeared the moment the turn settled — and was persisted that way.

## Fixes

- `desktop/macos/agent/src/adapters/pi-mono.ts` — emit the same `\n\n` iteration separator the backend loop inserts: before a continuation's first text delta when both boundary characters carry no whitespace, and between tool-separated text blocks when extracting the terminal answer (`terminalText`).
- `desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift` — apply `normalizeAssistantSentenceSpacing` to the authoritative terminal answer before it replaces the streamed projection (and is journaled).

Covered elsewhere, no change needed: mobile/web chat is fed by the backend `agentic.py` loop that already inserts the separator; the realtime voice surfaces re-utter the escalation answer as a fresh spoken turn rather than appending it to the pre-tool text.

## Verification

- `npm test` (agent vitest, `desktop/macos/agent`): `tests/pi-mono-adapter.test.ts` 55/55 pass, including five new iteration-separation tests (streamed gap after a tool pause, no double-separation when the continuation carries its own break, no separator after a tool-only iteration, terminal tool-separated blocks joined, adjacent text blocks preserved verbatim). The suite's 5 other failures (`mcp-stdio-client` timing, `runtime-stdio-contract` timeouts, `tool-surfaces-exhaustiveness` generator check) fail identically on a clean `origin/main` checkout in the same worktree — pre-existing/environmental, not from this change.
- `xcrun swift test -c debug --package-path Desktop --filter ChatCitationTests|ChatSentenceSpacingTests` — 49/49 + 8/8 pass, including the new `testFinalizationAppliesSentenceSpacingToJoinedAgentHandoffTerminalAnswer` regression (joined handoff terminal answer finalizes with the space inserted and persists normalized).
- `OMI_PR_BODY_FILE=/tmp/pr-body-handoff-spacing.md make preflight` — 26/26 checks pass (includes swift-format lint, SwiftLint, adapter contract conformance, and the failure-class protocol with the new `FC-agent-iteration-text-runs-together` definition).

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

