### PR TITLE
fix(desktop): capitalize sentence starts and "I" in dictation without the polisher

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
@@ -76,7 +76,10 @@ owns the dictate-or-ask decision and the delivery, and nothing else does.
      from on-screen text; live it turned "So, this is a test" into "Sil, …"
      and "hello there" into "hello then". Names are the polisher's job.
   3. **Format** (`DictationFormatter`, always): spoken fillers out, the
-     punctuation they leave behind repaired, first letter capitalized.
+     punctuation they leave behind repaired, sentence starts and the
+     pronoun "I" capitalized. The backend recognizer can return a whole
+     dictation in lowercase, and this is the only case pass that runs when
+     the polisher below is unavailable (offline, plan-gated, timed out).
      English-only fillers ("er") are stripped only for English.
   4. **Polish** (`DictationPolisher`, online only): the lightweight Gemini
      model through the backend proxy (`GeminiClient`, thinking off, 6 s cap)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3358,12 +3358,19 @@ class PushToTalkManager: ObservableObject {
             area: "voice_typing", from: "llm_polish", to: "local_format", reason: "policy", outcome: .degraded)
         }
       } catch {
+        // Observed live: every polish "failed" within 200ms and nothing said
+        // why. It was the plan gate — the same wall that stops live notes —
+        // so the reason is named and the gate lands in the "quota" bucket
+        // (a closed set; an unknown reason would be filed as "other").
         let timedOut = (error as? DictationPolisher.PolishError) == .timedOut
+        var planGated = false
+        if case GeminiClient.GeminiClientError.planGated = error { planGated = true }
         log(
-          "PushToTalkManager: dictation polish \(timedOut ? "timed out" : "failed") — keeping the formatted transcript")
+          "PushToTalkManager: dictation polish \(timedOut ? "timed out" : "failed") — "
+            + "keeping the formatted transcript (\(error.localizedDescription))")
         DesktopDiagnosticsManager.shared.recordFallback(
           area: "voice_typing", from: "llm_polish", to: "local_format",
-          reason: timedOut ? "timeout" : "other", outcome: .degraded)
+          reason: timedOut ? "timeout" : (planGated ? "quota" : "other"), outcome: .degraded)
       }
       guard isCurrent() else {
         run.abandoned = true

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationFormatter.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationFormatter.swift
@@ -5,7 +5,9 @@ import Foundation
 /// This runs on every dictation, online or not, and it is deliberately
 /// conservative: it removes only what is never wanted in written text (spoken
 /// fillers) and repairs what removing them leaves behind (doubled spaces,
-/// stranded commas, a lowercase first word). Everything that needs judgement —
+/// stranded commas) or what a recognizer never wrote in the first place (a
+/// capital at the start of each sentence, the pronoun "I"). Everything that
+/// needs judgement —
 /// self-corrections, spoken formatting commands, how a number or an email
 /// address is written — belongs to `DictationPolisher`, which can be skipped
 /// when there is no network without leaving the text broken.
@@ -24,6 +26,10 @@ enum DictationFormatter {
     var result = text.replacingOccurrences(of: "\r\n", with: "\n")
     result = removingFillers(result, language: language)
     result = normalizingWhitespace(result)
+    result = capitalizingSentenceStarts(result)
+    if capitalizesPronounI(language: language, text: result) {
+      result = capitalizingPronounI(result)
+    }
     result = VoiceTypeCommandParser.capitalizingFirstWord(result)
     return result
   }
@@ -72,5 +78,113 @@ enum DictationFormatter {
     result = result.replacingOccurrences(of: "[ \\t]+\\n", with: "\n", options: .regularExpression)
     result = result.replacingOccurrences(of: "\\n[ \\t]+", with: "\n", options: .regularExpression)
     return result.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // MARK: - Capitalization
+
+  /// Observed live: the backend's batch recognizer returned a whole dictation
+  /// in lowercase ("first of all, i'm typing right now and i think this will
+  /// work."), and with the polisher unavailable that is what was pasted. The
+  /// polisher fixes case when it runs; these two rules make the text right
+  /// when it does not.
+
+  /// A capital after each sentence end. Only ". ", "! " and "? " count, and a
+  /// full stop only when what precedes it is a word rather than an initial
+  /// ("J. smith"), an abbreviation ("dr. smith", "e.g. this"), or the rest
+  /// of an ellipsis ("wait... maybe"). A word already capitalized is left as
+  /// heard. Line breaks alone do not start a sentence: a dictated "new line"
+  /// may continue a list item.
+  static func capitalizingSentenceStarts(_ text: String) -> String {
+    var chars = Array(text)
+    var word = ""
+    var previous: Character?
+    var sentenceEnded = false
+    var spaceSeen = false
+    for index in chars.indices {
+      let char = chars[index]
+      defer { previous = char }
+      if char.isLetter || char.isNumber {
+        if sentenceEnded && spaceSeen && char.isLowercase {
+          let upper = String(char).uppercased()
+          if upper.count == 1, let first = upper.first { chars[index] = first }
+        }
+        sentenceEnded = false
+        spaceSeen = false
+        word.append(char)
+      } else if char == "." {
+        sentenceEnded = endsSentence(word: word, previous: previous)
+        spaceSeen = false
+        word = ""
+      } else if char == "!" || char == "?" {
+        sentenceEnded = true
+        spaceSeen = false
+        word = ""
+      } else if char.isWhitespace || char.isNewline {
+        if sentenceEnded { spaceSeen = true }
+        word = ""
+      } else if char == "'" || char == "’" {
+        // Inside a word ("don't"): the word goes on.
+        word.append(char)
+      } else if char == "," || char == ";" || char == ":" {
+        sentenceEnded = false
+        word = ""
+      } else {
+        // Quotes, brackets, dashes: neither end a sentence nor cancel one
+        // that just ended ("she said \"no.\" then left").
+        word = ""
+      }
+    }
+    return String(chars)
+  }
+
+  /// Tokens a full stop belongs to rather than ends.
+  private static let abbreviations: Set<String> = [
+    "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "vs", "etc", "inc", "ltd", "approx", "dept",
+  ]
+
+  private static func endsSentence(word: String, previous: Character?) -> Bool {
+    guard let previous, previous != "." else { return false }
+    let lowered = word.lowercased()
+    // A lone letter is an initial or half of "e.g." — except "i", which is a
+    // word that ends sentences all the time ("so do i. so does he").
+    if lowered.count == 1, let only = lowered.first, only.isLetter, lowered != "i" { return false }
+    return !abbreviations.contains(lowered)
+  }
+
+  /// The pronoun "i" and its contractions ("i'm", "i've", "i'll", "i'd") as a
+  /// standalone word. Not a letter glued into an address, a path, a hyphenated
+  /// word, or "i.e.", and not a list marker "(i)".
+  static func capitalizingPronounI(_ text: String) -> String {
+    text.replacingOccurrences(
+      of: "(?<![\\w'’@./\\-])i(?=(?:['’](?:m|ve|ll|d))?(?:[,;:!?]|\\.(?!\\w))?(?:\\s|$))",
+      with: "I", options: .regularExpression)
+  }
+
+  /// English is the only language in which a lone "i" is the pronoun: in
+  /// Italian it is an article ("i ragazzi"), in Catalan "and". When the
+  /// transcription language is "multi" the text itself has to look English.
+  static func capitalizesPronounI(language: String, text: String) -> Bool {
+    let base = language.lowercased().split(separator: "-").first.map(String.init) ?? language.lowercased()
+    if base == "en" { return true }
+    return base == "multi" && looksEnglish(text)
+  }
+
+  /// Function words that do not occur as words in the other languages the
+  /// recognizer commonly returns; two of them is enough to call a text English.
+  private static let englishMarkers: Set<String> = [
+    "the", "and", "is", "are", "was", "were", "you", "that", "this", "have", "has", "with", "not",
+    "will", "would", "can", "think", "just", "get", "got", "gonna", "let's", "we", "they", "my",
+    "your", "it", "of", "to", "i'm", "i've", "i'll", "i'd", "don't", "it's", "what", "there",
+  ]
+
+  static func looksEnglish(_ text: String) -> Bool {
+    var hits = 0
+    let tokens = text.lowercased().replacingOccurrences(of: "’", with: "'")
+      .split(whereSeparator: { !$0.isLetter && $0 != "'" })
+    for token in tokens where englishMarkers.contains(String(token)) {
+      hits += 1
+      if hits >= 2 { return true }
+    }
+    return false
   }
 }

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -361,6 +361,52 @@ final class DictationFormatterTests: XCTestCase {
     XCTAssertEqual(DictationFormatter.format("Nathan is here"), "Nathan is here")
     XCTAssertEqual(DictationFormatter.format("   "), "")
   }
+
+  func testSentenceStartsAndThePronounIAreCapitalized() {
+    // Verbatim from a live dictation the backend recognizer returned in
+    // lowercase while the polisher was unavailable; this is what was pasted.
+    XCTAssertEqual(
+      DictationFormatter.format(
+        "beat came for real. first of all, i'm typing right now and i think this will work. "
+          + "i'm just talking a lot. i think supreme board is pretty cool. there's i got a laptop. "
+          + "loki got a pack. i'm gonna get this bread. let's go."),
+      "Beat came for real. First of all, I'm typing right now and I think this will work. "
+        + "I'm just talking a lot. I think supreme board is pretty cool. There's I got a laptop. "
+        + "Loki got a pack. I'm gonna get this bread. Let's go.")
+    XCTAssertEqual(
+      DictationFormatter.format("yes, i’m here and i’ll go! are you?"), "Yes, I’m here and I’ll go! Are you?")
+    XCTAssertEqual(DictationFormatter.format("so do i. so does he"), "So do I. So does he")
+    XCTAssertEqual(DictationFormatter.format("wait, i"), "Wait, I")
+  }
+
+  func testALetterIInsideAnotherTokenIsNotThePronoun() {
+    XCTAssertEqual(DictationFormatter.format("say hi to him"), "Say hi to him")
+    XCTAssertEqual(DictationFormatter.format("the wi-fi is down"), "The wi-fi is down")
+    XCTAssertEqual(DictationFormatter.format("mail i@example.com now"), "Mail i@example.com now")
+    XCTAssertEqual(DictationFormatter.format("that is i.e. the one"), "That is i.e. the one")
+    XCTAssertEqual(DictationFormatter.format("see (i) and (ii)"), "See (i) and (ii)")
+    XCTAssertEqual(DictationFormatter.format("open /usr/i/notes"), "Open /usr/i/notes")
+  }
+
+  func testAbbreviationsInitialsAndEllipsesDoNotStartASentence() {
+    XCTAssertEqual(DictationFormatter.format("see e.g. the docs. it works"), "See e.g. the docs. It works")
+    XCTAssertEqual(DictationFormatter.format("ask dr. smith at 3.5 pm"), "Ask dr. smith at 3.5 pm")
+    XCTAssertEqual(DictationFormatter.format("meet J. smith. then go"), "Meet J. smith. Then go")
+    XCTAssertEqual(DictationFormatter.format("wait... maybe not"), "Wait... maybe not")
+    XCTAssertEqual(DictationFormatter.format("she said \"no.\" then left"), "She said \"no.\" Then left")
+    XCTAssertEqual(DictationFormatter.format("visit example.com. it loads"), "Visit example.com. It loads")
+  }
+
+  func testThePronounIIsOnlyCapitalizedInEnglish() {
+    // Italian "i" is an article; capitalizing it would rewrite the sentence.
+    XCTAssertEqual(DictationFormatter.format("guarda i ragazzi", language: "it"), "Guarda i ragazzi")
+    XCTAssertEqual(DictationFormatter.format("guarda i ragazzi", language: "multi"), "Guarda i ragazzi")
+    // Auto-detected language, English text: the text itself decides.
+    XCTAssertEqual(
+      DictationFormatter.format("so i think this is the one", language: "multi"), "So I think this is the one")
+    // Sentence starts are capitalized in every cased language.
+    XCTAssertEqual(DictationFormatter.format("er kommt. sie auch", language: "de"), "Er kommt. Sie auch")
+  }
 }
 
 final class DictationPolisherTests: XCTestCase {

--- a/desktop/macos/changelog/unreleased/20260906-dictation-capitalization.json
+++ b/desktop/macos/changelog/unreleased/20260906-dictation-capitalization.json
@@ -1,0 +1,3 @@
+{
+  "change": "Voice typing now capitalizes sentence starts and the pronoun \"I\" even when the AI cleanup is unavailable"
+}


### PR DESCRIPTION
## Summary

Voice typing pasted a whole dictation in lowercase: "first of all, i'm typing right now and i think this will work. i'm just talking a lot." Only the first word was capitalized.

Two things lined up:

- The backend batch recognizer (`provider=parakeet`) returns the transcript in lowercase, and `DictationFormatter` only ever capitalized the first word. Sentence starts and the pronoun "I" were left to the model polisher.
- The polisher never ran: every `DictationPolisher.polish` call threw `GeminiClientError.planGated` within ~150 ms on a dev build without a plan, and the catch logged it as a bare "dictation polish failed" with diagnostics reason `other`.

## Changes

- `DictationFormatter` gains two deterministic rules that run on every dictation, online or not: a capital after each sentence end (". ", "! ", "? ", skipping initials, abbreviations such as "dr." and "e.g.", and ellipses) and the pronoun "I" with its contractions. The "I" rule applies for English, and for `multi` only when the text reads as English, so Italian "i ragazzi" is untouched.
- The polish failure log names the error, and a plan-gated failure records diagnostics reason `quota` instead of `other`.
- Tests cover the live transcript verbatim, tokens that merely contain "i", abbreviations and initials, and the language gate.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Neither is touched: the change is text formatting after the turn closes plus the reason label on an existing fallback record. No new store, no lifecycle state, no second classifier.

Failure-Class: FC-typed-failure-collapsed-to-generic

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 3954 -> 3961 | the polish catch now classifies the plan gate and logs the error; the voice-typing turn body already lives in the VoiceTyping/ files and this is the one site that owns the fallback decision

## Test plan

- `swift test --filter 'DictationFormatterTests|VoiceTypeCommandParserTests'`
- Local preflight: 23 checks pass on the rebased branch.
- Live on a plan-gated dev build (polisher unavailable, `provider=parakeet` lowercase transcript): the paste read "I gotta do this thing. I'm pretty awesome. I've done this thing and I've heard it before, so I don't really get why I don't really want to do it." The log now reads `dictation polish failed — keeping the formatted transcript (AI features require an active plan or BYOK keys.)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYaCYruq43TXZuJJWdSTJY
