### PR TITLE
fix(desktop): resolve Rewind OCR languages from the user locale

### DIFF
--- a/.github/failure-classes/FC-recognition-scope-pinned-below-user-locale.json
+++ b/.github/failure-classes/FC-recognition-scope-pinned-below-user-locale.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-recognition-scope-pinned-below-user-locale",
+  "violated_contract": "A capability that reads the user's own content must scope itself from the user's locale, not from a compile-time constant. When the scope is pinned narrower than the user's languages, content outside it is not degraded but absent, and the surface built on top reports success over data it never saw.",
+  "canonical_prevention": "Resolve the recognition language list from Locale.preferredLanguages, keep only tags the framework reports as supported, and retain an English fallback for mixed screen text. Resolve once into the process-lifetime constant Vision's asynchronous enumeration requires, and unit-test the ordering, region-less matching, unsupported-tag dropping and empty-capability fallback without invoking Vision.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/RewindOCRQualityTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -176,22 +176,39 @@ actor RewindOCRService {
       }
     }
 
-    return resolved.isEmpty ? ["en-US"] : resolved
+    // Never hand back a tag Vision did not report: an unsupported language makes
+    // `perform` throw and takes the whole request down. When the capability list
+    // shares nothing with this user, fall back to the first language Vision does
+    // support. ["en-US"] is reserved for the empty-capability case above, where
+    // there is no reported list to choose from.
+    return resolved.isEmpty ? [supported[0]] : resolved
   }
 
   /// Matches a BCP-47 tag against Vision's supported tags: the exact tag first,
-  /// then the same language under any region, so a region-less preference such
-  /// as `ja` still selects a supported `ja-JP`.
+  /// then the same language *and script*.
+  ///
+  /// Script matters, and collapsing to the primary language gets it wrong: `zh`
+  /// alone would let a `zh-TW` reader be handed Vision's `zh-Hans` scope and
+  /// recognised with the Simplified model. Comparing maximised identifiers keeps
+  /// `zh-TW` on `zh-Hant`, while still letting `ja` reach `ja-JP` and `en-GB`
+  /// reach `en-US`, because those agree once likely subtags are filled in.
   private static func bestSupportedMatch(for tag: String, in supported: [String]) -> String? {
     if let exact = supported.first(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) {
       return exact
     }
-    let language = Self.primaryLanguage(of: tag)
-    return supported.first { Self.primaryLanguage(of: $0).caseInsensitiveCompare(language) == .orderedSame }
+    let requested = Self.languageAndScript(of: tag)
+    return supported.first { Self.languageAndScript(of: $0) == requested }
   }
 
-  private static func primaryLanguage(of tag: String) -> String {
-    tag.split(separator: "-").first.map(String.init) ?? tag
+  /// Language and script for a tag, with likely subtags filled in, so tags that
+  /// name the same written language compare equal regardless of how they spell
+  /// it (`zh-TW` and `zh-Hant`; `ja` and `ja-JP`).
+  static func languageAndScript(of tag: String) -> String {
+    let maximal = Locale.Language(identifier: tag).maximalIdentifier
+    let expanded = Locale.Language(identifier: maximal)
+    let language = expanded.languageCode?.identifier.lowercased() ?? tag.lowercased()
+    let script = expanded.script?.identifier.lowercased() ?? ""
+    return "\(language)-\(script)"
   }
 
   private init() {}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -107,15 +107,92 @@ actor RewindOCRService {
 
   /// Recognition languages passed to `VNRecognizeTextRequest`.
   ///
-  /// Held as a process-lifetime constant so the bridged NSArray backing storage
-  /// can never be released while Vision's TextRecognition framework enumerates
-  /// it asynchronously on `com.apple.root.utility-qos.cooperative`. A Swift
-  /// array literal assigned to `recognitionLanguages` has its storage tied to
-  /// the call frame; once the request is dispatched to a background queue the
-  /// storage can be freed, leaving TextRecognition iterating an
+  /// Resolved once from the user's own preferred languages instead of a pinned
+  /// locale: a language absent from this list is not recognised poorly, it is
+  /// not recognised at all, so pinning `en-US` left every non-Latin script
+  /// silently unsearchable.
+  ///
+  /// Still held as a process-lifetime constant so the bridged NSArray backing
+  /// storage can never be released while Vision's TextRecognition framework
+  /// enumerates it asynchronously on `com.apple.root.utility-qos.cooperative`.
+  /// A Swift array literal assigned to `recognitionLanguages` has its storage
+  /// tied to the call frame; once the request is dispatched to a background
+  /// queue the storage can be freed, leaving TextRecognition iterating an
   /// `__EmptyArrayStorage` and tripping `_assertionFailure` (EXC_BREAKPOINT /
-  /// SIGTRAP). Pinning the array breaks that race. See #5891, #5151.
-  private static let recognitionLanguages: [String] = ["en-US"]
+  /// SIGTRAP). Resolving into a `static let` keeps exactly one pinned array for
+  /// the process lifetime, so that race stays closed. See #5891, #5151.
+  private static let recognitionLanguages: [String] = resolveRecognitionLanguages(
+    preferred: Locale.preferredLanguages,
+    supported: visionSupportedRecognitionLanguages()
+  )
+
+  /// Languages Vision can actually recognise at the level this service uses.
+  ///
+  /// Falls back to English when the query fails rather than propagating: an
+  /// unavailable capability list must not take OCR down with it.
+  static func visionSupportedRecognitionLanguages() -> [String] {
+    (try? VNRecognizeTextRequest.supportedRecognitionLanguages(
+      for: recognitionLevel(),
+      revision: VNRecognizeTextRequest.currentRevision)) ?? ["en-US"]
+  }
+
+  /// Picks the recognition languages for a user, in Vision's priority order.
+  ///
+  /// Pure and injectable so the ordering, filtering and fallback rules are
+  /// testable without invoking Vision or changing the host's locale.
+  ///
+  /// Preferred languages Vision does not support are dropped rather than passed
+  /// through: `perform` throws on an unsupported tag, which would fail the whole
+  /// request and turn a partial-recognition bug into total OCR loss.
+  static func resolveRecognitionLanguages(
+    preferred: [String],
+    supported: [String]
+  ) -> [String] {
+    guard !supported.isEmpty else { return ["en-US"] }
+
+    var resolved: [String] = []
+    var seen = Set<String>()
+
+    func append(_ tag: String) {
+      guard seen.insert(tag).inserted else { return }
+      resolved.append(tag)
+    }
+
+    // Vision treats the list as a priority order, so the user's own languages
+    // lead.
+    for tag in preferred {
+      if let match = bestSupportedMatch(for: tag, in: supported) {
+        append(match)
+      }
+    }
+
+    // English is retained even when it is not a preferred language. Screen text
+    // is routinely mixed — identifiers, URLs, product names — and dropping it
+    // would regress the Latin half of the very lines this is meant to fix.
+    for fallback in ["en-US", "en"] {
+      if let match = bestSupportedMatch(for: fallback, in: supported) {
+        append(match)
+        break
+      }
+    }
+
+    return resolved.isEmpty ? ["en-US"] : resolved
+  }
+
+  /// Matches a BCP-47 tag against Vision's supported tags: the exact tag first,
+  /// then the same language under any region, so a region-less preference such
+  /// as `ja` still selects a supported `ja-JP`.
+  private static func bestSupportedMatch(for tag: String, in supported: [String]) -> String? {
+    if let exact = supported.first(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) {
+      return exact
+    }
+    let language = Self.primaryLanguage(of: tag)
+    return supported.first { Self.primaryLanguage(of: $0).caseInsensitiveCompare(language) == .orderedSame }
+  }
+
+  private static func primaryLanguage(of tag: String) -> String {
+    tag.split(separator: "-").first.map(String.init) ?? tag
+  }
 
   private init() {}
 

--- a/desktop/macos/Desktop/Tests/RewindOCRQualityTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindOCRQualityTests.swift
@@ -16,6 +16,51 @@ final class RewindOCRQualityTests: XCTestCase {
     XCTAssertTrue(RewindOCRService.usesLanguageCorrection())
   }
 
+  func testRecognitionLanguagesFollowThePreferredLocaleInsteadOfAPinnedOne() {
+    // The bug: the list was the constant ["en-US"], so a Japanese-preferring Mac
+    // recognised no Japanese at all — the script was out of scope, not misread.
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["ja-JP"],
+        supported: ["en-US", "ja-JP", "fr-FR"]),
+      ["ja-JP", "en-US"],
+      "the user's own language must lead, with English retained for mixed screen text")
+  }
+
+  func testRegionlessPreferredLanguageSelectsASupportedRegionalVariant() {
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["ja"],
+        supported: ["en-US", "ja-JP"]),
+      ["ja-JP", "en-US"],
+      "a region-less preference such as `ja` must still reach Vision's `ja-JP`")
+  }
+
+  func testUnsupportedPreferredLanguagesAreDroppedRatherThanPassedToVision() {
+    // Vision throws on an unsupported tag, which would fail the whole request —
+    // turning a partial-recognition bug into total OCR loss.
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["xx-YY"],
+        supported: ["en-US", "ja-JP"]),
+      ["en-US"])
+  }
+
+  func testEnglishIsNotDuplicatedWhenItIsAlreadyPreferred() {
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["en-US", "ja-JP"],
+        supported: ["en-US", "ja-JP"]),
+      ["en-US", "ja-JP"])
+  }
+
+  func testAnUnavailableSupportedListStillYieldsAUsableLanguage() {
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(preferred: ["ja-JP"], supported: []),
+      ["en-US"],
+      "a failed capability query must not leave the request with an empty language list")
+  }
+
   func testBatteryOptimizationLowersCaptureCadenceInsteadOfOCRQuality() {
     let settings = RewindSettings.shared
     let savedInterval = settings.captureInterval

--- a/desktop/macos/Desktop/Tests/RewindOCRQualityTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindOCRQualityTests.swift
@@ -54,11 +54,44 @@ final class RewindOCRQualityTests: XCTestCase {
       ["en-US", "ja-JP"])
   }
 
+  func testAScopeSharingNothingWithTheUserStillComesFromVisionsOwnList() {
+    // Returning a tag Vision did not report makes `perform` throw and takes the
+    // whole request down, so the no-overlap branch must pick from `supported`
+    // rather than falling back to a literal.
+    let supported = ["fr-FR", "de-DE"]
+    let resolved = RewindOCRService.resolveRecognitionLanguages(
+      preferred: ["ja-JP"],
+      supported: supported)
+
+    XCTAssertEqual(resolved.count, 1)
+    XCTAssertTrue(
+      supported.contains(resolved[0]),
+      "resolved \(resolved) must be drawn from Vision's reported list \(supported)")
+  }
+
+  func testTraditionalChineseIsNotRecognisedWithTheSimplifiedScope() {
+    // Collapsing zh-TW to its primary language would match zh-Hans and read
+    // Traditional text with the Simplified model.
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["zh-TW"],
+        supported: ["en-US", "zh-Hans", "zh-Hant"]),
+      ["zh-Hant", "en-US"])
+  }
+
+  func testSimplifiedChinesePicksItsOwnScope() {
+    XCTAssertEqual(
+      RewindOCRService.resolveRecognitionLanguages(
+        preferred: ["zh-CN"],
+        supported: ["en-US", "zh-Hans", "zh-Hant"]),
+      ["zh-Hans", "en-US"])
+  }
+
   func testAnUnavailableSupportedListStillYieldsAUsableLanguage() {
     XCTAssertEqual(
       RewindOCRService.resolveRecognitionLanguages(preferred: ["ja-JP"], supported: []),
       ["en-US"],
-      "a failed capability query must not leave the request with an empty language list")
+      "with no reported list there is nothing to choose from, so English is the only safe guess")
   }
 
   func testBatteryOptimizationLowersCaptureCadenceInsteadOfOCRQuality() {


### PR DESCRIPTION
Fixes #12797

## What

On macOS, Rewind's screen OCR recognises no Japanese text at all. Latin characters on the same frame come back fine, so this is not degraded recognition — the script is out of scope, and Rewind's search is silently non-functional for anyone working in a non-Latin script.

## Why it happens

`RewindOCRService` pins the recognition language list to a compile-time constant:

```swift
private static let recognitionLanguages: [String] = ["en-US"]
```

`VNRecognizeTextRequest` treats that list as the entire recognition scope. A language absent from it is not recognised poorly; it is not recognised at all. There is no setting that changes this.

That constant is not arbitrary, though — the comment above it records why it must stay a process-lifetime constant: Vision's TextRecognition enumerates the bridged `NSArray` asynchronously, and an array literal whose storage is tied to the call frame can be freed mid-enumeration, tripping `_assertionFailure` (#5891, #5151). Any fix has to widen the scope **without** reintroducing a per-call array.

## The change

`recognitionLanguages` is now resolved once, from the user's own locale, into the same pinned `static let`:

```swift
private static let recognitionLanguages: [String] = resolveRecognitionLanguages(
  preferred: Locale.preferredLanguages,
  supported: visionSupportedRecognitionLanguages()
)
```

- **Preferred languages lead.** Vision treats the list as a priority order.
- **Unsupported tags are dropped, not passed through.** `perform` throws on an unsupported language, which would fail the whole request — turning a partial-recognition bug into total OCR loss.
- **A region-less preference still matches.** `ja` selects Vision's `ja-JP`.
- **English is always retained**, even when it is not preferred. Screen text is routinely mixed (identifiers, URLs, product names), and dropping English would regress the Latin half of exactly the mixed lines this fixes.
- **The capability query degrades to English** rather than propagating, so an unavailable list never leaves the request with an empty language scope.

The crash-safety property is preserved: this still resolves to exactly one array held for the process lifetime.

Scope is deliberately limited to the recognition language list. I have not touched capture cadence, recognition level, or `usesLanguageCorrection`.

## Verification

`RewindOCRQualityTests` gains five cases against the pure resolver, so the ordering and filtering rules are testable without invoking Vision or changing the host's locale:

| case | asserts |
|---|---|
| `testRecognitionLanguagesFollowThePreferredLocaleInsteadOfAPinnedOne` | `ja-JP` preferred → `["ja-JP", "en-US"]` — fails on `main`, which yields `["en-US"]` |
| `testRegionlessPreferredLanguageSelectsASupportedRegionalVariant` | `ja` → `ja-JP` |
| `testUnsupportedPreferredLanguagesAreDroppedRatherThanPassedToVision` | `xx-YY` never reaches Vision |
| `testEnglishIsNotDuplicatedWhenItIsAlreadyPreferred` | no duplicate entry |
| `testAnUnavailableSupportedListStillYieldsAUsableLanguage` | empty capability list → `["en-US"]` |

The first case is the regression test: on `main` the resolver does not exist and the constant is `["en-US"]`, so a Japanese-preferring host cannot produce `ja-JP`.

I do not have a macOS host or an Xcode toolchain in this environment, so I have not run the Swift suite myself and am not claiming a device-level repro of the Japanese sample. The change was derived from the source and the issue's measurements. Please let the Desktop Swift checks run; I will fix anything they surface.

## Failure-Class: new

`FC-recognition-scope-pinned-below-user-locale`, added in `.github/failure-classes/` in this change.

**Root cause.** The constant was introduced to solve a lifetime problem — keep one array alive for the process — and the language *policy* was silently absorbed into that fix as a literal. Once a scope value lives inside a constant justified on other grounds, nothing points at it when the user's locale differs from it. The failure is quiet by construction: OCR returns text, the row is written, search runs, and every layer above reports success over content it never saw.

**Durable guard.** The canonical prevention artifact is `RewindOCRQualityTests.swift`, which asserts the resolver's behaviour rather than a fixed language list. A future change to the language set stays correct as long as it derives from the user's locale, and any reintroduction of a pinned scope fails the first case.

The distinction from the two neighbouring locale classes: `FC-repository-text-io-inherits-host-locale` and `FC-subprocess-output-inherits-host-locale` are both about *inheriting* an ambient locale where an explicit one was required. This is the inverse — an explicit constant pinned *below* the user's locale.

## Invariants

None named. No locked invariant globs `Sources/Rewind/Core/RewindOCRService.swift`; the Rewind paths that are covered are `RewindDatabase`/`RewindIndexer`/`RewindStorage` (`INV-AUTH`), `TaskChatMessageStorage` (`INV-CHAT-1`), `MemoryStorage`/`MemoryModels` (memory tiers) and `ActionItemStorage` (`INV-TASK-1`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

