### PR TITLE
fix(desktop): restore AutoCreatedTasksStep deleted by dead-module cleanup (#12891)

### DIFF
--- a/.github/failure-classes/FC-reachability-cleanup-deletes-live-reference.json
+++ b/.github/failure-classes/FC-reachability-cleanup-deletes-live-reference.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-reachability-cleanup-deletes-live-reference",
+  "violated_contract": "A cleanup that deletes files it classifies as unreferenced must prove reachability against every import in the tree it is scanning, not a subset. Deleting a module that a live file still imports and renders breaks that consumer's typecheck and build (a build that runs typecheck first fails before it ever bundles), and the break is invisible until something happens to touch that specific path again.",
+  "canonical_prevention": "Before deleting a module as dead, grep the full worktree (not just the directory being cleaned) for every relative and aliased import of its basename, and diff the deletion against a fresh `tsc --noEmit` / bundler resolve on the affected package; a genuinely dead module leaves both clean.",
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/windows/src/renderer/**",
+    "desktop/macos/**"
+  ],
+  "status": "open"
+}

--- a/desktop/windows/src/renderer/src/components/onboarding/AutoCreatedTasksStep.test.tsx
+++ b/desktop/windows/src/renderer/src/components/onboarding/AutoCreatedTasksStep.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { AutoCreatedTasksStep } from './AutoCreatedTasksStep'
+
+afterEach(cleanup)
+
+describe('AutoCreatedTasksStep', () => {
+  it('completes onboarding once, even when the button is double-clicked', () => {
+    const onFinish = vi.fn()
+    render(<AutoCreatedTasksStep onFinish={onFinish} />)
+
+    const button = screen.getByText('Take me to my tasks')
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktop/windows/src/renderer/src/components/onboarding/AutoCreatedTasksStep.tsx
+++ b/desktop/windows/src/renderer/src/components/onboarding/AutoCreatedTasksStep.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { Check, ListChecks } from 'lucide-react'
+
+type AutoCreatedTasksStepProps = {
+  /** Complete onboarding and jump straight to the Tasks tab. */
+  onFinish: () => void
+}
+
+// Illustrative sample rows shown on the onboarding completion screen — they
+// demonstrate the auto-task feature (real tasks come from conversations the user
+// hasn't had yet). "Getting started" starts completed; the rows are clickable so
+// the user can check the others off too.
+const SAMPLE_TASKS = [
+  { title: 'Task 1', subtitle: 'From today’s meeting' },
+  { title: 'Task 2', subtitle: 'Mentioned in Slack' },
+  { title: 'Task 3', subtitle: 'Getting started' }
+]
+
+function TaskRow({
+  title,
+  subtitle,
+  done,
+  onToggle
+}: {
+  title: string
+  subtitle: string
+  done: boolean
+  onToggle: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full items-center gap-3 rounded-xl bg-white/[0.06] px-4 py-2.5 text-left transition-colors hover:bg-white/[0.1]"
+    >
+      {done ? (
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-green-500">
+          <Check className="h-3 w-3 text-black" strokeWidth={3} />
+        </span>
+      ) : (
+        <span className="h-5 w-5 shrink-0 rounded-full border-2 border-white/25" />
+      )}
+      <div className="flex flex-col gap-0.5">
+        <span
+          className={
+            'text-sm font-medium transition-colors ' +
+            (done ? 'text-white/35 line-through' : 'text-white/90')
+          }
+        >
+          {title}
+        </span>
+        <span className="text-xs text-white/40">{subtitle}</span>
+      </div>
+    </button>
+  )
+}
+
+export function AutoCreatedTasksStep({ onFinish }: AutoCreatedTasksStepProps): React.JSX.Element {
+  // Track which sample rows are checked off. Task 3 ("Getting started") starts
+  // done; clicking any row toggles it.
+  const [done, setDone] = useState<Set<number>>(new Set([2]))
+  // Terminal step: guard against a double-click firing completeOnboarding twice
+  // (idempotent, but the second run is pure noise) — disable on the first click.
+  const [finishing, setFinishing] = useState(false)
+  const toggle = (i: number): void =>
+    setDone((prev) => {
+      const next = new Set(prev)
+      if (next.has(i)) next.delete(i)
+      else next.add(i)
+      return next
+    })
+
+  return (
+    <div className="animate-fade-in flex w-full max-w-[360px] flex-col items-center text-center">
+      <div className="relative mb-6 flex h-24 w-24 items-center justify-center">
+        {/* Soft radial glow behind the icon. */}
+        <div className="absolute inset-0 rounded-full bg-white/[0.07] blur-2xl" />
+        <div className="relative flex h-16 w-16 items-center justify-center rounded-3xl bg-white/[0.08]">
+          <ListChecks className="h-8 w-8 text-white/85" />
+        </div>
+      </div>
+
+      <h1 className="font-display text-3xl font-semibold text-white/95">Auto-created Tasks</h1>
+      <p className="mt-3 text-sm leading-relaxed text-white/50">
+        omi listens to your conversations and automatically creates tasks, action items, and
+        follow-ups for you.
+      </p>
+
+      <div className="mt-7 flex w-full flex-col gap-2">
+        {SAMPLE_TASKS.map((t, i) => (
+          <TaskRow
+            key={t.title}
+            title={t.title}
+            subtitle={t.subtitle}
+            done={done.has(i)}
+            onToggle={() => toggle(i)}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => {
+          if (finishing) return
+          setFinishing(true)
+          onFinish()
+        }}
+        disabled={finishing}
+        className="mt-8 rounded-xl bg-white px-8 py-3 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        Take me to my tasks
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

`desktop/windows/src/renderer/src/pages/Onboarding.tsx` (line 266) still imports and renders `AutoCreatedTasksStep` as onboarding step 14 (wired in #12229), but commit `5701283697` ("chore(desktop): remove retired agent-runtime residue and dead-module clusters") deleted the component and its test, misclassifying it as dead code — its reachability check missed this reference.

Since `5701283697` landed on main, `desktop/windows`'s `pnpm typecheck` fails with `TS2307: Cannot find module '../components/onboarding/AutoCreatedTasksStep'`, and because `npm run build` runs `typecheck` first, every build variant (`build:win`/`build:linux`/`build:unpack`) is broken too — confirmed live when PR #12878 touched that tree (see #12891).

## Fix

Restore `AutoCreatedTasksStep.tsx` and `AutoCreatedTasksStep.test.tsx` verbatim from `5701283697^` (the last commit where both existed and matched `Onboarding.tsx`'s usage). No other changes.

## Tested

- `pnpm typecheck` (node@22): clean — the `TS2307` error is gone.
- `pnpm test` (node@22, vitest): full suite green, 555 files / 5532 tests passed (29 skipped, pre-existing), including the restored `AutoCreatedTasksStep.test.tsx` (1/1).
- `pnpm lint`: 0 errors (710 pre-existing prettier warnings, unrelated to this diff).

Closes #12891.

Also registers `.github/failure-classes/FC-reachability-cleanup-deletes-live-reference.json` — no existing class covered "a dead-code cleanup's reachability scan missed a live import," and this is that class's first instance (`evidence_prs: []` per the protocol's own guidance: the fixing PR is the evidence, since its number doesn't exist yet when the file is written).

## Failure class (fixes)

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

