### PR TITLE
fix(backend): pass sample language through speaker-sample verification (#12899)

### DIFF
--- a/backend/tests/unit/test_speaker_sample.py
+++ b/backend/tests/unit/test_speaker_sample.py
@@ -453,3 +453,23 @@ def test_the_dominant_ratio_weighs_segments_by_their_words(monkeypatch):
     _transcript, is_valid, reason = asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000))
 
     assert (is_valid, reason) == (True, "ok")
+
+
+def test_verify_and_transcribe_sample_passes_language_to_transcriber(monkeypatch):
+    """A non-English sample must be transcribed in its own language, not silently as English.
+
+    Regression for #12899: the transcriber previously received no language argument at all, so it
+    always fell back to English, and the resulting mistranscription failed containment against the
+    original non-English segment text on every sample.
+    """
+    received_kwargs = {}
+
+    def fake_deepgram(*_args, **kwargs):
+        received_kwargs.update(kwargs)
+        return _make_words(["danke", "für", "das", "treffen", "heute"], speakers=["SPEAKER_00"] * 5)
+
+    monkeypatch.setattr(speaker_sample, "deepgram_prerecorded_from_bytes", fake_deepgram)
+
+    asyncio.run(speaker_sample.verify_and_transcribe_sample(b"audio", 16000, language="de"))
+
+    assert received_kwargs.get("language") == "de"

--- a/backend/utils/speaker_identification.py
+++ b/backend/utils/speaker_identification.py
@@ -500,7 +500,9 @@ async def extract_speaker_samples(
             wav_bytes = _pcm_to_wav_bytes(sample_audio, sample_rate)
 
             # Verify sample quality and get transcript using centralized function
-            transcript, is_valid, reason = await verify_and_transcribe_sample(wav_bytes, sample_rate, expected_text)
+            transcript, is_valid, reason = await verify_and_transcribe_sample(
+                wav_bytes, sample_rate, expected_text, language=conversation.get('language')
+            )
             if not is_valid:
                 logger.error(f"Sample failed quality check: {reason} {uid} {conversation_id}")
                 continue  # Try next segment

--- a/backend/utils/speaker_sample.py
+++ b/backend/utils/speaker_sample.py
@@ -23,6 +23,7 @@ async def verify_and_transcribe_sample(
     audio_bytes: bytes,
     sample_rate: int,
     expected_text: Optional[str] = None,
+    language: Optional[str] = None,
 ) -> Tuple[Optional[str], bool, str]:
     """
     Transcribe audio and verify quality using PR #4291 rules.
@@ -36,6 +37,8 @@ async def verify_and_transcribe_sample(
         audio_bytes: WAV format audio bytes
         sample_rate: Audio sample rate in Hz
         expected_text: Expected text from the segment for comparison (optional)
+        language: Language of the sample, so it's transcribed in the right language instead of
+            silently defaulting to English (optional)
 
     Returns:
         (transcript, is_valid, reason): Tuple of (str or None, bool, str)
@@ -44,7 +47,12 @@ async def verify_and_transcribe_sample(
     """
     try:
         raw_words = await run_blocking(
-            sync_executor, cast(Any, deepgram_prerecorded_from_bytes), audio_bytes, sample_rate, True
+            sync_executor,
+            cast(Any, deepgram_prerecorded_from_bytes),
+            audio_bytes,
+            sample_rate,
+            True,
+            language=language,
         )
     except RuntimeError as e:
         # Transient transcription failure - distinguish from quality issues


### PR DESCRIPTION
## Bug

`verify_and_transcribe_sample()` re-transcribes the candidate enrollment clip without ever
passing a language, so `get_prerecorded_service()` falls back to `'en'`. For a non-English
user this means the clip is transcribed *as English*, then compared against the original
non-English segment text with a 0.9 containment threshold. Containment is ~0.00, so every
sample is rejected with `text_mismatch` and no speaker embedding is ever stored.

The failure is silent: `PATCH /v1/conversations/{id}/segments/assign-bulk` returns 200, the
tag appears in the transcript, and the app shows no error. The only symptom is that the
person never gets a sample row on the People screen. Since tagging a transcript segment is
the only way to enroll another person's voice, this makes "Identify others" unusable for
non-English users. (Reported in #12899.)

## Root cause

`backend/utils/speaker_sample.py::verify_and_transcribe_sample()` had no `language`
parameter, so `deepgram_prerecorded_from_bytes` (really `prerecorded_from_bytes`) always
received `language=None`, which `normalized_stt_language()` turns into `'en'`.

## Fix

Thread the conversation's already-fetched `language` field through the one call site that
uses `expected_text` for containment (`extract_speaker_samples()` in
`backend/utils/speaker_identification.py`), down through `verify_and_transcribe_sample()`
to `prerecorded_from_bytes()` — mirroring how `language` is already passed elsewhere in the
STT pipeline. `language` defaults to `None` so existing callers (the v1→v2 sample migration,
which doesn't pass `expected_text` and isn't affected by this bug) are unchanged.

## Tested

- Added `test_verify_and_transcribe_sample_passes_language_to_transcriber` in
  `backend/tests/unit/test_speaker_sample.py`, asserting the transcriber receives the
  requested language instead of silently defaulting.
- `backend/.venv/bin/python -m pytest tests/unit/test_speaker_sample.py
  tests/unit/test_speaker_sample_migration.py tests/unit/test_speaker_person_embedding_recovery.py
  tests/unit/test_speaker_id_pipeline.py -q` → 151 passed.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

