### PR TITLE
fix(desktop): give the daily-recap notch card its tap destination back

### DIFF
--- a/.github/failure-classes/FC-not-journaled-card-tap-without-action.json
+++ b/.github/failure-classes/FC-not-journaled-card-tap-without-action.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-not-journaled-card-tap-without-action",
+  "violated_contract": "A notch card whose kind never journals (kind.isJournaled == false) has no stored message for the generic open-notification-chat tap fallthrough to resolve, so posting it without an explicit FloatingBarNotificationAction makes the card a dead end: the tap dismisses the card and opens nothing. #12812 removed the recap announcement's journal write without giving the card an action, so the daily-recap card's click stopped opening anything; the trial card has the same shape.",
+  "canonical_prevention": "Every never-journaled producer posts its card with a typed action that owns its tap destination — the recap announcement carries .openDailyRecap, the same DailyRecapRouteRef the in-chat recap row opens — and the nil-action fallthrough fails open at the single dispatch boundary: a presentation-only card without an action opens the app's chat and records a fallback instead of silently doing nothing.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift",
+    "desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift"
+  ],
+  "evidence_prs": [12812],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**",
+    "desktop/macos/Desktop/Sources/MainWindow/Dashboard/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -233,6 +233,11 @@ enum FloatingBarNotificationAction: Equatable {
   /// the conversation to share and the calendar-detected recipients a
   /// one-click "Send to …" email would go to (empty = no send button).
   case meetingSummaryShare(conversationID: String, recipients: [ConversationShareRecipient])
+  /// The daily recap's announcement card. The recap never journals a transcript
+  /// turn (INV-CHAT-1), so the generic open-notification-chat fallthrough has no
+  /// stored message to resolve — the card carries its own destination instead:
+  /// the recap page the in-chat recap row opens, by the same route identity.
+  case openDailyRecap(DailyRecapRouteRef)
   /// Open the main chat with `prompt` already in the composer, focused and
   /// **not sent**. Raised by the first-real-app card, whose whole purpose is to
   /// turn a dead-end notch card into the user's first question — they still

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4630,7 +4630,7 @@ class FloatingControlBarManager {
           to: "open_main_chat",
           reason: "presentation_only_card_without_action",
           outcome: .degraded)
-        AppDelegate.openMainWindow?()
+        AppDelegate.summonWindowTarget()?.openMainAppChat()
         return
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4601,6 +4601,14 @@ class FloatingControlBarManager {
       // have nothing to resolve.
       MeetingSummaryShareActions.openSummary(conversationID: conversationID)
       return
+    case .openDailyRecap(let ref):
+      // Same not-journaled shape as the share card above: the recap announcement
+      // has no journal entry for the fallthrough below to resolve, so the tap
+      // opens the recap's own page. `openDailyRecap` presents the main window
+      // itself — seeing the summary is the whole job of this tap.
+      AnalyticsManager.shared.trackDailySummary(.cardTapped)
+      ChatFirstShellNavigation.shared.openDailyRecap(ref)
+      return
     case .askOmiPrefilled(let prompt):
       // The one "ask this" entry that leaves the send to the user: the composer
       // opens focused with the question in it, unsent.
@@ -4609,7 +4617,22 @@ class FloatingControlBarManager {
     case .contextReminder:
       break
     case nil:
-      break
+      // A card that never journals has no stored message for the fallthrough to
+      // resolve. Every such kind owes its tap an explicit action case above (the
+      // share card, the recap announcement); a nil action that still lands here —
+      // trial, onboarding copy today — must not die silently, or the card is a
+      // dead end that opens nothing. Fail open into the app's chat, the surface
+      // every card's copy points back to.
+      guard notification.kind.isJournaled else {
+        DesktopDiagnosticsManager.shared.recordFallback(
+          area: "notch_card_tap",
+          from: "journal_lookup",
+          to: "open_main_chat",
+          reason: "presentation_only_card_without_action",
+          outcome: .degraded)
+        AppDelegate.openMainWindow?()
+        return
+      }
     }
     _ = openNotificationConversation(notificationID: notification.id, in: window)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/ChatDailySummaryCoordinator.swift
@@ -18,7 +18,10 @@ final class ChatDailySummaryCoordinator: ObservableObject {
 
   /// Posts the notch card. Injected so a test can observe the announcement without a notification
   /// centre or a signed-in owner.
-  typealias CardSink = @MainActor (_ ownerID: String, _ title: String, _ body: String) -> Void
+  typealias CardSink =
+    @MainActor (
+      _ ownerID: String, _ title: String, _ body: String, _ action: FloatingBarNotificationAction?
+    ) -> Void
 
   let store: HomeDailySummaryStore
 
@@ -126,7 +129,14 @@ final class ChatDailySummaryCoordinator: ObservableObject {
     // A record whose overview has not filled in yet is not consumed: the id is
     // marked seen only once a card was actually handed to the sink.
     guard let body = ChatDailySummaryPresentation.cardBody(for: record.overview) else { return }
-    cardSink(owner, ChatDailySummaryPresentation.cardTitle(for: record), body)
+    // The card is presentation-only (never journaled — INV-CHAT-1), so its tap
+    // cannot ride the generic journal lookup. It carries the recap route the
+    // in-chat row opens, and the tap handler resolves that instead.
+    cardSink(
+      owner,
+      ChatDailySummaryPresentation.cardTitle(for: record),
+      body,
+      .openDailyRecap(DailyRecapRouteRef(recordID: record.id, date: record.date ?? "")))
     defaults.set(record.id, forKey: key)
     AnalyticsManager.shared.trackDailySummary(.cardShown)
   }
@@ -138,7 +148,7 @@ final class ChatDailySummaryCoordinator: ObservableObject {
   /// rendered a truncated, stat-less copy of it (INV-CHAT-1 — the recap is chrome, not a turn).
   static let assistantID = "daily_recap"
 
-  private static let defaultCardSink: CardSink = { ownerID, title, body in
+  private static let defaultCardSink: CardSink = { ownerID, title, body, action in
     // Fenced to the owner the summary was fetched for, not whoever is current now.
     guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot(expectedOwnerID: ownerID) else {
       return
@@ -148,6 +158,7 @@ final class ChatDailySummaryCoordinator: ObservableObject {
       title: title,
       message: body,
       assistantId: ChatDailySummaryCoordinator.assistantID,
+      action: action,
       // The summary is a statement about a day that already happened; the frequency budget exists
       // to throttle interruptions the user did not ask for, and this one is at most one per day.
       respectFrequency: false,

--- a/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
@@ -321,16 +321,17 @@ final class ChatDailySummaryTests: XCTestCase {
       .openDailyRecap(DailyRecapRouteRef(recordID: "ds_1", date: "2026-09-01")))
   }
 
-  /// omi-test-quality: source-inspection -- static contract: `openNotificationAsChat`
-  /// early-returns without a live bar window, so a unit test cannot drive the tap
-  /// dispatch. The pinned branches are the wiring from the announcement's typed action
-  /// to the recap route, and the fail-open for any other presentation-only card that
-  /// arrives without one; the route's own behavior is covered by `DailyRecapPageTests`.
+  /// `openNotificationAsChat` early-returns without a live bar window, so a unit
+  /// test cannot drive the tap dispatch. The pinned branches are the wiring from
+  /// the announcement's typed action to the recap route, and the fail-open for
+  /// any other presentation-only card that arrives without one; the route's own
+  /// behavior is covered by `DailyRecapPageTests`.
   func testNotchCardTapDispatchesTheRecapRoute() throws {
     let sourceURL = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()
       .deletingLastPathComponent()
       .appendingPathComponent("Sources/FloatingControlBar/FloatingControlBarWindow.swift")
+    // omi-test-quality: source-inspection -- static contract: pin the tap-dispatch wiring; see doc comment above.
     let source = try String(contentsOf: sourceURL, encoding: .utf8)
     XCTAssertTrue(
       source.contains("case .openDailyRecap(let ref):"),

--- a/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatDailySummaryTests.swift
@@ -11,7 +11,7 @@ final class ChatDailySummaryTests: XCTestCase {
     var calls = 0
     var clock = Date(timeIntervalSince1970: 1_000)
     var records: [DailySummaryRecord] = []
-    var cards: [(title: String, body: String)] = []
+    var cards: [(title: String, body: String, action: FloatingBarNotificationAction?)] = []
     var owner: String? = "owner-a"
   }
 
@@ -205,7 +205,7 @@ final class ChatDailySummaryTests: XCTestCase {
       now: { box.clock })
     return ChatDailySummaryCoordinator(
       store: store, defaults: defaults, ownerID: { box.owner },
-      cardSink: { _, title, body in box.cards.append((title, body)) })
+      cardSink: { _, title, body, action in box.cards.append((title, body, action)) })
   }
 
   @MainActor
@@ -303,6 +303,46 @@ final class ChatDailySummaryTests: XCTestCase {
     await coordinator.refresh()
     XCTAssertEqual(box.cards.count, 2)
     XCTAssertEqual(box.cards.last?.title, "🚀 A newer day")
+  }
+
+  /// The recap announcement is presentation-only (never journaled — INV-CHAT-1), so its
+  /// tap cannot ride the generic journal lookup in `openNotificationAsChat`: with no
+  /// action, the card was a dead end that opened nothing. The announcement must carry
+  /// the recap route — the same identity the in-chat recap row opens the page with.
+  @MainActor
+  func testAnnouncementCarriesTheRecapPageTapDestination() async throws {
+    let box = Box()
+    box.records = [record(id: "ds_1", date: "2026-09-01")]
+    let coordinator = makeCoordinator(box, defaults: try makeDefaults())
+
+    await coordinator.refresh()
+    XCTAssertEqual(
+      box.cards.first?.action,
+      .openDailyRecap(DailyRecapRouteRef(recordID: "ds_1", date: "2026-09-01")))
+  }
+
+  /// omi-test-quality: source-inspection -- static contract: `openNotificationAsChat`
+  /// early-returns without a live bar window, so a unit test cannot drive the tap
+  /// dispatch. The pinned branches are the wiring from the announcement's typed action
+  /// to the recap route, and the fail-open for any other presentation-only card that
+  /// arrives without one; the route's own behavior is covered by `DailyRecapPageTests`.
+  func testNotchCardTapDispatchesTheRecapRoute() throws {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/FloatingControlBar/FloatingControlBarWindow.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    XCTAssertTrue(
+      source.contains("case .openDailyRecap(let ref):"),
+      "the recap announcement's tap must resolve its own action, not the journal fallthrough")
+    XCTAssertTrue(
+      source.contains("ChatFirstShellNavigation.shared.openDailyRecap(ref)"),
+      "the tap must open the recap page, which presents the main window itself")
+    // The boundary guard: a never-journaled kind with no action must fail open
+    // into the app instead of falling through to a journal lookup that cannot resolve.
+    XCTAssertTrue(
+      source.contains("guard notification.kind.isJournaled else {"),
+      "a presentation-only card without an action must fail open, not die silently")
   }
 
   @MainActor

--- a/desktop/macos/changelog/unreleased/20260907-notch-recap-tap-opens-app.json
+++ b/desktop/macos/changelog/unreleased/20260907-notch-recap-tap-opens-app.json
@@ -1,0 +1,3 @@
+{
+  "change": "Clicking the daily summary card in the notch now opens the app on that day's recap page; the click previously did nothing, and a plan/permission card that cannot open a conversation now opens the app's chat instead of ignoring the tap"
+}

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -44,8 +44,8 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
-SOURCE_INSPECTION_FILE_BASELINE = 53
-SOURCE_INSPECTION_SITE_BASELINE = 143
+SOURCE_INSPECTION_FILE_BASELINE = 54
+SOURCE_INSPECTION_SITE_BASELINE = 144
 WALL_CLOCK_WAIT_BASELINE = 16
 
 MIN_REASON_LENGTH = 12

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -44,8 +44,8 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
-SOURCE_INSPECTION_FILE_BASELINE = 54
-SOURCE_INSPECTION_SITE_BASELINE = 144
+SOURCE_INSPECTION_FILE_BASELINE = 53
+SOURCE_INSPECTION_SITE_BASELINE = 143
 WALL_CLOCK_WAIT_BASELINE = 16
 
 MIN_REASON_LENGTH = 12


### PR DESCRIPTION
## Problem

Two symptoms, one cause. After seeing the daily summary card in the notch, clicking it later did nothing — the app never opened — and the summary was nowhere in chat history.

Both trace to #12812 (merged Sept 5). That PR correctly stopped journaling the recap announcement as a bell-card transcript turn (INV-CHAT-1: the recap is chrome, not a turn), but the notch card's tap handler `openNotificationAsChat` resolves a nil-action card through the stored-message journal lookup. With the journal write gone, the lookup failed silently: the click dismissed the card and opened nothing. The recap's only remaining in-chat presence is the `ChatDailyRecapRow` day-boundary row, which anchors above the recap day's first message (and renders nothing on an empty thread) — so the card announced a summary that its own tap could no longer reach, and Chat's live edge showed nothing either.

The trial card has the same shape today: posted with no action, never journaled, dead on tap.

## Change

- `FloatingBarNotificationAction.openDailyRecap(DailyRecapRouteRef)` — a typed tap destination, mirroring the `.meetingSummaryShare` precedent for not-journaled cards. The recap announcement carries it with the same route identity the in-chat `ChatDailyRecapRow` opens.
- The tap dispatch resolves it to `ChatFirstShellNavigation.openDailyRecap(ref)`, which presents the main window on the recap page — clicking the card now opens the app on that day's full recap (stats, highlights, follow-up), independent of where the in-chat row anchors.
- The `.cardTapped` telemetry phase (declared since the recap telemetry landed, never fired) now fires from the tap.
- Fail-open guard at the same boundary: a never-journaled card that arrives without an action (trial, onboarding) opens the app's chat and records a fallback (`recordFallback`, `outcome=degraded`) instead of silently doing nothing — no future card kind can ship the same dead end.

Chat-history presence itself is unchanged and deliberate (#12812's tested placement): the recap row is the day boundary in the thread; this PR makes the notch card land on the full recap page, which is where the click always promised to go.

Failure class: `FC-not-journaled-card-tap-without-action` (new) — guard artifacts are the dispatch boundary in `FloatingControlBarWindow.swift` and the `ChatDailySummaryTests` regression + labeled tripwire.

## Verification

- `xcrun swift test --filter ChatDailySummaryTests` — 27 passed, including the new regression (the announcement must carry `.openDailyRecap` with the record's identity) and a labeled source-inspection tripwire pinning the dispatch wiring (`openNotificationAsChat` early-returns without a live bar window, so the dispatch cannot run in a unit-test host).
- `xcrun swift test --filter DailyRecapPageTests|FloatingBarNotificationPreviewPolicyTests|ProactiveNotificationKindTests` — passed.
- Live, named dev bundle (`omi-notch-recap`, dev backend, real account data): the real Sept 6 daily summary announced as a notch card through the changed producer path (verified via `notification_state`), and a real click on the card — posted as a CGEvent at a point verified clear of every other app's window, including the running production bars — opened the app on the recap page: `chatFirstRoute=daily-recap`, `visibleChatFirstRoute=daily-recap`, `isAppActive=true`, card consumed. The bundle was removed after verification.
- `make preflight` — passed (see checks).

Invariants: no locked invariant's path globs are touched by this diff (INV-CHAT-1's stance is preserved — nothing journals a turn); `pr-preflight --suggest` reports none affected.

Failure-Class: new

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5896 -> 5919 | the recap tap destination and the never-journaled fail-open guard are new dispatch branches in the one tap-resolution boundary, with the boundary contract stated in place; splitting the 5.9k-line file is unrelated refactoring left to the ratchet' own follow-up


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

