### PR TITLE
feat(app): add plan-authoritative SttModeResolver for S17

### DIFF
--- a/app/lib/models/custom_stt_config.dart
+++ b/app/lib/models/custom_stt_config.dart
@@ -19,6 +19,10 @@ class CustomSttConfig {
   final Map<String, dynamic>? schemaJson;
   final bool sendRawAudioToOmi;
 
+  /// Overrides [sttConfigId] when set. Used for synthesized freemium configs so
+  /// a plan change mid-session forces a reconnect (`freemium:on-device`).
+  final String? identity;
+
   const CustomSttConfig({
     required this.provider,
     this.apiKey,
@@ -33,6 +37,7 @@ class CustomSttConfig {
     this.audioFieldName,
     this.schemaJson,
     this.sendRawAudioToOmi = true,
+    this.identity,
   });
 
   /// Determine if live/streaming based on request_type
@@ -104,6 +109,7 @@ class CustomSttConfig {
   }
 
   String get sttConfigId {
+    if (identity != null && identity!.isNotEmpty) return identity!;
     if (!isEnabled) return 'omi:default';
 
     final configData = {
@@ -186,6 +192,7 @@ class CustomSttConfig {
     String? audioFieldName,
     Map<String, dynamic>? schemaJson,
     bool? sendRawAudioToOmi,
+    String? identity,
   }) {
     return CustomSttConfig(
       provider: provider ?? this.provider,
@@ -201,6 +208,7 @@ class CustomSttConfig {
       audioFieldName: audioFieldName ?? this.audioFieldName,
       schemaJson: schemaJson ?? this.schemaJson,
       sendRawAudioToOmi: sendRawAudioToOmi ?? this.sendRawAudioToOmi,
+      identity: identity ?? this.identity,
     );
   }
 

--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -1,4 +1,5 @@
 import 'package:omi/backend/schema/gen/subscription_usage_wire.g.dart' as wire;
+import 'package:omi/models/transcription_allowance.dart';
 
 enum SubscriptionStatus { active, inactive }
 
@@ -345,6 +346,7 @@ class UserSubscriptionResponse {
   final bool chatQuotaAllowed;
   final int? chatQuotaResetAt;
   final PhoneCallQuota? phoneCallQuota;
+  final TranscriptionAllowanceSnapshot? transcriptionAllowance;
 
   UserSubscriptionResponse({
     required this.subscription,
@@ -362,6 +364,7 @@ class UserSubscriptionResponse {
     this.chatQuotaAllowed = true,
     this.chatQuotaResetAt,
     this.phoneCallQuota,
+    this.transcriptionAllowance,
   });
 
   factory UserSubscriptionResponse.fromJson(Map<String, dynamic> json) {
@@ -385,6 +388,9 @@ class UserSubscriptionResponse {
       chatQuotaAllowed: generated.chatQuotaAllowed,
       chatQuotaResetAt: generated.chatQuotaResetAt,
       phoneCallQuota: generated.phoneCallQuota == null ? null : PhoneCallQuota.fromGenerated(generated.phoneCallQuota!),
+      transcriptionAllowance: generated.transcriptionAllowance == null
+          ? null
+          : TranscriptionAllowanceSnapshot.fromGenerated(generated.transcriptionAllowance!),
     );
   }
 
@@ -405,6 +411,7 @@ class UserSubscriptionResponse {
       chatQuotaAllowed: chatQuotaAllowed,
       chatQuotaResetAt: chatQuotaResetAt,
       phoneCallQuota: phoneCallQuota?.toGenerated(),
+      transcriptionAllowance: transcriptionAllowance?.toGenerated(),
     );
   }
 

--- a/app/lib/models/transcription_allowance.dart
+++ b/app/lib/models/transcription_allowance.dart
@@ -1,0 +1,47 @@
+import 'package:omi/backend/schema/gen/subscription_usage_wire.g.dart' as wire;
+
+/// Client view of S16's one allowance answer.
+///
+/// Modes match `resolve_transcription_allowance`: `managed`, `on_device`, `blocked`.
+/// This type does not re-derive the answer. It only carries what the snapshot said.
+class TranscriptionAllowanceSnapshot {
+  static const modeManaged = 'managed';
+  static const modeOnDevice = 'on_device';
+  static const modeBlocked = 'blocked';
+
+  final String mode;
+  final String reason;
+  final int? remainingSeconds;
+
+  const TranscriptionAllowanceSnapshot({
+    required this.mode,
+    required this.reason,
+    this.remainingSeconds,
+  });
+
+  bool get isManaged => mode == modeManaged;
+  bool get isOnDevice => mode == modeOnDevice;
+  bool get isBlocked => mode == modeBlocked;
+
+  factory TranscriptionAllowanceSnapshot.fromGenerated(wire.GeneratedTranscriptionAllowanceSnapshot generated) {
+    return TranscriptionAllowanceSnapshot(
+      mode: generated.mode,
+      reason: generated.reason,
+      remainingSeconds: generated.remainingSeconds,
+    );
+  }
+
+  wire.GeneratedTranscriptionAllowanceSnapshot toGenerated() {
+    return wire.GeneratedTranscriptionAllowanceSnapshot(
+      mode: mode,
+      reason: reason,
+      remainingSeconds: remainingSeconds,
+    );
+  }
+
+  factory TranscriptionAllowanceSnapshot.fromJson(Map<String, dynamic> json) {
+    return TranscriptionAllowanceSnapshot.fromGenerated(wire.GeneratedTranscriptionAllowanceSnapshot.fromJson(json));
+  }
+
+  Map<String, dynamic> toJson() => toGenerated().toJson();
+}

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -5,6 +5,7 @@ import 'package:omi/backend/http/api/payment.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/models/subscription.dart';
 import 'package:omi/models/user_usage.dart';
+import 'package:omi/services/capture/transcription_allowance_cache.dart';
 import 'package:omi/utils/logger.dart';
 
 class UsageProvider with ChangeNotifier {
@@ -106,12 +107,14 @@ class UsageProvider with ChangeNotifier {
   @visibleForTesting
   void debugSetSubscription(UserSubscriptionResponse? value) {
     _subscription = value;
+    TranscriptionAllowanceCache.replace(value?.transcriptionAllowance);
     notifyListeners();
   }
 
   /// Wipes user-scoped state on logout so the next account doesn't inherit
   /// the previous account's subscription/usage (e.g. a stale Pro badge).
   void clearUserData() {
+    TranscriptionAllowanceCache.clear();
     _subscription = null;
     _todayUsage = null;
     _monthlyUsage = null;
@@ -152,8 +155,9 @@ class UsageProvider with ChangeNotifier {
       final subscription = await getUserSubscription();
       if (generation != _sessionGeneration) return; // Session cleared mid-flight; discard stale response.
       _subscription = subscription;
-      if (_subscription != null) {
-        PlatformManager.instance.analytics.setSubscriptionTier(_subscription!.subscription.plan.name);
+      if (subscription != null) {
+        TranscriptionAllowanceCache.replace(subscription.transcriptionAllowance);
+        PlatformManager.instance.analytics.setSubscriptionTier(subscription.subscription.plan.name);
       }
     } catch (e) {
       if (generation != _sessionGeneration) return;

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -33,6 +33,7 @@ import 'package:omi/utils/audio/foreground.dart';
 import 'package:omi/services/capture/native_batch_geolocation.dart';
 import 'package:omi/services/capture/native_ble_stream_config.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
+import 'package:omi/services/capture/stt_mode_resolver.dart';
 import 'package:omi/services/capture/recording_lifecycle_telemetry.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
@@ -802,24 +803,38 @@ class CaptureController extends ChangeNotifier
     String language =
         SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
+    final decision = await SttModeResolver.instance.decide(
+      persistedCustomStt: customSttConfig,
+      codec: codec,
+    );
 
-    Logger.debug('Custom STT enabled: ${customSttConfig.isEnabled}, provider: ${customSttConfig.provider}');
+    Logger.debug(
+      'STT mode: path=${decision.path.name} reason=${decision.reason} '
+      'custom=${customSttConfig.isEnabled} provider=${customSttConfig.provider}',
+    );
 
-    // Check codec compatibility for custom STT - fallback to default if incompatible
-    CustomSttConfig? effectiveConfig = customSttConfig.isEnabled ? customSttConfig : null;
+    if (decision.blockSocket) {
+      Logger.warning('[SttMode] Blocking transcription socket (${decision.reason})');
+      await _abandonTranscriptionSocket(reason: 'stt mode blocked: ${decision.reason}');
+      await _reconcileNativeBackgroundStreamingPolicy();
+      notifyListeners();
+      _startKeepAliveServices();
+      return;
+    }
+
+    // Check codec compatibility for custom STT - fallback to default if incompatible.
+    // On-device allowance never falls back to a billed Omi socket (S17).
+    CustomSttConfig? effectiveConfig = decision.customSttConfig;
     if (effectiveConfig != null && !TranscriptSocketServiceFactory.isCodecSupportedForCustomStt(codec)) {
-      if (TranscriptSocketServiceFactory.shouldBlockUnsupportedCodecFallback(codec, effectiveConfig)) {
+      if (TranscriptSocketServiceFactory.shouldBlockUnsupportedCodecFallback(
+        codec,
+        effectiveConfig,
+        allowanceOnDevice: decision.allowanceOnDevice,
+      )) {
         Logger.warning(
-          '[CustomSTT] Codec $codec is unsupported; refusing Omi fallback because raw audio forwarding is disabled',
+          '[CustomSTT] Codec $codec is unsupported; refusing Omi fallback (${decision.reason})',
         );
-        final previousSocket = _socket;
-        _socket = null;
-        _transcriptServiceReady = false;
-        try {
-          await previousSocket?.stop(reason: 'unsupported custom STT codec with raw audio forwarding disabled');
-        } catch (e, stack) {
-          Logger.error('[CustomSTT] Failed to stop the previous socket after blocking Omi fallback: $e\n$stack');
-        }
+        await _abandonTranscriptionSocket(reason: 'unsupported custom STT codec');
         await _reconcileNativeBackgroundStreamingPolicy();
         notifyListeners();
         _startKeepAliveServices();
@@ -1176,7 +1191,15 @@ class CaptureController extends ChangeNotifier
     var language =
         SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
-    final sttConfigId = customSttConfig.sttConfigId;
+    final decision = await SttModeResolver.instance.decide(
+      persistedCustomStt: customSttConfig,
+      codec: codec,
+    );
+    if (decision.blockSocket) {
+      await _abandonTranscriptionSocket(reason: 'stt mode blocked: ${decision.reason}');
+      return;
+    }
+    final sttConfigId = decision.socketIdentity;
 
     if (language != _socket?.language ||
         codec != _socket?.codec ||
@@ -1184,6 +1207,17 @@ class CaptureController extends ChangeNotifier
         _socket?.sttConfigId != sttConfigId ||
         _sessionGeolocationDiffersFromSocket()) {
       await _initiateWebsocket(audioCodec: codec, force: true, source: _getConversationSourceFromDevice());
+    }
+  }
+
+  Future<void> _abandonTranscriptionSocket({required String reason}) async {
+    final previousSocket = _socket;
+    _socket = null;
+    _transcriptServiceReady = false;
+    try {
+      await previousSocket?.stop(reason: reason);
+    } catch (e, stack) {
+      Logger.error('[SttMode] Failed to stop the previous socket after $reason: $e\n$stack');
     }
   }
 

--- a/app/lib/services/capture/free_tier_on_device_stt_flag.dart
+++ b/app/lib/services/capture/free_tier_on_device_stt_flag.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:omi/backend/preferences.dart';
+
+/// Client gate for S17 plan-authoritative on-device STT. Default off (dark).
+///
+/// Env wins so dogfood can flip without a settings write. Prefs default false
+/// so today's Deepgram path stays until the flag is lit.
+class FreeTierOnDeviceSttFlag {
+  static const environmentKey = 'OMI_FREE_TIER_ON_DEVICE_STT';
+  static const prefsKey = 'freeTierOnDeviceStt';
+
+  static bool isEnabled({
+    Map<String, String>? environment,
+    bool? prefsOverride,
+  }) {
+    final env = environment ?? Platform.environment;
+    if (isTruthy(env[environmentKey])) return true;
+    if (prefsOverride != null) return prefsOverride;
+    return SharedPreferencesUtil().getBool(prefsKey);
+  }
+
+  static bool isTruthy(String? raw) {
+    if (raw == null) return false;
+    switch (raw.trim().toLowerCase()) {
+      case '1':
+      case 'true':
+      case 'yes':
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/app/lib/services/capture/stt_mode_resolver.dart
+++ b/app/lib/services/capture/stt_mode_resolver.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/transcription_allowance.dart';
+import 'package:omi/services/capture/free_tier_on_device_stt_flag.dart';
+import 'package:omi/services/capture/transcription_allowance_cache.dart';
+import 'package:omi/services/freemium_transcription_service.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+
+enum SttResolvedPath {
+  /// Today's Omi managed socket (`customSttConfig == null`).
+  managed,
+
+  /// Honor the user's persisted Custom STT config.
+  honorCustom,
+
+  /// Synthesized on-device config (`freemium:on-device`).
+  onDevice,
+
+  /// No transcription socket. Never a billed fallback.
+  blocked,
+}
+
+class SttModeDecision {
+  final SttResolvedPath path;
+  final CustomSttConfig? customSttConfig;
+  final String reason;
+  final bool allowanceOnDevice;
+
+  const SttModeDecision({
+    required this.path,
+    required this.reason,
+    this.customSttConfig,
+    this.allowanceOnDevice = false,
+  });
+
+  bool get opensManagedOmiSocket => path == SttResolvedPath.managed;
+
+  bool get blockSocket => path == SttResolvedPath.blocked;
+
+  String get socketIdentity {
+    if (blockSocket) return 'blocked';
+    return customSttConfig?.sttConfigId ?? 'omi:default';
+  }
+}
+
+/// Plan-authoritative STT mode. Reads S16's snapshot; does not re-derive it.
+///
+/// Order (flag on): persisted Custom STT → allowance `managed` → allowance
+/// `on_device` (ready ⇒ synthesize, else block) → allowance `blocked` →
+/// missing snapshot fails closed to on-device (no billed socket).
+class SttModeResolver {
+  static const freemiumOnDeviceId = 'freemium:on-device';
+
+  static SttModeResolver instance = SttModeResolver();
+
+  final bool Function() flagReader;
+  final TranscriptionAllowanceSnapshot? Function() allowanceReader;
+  final Future<FreemiumReadiness> Function() readinessReader;
+  final CustomSttConfig? Function() onDeviceConfigBuilder;
+
+  SttModeResolver({
+    bool Function()? flagReader,
+    TranscriptionAllowanceSnapshot? Function()? allowanceReader,
+    Future<FreemiumReadiness> Function()? readinessReader,
+    CustomSttConfig? Function()? onDeviceConfigBuilder,
+  })  : flagReader = flagReader ?? _defaultFlag,
+        allowanceReader = allowanceReader ?? _defaultAllowance,
+        readinessReader = readinessReader ?? _defaultReadiness,
+        onDeviceConfigBuilder = onDeviceConfigBuilder ?? _defaultOnDeviceConfig;
+
+  @visibleForTesting
+  static void debugResetInstance() {
+    instance = SttModeResolver();
+  }
+
+  static bool _defaultFlag() => FreeTierOnDeviceSttFlag.isEnabled();
+
+  static TranscriptionAllowanceSnapshot? _defaultAllowance() => TranscriptionAllowanceCache.current;
+
+  static Future<FreemiumReadiness> _defaultReadiness() => FreemiumTranscriptionService().checkReadiness();
+
+  static CustomSttConfig? _defaultOnDeviceConfig() {
+    final config = FreemiumTranscriptionService().getFreemiumConfig();
+    if (config == null) return null;
+    return config.copyWith(identity: freemiumOnDeviceId);
+  }
+
+  Future<SttModeDecision> decide({
+    required CustomSttConfig persistedCustomStt,
+    required BleAudioCodec codec,
+  }) async {
+    FreemiumReadiness readiness = FreemiumReadiness.ready;
+    final flag = flagReader();
+    final allowance = allowanceReader();
+    if (flag && !persistedCustomStt.isEnabled && _needsOnDeviceReadiness(allowance)) {
+      readiness = await readinessReader();
+    }
+    return resolve(
+      flagEnabled: flag,
+      persistedCustomStt: persistedCustomStt,
+      allowance: allowance,
+      readiness: readiness,
+      codec: codec,
+    );
+  }
+
+  bool _needsOnDeviceReadiness(TranscriptionAllowanceSnapshot? allowance) {
+    if (allowance == null) return true;
+    return allowance.isOnDevice;
+  }
+
+  SttModeDecision resolve({
+    required bool flagEnabled,
+    required CustomSttConfig persistedCustomStt,
+    required TranscriptionAllowanceSnapshot? allowance,
+    required FreemiumReadiness readiness,
+    required BleAudioCodec codec,
+  }) {
+    if (persistedCustomStt.isEnabled) {
+      return SttModeDecision(
+        path: SttResolvedPath.honorCustom,
+        customSttConfig: persistedCustomStt,
+        reason: 'explicit_custom_stt',
+      );
+    }
+
+    if (!flagEnabled) {
+      return const SttModeDecision(path: SttResolvedPath.managed, reason: 'flag_off');
+    }
+
+    final effective = allowance ??
+        const TranscriptionAllowanceSnapshot(
+          mode: TranscriptionAllowanceSnapshot.modeOnDevice,
+          reason: 'allowance_unavailable',
+        );
+
+    if (effective.isBlocked) {
+      return SttModeDecision(path: SttResolvedPath.blocked, reason: effective.reason, allowanceOnDevice: false);
+    }
+
+    if (effective.isManaged) {
+      return SttModeDecision(path: SttResolvedPath.managed, reason: effective.reason);
+    }
+
+    // on_device, or any unknown mode — fail closed, never a billed socket.
+    final onDeviceReason = effective.isOnDevice ? effective.reason : 'allowance_unrecognized';
+    if (readiness != FreemiumReadiness.ready) {
+      return SttModeDecision(
+        path: SttResolvedPath.blocked,
+        reason: 'on_device_not_ready',
+        allowanceOnDevice: true,
+      );
+    }
+
+    if (TranscriptSocketServiceFactory.shouldBlockUnsupportedCodecFallback(
+      codec,
+      null,
+      allowanceOnDevice: true,
+    )) {
+      return SttModeDecision(
+        path: SttResolvedPath.blocked,
+        reason: 'unsupported_codec_on_device',
+        allowanceOnDevice: true,
+      );
+    }
+
+    final synthesized = onDeviceConfigBuilder();
+    if (synthesized == null) {
+      return const SttModeDecision(
+        path: SttResolvedPath.blocked,
+        reason: 'on_device_config_unavailable',
+        allowanceOnDevice: true,
+      );
+    }
+
+    return SttModeDecision(
+      path: SttResolvedPath.onDevice,
+      customSttConfig: synthesized.copyWith(identity: freemiumOnDeviceId),
+      reason: onDeviceReason,
+      allowanceOnDevice: true,
+    );
+  }
+}

--- a/app/lib/services/capture/stt_mode_resolver.dart
+++ b/app/lib/services/capture/stt_mode_resolver.dart
@@ -147,7 +147,7 @@ class SttModeResolver {
     // on_device, or any unknown mode — fail closed, never a billed socket.
     final onDeviceReason = effective.isOnDevice ? effective.reason : 'allowance_unrecognized';
     if (readiness != FreemiumReadiness.ready) {
-      return SttModeDecision(
+      return const SttModeDecision(
         path: SttResolvedPath.blocked,
         reason: 'on_device_not_ready',
         allowanceOnDevice: true,
@@ -159,7 +159,7 @@ class SttModeResolver {
       null,
       allowanceOnDevice: true,
     )) {
-      return SttModeDecision(
+      return const SttModeDecision(
         path: SttResolvedPath.blocked,
         reason: 'unsupported_codec_on_device',
         allowanceOnDevice: true,

--- a/app/lib/services/capture/transcription_allowance_cache.dart
+++ b/app/lib/services/capture/transcription_allowance_cache.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/models/transcription_allowance.dart';
+import 'package:omi/utils/logger.dart';
+
+/// Last-known-good S16 snapshot for the STT resolver.
+///
+/// Memory first, then the persisted copy so a failed refresh does not drop a
+/// known basic user onto a billed socket.
+class TranscriptionAllowanceCache {
+  static const prefsKey = 'transcriptionAllowanceLastKnown';
+
+  static TranscriptionAllowanceSnapshot? _memory;
+
+  static TranscriptionAllowanceSnapshot? get current {
+    if (_memory != null) return _memory;
+    return _readPersisted();
+  }
+
+  static void replace(TranscriptionAllowanceSnapshot? value) {
+    _memory = value;
+    if (value == null) {
+      SharedPreferencesUtil().saveString(prefsKey, '');
+      return;
+    }
+    SharedPreferencesUtil().saveString(prefsKey, jsonEncode(value.toJson()));
+  }
+
+  static void clear() {
+    _memory = null;
+    SharedPreferencesUtil().saveString(prefsKey, '');
+  }
+
+  static TranscriptionAllowanceSnapshot? _readPersisted() {
+    final raw = SharedPreferencesUtil().getString(prefsKey);
+    if (raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return null;
+      return TranscriptionAllowanceSnapshot.fromJson(decoded);
+    } catch (e) {
+      Logger.debug('[SttMode] failed to read persisted transcription allowance: $e');
+      return null;
+    }
+  }
+}

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -328,8 +328,15 @@ class TranscriptSocketServiceFactory {
     return _customSttSupportedCodecs.contains(codec);
   }
 
-  static bool shouldBlockUnsupportedCodecFallback(BleAudioCodec codec, CustomSttConfig config) {
-    return config.isEnabled && !isCodecSupportedForCustomStt(codec) && !config.sendRawAudioToOmi;
+  static bool shouldBlockUnsupportedCodecFallback(
+    BleAudioCodec codec,
+    CustomSttConfig? config, {
+    bool allowanceOnDevice = false,
+  }) {
+    if (isCodecSupportedForCustomStt(codec)) return false;
+    if (allowanceOnDevice) return true;
+    if (config == null || !config.isEnabled) return false;
+    return !config.sendRawAudioToOmi;
   }
 
   /// Create default Omi transcription service

--- a/app/test/services/capture/stt_mode_capture_entry_test.dart
+++ b/app/test/services/capture/stt_mode_capture_entry_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/stt_provider.dart';
+import 'package:omi/models/transcription_allowance.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/services/capture/stt_mode_resolver.dart';
+import 'package:omi/services/freemium_transcription_service.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+
+class _RecordingSocketCapture extends CaptureProvider {
+  CustomSttConfig? lastConfig;
+  int openCalls = 0;
+
+  @override
+  Future<TranscriptSegmentSocketService?> openConversationSocket({
+    required BleAudioCodec codec,
+    required int sampleRate,
+    required String language,
+    required bool force,
+    String? source,
+    String? clientConversationId,
+    CustomSttConfig? customSttConfig,
+  }) async {
+    openCalls++;
+    lastConfig = customSttConfig;
+    return null;
+  }
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SharedPreferencesUtil().batchModeEnabled = false;
+  });
+
+  tearDown(SttModeResolver.debugResetInstance);
+
+  Future<void> start(_RecordingSocketCapture capture, {BleAudioCodec codec = BleAudioCodec.opus}) {
+    return capture.changeAudioRecordProfile(
+      audioCodec: codec,
+      sampleRate: 16000,
+      source: ConversationSource.phone.name,
+    );
+  }
+
+  test('entry: basic on_device + ready never opens a managed Omi socket', () async {
+    SttModeResolver.instance = SttModeResolver(
+      flagReader: () => true,
+      allowanceReader: () => const TranscriptionAllowanceSnapshot(
+        mode: 'on_device',
+        reason: 'plan_allowance_exhausted',
+      ),
+      readinessReader: () async => FreemiumReadiness.ready,
+      onDeviceConfigBuilder: () => const CustomSttConfig(
+        provider: SttProvider.onDeviceWhisper,
+        identity: SttModeResolver.freemiumOnDeviceId,
+      ),
+    );
+    final capture = _RecordingSocketCapture();
+    await start(capture);
+
+    expect(capture.openCalls, 1);
+    expect(capture.lastConfig, isNotNull);
+    expect(capture.lastConfig!.sttConfigId, SttModeResolver.freemiumOnDeviceId);
+    expect(capture.lastConfig!.isEnabled, isTrue);
+  });
+
+  test('entry: Android not-ready basic never reaches openConversationSocket', () async {
+    SttModeResolver.instance = SttModeResolver(
+      flagReader: () => true,
+      allowanceReader: () => const TranscriptionAllowanceSnapshot(
+        mode: 'on_device',
+        reason: 'subscription_inactive',
+      ),
+      readinessReader: () async => FreemiumReadiness.requiresSetup,
+      onDeviceConfigBuilder: () => const CustomSttConfig(provider: SttProvider.onDeviceWhisper),
+    );
+    final capture = _RecordingSocketCapture();
+    await start(capture);
+
+    expect(capture.openCalls, 0, reason: 'managed socket must be unreachable for Android-not-ready basic');
+  });
+
+  test('entry: unsupported codec + on_device never falls back to Omi', () async {
+    SttModeResolver.instance = SttModeResolver(
+      flagReader: () => true,
+      allowanceReader: () => const TranscriptionAllowanceSnapshot(
+        mode: 'on_device',
+        reason: 'plan_allowance_exhausted',
+      ),
+      readinessReader: () async => FreemiumReadiness.ready,
+      onDeviceConfigBuilder: () => const CustomSttConfig(
+        provider: SttProvider.onDeviceWhisper,
+        identity: SttModeResolver.freemiumOnDeviceId,
+      ),
+    );
+    final capture = _RecordingSocketCapture();
+    await start(capture, codec: BleAudioCodec.aac);
+
+    expect(capture.openCalls, 0);
+  });
+
+  test('entry: flag off still opens today\'s managed socket for basic', () async {
+    SttModeResolver.instance = SttModeResolver(
+      flagReader: () => false,
+      allowanceReader: () => const TranscriptionAllowanceSnapshot(
+        mode: 'on_device',
+        reason: 'plan_allowance_exhausted',
+      ),
+      readinessReader: () async => FreemiumReadiness.ready,
+      onDeviceConfigBuilder: () => const CustomSttConfig(provider: SttProvider.onDeviceWhisper),
+    );
+    final capture = _RecordingSocketCapture();
+    await start(capture);
+
+    expect(capture.openCalls, 1);
+    expect(capture.lastConfig, isNull, reason: 'flag off keeps the Omi default socket');
+  });
+}

--- a/app/test/unit/custom_stt_config_test.dart
+++ b/app/test/unit/custom_stt_config_test.dart
@@ -24,7 +24,7 @@ void main() {
     });
 
     test('identity override is the socket id without entering JSON', () {
-      final config = CustomSttConfig(
+      const config = CustomSttConfig(
         provider: SttProvider.onDeviceWhisper,
         identity: 'freemium:on-device',
       );

--- a/app/test/unit/custom_stt_config_test.dart
+++ b/app/test/unit/custom_stt_config_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/stt_provider.dart';
 
 void main() {
   group('CustomSttConfig raw audio forwarding', () {
@@ -20,6 +21,16 @@ void main() {
       final transcriptOnly = CustomSttConfig.fromJson({'provider': 'customLive', 'send_raw_audio_to_omi': false});
 
       expect(forwarding.sttConfigId, isNot(transcriptOnly.sttConfigId));
+    });
+
+    test('identity override is the socket id without entering JSON', () {
+      final config = CustomSttConfig(
+        provider: SttProvider.onDeviceWhisper,
+        identity: 'freemium:on-device',
+      );
+
+      expect(config.sttConfigId, 'freemium:on-device');
+      expect(config.toJson().containsKey('identity'), isFalse);
     });
   });
 }

--- a/app/test/unit/stt_mode_resolver_test.dart
+++ b/app/test/unit/stt_mode_resolver_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/stt_provider.dart';
+import 'package:omi/models/subscription.dart';
+import 'package:omi/models/transcription_allowance.dart';
+import 'package:omi/services/capture/stt_mode_resolver.dart';
+import 'package:omi/services/freemium_transcription_service.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+
+const _default = CustomSttConfig.defaultConfig;
+
+const _custom = CustomSttConfig(
+  provider: SttProvider.deepgramLive,
+  apiKey: 'dg-user-key',
+  url: 'wss://api.deepgram.com/v1/listen',
+);
+
+TranscriptionAllowanceSnapshot _allowance(String mode, {String reason = 'test'}) {
+  return TranscriptionAllowanceSnapshot(mode: mode, reason: reason, remainingSeconds: 0);
+}
+
+CustomSttConfig _onDevice() {
+  return const CustomSttConfig(
+    provider: SttProvider.onDeviceWhisper,
+    language: 'en',
+    identity: SttModeResolver.freemiumOnDeviceId,
+  );
+}
+
+SttModeDecision _resolve({
+  bool flag = true,
+  CustomSttConfig persisted = _default,
+  TranscriptionAllowanceSnapshot? allowance,
+  FreemiumReadiness readiness = FreemiumReadiness.ready,
+  BleAudioCodec codec = BleAudioCodec.opus,
+}) {
+  return SttModeResolver(
+    onDeviceConfigBuilder: _onDevice,
+  ).resolve(
+    flagEnabled: flag,
+    persistedCustomStt: persisted,
+    allowance: allowance,
+    readiness: readiness,
+    codec: codec,
+  );
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  group('SttModeResolver matrix', () {
+    test('flag off keeps today\'s managed path even for basic on_device', () {
+      final decision = _resolve(
+        flag: false,
+        allowance: _allowance('on_device', reason: 'plan_allowance_exhausted'),
+      );
+      expect(decision.path, SttResolvedPath.managed);
+      expect(decision.opensManagedOmiSocket, isTrue);
+      expect(decision.reason, 'flag_off');
+    });
+
+    test('explicit custom STT is honored before allowance', () {
+      final decision = _resolve(
+        persisted: _custom,
+        allowance: _allowance('on_device', reason: 'plan_allowance_exhausted'),
+      );
+      expect(decision.path, SttResolvedPath.honorCustom);
+      expect(decision.customSttConfig?.provider, SttProvider.deepgramLive);
+      expect(decision.customSttConfig?.apiKey, 'dg-user-key');
+      expect(decision.opensManagedOmiSocket, isFalse);
+    });
+
+    for (final case_ in [
+      ('no-subscription / cache-miss', null, 'allowance_unavailable'),
+      (
+        'basic under cap still on_device from S16 inactive/exhausted shapes',
+        _allowance('on_device', reason: 'subscription_inactive'),
+        'subscription_inactive'
+      ),
+      ('basic over cap', _allowance('on_device', reason: 'plan_allowance_exhausted'), 'plan_allowance_exhausted'),
+    ]) {
+      test('iOS ready + ${case_.$1} ⇒ on-device, managed unreachable', () {
+        final decision = _resolve(allowance: case_.$2, readiness: FreemiumReadiness.ready);
+        expect(decision.path, SttResolvedPath.onDevice);
+        expect(decision.opensManagedOmiSocket, isFalse);
+        expect(decision.customSttConfig?.sttConfigId, SttModeResolver.freemiumOnDeviceId);
+        expect(decision.reason, case_.$3);
+      });
+
+      test('Android not ready + ${case_.$1} ⇒ blocked, managed unreachable', () {
+        final decision = _resolve(allowance: case_.$2, readiness: FreemiumReadiness.requiresSetup);
+        expect(decision.path, SttResolvedPath.blocked);
+        expect(decision.opensManagedOmiSocket, isFalse);
+        expect(decision.blockSocket, isTrue);
+        expect(decision.reason, 'on_device_not_ready');
+      });
+    }
+
+    test('plus / managed stays on the Omi socket', () {
+      final decision = _resolve(allowance: _allowance('managed', reason: 'plan_within_allowance'));
+      expect(decision.path, SttResolvedPath.managed);
+      expect(decision.opensManagedOmiSocket, isTrue);
+    });
+
+    test('unlimited / plan_unlimited stays managed', () {
+      final decision = _resolve(allowance: _allowance('managed', reason: 'plan_unlimited'));
+      expect(decision.opensManagedOmiSocket, isTrue);
+    });
+
+    test('BYOK reason is managed (user key rides the server BYOK path)', () {
+      final decision = _resolve(allowance: _allowance('managed', reason: 'byok'));
+      expect(decision.path, SttResolvedPath.managed);
+      expect(decision.reason, 'byok');
+    });
+
+    test('trial-paywalled is blocked', () {
+      final decision = _resolve(allowance: _allowance('blocked', reason: 'trial_paywalled'));
+      expect(decision.path, SttResolvedPath.blocked);
+      expect(decision.opensManagedOmiSocket, isFalse);
+    });
+
+    test('unsupported codec + on_device blocks instead of Omi fallback', () {
+      final decision = _resolve(
+        allowance: _allowance('on_device', reason: 'plan_allowance_exhausted'),
+        codec: BleAudioCodec.aac,
+      );
+      expect(decision.path, SttResolvedPath.blocked);
+      expect(decision.reason, 'unsupported_codec_on_device');
+      expect(decision.opensManagedOmiSocket, isFalse);
+    });
+
+    test('unknown allowance mode fails closed', () {
+      final decision = _resolve(allowance: _allowance('surprise', reason: 'future'));
+      expect(decision.opensManagedOmiSocket, isFalse);
+      expect(decision.path, SttResolvedPath.onDevice);
+    });
+  });
+
+  group('shouldBlockUnsupportedCodecFallback S17', () {
+    test('on_device allowance blocks an unsupported codec even without a custom config', () {
+      expect(
+        TranscriptSocketServiceFactory.shouldBlockUnsupportedCodecFallback(
+          BleAudioCodec.aac,
+          null,
+          allowanceOnDevice: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('supported pendant codecs still pass on_device', () {
+      expect(
+        TranscriptSocketServiceFactory.shouldBlockUnsupportedCodecFallback(
+          BleAudioCodec.opus,
+          null,
+          allowanceOnDevice: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('subscription wire plumbs S16 allowance', () {
+    test('UserSubscriptionResponse.roundtrips transcription_allowance', () {
+      final response = UserSubscriptionResponse(
+        subscription: Subscription(plan: PlanType.basic, status: SubscriptionStatus.active),
+        transcriptionSecondsUsed: 0,
+        transcriptionSecondsLimit: 18000,
+        wordsTranscribedUsed: 0,
+        wordsTranscribedLimit: 0,
+        insightsGainedUsed: 0,
+        insightsGainedLimit: 0,
+        transcriptionAllowance: const TranscriptionAllowanceSnapshot(
+          mode: 'on_device',
+          reason: 'plan_allowance_exhausted',
+          remainingSeconds: 0,
+        ),
+      );
+
+      final decoded = UserSubscriptionResponse.fromJson(response.toJson());
+      expect(decoded.transcriptionAllowance?.mode, 'on_device');
+      expect(decoded.transcriptionAllowance?.reason, 'plan_allowance_exhausted');
+    });
+  });
+}


### PR DESCRIPTION
## S17 — client SttModeResolver

Shard S17 of the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S17; spec `40-mobile-pendant-port.md` §4.1). Plan-authoritative on-device-before-managed-socket for basic users. Reads S16 `transcription_allowance`. Does not re-derive the allowance.

**#11681 (2026-09-07):** still OPEN, last updated 2026-08-19, head `f2b1755`. David locked Option A: this PR branches from current `origin/main` (`9594e01002`). #11681 stays OPEN and idle. Do not merge it. Do not fold `localOnly` / `SttPrivacyPolicy` into this shard. If anyone later rebases or recuts #11681, preserve [@Dr-Amp](https://github.com/Dr-Amp) credit (Co-authored-by / keep their commits).

### Plan correction (dated 2026-09-07)

1. The S16 Dart *generated* wire already carries `transcription_allowance`. The domain `UserSubscriptionResponse` did not surface it. S17 plumbs it through; it does not regenerate OpenAPI.
2. Cache-miss / missing snapshot with the flag **on** fails closed to on-device (no billed socket). S19 desktop fails open on cache-miss; S17 is the STT-minutes money shard, so a billed socket is never the default. Last-known-good is persisted.
3. Line cites in 40 (`_initiateWebsocket` ~684, `_ensureDeviceSocketConnection` ~1135) moved: connect is `_connectTranscriptionSocket` (~777) called from `_initiateWebsocket` (~709); device reconnect is still `_ensureDeviceSocketConnection` (~1171).

### What changed

- `SttModeResolver` at both socket entry points. Order: persisted Custom STT (honor, including user Deepgram) → flag off (today's Omi path) → allowance `managed` → allowance `on_device` (ready ⇒ `freemium:on-device`, else block) → `blocked` → missing snapshot fails closed.
- Flag `OMI_FREE_TIER_ON_DEVICE_STT` / prefs `freeTierOnDeviceStt`, default **off** (dark).
- `shouldBlockUnsupportedCodecFallback` takes `allowanceOnDevice`: unsupported codec + on-device never falls back to Omi.
- `UsageProvider` writes S16's snapshot into `TranscriptionAllowanceCache` (memory + last-known-good prefs); logout clears it.

### Automatic-or-dead check

Matrix: basic × {iOS-ready, Android-not-ready} ⇒ `opensManagedOmiSocket` is false. Unsupported codec (`aac`) + on_device ⇒ blocked. Entry-point test drives `CaptureController.changeAudioRecordProfile` → `openConversationSocket`: Android-not-ready and unsupported-codec cases never call it; ready on_device calls it with `sttConfigId == freemium:on-device`, never `null`.

Red-proof: drop the `allowanceOnDevice` codec clause or treat cache-miss as managed, and `stt_mode_resolver_test` / `stt_mode_capture_entry_test` fail.

### Proof

`flutter test test/unit/stt_mode_resolver_test.dart test/services/capture/stt_mode_capture_entry_test.dart test/unit/custom_stt_config_test.dart test/unit/composite_transcription_socket_test.dart test/providers/usage_provider_test.dart test/providers/capture_provider_test.dart` — 124 passed locally (38 focused + 86 capture_provider).

Dest: mobile client only. Merging does not deploy Cloud Run.

### Line-count ratchet

Line-Count-Exception: app/lib/services/capture/capture_controller.dart | 2630 -> 2664 | S17: consult SttModeResolver at both socket entry points
Line-Count-Exception: app/lib/services/sockets/transcription_service.dart | 570 -> 577 | S17: fail-closed codec gate when allowance is on_device
Line-Count-Exception: app/lib/models/subscription.dart | 412 -> 419 | S17: plumb S16 transcription_allowance through the domain model
Line-Count-Exception: app/lib/models/custom_stt_config.dart | 210 -> 218 | S17: identity override so freemium:on-device reconnects on plan change
Line-Count-Exception: app/lib/providers/usage_provider.dart | 330 -> 334 | S17: publish allowance snapshot into the resolver cache

## Product invariants affected

none

### Cut list

- S18 copy + threshold-event demotion (dialog stays; free path still does not depend on it once the flag is on).
- S19 mobile pendant-local (desktop half already on main as #12866).
- Folding #11681 `localOnly` / `SttPrivacyPolicy` into this PR.
- Lighting `OMI_FREE_TIER_ON_DEVICE_STT` in prod.
- Download-UX copy for Android-not-ready (block + WAL is the S17 answer).
- Named speaker-ID on free.

## How it was verified

- Resolver matrix + capture entry-point tests as above
- Branched from `origin/main` `9594e01002`, not #11681

## Tests

- `stt_mode_resolver_test.dart` — allowance matrix
- `stt_mode_capture_entry_test.dart` — real `_connectTranscriptionSocket` path
- existing custom-STT / capture_provider / usage_provider suites still green

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

