### PR TITLE
fix(desktop): admit planned JIT on validated facts

### DIFF
--- a/.github/failure-classes/FC-shared-eligibility-gate-collapses-distinct-lanes.json
+++ b/.github/failure-classes/FC-shared-eligibility-gate-collapses-distinct-lanes.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-shared-eligibility-gate-collapses-distinct-lanes",
+  "violated_contract": "When two lanes share a visit entry point but have different admission contracts, the outer gate must not require the stricter lane's precondition before the cheaper lane can evaluate.",
+  "canonical_prevention": "Route visits by validated facts for planned JIT and keep positive worthiness on the legacy director and ambient nano locallyRelevant gate. Pin both with hermetic tests that zero-worthiness validated facts reach planned admission while ambient cannot purchase nano.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift",
+    "desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift",
+    "desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityCoordinator.swift",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -65,6 +65,36 @@ enum ContextDirectorEligibility {
   static func permitsEvaluation(of snapshot: ContextBucketSnapshot) -> Bool {
     snapshot.notifyWorthiness > 0 && !snapshot.validatedFacts.isEmpty
   }
+
+  /// Planned JIT matching is grounded on validated facts, not director worthiness.
+  /// A standing Safari trigger still has to see a Safari fact whose
+  /// `notifyWorthiness` is 0. Ambient nano keeps the worthiness gate via
+  /// `JITAmbientRuntimeContext.locallyRelevant`.
+  static func permitsJITEvaluation(of snapshot: ContextBucketSnapshot) -> Bool {
+    !snapshot.validatedFacts.isEmpty
+  }
+}
+
+enum ContextProactivityVisitRoute: Equatable, Sendable {
+  case skip
+  case jitOnly
+  case jitThenLegacyDirector
+}
+
+enum ContextProactivityAdmissionOutcome: Equatable, Sendable {
+  case skipped
+  case jitConsumed
+  case legacyDirector
+}
+
+enum ContextProactivityVisitAdmission {
+  static func route(for snapshot: ContextBucketSnapshot) -> ContextProactivityVisitRoute {
+    guard ContextDirectorEligibility.permitsJITEvaluation(of: snapshot) else { return .skip }
+    if ContextDirectorEligibility.permitsEvaluation(of: snapshot) {
+      return .jitThenLegacyDirector
+    }
+    return .jitOnly
+  }
 }
 
 enum ContextDirectorGrounding {
@@ -139,10 +169,16 @@ enum ContextDirectorTaskSelection {
 
 actor ContextProactivityEngine {
   static let shared = ContextProactivityEngine(client: .shared, store: .shared)
+  typealias JITHandle =
+    @Sendable (
+      ContextVisitFence, ContextBucketSnapshot, CapturedFrame, RuntimeOwnerAuthorizationSnapshot
+    ) async -> Bool
+
   private let client: ProactiveLaneClient
   private let store: ContextBucketStore
   private let presentationPreflight: @Sendable (String) async -> OwnerBoundNotificationPresentationResult
   private let retrieve: @Sendable (String, RuntimeOwnerAuthorizationSnapshot) async -> [ContextRetrievedItem]
+  private let jitHandle: JITHandle
   private var dwellAdmission = ContextVisitDwellAdmission()
   private let dwellNanoseconds: UInt64
 
@@ -158,6 +194,11 @@ actor ContextProactivityEngine {
       query, authorizationSnapshot in
       await ContextDirectorRetrievalExecutor.retrieve(
         query: query, authorizationSnapshot: authorizationSnapshot)
+    },
+    jitHandle: @escaping JITHandle = { fence, snapshot, frame, authorizationSnapshot in
+      await JITProactivityCoordinator.shared.handle(
+        fence: fence, snapshot: snapshot, frame: frame,
+        authorizationSnapshot: authorizationSnapshot)
     }
   ) {
     self.client = client
@@ -165,6 +206,7 @@ actor ContextProactivityEngine {
     self.dwellNanoseconds = dwellNanoseconds
     self.presentationPreflight = presentationPreflight
     self.retrieve = retrieve
+    self.jitHandle = jitHandle
   }
 
   func contextEntered(_ fence: ContextVisitFence) async {
@@ -195,9 +237,10 @@ actor ContextProactivityEngine {
       freshness.fresh,
       let snapshot = await store.snapshot(for: fence)
     else { return }
-    // Facts are the only source of notification worthiness. A bucket containing
-    // ambient narrative alone cannot purchase a frontier-model call.
-    guard ContextDirectorEligibility.permitsEvaluation(of: snapshot) else { return }
+    // Validated facts are enough to run planned JIT matching. A bucket of
+    // ambient narrative alone still cannot purchase a frontier-model call;
+    // `admitJITThenLegacyDirector` keeps that worthiness gate on the director.
+    guard ContextProactivityVisitAdmission.route(for: snapshot) != .skip else { return }
     // After a departure the latest tracked frame can be the NEXT context's
     // screen. Sample the frame first, then re-read freshness and bound the
     // sample against it: the transition persists `endedAt` before the next
@@ -219,16 +262,10 @@ actor ContextProactivityEngine {
         startedAt: fence.startedAt,
         endedAt: frameFreshness.endedAt)
     else { return }
-    if await JITProactivityCoordinator.shared.handle(
-      fence: fence, snapshot: snapshot, frame: frameSample.frame,
-      authorizationSnapshot: authorizationSnapshot)
-    {
-      return
-    }
-    await evaluateAndDeliver(
+    await admitJITThenLegacyDirector(
       fence: fence,
       snapshot: snapshot,
-      currentFrame: frameSample.frame,
+      frame: frameSample.frame,
       authorizationSnapshot: authorizationSnapshot)
   }
 
@@ -271,24 +308,41 @@ actor ContextProactivityEngine {
       log("DepartureEvalDebug: no snapshot")
       return
     }
-    guard ContextDirectorEligibility.permitsEvaluation(of: snapshot) else {
+    let route = ContextProactivityVisitAdmission.route(for: snapshot)
+    guard route != .skip else {
       log(
         "DepartureEvalDebug: ineligible snapshot worthiness=\(snapshot.notifyWorthiness) facts=\(snapshot.validatedFacts.count)"
       )
       return
     }
-    if await JITProactivityCoordinator.shared.handle(
-      fence: fence, snapshot: snapshot, frame: departingFrame,
+    _ = await admitJITThenLegacyDirector(
+      fence: fence,
+      snapshot: snapshot,
+      frame: departingFrame,
       authorizationSnapshot: authorizationSnapshot)
-    {
-      return
+  }
+
+  /// Shared post-snapshot tail: planned JIT may run on validated facts even at
+  /// zero worthiness; the legacy director still requires positive worthiness.
+  @discardableResult
+  func admitJITThenLegacyDirector(
+    fence: ContextVisitFence,
+    snapshot: ContextBucketSnapshot,
+    frame: CapturedFrame,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async -> ContextProactivityAdmissionOutcome {
+    let route = ContextProactivityVisitAdmission.route(for: snapshot)
+    guard route != .skip else { return .skipped }
+    if await jitHandle(fence, snapshot, frame, authorizationSnapshot) {
+      return .jitConsumed
     }
-    log("DepartureEvalDebug: proceeding to evaluateAndDeliver")
+    guard route == .jitThenLegacyDirector else { return .skipped }
     await evaluateAndDeliver(
       fence: fence,
       snapshot: snapshot,
-      currentFrame: departingFrame,
+      currentFrame: frame,
       authorizationSnapshot: authorizationSnapshot)
+    return .legacyDirector
   }
 
   /// The shared post-settle tail of the director pipeline: presentation

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityCoordinator.swift
@@ -17,13 +17,7 @@ actor JITProactivityCoordinator {
     // pay for (or prompt for) calendar access to reach a decision that ignores the observation.
     let decision = await JITProactivityRuntime.shared.admission(
       authorizationSnapshot: authorizationSnapshot,
-      ambient: JITAmbientRuntimeContext(
-        id: snapshot.bucketID,
-        semanticFingerprint: JITAmbientRuntimeContext.semanticFingerprint(
-          contextID: snapshot.bucketID, validatedFacts: snapshot.validatedFacts),
-        locallyRelevant: snapshot.notifyWorthiness > 0,
-        boundedEvidence: snapshot.validatedFacts.prefix(20).map { String($0.prefix(400)) }
-          .joined(separator: "\n")),
+      ambient: JITAmbientRuntimeContext.fromSnapshot(snapshot),
       observationProvider: {
         let calendarEvents = await SystemCalendarMeetingContextService.shared
           .authorizedTriggerEvents(around: frame.captureTime)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityRuntime.swift
@@ -99,6 +99,18 @@ struct JITAmbientRuntimeContext: Equatable, Sendable {
     !id.isEmpty && semanticFingerprint.count == 64 && locallyRelevant && !boundedEvidence.isEmpty
   }
 
+  /// Planned matching reads validated facts as observation text. Ambient nano
+  /// still requires positive worthiness through `locallyRelevant`.
+  static func fromSnapshot(_ snapshot: ContextBucketSnapshot) -> JITAmbientRuntimeContext {
+    JITAmbientRuntimeContext(
+      id: snapshot.bucketID,
+      semanticFingerprint: semanticFingerprint(
+        contextID: snapshot.bucketID, validatedFacts: snapshot.validatedFacts),
+      locallyRelevant: snapshot.notifyWorthiness > 0,
+      boundedEvidence: snapshot.validatedFacts.prefix(20).map { String($0.prefix(400)) }
+        .joined(separator: "\n"))
+  }
+
   static func semanticFingerprint(contextID: String, validatedFacts: [String]) -> String {
     let facts = validatedFacts.map {
       $0.split(whereSeparator: \.isWhitespace).joined(separator: " ").lowercased()

--- a/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
@@ -227,6 +227,14 @@
       XCTAssertTrue(ContextDirectorEligibility.permitsEvaluation(of: eligible))
       XCTAssertFalse(ContextDirectorEligibility.permitsEvaluation(of: noFacts))
       XCTAssertFalse(ContextDirectorEligibility.permitsEvaluation(of: zeroWorthiness))
+      XCTAssertTrue(ContextDirectorEligibility.permitsJITEvaluation(of: eligible))
+      XCTAssertFalse(ContextDirectorEligibility.permitsJITEvaluation(of: noFacts))
+      XCTAssertTrue(
+        ContextDirectorEligibility.permitsJITEvaluation(of: zeroWorthiness),
+        "planned JIT matching is grounded on validated facts, not director worthiness")
+      XCTAssertEqual(ContextProactivityVisitAdmission.route(for: eligible), .jitThenLegacyDirector)
+      XCTAssertEqual(ContextProactivityVisitAdmission.route(for: noFacts), .skip)
+      XCTAssertEqual(ContextProactivityVisitAdmission.route(for: zeroWorthiness), .jitOnly)
     }
 
     func testReplayReturnsEffectiveSilenceForZeroWorthinessWithoutModel() async throws {

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -3,6 +3,18 @@ import XCTest
 
 @testable import Omi_Computer
 
+private actor VisitAdmissionRecorder {
+  private(set) var events: [String] = []
+
+  func record(_ event: String) {
+    events.append(event)
+  }
+
+  func snapshot() -> [String] {
+    events
+  }
+}
+
 final class ContextProactivityEngineTests: XCTestCase {
   func testDwellAdmissionTracksVisitsInsteadOfSuppressingARevisitToTheSameBucket() {
     var admission = ContextVisitDwellAdmission()
@@ -259,6 +271,108 @@ final class ContextProactivityEngineTests: XCTestCase {
     XCTAssertFalse(ContextProactivityEngine.presentationSurfaceAvailable(.windowUnavailable))
     XCTAssertFalse(ContextProactivityEngine.presentationSurfaceAvailable(.rejectedOwnerChange))
     XCTAssertFalse(ContextProactivityEngine.presentationSurfaceAvailable(.presented))
+  }
+
+  func testZeroWorthinessValidatedFactsReachJITHandleAndSkipLegacyDirector() async throws {
+    let recorder = VisitAdmissionRecorder()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0,
+      presentationPreflight: { _ in
+        await recorder.record("director")
+        return .suppressed
+      },
+      jitHandle: { _, snapshot, _, _ in
+        await recorder.record("jit:\(snapshot.notifyWorthiness):\(snapshot.validatedFacts.count)")
+        return false
+      })
+
+    let outcome = await engine.admitJITThenLegacyDirector(
+      fence: visitFence(),
+      snapshot: bucketSnapshot(facts: ["Safari is showing github.com/BasedHardware/omi"], worthiness: 0),
+      frame: visitFrame(),
+      authorizationSnapshot: try authorizationSnapshot())
+
+    XCTAssertEqual(outcome, .skipped)
+    let events = await recorder.snapshot()
+    XCTAssertEqual(events, ["jit:0.0:1"])
+  }
+
+  func testEmptyFactsSkipJITAndLegacyDirector() async throws {
+    let recorder = VisitAdmissionRecorder()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0,
+      presentationPreflight: { _ in
+        await recorder.record("director")
+        return .suppressed
+      },
+      jitHandle: { _, _, _, _ in
+        await recorder.record("jit")
+        return true
+      })
+
+    let outcome = await engine.admitJITThenLegacyDirector(
+      fence: visitFence(),
+      snapshot: bucketSnapshot(facts: [], worthiness: 1),
+      frame: visitFrame(),
+      authorizationSnapshot: try authorizationSnapshot())
+
+    XCTAssertEqual(outcome, .skipped)
+    let events = await recorder.snapshot()
+    XCTAssertEqual(events, [])
+  }
+
+  func testPositiveWorthinessFallsThroughToLegacyDirectorWhenJITDeclines() async throws {
+    let recorder = VisitAdmissionRecorder()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0,
+      presentationPreflight: { _ in
+        await recorder.record("director")
+        return .suppressed
+      },
+      jitHandle: { _, _, _, _ in
+        await recorder.record("jit")
+        return false
+      })
+
+    let outcome = await engine.admitJITThenLegacyDirector(
+      fence: visitFence(),
+      snapshot: bucketSnapshot(facts: ["Safari is showing github.com/BasedHardware/omi"], worthiness: 0.8),
+      frame: visitFrame(),
+      authorizationSnapshot: try authorizationSnapshot())
+
+    XCTAssertEqual(outcome, .legacyDirector)
+    let events = await recorder.snapshot()
+    XCTAssertEqual(events.first, "jit")
+  }
+
+  private func visitFence() -> ContextVisitFence {
+    ContextVisitFence(
+      visitID: 1, contextGeneration: 1, poolEpoch: 1, bucketID: "safari",
+      startedAt: Date(timeIntervalSince1970: 1_725_000_000))
+  }
+
+  private func visitFrame() -> CapturedFrame {
+    CapturedFrame(
+      jpegData: Data(), appName: "Safari", windowTitle: "GitHub", frameNumber: 0,
+      captureTime: Date(timeIntervalSince1970: 1_725_000_000))
+  }
+
+  private func bucketSnapshot(facts: [String], worthiness: Double) -> ContextBucketSnapshot {
+    ContextBucketSnapshot(
+      bucketID: "safari", versionID: 1, version: 1, header: "Safari",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: facts, notifyWorthiness: worthiness)
+  }
+
+  private func authorizationSnapshot() throws -> RuntimeOwnerAuthorizationSnapshot {
+    let authority = RuntimeOwnerAuthorizationAuthority()
+    authority.endTransition(ownerID: "owner")
+    return try XCTUnwrap(authority.capture(ownerID: "owner", expectedOwnerID: "owner"))
   }
 
   func testHttpLaneErrorRecordsStatusInTerminalProvenanceJSON() throws {

--- a/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
@@ -486,6 +486,51 @@ final class JITProactivityRuntimeTests: XCTestCase {
     XCTAssertEqual(execution?.claim.triggerID, "z-confirmed")
   }
 
+  func testZeroWorthinessValidatedFactsStillAdmitMatchingPlannedTrigger() async throws {
+    let snapshotFacts = ["Safari is showing github.com/BasedHardware/omi"]
+    let bucket = ContextBucketSnapshot(
+      bucketID: "safari", versionID: 1, version: 1, header: "Safari",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: snapshotFacts, notifyWorthiness: 0)
+    let runtime = try wiredRuntime(
+      triggers: [try compiledTrigger(id: "safari-trigger", condition: ["keywords": ["safari"]])])
+
+    let decision = await runtime.admission(
+      authorizationSnapshot: try snapshot(),
+      observation: .init(
+        text: snapshotFacts.joined(separator: "\n"),
+        appName: "Safari",
+        occurredAt: Date(timeIntervalSince1970: 1_777_248_000)),
+      ambient: JITAmbientRuntimeContext.fromSnapshot(bucket))
+
+    guard case .deliver(.planned, "safari-trigger", _) = decision else {
+      return XCTFail("zero-worthiness validated facts must still match planned triggers: \(decision)")
+    }
+    XCTAssertFalse(JITAmbientRuntimeContext.fromSnapshot(bucket).permitsNanoTriage)
+  }
+
+  func testZeroWorthinessAmbientDoesNotPurchaseNanoWhenNoPlannedMatch() async throws {
+    let bucket = ContextBucketSnapshot(
+      bucketID: "safari", versionID: 1, version: 1, header: "Safari",
+      frozenRankedSegment: Data(), tail: [],
+      validatedFacts: ["Safari is showing github.com/BasedHardware/omi"], notifyWorthiness: 0)
+    let runtime = try wiredRuntime(
+      triggers: [try compiledTrigger(id: "planned", condition: ["keywords": ["release"]])],
+      nano: { _, _ in
+        XCTFail("zero-worthiness ambient must not purchase nano")
+        return .approved
+      })
+
+    let decision = await runtime.admission(
+      authorizationSnapshot: try snapshot(),
+      observation: .init(
+        text: bucket.validatedFacts.joined(separator: "\n"),
+        occurredAt: Date(timeIntervalSince1970: 1_777_248_000)),
+      ambient: JITAmbientRuntimeContext.fromSnapshot(bucket))
+
+    XCTAssertEqual(decision, .suppressed(reason: "ambient_local_gate"))
+    XCTAssertFalse(JITAmbientRuntimeContext.fromSnapshot(bucket).permitsNanoTriage)
+  }
+
   func testAmbiguousOnlySuppressesWithoutAmbientOrNewModelAuthority() async throws {
     let runtime = try wiredRuntime(
       triggers: [try compiledTrigger(id: "ambiguous", condition: ["apps": ["Slack"]])])

--- a/desktop/macos/changelog/unreleased/20260907-jit-planned-zero-worthiness.json
+++ b/desktop/macos/changelog/unreleased/20260907-jit-planned-zero-worthiness.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed planned reminders not firing when a matching app was on screen but that context was not independently notification-worthy"
+}


### PR DESCRIPTION
## Summary

Planned JIT standing triggers were unreachable whenever the captured context had validated facts but `notifyWorthiness == 0`. Split the visit admission route so planned JIT can match validated facts while the legacy director and ambient nano retain their positive-worthiness gates.

## Verification

- `xcrun swift test -c debug --package-path Desktop --filter 'ContextProactivityEngineTests|ContextBucketDirectorProbeTests|JITProactivityRuntimeTests'` (71 tests, 0 failures)
- PR pre-push checks passed except the initial missing PR-body declaration; rerun with this body.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

