### PR TITLE
feat(listen): demote freemium threshold event to Plus-only for S18

### DIFF
--- a/app/lib/services/capture/freemium_threshold_tracker.dart
+++ b/app/lib/services/capture/freemium_threshold_tracker.dart
@@ -1,4 +1,5 @@
 import 'package:omi/backend/schema/message_event.dart';
+import 'package:omi/models/subscription.dart';
 import 'package:omi/utils/logger.dart';
 
 class FreemiumThresholdTracker {
@@ -9,6 +10,16 @@ class FreemiumThresholdTracker {
   bool get reached => _reached;
   int get remainingSeconds => _remainingSeconds;
   bool get requiresUserAction => _requiresUserAction;
+
+  /// S18: the listen threshold event is the Plus meter warning only.
+  /// Basic enters on-device through S17; this sheet stays opt-in from Settings.
+  static bool shouldShowPlusMeterPaywall({
+    required bool reached,
+    required bool requiresUserAction,
+    required PlanType? plan,
+  }) {
+    return reached && requiresUserAction && plan == PlanType.plus;
+  }
 
   bool handle(FreemiumThresholdReachedEvent event) {
     if (_reached) return false;

--- a/app/lib/widgets/freemium_switch_dialog.dart
+++ b/app/lib/widgets/freemium_switch_dialog.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:omi/pages/settings/widgets/plans_sheet.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
+import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 import 'package:omi/services/freemium_transcription_service.dart';
 
 /// Handler for freemium transcription switching
@@ -20,7 +21,11 @@ class FreemiumSwitchHandler {
 
     if (!context.read<UsageProvider>().showSubscriptionUI) return false;
 
-    if (captureProvider.freemiumThresholdReached && captureProvider.freemiumRequiresUserAction) {
+    if (FreemiumThresholdTracker.shouldShowPlusMeterPaywall(
+      reached: captureProvider.freemiumThresholdReached,
+      requiresUserAction: captureProvider.freemiumRequiresUserAction,
+      plan: context.read<UsageProvider>().subscription?.subscription.plan,
+    )) {
       _freemiumService.markDialogShown();
 
       if (!context.mounted) return false;

--- a/app/test/services/capture/freemium_threshold_tracker_test.dart
+++ b/app/test/services/capture/freemium_threshold_tracker_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/schema/message_event.dart';
+import 'package:omi/models/subscription.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
 
 void main() {
@@ -29,5 +30,40 @@ void main() {
     expect(tracker.reached, isFalse);
     expect(tracker.remainingSeconds, 0);
     expect(tracker.requiresUserAction, isFalse);
+  });
+
+  test('plus meter paywall is Plus-only', () {
+    expect(
+      FreemiumThresholdTracker.shouldShowPlusMeterPaywall(
+        reached: true,
+        requiresUserAction: true,
+        plan: PlanType.plus,
+      ),
+      isTrue,
+    );
+    expect(
+      FreemiumThresholdTracker.shouldShowPlusMeterPaywall(
+        reached: true,
+        requiresUserAction: true,
+        plan: PlanType.basic,
+      ),
+      isFalse,
+    );
+    expect(
+      FreemiumThresholdTracker.shouldShowPlusMeterPaywall(
+        reached: true,
+        requiresUserAction: true,
+        plan: null,
+      ),
+      isFalse,
+    );
+    expect(
+      FreemiumThresholdTracker.shouldShowPlusMeterPaywall(
+        reached: true,
+        requiresUserAction: false,
+        plan: PlanType.plus,
+      ),
+      isFalse,
+    );
   });
 }

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -88,6 +88,15 @@ PUSHER_ENABLED = bool(os.getenv('HOSTED_PUSHER_API_URL'))
 FREEMIUM_THRESHOLD_SECONDS = 180
 
 
+def should_emit_plus_meter_warning(subscription: Any) -> bool:
+    """S18: the listen threshold event is the Plus (1,500-min) meter warning only.
+
+    Basic no longer enters on-device through this event (S17). Inactive or
+    missing subscriptions must not emit it.
+    """
+    return getattr(subscription, 'plan', None) == PlanType.plus
+
+
 def _account_deletion_blocks_owner_persistence(uid: str) -> bool:
     status = user_db.get_user_deletion_wipe_status(uid)
     return account_deletion_blocks_access(status)
@@ -401,13 +410,15 @@ class ListenSessionRuntime:
         self._build_components()
         if not self.user_has_credits:
             try:
-                await send_credit_limit_notification(request.uid)
-                await request.websocket.send_json(
-                    FreemiumThresholdReachedEvent(
-                        remaining_seconds=0, action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT
-                    ).to_json()
-                )
-                self.state.freemium_threshold_sent = True
+                subscription = await self.persistence.call(user_db.get_user_valid_subscription, request.uid)
+                if should_emit_plus_meter_warning(subscription):
+                    await send_credit_limit_notification(request.uid)
+                    await request.websocket.send_json(
+                        FreemiumThresholdReachedEvent(
+                            remaining_seconds=0, action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT
+                        ).to_json()
+                    )
+                    self.state.freemium_threshold_sent = True
             except Exception as error:
                 logger.error('Credit-limit notification failed type=%s', type(error).__name__)
         if FAIR_USE_ENABLED:
@@ -532,19 +543,22 @@ class ListenSessionRuntime:
         elif self.state.remaining_seconds_cache is not None and transcription_seconds > 0:
             self.state.remaining_seconds_cache = max(0, self.state.remaining_seconds_cache - transcription_seconds)
         remaining = self.state.remaining_seconds_cache
+        subscription = await self.persistence.call(user_db.get_user_valid_subscription, self.request.uid)
         if remaining is not None and remaining <= FREEMIUM_THRESHOLD_SECONDS and not self.state.freemium_threshold_sent:
-            await self.asend_event(
-                FreemiumThresholdReachedEvent(remaining_seconds=remaining, action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT)
-            )
-            self.state.freemium_threshold_sent = True
-            try:
-                await send_credit_limit_notification(self.request.uid)
-            except Exception as error:
-                logger.error('Credit-limit notification refresh failed type=%s', type(error).__name__)
+            if should_emit_plus_meter_warning(subscription):
+                await self.asend_event(
+                    FreemiumThresholdReachedEvent(
+                        remaining_seconds=remaining, action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT
+                    )
+                )
+                self.state.freemium_threshold_sent = True
+                try:
+                    await send_credit_limit_notification(self.request.uid)
+                except Exception as error:
+                    logger.error('Credit-limit notification refresh failed type=%s', type(error).__name__)
         self.user_has_credits = remaining is None or remaining > 0
         if self.user_has_credits and (remaining is None or remaining > FREEMIUM_THRESHOLD_SECONDS):
             self.state.freemium_threshold_sent = False
-        subscription = await self.persistence.call(user_db.get_user_valid_subscription, self.request.uid)
         if not subscription or subscription.plan == PlanType.basic:
             last_words = self.state.last_transcript_time or self.state.first_audio_byte_timestamp
             if (

--- a/backend/tests/unit/test_listen_persistence.py
+++ b/backend/tests/unit/test_listen_persistence.py
@@ -2,9 +2,20 @@
 
 import pytest
 
+from models.users import PlanType
 from routers.listen.contracts import ListenLimits, ListenSessionState
 from routers.listen.persistence import ListenPersistence
 from routers.listen import runtime as listen_runtime
+
+
+def test_should_emit_plus_meter_warning_is_plus_only():
+    from types import SimpleNamespace
+
+    assert listen_runtime.should_emit_plus_meter_warning(None) is False
+    assert listen_runtime.should_emit_plus_meter_warning(SimpleNamespace(plan=PlanType.basic)) is False
+    assert listen_runtime.should_emit_plus_meter_warning(SimpleNamespace(plan=PlanType.unlimited)) is False
+    assert listen_runtime.should_emit_plus_meter_warning(SimpleNamespace()) is False
+    assert listen_runtime.should_emit_plus_meter_warning(SimpleNamespace(plan=PlanType.plus)) is True
 
 
 @pytest.fixture
@@ -68,7 +79,7 @@ async def test_credit_refresh_decrements_cached_credits_and_preserves_source(mon
 
 
 @pytest.mark.anyio
-async def test_credit_refresh_fetches_with_source_and_emits_threshold_event(monkeypatch):
+async def test_credit_refresh_fetches_with_source_and_skips_threshold_for_basic(monkeypatch):
     from types import SimpleNamespace
 
     runtime = object.__new__(listen_runtime.ListenSessionRuntime)
@@ -87,6 +98,44 @@ async def test_credit_refresh_fetches_with_source_and_emits_threshold_event(monk
             return 120
         if function is listen_runtime.user_db.get_user_valid_subscription:
             return None
+        raise AssertionError(f'unexpected persistence call: {function}')
+
+    async def asend_event(event):
+        events.append(event)
+
+    runtime.persistence = SimpleNamespace(call=call)
+    runtime.asend_event = asend_event
+    monkeypatch.setattr(listen_runtime, 'send_credit_limit_notification', lambda _uid: _completed())
+
+    await runtime._refresh_credits()
+
+    assert runtime.state.freemium_threshold_sent is False
+    assert events == []
+    assert (listen_runtime.get_remaining_transcription_seconds, ('user-1',), {'source': 'desktop'}) in calls
+
+
+@pytest.mark.anyio
+async def test_credit_refresh_emits_threshold_event_for_plus(monkeypatch):
+    from types import SimpleNamespace
+
+    from models.users import PlanType
+
+    runtime = object.__new__(listen_runtime.ListenSessionRuntime)
+    runtime.request = SimpleNamespace(uid='user-1', source='desktop')
+    runtime.limits = ListenLimits(credits_refresh_seconds=900)
+    runtime.state = ListenSessionState()
+    runtime.user_has_credits = True
+    events = []
+    calls = []
+
+    async def call(function, *args, **kwargs):
+        calls.append((function, args, kwargs))
+        if function is listen_runtime.check_credits_invalidation:
+            return False
+        if function is listen_runtime.get_remaining_transcription_seconds:
+            return 120
+        if function is listen_runtime.user_db.get_user_valid_subscription:
+            return SimpleNamespace(plan=PlanType.plus)
         raise AssertionError(f'unexpected persistence call: {function}')
 
     async def asend_event(event):

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -124,12 +124,11 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
         memory_summaries = [_memory_content(m) for m in memories]  # Use all memories for context
         memory_context = f"\nRecent conversations include: {', '.join(memory_summaries[:100])}..."
 
-    system_prompt = """You're Omi, and you need to gently let a user know they've hit their transcription limits while encouraging them to upgrade to unlimited. 
+    system_prompt = """You're Omi, and you need to gently let a Plus user know they've used most of this month's premium transcription minutes.
 
     Your Style:
     - Warm and understanding, not pushy
     - Show genuine care for their journey with you
-    - Make the upgrade feel like a natural next step
     - Reference their usage to show value
     - Keep it conversational and friendly
     - No emojis (express yourself in words!)
@@ -137,21 +136,23 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
 
     Key Points to Include:
     - They've been actively using transcription (show appreciation)
-    - Unlimited plan removes all limits
+    - On-device transcription continues normally
     - Can check usage/plans in the app under Settings > Plan & Usages
     - Make it feel like you're helping them, not selling to them
     """
 
-    user_prompt = f"""Create a credit limit notification for {name} who has reached their transcription limits.
+    user_prompt = f"""Create a Plus premium-minutes notification for {name}.
 
     Context:
     - User's name: {name}
     - They've been actively transcribing conversations
-    - Need to encourage unlimited plan subscription{memory_context}
+    - This is the Plus (1,500-min) meter warning, not a stop
+    - On-device transcription continues normally{memory_context}
 
     The message should:
     - Acknowledge their active usage positively
-    - Suggest checking plans in the app under Settings > Plan & Usages
+    - Say on-device transcription continues normally
+    - Suggest checking usage in the app under Settings > Plan & Usages
     - Feel helpful, not sales-y
     - Be warm and personal to {name}
     
@@ -169,7 +170,7 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
     # Fallback message
     return (
         "omi",
-        f"Hey {name}! You've been actively using transcription - that's awesome! You've hit your limit, but unlimited plans remove all restrictions. You can check your usage and upgrade in the app under Settings > Plan & Usages.",
+        f"Hey {name}! You've used most of this month's Plus premium minutes. On-device transcription continues normally. Check usage under Settings > Plan & Usages.",
     )
 
 


### PR DESCRIPTION
## S18 — copy truth + threshold event demoted to the Plus meter warning

Shard S18 of the ratified local-models free-tier program (`omi-knowledge-base/projects/local-models-free-tier/implementation/60-shards.md` S18; spec `40-mobile-pendant-port.md` §4.1). `FreemiumThresholdReachedEvent` stops being the free-tier entry and becomes the **Plus (1,500-min) meter warning** only. Keep `FreemiumThresholdTracker`. The opt-in dialog stays reachable from Settings.

**#11681 (2026-09-07):** still OPEN, last updated 2026-08-19. Option A remains locked: S17 already landed from `main` (#12904 `ba6d7578`). This PR also branches from current `origin/main`. Do not merge #11681. Later rebase/recut must preserve [@Dr-Amp](https://github.com/Dr-Amp) credit.

### Plan correction (dated 2026-09-07)

1. `app_en.arb` already says "300 premium mins + unlimited on-device" for basic. Fair-use restrict copy already says "On-device transcription continues normally." Regenerating l10n on Flutter 3.44.5 re-emits every locale file through a newer dart formatter (~45k-line churn). This PR therefore does **not** retouch `app_en.arb`; the lying strings were the listen threshold event (basic still received `FREEMIUM_ACTION_SETUP_ON_DEVICE_STT` at `remaining <= 180`) and the credit-limit notification ("You've hit your limit").
2. After S16, basic often has `remaining == 0` / `on_device`, so `_refresh_credits` and the no-credits bootstrap path still fired the old "setup on-device" event. That was free's remaining dependence on the event.

### What changed

- `should_emit_plus_meter_warning(subscription)` — Plus only. Missing / basic / unlimited / other plans do not emit.
- Listen `_refresh_credits` and the no-credits bootstrap path both consult it before sending the event or `send_credit_limit_notification`.
- Client `FreemiumSwitchHandler` auto-paywall is Plus-only (`FreemiumThresholdTracker.shouldShowPlusMeterPaywall`). Dialog is not deleted.
- Credit-limit notification prompt + fallback: Plus premium-minutes warning; "On-device transcription continues normally."

### Automatic-or-dead check

`test_should_emit_plus_meter_warning_is_plus_only` + `test_credit_refresh_fetches_with_source_and_skips_threshold_for_basic` fail if basic / missing subscription emit the event. `test_credit_refresh_emits_threshold_event_for_plus` fails if Plus stops getting the 180s warning. Dart `shouldShowPlusMeterPaywall` fails if basic or a missing plan auto-opens the plans sheet.

### Proof

- `backend/tests/unit/test_listen_persistence.py` — 5 passed
- `app/test/services/capture/freemium_threshold_tracker_test.dart` — 3 passed

### Cut list

- Removing the opt-in dialog / Settings path
- Regenerating `app_en.arb` locales (formatter tax; English plan/usage copy already matches)
- S19 mobile pendant-local
- Lighting `OMI_FREE_TIER_ON_DEVICE_STT` in prod
- Merging or racing #11681
- S20 / S22 / S12 AFM / S5b / S10b

## Product invariants affected

none

## How it was verified

- Persistence suite above (basic skip / Plus emit / helper matrix)
- Tracker unit test for Plus-only paywall
- Did not dest-test listen yet (PR not merged). Dest auto-deploy applies because `runtime.py` changed.

## Tests

- `test_listen_persistence.py` — Plus emits; basic / no-sub does not
- `freemium_threshold_tracker_test.dart` — paywall predicate

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

