### PR TITLE
feat(app): keep freemium on-device STT unnamed and off the billed socket (S19)

### DIFF
--- a/app/lib/services/capture/stt_mode_resolver.dart
+++ b/app/lib/services/capture/stt_mode_resolver.dart
@@ -84,7 +84,7 @@ class SttModeResolver {
   static CustomSttConfig? _defaultOnDeviceConfig() {
     final config = FreemiumTranscriptionService().getFreemiumConfig();
     if (config == null) return null;
-    return config.copyWith(identity: freemiumOnDeviceId);
+    return config.copyWith(identity: freemiumOnDeviceId, sendRawAudioToOmi: false);
   }
 
   Future<SttModeDecision> decide({

--- a/app/lib/services/freemium_transcription_service.dart
+++ b/app/lib/services/freemium_transcription_service.dart
@@ -139,6 +139,7 @@ class FreemiumTranscriptionService extends ChangeNotifier {
       return CustomSttConfig(
         provider: SttProvider.onDeviceWhisper, // Uses OnDeviceAppleProvider on iOS
         language: effectiveLanguage,
+        sendRawAudioToOmi: false,
       );
     }
 
@@ -160,6 +161,7 @@ class FreemiumTranscriptionService extends ChangeNotifier {
       language: effectiveLanguage,
       model: modelName ?? 'tiny',
       url: effectiveModelPath,
+      sendRawAudioToOmi: false,
     );
   }
 

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -71,7 +71,8 @@ class CustomSttTranscriptSegmentSocketService extends TranscriptSegmentSocketSer
     super.source,
     super.geolocation,
     super.clientConversationId,
-  }) : super.create(includeSpeechProfile: true, customSttMode: true);
+    bool includeSpeechProfile = true,
+  }) : super.create(includeSpeechProfile: includeSpeechProfile, customSttMode: true);
 }
 
 enum SocketServiceState { connected, disconnected }
@@ -421,6 +422,12 @@ class TranscriptSocketServiceFactory {
     );
   }
 
+  /// S19: synthesized freemium local mode is unnamed. User Custom STT keeps
+  /// today's speech-profile request on the Omi secondary socket.
+  static bool includeSpeechProfileForCustomSecondary(String? sttConfigId) {
+    return sttConfigId != 'freemium:on-device';
+  }
+
   /// Create streaming WebSocket for live STT
   static IPureSocket _createStreamingSocket(int sampleRate, BleAudioCodec codec, CustomSttConfig config) {
     final transcoder = AudioTranscoderFactory.createToRawPcm(sourceCodec: codec, sampleRate: sampleRate);
@@ -555,6 +562,7 @@ class TranscriptSocketServiceFactory {
       source: source,
       geolocation: geolocation,
       clientConversationId: clientConversationId,
+      includeSpeechProfile: includeSpeechProfileForCustomSecondary(sttConfigId),
     );
     final compositeSocket = CompositeTranscriptionSocket(
       primarySocket: primarySocket,

--- a/app/test/unit/composite_transcription_socket_test.dart
+++ b/app/test/unit/composite_transcription_socket_test.dart
@@ -96,6 +96,29 @@ void main() {
       expect(secondary.sent, [same(audio)]);
     });
 
+    test('freemium on-device composite stays unnamed and does not forward audio', () {
+      const config = CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        identity: 'freemium:on-device',
+        sendRawAudioToOmi: false,
+      );
+
+      expect(TranscriptSocketServiceFactory.includeSpeechProfileForCustomSecondary(config.sttConfigId), isFalse);
+
+      final service = TranscriptSocketServiceFactory.createFromCustomConfig(16000, BleAudioCodec.pcm16, 'en', config);
+
+      expect(service.socket, isA<CompositeTranscriptionSocket>());
+      expect((service.socket as CompositeTranscriptionSocket).forwardRawAudioToSecondary, isFalse);
+    });
+
+    test('user custom STT still requests a speech profile on the Omi secondary', () {
+      expect(
+        TranscriptSocketServiceFactory.includeSpeechProfileForCustomSecondary('custom:deepgram'),
+        isTrue,
+      );
+    });
+
     test('factory applies the persisted forwarding setting', () {
       const config = CustomSttConfig(
         provider: SttProvider.customLive,

--- a/app/test/unit/stt_mode_resolver_test.dart
+++ b/app/test/unit/stt_mode_resolver_test.dart
@@ -28,6 +28,7 @@ CustomSttConfig _onDevice() {
     provider: SttProvider.onDeviceWhisper,
     language: 'en',
     identity: SttModeResolver.freemiumOnDeviceId,
+    sendRawAudioToOmi: false,
   );
 }
 
@@ -91,6 +92,7 @@ void main() {
         expect(decision.path, SttResolvedPath.onDevice);
         expect(decision.opensManagedOmiSocket, isFalse);
         expect(decision.customSttConfig?.sttConfigId, SttModeResolver.freemiumOnDeviceId);
+        expect(decision.customSttConfig?.sendRawAudioToOmi, isFalse);
         expect(decision.reason, case_.$3);
       });
 


### PR DESCRIPTION
## S19 mobile — pendant local, unnamed

Shard S19 mobile half of the ratified local-models free-tier program (`60-shards.md` S19; spec `40-mobile-pendant-port.md` §4.2). Desktop half already landed (#12866 `597e94fe9e`). This PR is the mobile remainder: a pendant/mic session on basic runs local and unnamed.

**#11681 (2026-09-07):** still OPEN, last updated 2026-08-19. Option A remains locked. This PR branches from current `origin/main` (`f5a63571`, S18). Do not merge #11681. Later rebase/recut must preserve [@Dr-Amp](https://github.com/Dr-Amp) credit.

### Plan correction (dated 2026-09-07)

S17 already consults `SttModeResolver` on `_ensureDeviceSocketConnection` (BLE/pendant) and `_connectTranscriptionSocket` (mic). The remaining leak was the synthesized `freemium:on-device` config: `CustomSttConfig.sendRawAudioToOmi` defaults **true**, and `CustomSttTranscriptSegmentSocketService` always requested `include_speech_profile=true` on the Omi secondary socket. That is named speaker-ID plus a billed audio path on the free local mode.

### What changed

- `createOnDeviceSttConfig` and the resolver's synthesized copy set `sendRawAudioToOmi: false`.
- Factory `includeSpeechProfileForCustomSecondary` is false for `freemium:on-device`; user Custom STT keeps today's speech-profile request.
- Dialog / Settings opt-in on-device path gets the same unnamed + no-forward defaults.

### Automatic-or-dead check

Resolver matrix asserts on-device decisions have `sendRawAudioToOmi == false`. Factory helper is false for `freemium:on-device` and true for user custom IDs. Composite built from a freemium identity does not forward raw audio.

### Proof

- `stt_mode_resolver_test.dart` + `composite_transcription_socket_test.dart` — 27 passed

### Cut list

- Named speaker-ID on free
- Lighting `OMI_FREE_TIER_ON_DEVICE_STT` in prod
- Merging or racing #11681
- S20 / S22 / S12 AFM / S5b / S10b

## Product invariants affected

none

## How it was verified

- Unit tests above
- Dest: N/A (mobile-only). S18 dest Auto Deploy Backend is a separate in-progress run on `f5a63571`.

## Tests

- Resolver on-device rows require `sendRawAudioToOmi == false`
- Factory unnamed helper + composite no-forward for `freemium:on-device`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

