### PR TITLE
fix: authenticate JIT QA Typesense runner pull

### DIFF
--- a/.github/workflows/jit_qa_typesense_projection.yml
+++ b/.github/workflows/jit_qa_typesense_projection.yml
@@ -414,6 +414,8 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v3
+      - name: Authenticate Docker to Artifact Registry
+        run: gcloud auth configure-docker gcr.io --quiet
       - name: Run canonical rebuild and real search_knowledge proof
         env:
           SOURCE_SHA: ${{ needs.admit.outputs.source_sha }}

--- a/backend/tests/unit/test_jit_qa_typesense_projection_workflow.py
+++ b/backend/tests/unit/test_jit_qa_typesense_projection_workflow.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".." / ".github" / "workflows" / "jit_qa_typesense_projection.yml"
+
+
+def _rehydrate_steps():
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return document["jobs"]["rehydrate"]["steps"]
+
+
+def test_rehydrate_authenticates_docker_before_pulling_private_runner_image():
+    steps = _rehydrate_steps()
+    auth_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Authenticate Docker to Artifact Registry"
+    )
+    auth_step = steps[auth_index]
+    assert auth_step["run"] == "gcloud auth configure-docker gcr.io --quiet"
+    assert auth_index < next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Run canonical rebuild and real search_knowledge proof"
+    )


### PR DESCRIPTION
## Summary
- authenticate the rehydrate job to Artifact Registry before pulling its private immutable runner image
- add a unit guard that requires this step before the proof command

## Validation
- `backend/.venv/bin/python -m pytest backend/tests/unit/test_jit_qa_typesense_projection_workflow.py -q`
- `make preflight`
- bounded pre-push checks passed except the PR-body declaration was unavailable before this file was supplied

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

