### PR TITLE
Chat composer always says "Ask Omi" instead of "Ask a follow-up…"

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
@@ -424,7 +424,7 @@ struct QueryHeroBar: View {
   }
 
   private var placeholder: String {
-    mode == .answer ? "Ask a follow-up…" : RewindSearchMetrics.placeholder
+    QueryComposerPlaceholder.text(mode: mode)
   }
 
   private var fontSize: CGFloat {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -141,6 +141,23 @@ enum QueryShellMode: Equatable, Sendable {
   static let homeDefault: QueryShellMode = .answer
 }
 
+/// **What the empty composer says.**
+///
+/// The chat composer used to say `Ask a follow-up…` whenever it stood under the conversation,
+/// including the moment after the reader cleared it: an invitation to follow up on nothing. It now
+/// says the one thing it always means — `Ask Omi` — whatever the transcript holds. Only the search
+/// placement carries a different prompt, because it is a different control.
+enum QueryComposerPlaceholder {
+  static let chat = "Ask Omi"
+
+  static func text(mode: QueryShellMode) -> String {
+    switch mode {
+    case .results: return RewindSearchMetrics.placeholder
+    case .answer: return chat
+    }
+  }
+}
+
 /// The `home_*` bridge actions, as the search-text transition each one promises.
 ///
 /// Home's mode is derived from the search text, so a bridge action that promises the conversation
@@ -223,7 +240,7 @@ enum QueryShellSubmit: Equatable, Sendable {
 /// **One submit, resolved once — including what the field is left holding.**
 ///
 /// The text is a *message*, and a composer that keeps the message it just sent is a composer you
-/// have to empty by hand before you can write the next one: the `Ask a follow-up…` placeholder was
+/// have to empty by hand before you can write the next one: the `Ask Omi` placeholder was
 /// unreachable, a second `⏎` re-sent the question verbatim, and emptying the field to type a
 /// follow-up used to throw the whole conversation away because an empty field was read as "take me
 /// back to the list".

--- a/desktop/macos/Desktop/Tests/QueryComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryComposerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 /// 1. The composer bound a `@State` on `QueryShellHome` while `ChatProvider.draftText` — what
 ///    persistence restores, what a send clears and what the automation bridge's `set_chat_drafts`
 ///    writes — went somewhere nothing rendered. `chat_drafts_snapshot` reported a draft stored and
-///    the bar went on showing `Ask a follow-up…`, so every harness assertion made through the bridge
+///    the bar went on showing its placeholder, so every harness assertion made through the bridge
 ///    was an assertion about a dead variable.
 /// 2. It was an `NSTextField`. A pasted three-line block was stored in full and drawn as its last
 ///    line, a long question scrolled its own beginning out of view, and Shift-⏎ did nothing.

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -28,9 +28,24 @@ final class QueryShellTests: XCTestCase {
     }
   }
 
+  // MARK: - What the empty bar says
+
+  /// Clearing the chat left the bar saying `Ask a follow-up…` over an empty transcript — an
+  /// invitation to follow up on nothing. The composer now says `Ask Omi`, full stop: the prompt
+  /// does not depend on what the transcript holds, so there is no state for it to get wrong.
+  func testTheChatComposerAlwaysSaysAskOmi() {
+    XCTAssertEqual(QueryComposerPlaceholder.text(mode: .answer), "Ask Omi")
+    XCTAssertEqual(QueryComposerPlaceholder.chat, "Ask Omi")
+  }
+
+  /// The search placement keeps its own prompt; it is a different control.
+  func testSearchingKeepsTheSearchPlaceholder() {
+    XCTAssertEqual(QueryComposerPlaceholder.text(mode: .results), RewindSearchMetrics.placeholder)
+  }
+
   // MARK: - What a submit leaves behind
 
-  /// A composer that keeps the message it just sent leaves `Ask a follow-up…` permanently
+  /// A composer that keeps the message it just sent leaves its placeholder permanently
   /// unreachable, makes a second `⏎` re-send the question verbatim, and forces the reader to empty
   /// the field by hand before they can write the next one.
   func testAskingSendsTheTrimmedQuestionAndEmptiesTheComposer() {

--- a/desktop/macos/changelog/unreleased/20260907-empty-chat-placeholder.json
+++ b/desktop/macos/changelog/unreleased/20260907-empty-chat-placeholder.json
@@ -1,0 +1,3 @@
+{
+  "change": "The chat composer now always reads \"Ask Omi\" instead of \"Ask a follow-up…\""
+}

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -32,7 +32,7 @@ preconditions:
 steps:
   - id: S1
     name: Verify Home tab is active
-    do: "Verify the app opens on the conversation. The top bar shows Home, Memories, Tasks, Rewind and Apps pills. Below it, a search bar with the placeholder 'Search what you've seen and heard…' sits above the chat panel, whose own composer ('Ask a follow-up…') is pinned under the transcript. Typing in the search bar swaps the panel to live-narrowing results; clearing it returns to the chat."
+    do: "Verify the app opens on the conversation. The top bar shows Home, Memories, Tasks, Rewind and Apps pills. Below it, a search bar with the placeholder 'Search what you've seen and heard…' sits above the chat panel, whose own composer ('Ask Omi') is pinned under the transcript. Typing in the search bar swaps the panel to live-narrowing results; clearing it returns to the chat."
     expect:
       interactive_count: { min: 6 }
       text_visible:


### PR DESCRIPTION
## What changed and why

The chat composer read "Ask a follow-up…" whenever it sat under the conversation, including right after clearing the chat, where there was nothing to follow up on. The composer now always says **"Ask Omi"**. There is no follow-up variant and no dependence on what the transcript holds, so there is no state for the copy to get wrong. The search placement keeps its own prompt. The rule is one pure function (`QueryComposerPlaceholder.text(mode:)`) so the bar and the tests cannot disagree. The home e2e flow doc describes the new copy.

## Carried fix (temporary)

Rebased onto current `main` and carrying the one-commit fix from #12932 (Vision OCR language query via the request instance) so the Desktop Swift checks can run past the deprecation error that has broken `main` since #12888 (#12931). It is byte-identical to #12932; once that merges, a rebase drops it from this PR automatically. This PR does not otherwise touch Rewind.

## Product invariants affected

none

## How it was verified

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'QueryShellTests|QueryComposerTests'` in `desktop/macos/Desktop` → 57 tests, 0 failures.
- Exercised in the running app (named bundle `omi-follow-up-text-incorrect`, signed in against the dev backend): the composer reads "Ask Omi" with an empty transcript and still reads "Ask Omi" after a message is sent and answered. Window screenshots taken for both states.
- Pinned swift-format lint clean; bounded pre-push gate passed.

## Tests

- `QueryShellTests.testTheChatComposerAlwaysSaysAskOmi` is the regression test: the `.answer` placement yields "Ask Omi".
- `testSearchingKeepsTheSearchPlaceholder` pins the search placement.

## Failure class (fixes)

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDiUGZjXHZBEzDQbCqLMeB
