### PR TITLE
fix(desktop): replace the tasks "…" menu with a Select button

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/PageQueryToolbar.swift
@@ -148,7 +148,9 @@ struct PageQueryControlLabel: View {
 /// Textual action chrome for page-level operations. Primary actions invert the
 /// shared ink; secondary actions retain the neutral chip treatment.
 struct PageQueryActionLabel: View {
-  let icon: String
+  /// A glyph the chip can collapse to when the toolbar is narrow. `nil` draws the word alone —
+  /// for an action whose word already says everything a glyph could.
+  var icon: String? = nil
   let title: String
   var isPrimary = false
   @State private var isHovering = false
@@ -156,15 +158,19 @@ struct PageQueryActionLabel: View {
   var body: some View {
     ViewThatFits(in: .horizontal) {
       HStack(spacing: OmiSpacing.xs) {
-        Image(systemName: icon)
-          .scaledFont(size: OmiType.caption, weight: .semibold)
+        if let icon {
+          Image(systemName: icon)
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+        }
         Text(title)
           .scaledFont(size: OmiType.caption, weight: .semibold)
           .lineLimit(1)
       }
 
-      Image(systemName: icon)
-        .scaledFont(size: OmiType.caption, weight: .semibold)
+      if let icon {
+        Image(systemName: icon)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+      }
     }
     .foregroundStyle(isPrimary ? Ink.surface : Ink.primary)
     .tint(isPrimary ? Ink.surface : Ink.primary)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -3899,7 +3899,12 @@ struct TasksPage: View {
           }
           cancelMultiSelectButton
         } else {
-          tasksMoreMenu
+          if !viewModel.displayTasks.isEmpty {
+            selectTasksButton
+          }
+          if chatProvider != nil && TaskAgentSettings.shared.isChatEnabled {
+            taskAssistantButton
+          }
           addTaskButton
         }
       }
@@ -4035,30 +4040,6 @@ struct TasksPage: View {
     .help("Filter tasks by status")
   }
 
-  private var selectModeButton: some View {
-    Button {
-      OmiMotion.withGated(.easeInOut(duration: 0.2)) {
-        viewModel.toggleMultiSelectMode()
-      }
-    } label: {
-      HStack(spacing: OmiSpacing.xs) {
-        Image(
-          systemName: viewModel.isMultiSelectMode ? "checkmark.circle" : "checkmark.circle.badge.questionmark"
-        )
-        .scaledFont(size: OmiType.caption)
-        Text(viewModel.isMultiSelectMode ? "Done" : "Select")
-          .scaledFont(size: OmiType.body, weight: .medium)
-      }
-      .foregroundColor(viewModel.isMultiSelectMode ? Ink.primary : Ink.secondary)
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .glassChip(isActive: viewModel.isMultiSelectMode)
-    }
-    .buttonStyle(.plain)
-    .help(viewModel.isMultiSelectMode ? "Exit selection" : "Select tasks for bulk actions")
-    .accessibilityIdentifier("tasks-select-toggle")
-  }
-
   private var multiSelectControls: some View {
     HStack(spacing: OmiSpacing.md) {
       Button {
@@ -4137,76 +4118,43 @@ struct TasksPage: View {
     .buttonStyle(.plain)
   }
 
-  private var tasksMoreMenu: some View {
-    Menu {
-      if !viewModel.displayTasks.isEmpty {
-        Button {
-          OmiMotion.withGated(.easeInOut(duration: 0.2)) {
-            viewModel.toggleMultiSelectMode()
-          }
-        } label: {
-          Label("Select tasks…", systemImage: "checkmark.circle")
-        }
-      }
-
-      if chatProvider != nil && TaskAgentSettings.shared.isChatEnabled {
-        Button {
-          if showChatPanel {
-            closeChatPanel()
-          } else if let selectedId = viewModel.keyboardSelectedTaskId,
-            let task = viewModel.displayTasks.first(where: { $0.id == selectedId })
-          {
-            openChatForTask(task)
-          } else {
-            adjustWindowWidth(expand: true)
-            OmiMotion.withGated(.easeInOut(duration: 0.25)) {
-              showChatPanel = true
-            }
-          }
-        } label: {
-          Label(showChatPanel ? "Close task assistant" : "Open task assistant", systemImage: "bubble.left")
-        }
+  /// Selection is the one thing most readers come to this corner for, so it is a labelled button
+  /// and not an item folded behind `…`. A word says what a glyph made you guess.
+  private var selectTasksButton: some View {
+    Button {
+      OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+        viewModel.toggleMultiSelectMode()
       }
     } label: {
-      PageQueryActionLabel(icon: "ellipsis", title: "More")
+      PageQueryActionLabel(icon: "checkmark.circle", title: "Select")
     }
-    .menuStyle(.borderlessButton)
-    .menuIndicator(.hidden)
-    .fixedSize()
-    .help("More task actions")
-    .accessibilityLabel("More task actions")
-    .accessibilityIdentifier("tasks-more-actions")
+    .buttonStyle(.plain)
+    .help("Select tasks for bulk actions")
+    .accessibilityLabel("Select tasks")
+    .accessibilityIdentifier("tasks-select-toggle")
   }
 
-  private var chatToggleButton: some View {
+  private var taskAssistantButton: some View {
     Button {
       if showChatPanel {
         closeChatPanel()
       } else if let selectedId = viewModel.keyboardSelectedTaskId,
         let task = viewModel.displayTasks.first(where: { $0.id == selectedId })
       {
-        // A task is selected — open chat directly for it
         openChatForTask(task)
       } else {
-        // No task selected — open empty sidebar
         adjustWindowWidth(expand: true)
         OmiMotion.withGated(.easeInOut(duration: 0.25)) {
           showChatPanel = true
         }
       }
     } label: {
-      Image(systemName: showChatPanel ? "bubble.left.and.bubble.right.fill" : "bubble.left.and.bubble.right")
-        .scaledFont(size: OmiType.caption)
-        .foregroundColor(showChatPanel ? Ink.primary : Ink.secondary)
-        .padding(OmiSpacing.sm)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.elementRadius)
-            .fill(showChatPanel ? Ink.primary.opacity(0.12) : Ink.rowFill)
-        )
+      PageQueryActionLabel(icon: "bubble.left", title: showChatPanel ? "Close Assistant" : "Assistant")
     }
     .buttonStyle(.plain)
-    .help(showChatPanel ? "Close chat panel" : "Open task chat")
-    .accessibilityLabel(showChatPanel ? "Close task chat" : "Open task chat")
+    .help(showChatPanel ? "Close task assistant" : "Open task assistant")
+    .accessibilityLabel(showChatPanel ? "Close task assistant" : "Open task assistant")
+    .accessibilityIdentifier("tasks-assistant-toggle")
   }
 
   // MARK: - Loading View

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -4126,7 +4126,7 @@ struct TasksPage: View {
         viewModel.toggleMultiSelectMode()
       }
     } label: {
-      PageQueryActionLabel(icon: "checkmark.circle", title: "Select")
+      PageQueryActionLabel(title: "Select")
     }
     .buttonStyle(.plain)
     .help("Select tasks for bulk actions")

--- a/desktop/macos/changelog/unreleased/20260907-tasks-select-button.json
+++ b/desktop/macos/changelog/unreleased/20260907-tasks-select-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Replaced the To-Do page's \"…\" menu with a labelled Select button for choosing tasks"
+}


### PR DESCRIPTION
## What changed and why

The To-Do page toolbar hid "Select tasks…" behind a three-dot **More** menu, so the page's most common secondary action took a click, a read, and a guess. The menu is replaced by a **Select** button, the word alone with no glyph, drawn with the toolbar's existing `PageQueryActionLabel` (which now takes an optional icon), shown whenever there are tasks to select. The task-assistant toggle that shared the menu keeps its flag gate (`TaskAgentSettings.isChatEnabled`) and becomes its own labelled **Assistant** button. Two unused chip-styled variants of these buttons that were never mounted are removed.

## Carried fix (temporary)

Rebased onto current `main` and carrying the one-commit fix from #12932 (Vision OCR language query via the request instance) so the Desktop Swift checks can run past the deprecation error that has broken `main` since #12888 (#12931). It is byte-identical to #12932; once that merges, a rebase drops it from this PR automatically. This PR does not otherwise touch Rewind.

## Product invariants affected

- INV-NAV-1 (path match only: `MainWindow/Pages/TasksPage.swift`; the toolbar action changed, no navigation or destination routing)
- INV-TASK-1 (path match only; task loading, buckets, and paging untouched)

## How it was verified

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c debug` in `desktop/macos/Desktop` → Build complete, no warnings in `TasksPage.swift`; pinned swift-format lint clean
- Exercised in the running app (named bundle `omi-todo-select-button`, signed in against the dev backend): the To-Do toolbar shows `To Do ▾` on the left and `Select` + `New Task` on the right, no three-dot menu. Window screenshot taken.
- The new button calls the same `toggleMultiSelectMode()` the menu item called, and the multi-select toolbar (Cancel / Delete) it hands off to is unchanged.

## Tests

No test change. The change is a toolbar control swap with no new logic; both actions were already reachable through the same view-model calls, and the accessibility identifier `tasks-select-toggle` is now the mounted control for automation.

## Failure class (fixes)

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDiUGZjXHZBEzDQbCqLMeB
