### PR TITLE
fix(dev-harness): require Java 21+ for Firebase emulators at prereq time

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -292,25 +292,36 @@ def _python_importable(module: str) -> bool:
     )
 
 
-def _java_runtime_present() -> bool:
-    """Report whether a usable JVM exists, not merely whether `java` is on PATH.
+# firebase-tools refuses to start the emulators on a JDK older than 21
+# ("firebase-tools no longer supports Java version before 21"), so the harness
+# rejects it at prereq time instead of failing firestore/auth health checks.
+FIREBASE_EMULATORS_MIN_JAVA_MAJOR = 21
+
+
+def _java_major_version() -> int | None:
+    """Major JDK version `java -version` reports, or None when unusable.
 
     macOS ships a stub at /usr/bin/java that is always present and exits 1 with
     "Unable to locate a Java Runtime" when no JDK is installed, so a PATH lookup
-    passes on every Mac. Running the binary is the only check that distinguishes
-    the stub from a real runtime.
+    passes on every Mac. Running the binary and parsing its version line is the
+    only check that distinguishes the stub from a real runtime — and reports the
+    version firebase-tools would otherwise reject only at emulator start.
     """
     if not _which("java"):
-        return False
+        return None
     try:
-        return (
-            subprocess.run(
-                ["java", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30
-            ).returncode
-            == 0
-        )
+        proc = subprocess.run(["java", "-version"], capture_output=True, text=True, timeout=30)
     except (OSError, subprocess.SubprocessError):
-        return False
+        return None
+    if proc.returncode != 0:
+        return None
+    match = re.search(r'version "([0-9][0-9._]*)', proc.stderr)
+    if not match:
+        return None
+    parts = match.group(1).split(".")  # "21.0.1" → 21; legacy "1.8.0_191" → 8
+    if parts[0] == "1" and len(parts) > 1:
+        return int(parts[1])
+    return int(parts[0])
 
 
 def _node_major_version() -> int | None:
@@ -361,10 +372,17 @@ def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]
         missing.append(
             "firebase-tools CLI or npx (install with npm install, npm install -g firebase-tools, or use npx)"
         )
-    if not _java_runtime_present():
+    java_major = _java_major_version()
+    if java_major is None:
         missing.append(
             "java runtime (required by the Firestore and Auth emulators; "
             "install one with `brew install --cask temurin` or from https://adoptium.net)"
+        )
+    elif java_major < FIREBASE_EMULATORS_MIN_JAVA_MAJOR:
+        missing.append(
+            f"java {java_major} is too old for the Firebase emulators (firebase-tools requires "
+            f"Java {FIREBASE_EMULATORS_MIN_JAVA_MAJOR}+; install e.g. `brew install openjdk@21` "
+            "and put it first on PATH)"
         )
     if not _which("redis-server"):
         missing.append("redis-server (required for local Redis on loopback)")

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -67,6 +67,10 @@ def test_real_check_lists_provider_credentials(monkeypatch: pytest.MonkeyPatch, 
     assert any("DEEPGRAM_API_KEY" in item for item in missing)
 
 
+def _fake_java(returncode: int, stderr: str = "") -> object:
+    return lambda *_args, **_kwargs: subprocess.CompletedProcess([], returncode, stderr=stderr)
+
+
 def test_java_stub_that_exits_nonzero_is_not_a_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     """macOS ships /usr/bin/java as a stub that is always on PATH but has no JVM behind it.
 
@@ -74,16 +78,25 @@ def test_java_stub_that_exits_nonzero_is_not_a_runtime(monkeypatch: pytest.Monke
     ~135s later as an unexplained firestore/auth health-check timeout.
     """
     monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
-    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1))
+    monkeypatch.setattr(cli.subprocess, "run", _fake_java(1))
 
-    assert cli._java_runtime_present() is False
+    assert cli._java_major_version() is None
 
 
-def test_java_present_when_the_binary_reports_a_version(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_java_reports_its_major_version(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
-    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(
+        cli.subprocess, "run", _fake_java(0, 'openjdk version "21.0.12.1" 2026-08-18\n')
+    )
 
-    assert cli._java_runtime_present() is True
+    assert cli._java_major_version() == 21
+
+
+def test_legacy_java_1_8_version_line_reports_major_8(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
+    monkeypatch.setattr(cli.subprocess, "run", _fake_java(0, 'java version "1.8.0_191"\n'))
+
+    assert cli._java_major_version() == 8
 
 
 def test_missing_java_runtime_is_reported_as_a_prerequisite(
@@ -91,12 +104,28 @@ def test_missing_java_runtime_is_reported_as_a_prerequisite(
 ) -> None:
     monkeypatch.setenv("PROVIDER_MODE", "offline")
     monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
-    monkeypatch.setattr(cli, "_java_runtime_present", lambda: False)
+    monkeypatch.setattr(cli, "_java_major_version", lambda: None)
     cfg = config.load_config(REPO_ROOT)
 
     missing, _warnings = cli.prerequisite_report(cfg)
 
     assert any("java runtime" in item for item in missing)
+
+
+def test_pre_21_java_is_reported_as_a_prerequisite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """firebase-tools rejects JDKs before 21, so the harness must too — not at
+    emulator start (45s/90s health-check timeout) but in the prereq report.
+    """
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_java_major_version", lambda: 17)
+    cfg = config.load_config(REPO_ROOT)
+
+    missing, _warnings = cli.prerequisite_report(cfg)
+
+    assert any("too old" in item and "17" in item and "Java 21" in item for item in missing)
 
 
 def test_minimum_node_major_reads_the_pinned_firebase_tools_engines_range() -> None:


### PR DESCRIPTION
## Soft-path rebase of #12683

Rebases KianWeng#12683 onto current `main` (conflict was only in `scripts/dev-harness/tests/test_cli.py` — kept main's Node>=20 prereq tests and this PR's pre-21 Java rejection test).

Original PR: https://github.com/BasedHardware/omi/pull/12683 (APPROVED; fork push blocked by OAuth `workflow` scope when updating `dev`).

### What changed and why
Fail fast in `make dev-up` prereq when JDK < 21 (firebase-tools requirement) instead of opaque emulator health-check timeouts.

### Product invariants affected
none

### How it was verified
Local: `pytest scripts/dev-harness/tests/test_cli.py -k 'java or node_major or old_node or current_node or pre_21 or missing_java'` → 9 passed.

### Tests
New/updated unit tests for `_java_major_version` + pre-21 prereq message; Node tests from main preserved.

### Failure class (fixes)
Failure-Class: none

Supersedes #12683.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev-harness prerequisite checks only; no production auth, data, or runtime behavior changes.
> 
> **Overview**
> The dev harness **fails fast on JDK version** during `make dev-up` / `check` instead of letting Firebase emulators stall on long Firestore/Auth health-check timeouts.
> 
> **`_java_runtime_present()` is replaced by `_java_major_version()`**, which runs `java -version`, handles the macOS `/usr/bin/java` stub, and parses modern (`21.x`) and legacy (`1.8.x`) version strings. **`FIREBASE_EMULATORS_MIN_JAVA_MAJOR = 21`** mirrors firebase-tools’ requirement.
> 
> **`prerequisite_report`** still reports a missing JVM when no usable Java is found, and now adds a separate message when Java is installed but **below 21**, with install/PATH hints (e.g. `openjdk@21`).
> 
> **Tests** cover version parsing, stub behavior, missing Java, and JDK 17 rejected at prereq time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc88aaf22a4affbe2ab0d6858b4d945d4e052151. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->