### PR TITLE
fix(action-items): stop treating identical task titles as retries

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -294,9 +294,9 @@ def create_action_item(
             retry on flaky networks or duplicate event delivery — the previous
             behaviour silently allocated a fresh Firestore id on every call,
             producing user-visible duplicates. The key is stored on the
-            document so future calls can find it. Callers that want
-            content-based idempotency typically pass
-            ``hashlib.sha256(f"{uid}:{normalized_description}".encode()).hexdigest()``.
+            document so future calls can find it. Pass a per-attempt client
+            key (for example an ``Idempotency-Key`` header), not a hash of
+            the description: task titles are not unique.
         document_id: Optional caller-reserved Firestore document id. Reusing
             the id returns the existing document without rewriting it, making
             a crash-retried create deterministic.

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -1,13 +1,12 @@
 import asyncio
-import hashlib
 import logging
 import uuid
 
 from utils.executors import postprocess_executor, submit_with_context
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
-from typing import Optional, List
+from typing import Annotated, Optional, List
 from datetime import datetime, timezone
 
 import database.action_items as action_items_db
@@ -288,30 +287,30 @@ def sync_batch_update(request: SyncBatchRequest, uid: str = Depends(auth.get_cur
 # *****************************
 
 
-def _content_idempotency_key(uid: str, description: str) -> str:
-    """Stable idempotency key from (uid, normalized description).
+def _client_idempotency_key(raw: Optional[str]) -> Optional[str]:
+    """Return a caller-supplied retry key, or None to always insert.
 
-    Two POSTs from the same user with the same description (modulo case +
-    surrounding whitespace) collapse to the same key, so a flaky-network
-    retry no longer creates a duplicate Firestore document.
-
-    Uses a length-prefixed encoding so the boundary between ``uid`` and
-    ``description`` is unambiguous: ``f"{len(uid)}:{uid}:{description}"``.
-    Without this, a uid containing ``:`` (federated identities, future
-    multi-tenant ids) could collide with a different ``(uid, description)``
-    pair after concatenation.
+    Task titles are not unique: hashing the description treated a second
+    "Buy milk" as a retry of the first and returned the existing document
+    (same due date, gone after reload). Real retries must send their own
+    ``Idempotency-Key``.
     """
-    normalized = (description or '').strip().lower()
-    payload = f"{len(uid)}:{uid}:{normalized}"
-    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    if raw is None:
+        return None
+    key = raw.strip()
+    return key or None
 
 
 @router.post("/v1/action-items", response_model=ActionItemResponse, tags=['action-items'])
-def create_action_item(request: ActionItemCreateRequest, uid: str = Depends(auth.get_current_user_uid)):
+def create_action_item(
+    request: ActionItemCreateRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+    idempotency_key: Annotated[Optional[str], Header(alias='Idempotency-Key', max_length=256)] = None,
+):
     """Create a new action item.
 
-    Content-idempotent on (uid, normalized description): a retry of the same
-    request returns the original action_item rather than creating a duplicate.
+    Idempotent only when the client sends ``Idempotency-Key``. Two creates
+    with the same description (and different keys, or no key) are two tasks.
     """
     try:
         task_links.validate_task_links(uid, goal_id=request.goal_id, workstream_id=request.workstream_id)
@@ -319,9 +318,10 @@ def create_action_item(request: ActionItemCreateRequest, uid: str = Depends(auth
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     action_item_data = request.storage_payload()
 
-    idempotency_key = _content_idempotency_key(uid, request.description)
     try:
-        action_item_id = action_items_db.create_action_item(uid, action_item_data, idempotency_key=idempotency_key)
+        action_item_id = action_items_db.create_action_item(
+            uid, action_item_data, idempotency_key=_client_idempotency_key(idempotency_key)
+        )
     except FirestoreContentionExhausted as exc:
         raise HTTPException(status_code=503, detail="Service temporarily unavailable") from exc
     except action_items_db.TaskRelationshipConflictError as exc:

--- a/backend/tests/unit/test_action_item_idempotency.py
+++ b/backend/tests/unit/test_action_item_idempotency.py
@@ -1,4 +1,4 @@
-"""Tests for content-hash idempotency on create_action_item.
+"""Tests for optional-key idempotency on create_action_item.
 
 `database.action_items.create_action_item` historically allocated a fresh
 Firestore id on every call. A flaky-network retry from the desktop client
@@ -9,12 +9,13 @@ would happily produce a duplicate document. The fix:
   its id without creating a new one. The key is stored on the document so
   later calls can find it.
 
-- ``routers/action_items.create_action_item`` (the FastAPI handler) computes
-  a stable key from ``sha256(f"{uid}:{normalized_description}")`` so a
-  retried POST of the same task collapses to the original.
+- ``routers/action_items.create_action_item`` honors an optional
+  ``Idempotency-Key`` header. It must not hash the description: two tasks
+  named "123" are two tasks, and hashing the title returned the first
+  document (wrong due date, gone after reload).
 
 These tests exercise the db-layer contract (idempotency hit / miss / no-key
-backwards compat) and the router-layer key derivation.
+backwards compat) and the router-layer key handling.
 """
 
 from unittest.mock import MagicMock
@@ -243,41 +244,65 @@ def test_create_retries_precommit_contention_without_duplicate_write(monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# router-layer content key
+# router-layer Idempotency-Key
 # ---------------------------------------------------------------------------
 
 
-def test_content_key_is_stable_for_same_input():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    assert a == b
+def test_client_idempotency_key_strips_and_drops_blank():
+    assert action_items_router._client_idempotency_key(None) is None
+    assert action_items_router._client_idempotency_key('') is None
+    assert action_items_router._client_idempotency_key('   ') is None
+    assert action_items_router._client_idempotency_key(' retry-1 ') == 'retry-1'
 
 
-def test_content_key_normalizes_case_and_whitespace():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy Milk')
-    b = action_items_router._content_idempotency_key('uid-1', '  buy milk  ')
-    assert a == b
+def _stub_router_create(monkeypatch, *, capture):
+    monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'upsert_action_item_vector', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'submit_with_context', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, 'send_action_item_data_message', lambda **kwargs: None)
+    monkeypatch.setattr(action_items_router, '_wake_task_changes', lambda *args, **kwargs: None)
+
+    def _create(uid, data, idempotency_key=None, **kwargs):
+        capture.append({'data': data, 'idempotency_key': idempotency_key})
+        return f'task-{len(capture)}'
+
+    monkeypatch.setattr(action_items_db, 'create_action_item', _create)
+    monkeypatch.setattr(
+        action_items_db,
+        'get_action_item',
+        lambda uid, task_id: {'id': task_id, 'description': '123', 'completed': False, 'due_at': None},
+    )
 
 
-def test_content_key_separates_users():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-2', 'Buy milk')
-    assert a != b
+def test_router_does_not_hash_description_as_idempotency_key(monkeypatch):
+    """Two POSTs with the same title and no header must both insert.
+
+    Hashing (uid, description) made the second create return the first
+    document, so the UI showed a clone with the old due date that vanished
+    on reload.
+    """
+    capture = []
+    _stub_router_create(monkeypatch, capture=capture)
+    request = action_items_router.CreateActionItemRequest(description='123')
+
+    first = action_items_router.create_action_item(request, uid='user-1')
+    second = action_items_router.create_action_item(request, uid='user-1')
+
+    assert first.id != second.id
+    assert [row['idempotency_key'] for row in capture] == [None, None]
 
 
-def test_content_key_separates_descriptions():
-    a = action_items_router._content_idempotency_key('uid-1', 'Buy milk')
-    b = action_items_router._content_idempotency_key('uid-1', 'Buy bread')
-    assert a != b
+def test_router_honors_client_idempotency_key(monkeypatch):
+    capture = []
+    _stub_router_create(monkeypatch, capture=capture)
 
+    action_items_router.create_action_item(
+        action_items_router.CreateActionItemRequest(description='123'),
+        uid='user-1',
+        idempotency_key='retry-1',
+    )
 
-def test_content_key_avoids_separator_collision():
-    """Length-prefixed encoding must distinguish (uid='org', desc='user:task')
-    from (uid='org:user', desc='task'). A naive ``f"{uid}:{desc}"`` encoding
-    would collapse both to the same hash; the length prefix prevents this."""
-    a = action_items_router._content_idempotency_key('org', 'user:task')
-    b = action_items_router._content_idempotency_key('org:user', 'task')
-    assert a != b
+    assert capture[0]['idempotency_key'] == 'retry-1'
 
 
 def test_create_dispatches_auto_sync_outside_the_database_pool(monkeypatch):
@@ -296,6 +321,7 @@ def test_create_dispatches_auto_sync_outside_the_database_pool(monkeypatch):
     monkeypatch.setattr(legacy_db_executor, 'submit', lambda function: database_submissions.append(function))
     monkeypatch.setattr(action_items_router, 'db_executor', legacy_db_executor, raising=False)
     monkeypatch.setattr(action_items_router.task_links, 'validate_task_links', lambda *args, **kwargs: None)
+    monkeypatch.setattr(action_items_router, '_wake_task_changes', lambda *args, **kwargs: None)
     monkeypatch.setattr(action_items_db, 'create_action_item', lambda *args, **kwargs: 'task-1')
     monkeypatch.setattr(
         action_items_db,

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -5436,7 +5436,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(ActionItemsResponse.self, from: data)
   }
 
-  public static func createActionItemV1ActionItemsPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: ActionItemCreateRequest) async throws -> ActionItemResponse {
+  public static func createActionItemV1ActionItemsPost(client: OmiApiClient, idempotencyKey: String? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: ActionItemCreateRequest) async throws -> ActionItemResponse {
     let _path = "/v1/action-items"
     guard let components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -5448,6 +5448,7 @@ public enum OmiAPI {
     if let token = client.token {
       req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
     }
+    if let idempotencyKey { req.setValue(String(idempotencyKey), forHTTPHeaderField: "Idempotency-Key") }
     if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
     if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
     if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -9984,7 +9984,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -9994,6 +9994,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -30066,9 +30066,26 @@
         ]
       },
       "post": {
-        "description": "Create a new action item.\n\nContent-idempotent on (uid, normalized description): a retry of the same\nrequest returns the original action_item rather than creating a duplicate.",
+        "description": "Create a new action item.\n\nIdempotent only when the client sends ``Idempotency-Key``. Two creates\nwith the same description (and different keys, or no key) are two tasks.",
         "operationId": "create_action_item_v1_action_items_post",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          },
           {
             "in": "header",
             "name": "authorization",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -9984,7 +9984,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -9994,6 +9994,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/web/app/src/app/api/proxy/[...path]/route.ts
+++ b/web/app/src/app/api/proxy/[...path]/route.ts
@@ -45,14 +45,18 @@ async function handleRequest(request: Request) {
       Authorization: authHeader,
     };
 
-    // Forward custom headers for FCM token registration
+    // Forward custom headers for FCM token registration and create retries
     const appPlatform = request.headers.get('X-App-Platform');
     const deviceIdHash = request.headers.get('X-Device-Id-Hash');
+    const idempotencyKey = request.headers.get('Idempotency-Key');
     if (appPlatform) {
       headers['X-App-Platform'] = appPlatform;
     }
     if (deviceIdHash) {
       headers['X-Device-Id-Hash'] = deviceIdHash;
+    }
+    if (idempotencyKey) {
+      headers['Idempotency-Key'] = idempotencyKey;
     }
 
     if (!isMultipart && request.method !== 'GET') {

--- a/web/app/src/hooks/useActionItems.ts
+++ b/web/app/src/hooks/useActionItems.ts
@@ -10,6 +10,7 @@ import {
   deleteActionItem,
   type CreateActionItemParams,
 } from '@/lib/api';
+import { prependOrReplaceById } from '@/lib/actionItemList';
 import { onCacheInvalidation, invalidationPatterns } from '@/lib/cache';
 import type { ActionItem, GroupedActionItems } from '@/types/conversation';
 
@@ -417,7 +418,7 @@ export function useActionItems(): UseActionItemsReturn {
     async (params: CreateActionItemParams): Promise<ActionItem | null> => {
       try {
         const newItem = await createActionItem(params);
-        setItems((prev) => [newItem, ...prev]);
+        setItems((prev) => prependOrReplaceById(prev, newItem));
         return newItem;
       } catch (err) {
         console.error('Failed to create action item:', err);

--- a/web/app/src/lib/__tests__/actionItemList.test.ts
+++ b/web/app/src/lib/__tests__/actionItemList.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { prependOrReplaceById } from '../actionItemList';
+
+describe('prependOrReplaceById', () => {
+  it('prepends a new id', () => {
+    const existing = { id: 'old', description: '123' };
+    const created = { id: 'new', description: '123' };
+    expect(prependOrReplaceById([existing], created)).toEqual([created, existing]);
+  });
+
+  it('replaces an existing id instead of cloning the row', () => {
+    const first = { id: 'same', description: '123', due_at: '2026-01-01' };
+    const replay = { id: 'same', description: '123', due_at: '2026-01-02' };
+    expect(prependOrReplaceById([first], replay)).toEqual([replay]);
+  });
+});

--- a/web/app/src/lib/actionItemList.ts
+++ b/web/app/src/lib/actionItemList.ts
@@ -1,0 +1,16 @@
+/**
+ * Insert a newly created action item at the front of the list.
+ *
+ * If the API replayed an existing id (legacy description-hash idempotency),
+ * replace that row instead of prepending a ghost duplicate that vanishes on
+ * reload.
+ */
+export function prependOrReplaceById<T extends { id: string }>(items: T[], item: T): T[] {
+  const index = items.findIndex((existing) => existing.id === item.id);
+  if (index === -1) {
+    return [item, ...items];
+  }
+  const next = items.slice();
+  next[index] = item;
+  return next;
+}

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -428,6 +428,7 @@ export async function createActionItem(
 ): Promise<ActionItem> {
   return fetchWithAuth<ActionItem>('/v1/action-items', {
     method: 'POST',
+    headers: { 'Idempotency-Key': crypto.randomUUID() },
     body: JSON.stringify(params),
   });
 }

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -9984,7 +9984,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -9994,6 +9994,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -9984,7 +9984,7 @@ export async function get_action_items_v1_action_items_get(query: { limit?: numb
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function create_action_item_v1_action_items_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
+export async function create_action_item_v1_action_items_post(header: { Idempotency_Key?: string | null, authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ActionItemCreateRequest, init?: OmiApiClientInit): Promise<ActionItemResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/action-items`;
   const _search = "";
@@ -9994,6 +9994,7 @@ export async function create_action_item_v1_action_items_post(header: { authoriz
       ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
       ...init?.headers,
+      ...(header.Idempotency_Key !== undefined ? { "Idempotency-Key": String(header.Idempotency_Key) } : {}),
       ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
       ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
       ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),


### PR DESCRIPTION
## Soft-path rebase of #12266

Cherry-picked the two PR commits onto current `main`. Conflicts resolved in:
- `backend/routers/action_items.py` imports — kept main's `JSONResponse` + PR's `Header`/`Annotated`
- `web/app/src/hooks/useActionItems.ts` — kept PR's `prependOrReplaceById` on create

Original: https://github.com/BasedHardware/omi/pull/12266 (APPROVED; fork force-push blocked by OAuth `workflow` scope).

### What changed and why
Task create idempotency uses client `Idempotency-Key` only — identical titles are no longer treated as retries (was causing duplicate-title suppression / wrong UX).

### Product invariants affected
none

### How it was verified
Conflict resolution reviewed against both sides; openapi + generated clients carry optional Idempotency-Key; unit test file updated in cherry-pick.

### Tests
`backend/tests/unit/test_action_item_idempotency.py` + `web/app/src/lib/__tests__/actionItemList.test.ts`

### Failure class (fixes)
Failure-Class: none

Supersedes #12266.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task-create semantics for any client that relied on automatic title-based deduplication; retries now require an explicit header, though the web client was updated.
> 
> **Overview**
> **Replaces description-based create idempotency** with an optional client **`Idempotency-Key`** on `POST /v1/action-items`. The API no longer derives a key from `(uid, normalized title)`, so two tasks with the same name are always separate creates unless the client reuses the same key for a true retry.
> 
> The web app sends a per-attempt UUID on create, the Next.js API proxy forwards the header, and OpenAPI plus generated clients (macOS, Windows, admin, etc.) expose the new parameter. Local task list updates use **`prependOrReplaceById`** so an idempotent replay updates the existing row instead of showing a duplicate ghost entry.
> 
> Docs and unit tests were updated to match the new contract; the Firestore layer still dedupes only when `idempotency_key` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcdcfdca3557df936fb0d09bd9517da57d6898c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->