### PR TITLE
feat(backend): add button event webhook dispatch

### DIFF
--- a/app/lib/backend/schema/gen/users_wire.g.dart
+++ b/app/lib/backend/schema/gen/users_wire.g.dart
@@ -28,12 +28,14 @@ class GeneratedUserStatusResponse {
 
 class GeneratedUserWebhooksStatusResponse {
   final bool audioBytes;
+  final bool buttonEvent;
   final bool daySummary;
   final bool memoryCreated;
   final bool realtimeTranscript;
 
   const GeneratedUserWebhooksStatusResponse({
     required this.audioBytes,
+    this.buttonEvent = false,
     required this.daySummary,
     required this.memoryCreated,
     required this.realtimeTranscript,
@@ -42,6 +44,7 @@ class GeneratedUserWebhooksStatusResponse {
   factory GeneratedUserWebhooksStatusResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedUserWebhooksStatusResponse(
       audioBytes: _required(_readFieldValue<bool>(_readField(json, const ["audio_bytes"]), "audio_bytes", _readBool, requiredField: true, nullable: false), "audio_bytes"),
+      buttonEvent: _required(_readFieldValue<bool>(_readField(json, const ["button_event"]), "button_event", _readBool, requiredField: false, nullable: false, defaultValue: false), "button_event"),
       daySummary: _required(_readFieldValue<bool>(_readField(json, const ["day_summary"]), "day_summary", _readBool, requiredField: true, nullable: false), "day_summary"),
       memoryCreated: _required(_readFieldValue<bool>(_readField(json, const ["memory_created"]), "memory_created", _readBool, requiredField: true, nullable: false), "memory_created"),
       realtimeTranscript: _required(_readFieldValue<bool>(_readField(json, const ["realtime_transcript"]), "realtime_transcript", _readBool, requiredField: true, nullable: false), "realtime_transcript"),
@@ -51,6 +54,7 @@ class GeneratedUserWebhooksStatusResponse {
   Map<String, dynamic> toJson() {
     return {
       'audio_bytes': audioBytes,
+      'button_event': buttonEvent,
       'day_summary': daySummary,
       'memory_created': memoryCreated,
       'realtime_transcript': realtimeTranscript,

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -13,6 +13,7 @@ class WebhookType(str, Enum):
     realtime_transcript = 'realtime_transcript'
     memory_created = ('memory_created',)
     day_summary = 'day_summary'
+    button_event = 'button_event'
 
 
 def webhook_url_from_setting(wtype: WebhookType | str, value: Optional[str]) -> str:

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -262,6 +262,30 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: POST
+    path: /v1/users/developer/button-event
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: GET
     path: /v1/config/api-keys
     policy: *desktop_migration_policy

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import re
 import uuid
-from typing import Annotated, List, Dict, Any, Union, Optional
+from typing import Annotated, List, Dict, Any, Literal, Union, Optional
+import hashlib
 import os
 import asyncio
 
 import pytz
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from database import (
     conversations as conversations_db,
@@ -136,9 +137,10 @@ from utils.other.storage import (
     delete_user_person_speech_samples,
     delete_user_person_speech_sample,
 )
-from utils.webhooks import webhook_first_time_setup
+from utils.webhooks import button_event_webhook, webhook_first_time_setup
 from utils.byok import (
     get_byok_key,
+    has_byok_keys,
     invalidate_byok_state_cache,
     peppered_fingerprint,
 )
@@ -198,6 +200,7 @@ class UserWebhooksStatusResponse(BaseModel):
     memory_created: bool
     realtime_transcript: bool
     day_summary: bool
+    button_event: bool = False
 
 
 class UserWebhookUrlResponse(BaseModel):
@@ -523,6 +526,28 @@ def enable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get
     return {'status': 'ok'}
 
 
+class ButtonEventRequest(BaseModel):
+    button_event: Literal['single_tap', 'double_tap', 'long_tap']
+    device_id: str = Field(min_length=1, max_length=128)
+    event_id: uuid.UUID = Field(description='Stable id for the physical gesture across retries')
+    timestamp: AwareDatetime
+    session_id: Optional[str] = Field(default=None, min_length=1, max_length=128)
+
+
+@router.post('/v1/users/developer/button-event', tags=['v1'], response_model=UserStatusResponse)
+async def post_developer_button_event(body: ButtonEventRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """App → backend forward of an opt-in hardware button gesture (#11719)."""
+    await button_event_webhook(
+        uid,
+        button_event=body.button_event,
+        device_id=body.device_id,
+        event_id=str(body.event_id),
+        timestamp=body.timestamp.isoformat(),
+        session_id=body.session_id,
+    )
+    return {'status': 'ok'}
+
+
 @router.get('/v1/users/developer/webhooks/status', tags=['v1'], response_model=UserWebhooksStatusResponse)
 def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
     # This only happens the first time because the user_webhook_status_db function will return None for existing users
@@ -538,11 +563,15 @@ def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
     day_summary = user_webhook_status_db(uid, WebhookType.day_summary)
     if day_summary is None:
         day_summary = webhook_first_time_setup(uid, WebhookType.day_summary)
+    button_event = user_webhook_status_db(uid, WebhookType.button_event)
+    if button_event is None:
+        button_event = webhook_first_time_setup(uid, WebhookType.button_event)
     return {
         'audio_bytes': audio_bytes,
         'memory_created': memory_created,
         'realtime_transcript': realtime_transcript,
         'day_summary': day_summary,
+        'button_event': button_event,
     }
 
 

--- a/backend/tests/unit/test_button_event_webhook.py
+++ b/backend/tests/unit/test_button_event_webhook.py
@@ -1,0 +1,115 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from routers.users import ButtonEventRequest, post_developer_button_event
+
+
+@pytest.mark.asyncio
+async def test_button_event_route_forwards_validated_contract():
+    body = ButtonEventRequest.model_validate(
+        {
+            'button_event': 'double_tap',
+            'device_id': 'omi-1',
+            'event_id': 'a02765ac-c962-4118-bfcc-a06c0d7750d9',
+            'timestamp': '2026-08-21T04:15:00Z',
+            'session_id': 'session-1',
+        }
+    )
+
+    with patch('routers.users.button_event_webhook', new_callable=AsyncMock) as mock_webhook:
+        response = await post_developer_button_event(body, uid='uid-1')
+
+    assert response == {'status': 'ok'}
+    mock_webhook.assert_awaited_once_with(
+        'uid-1',
+        button_event='double_tap',
+        device_id='omi-1',
+        event_id='a02765ac-c962-4118-bfcc-a06c0d7750d9',
+        timestamp='2026-08-21T04:15:00+00:00',
+        session_id='session-1',
+    )
+
+
+def test_button_event_contract_rejects_naive_timestamp():
+    with pytest.raises(ValidationError):
+        ButtonEventRequest.model_validate(
+            {
+                'button_event': 'single_tap',
+                'device_id': 'omi-1',
+                'event_id': 'a02765ac-c962-4118-bfcc-a06c0d7750d9',
+                'timestamp': '2026-08-21T04:15:00',
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_button_events_keep_stable_id_and_serialize_per_device(monkeypatch):
+    from utils import webhooks
+
+    monkeypatch.setattr(webhooks, 'user_webhook_status_db', MagicMock(return_value=True))
+    monkeypatch.setattr(webhooks, 'get_user_webhook_db', MagicMock(return_value='https://example.com/hook'))
+    monkeypatch.setattr(webhooks, 'record_dev_webhook_success', MagicMock())
+    circuit_breaker = MagicMock()
+    circuit_breaker.allow_request.return_value = True
+    monkeypatch.setattr(webhooks, 'get_webhook_circuit_breaker', MagicMock(return_value=circuit_breaker))
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    delivered: list[str] = []
+
+    async def post_webhook(_name, _url, *, json, idempotency_key, **_kwargs):
+        delivered.append(idempotency_key)
+        if idempotency_key == 'event-1':
+            first_started.set()
+            await release_first.wait()
+        return MagicMock(status_code=200)
+
+    monkeypatch.setattr(webhooks, '_post_dev_webhook', post_webhook)
+
+    first = asyncio.create_task(
+        webhooks.button_event_webhook(
+            'uid-1',
+            button_event='single_tap',
+            device_id='omi-1',
+            event_id='event-1',
+            timestamp='2026-08-21T04:15:00Z',
+        )
+    )
+    await first_started.wait()
+    second = asyncio.create_task(
+        webhooks.button_event_webhook(
+            'uid-1',
+            button_event='double_tap',
+            device_id='omi-1',
+            event_id='event-2',
+            timestamp='2026-08-21T04:15:01Z',
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert delivered == ['event-1']
+    release_first.set()
+    await asyncio.gather(first, second)
+    assert delivered == ['event-1', 'event-2']
+
+
+@pytest.mark.asyncio
+async def test_button_event_is_noop_when_not_configured(monkeypatch):
+    from utils import webhooks
+
+    monkeypatch.setattr(webhooks, 'user_webhook_status_db', MagicMock(return_value=False))
+    post_webhook = AsyncMock()
+    monkeypatch.setattr(webhooks, '_post_dev_webhook', post_webhook)
+
+    await webhooks.button_event_webhook(
+        'uid-1',
+        button_event='long_tap',
+        device_id='omi-1',
+        event_id='event-1',
+        timestamp='2026-08-21T04:15:00Z',
+    )
+
+    post_webhook.assert_not_awaited()

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Iterable, List, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from weakref import WeakValueDictionary
 
 from database.redis_db import (
     get_user_webhook_db,
@@ -65,6 +66,8 @@ _SAMPLE_RATE_RE = re.compile(r'^[1-9]\d{2,5}$')
 
 _audio_bytes_send_locks: dict[str, asyncio.Lock] = {}
 _audio_bytes_send_locks_guard = asyncio.Lock()
+_button_event_send_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
+_button_event_send_locks_guard = asyncio.Lock()
 
 
 async def _get_audio_bytes_send_lock(uid: str) -> asyncio.Lock:
@@ -73,6 +76,16 @@ async def _get_audio_bytes_send_lock(uid: str) -> asyncio.Lock:
         if lock is None:
             lock = asyncio.Lock()
             _audio_bytes_send_locks[uid] = lock
+        return lock
+
+
+async def _get_button_event_send_lock(uid: str, device_id: str) -> asyncio.Lock:
+    key = f'{uid}:{device_id}'
+    async with _button_event_send_locks_guard:
+        lock = _button_event_send_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _button_event_send_locks[key] = lock
         return lock
 
 
@@ -492,6 +505,87 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
             logger.error(f"Error sending audio bytes to developer webhook: {e}")
+
+
+async def button_event_webhook(
+    uid: str,
+    *,
+    button_event: str,
+    device_id: str,
+    event_id: str,
+    timestamp: str,
+    session_id: Optional[str] = None,
+) -> None:
+    """Forward an opt-in hardware button gesture to the developer webhook (#11719)."""
+    lock = await _get_button_event_send_lock(uid, device_id)
+    async with lock:
+        await _button_event_webhook_serialized(
+            uid,
+            button_event=button_event,
+            device_id=device_id,
+            event_id=event_id,
+            timestamp=timestamp,
+            session_id=session_id,
+        )
+
+
+async def _button_event_webhook_serialized(
+    uid: str,
+    *,
+    button_event: str,
+    device_id: str,
+    event_id: str,
+    timestamp: str,
+    session_id: Optional[str] = None,
+) -> None:
+    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.button_event)
+    if not toggled:
+        return
+    webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.button_event)
+    if not webhook_url:
+        return
+    webhook_url = _append_query_params(webhook_url, {'uid': uid})
+    cb = get_webhook_circuit_breaker(webhook_url)
+    if not cb.allow_request():
+        logger.info(f'button_event_webhook: circuit breaker open for {webhook_url[:80]}')
+        return
+    payload = {
+        'event_type': 'button_event',
+        'button_event': button_event,
+        'device_id': device_id,
+        'event_id': event_id,
+        'timestamp': timestamp,
+        'session_id': session_id,
+    }
+    try:
+        response = await _post_dev_webhook(
+            'button_event_webhook',
+            webhook_url,
+            json=payload,
+            headers={'Content-Type': 'application/json'},
+            idempotency_key=event_id,
+        )
+        if 200 <= response.status_code < 300:
+            cb.record_success()
+            await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.button_event)
+        else:
+            cb.record_failure()
+            should_disable = await run_blocking(
+                db_executor,
+                record_dev_webhook_failure,
+                uid,
+                WebhookType.button_event,
+                response.status_code,
+                f'HTTP {response.status_code}',
+            )
+            await _handle_dev_webhook_disable(uid, WebhookType.button_event, should_disable)
+    except Exception as e:
+        cb.record_failure()
+        should_disable = await run_blocking(
+            db_executor, record_dev_webhook_failure, uid, WebhookType.button_event, 0, type(e).__name__
+        )
+        await _handle_dev_webhook_disable(uid, WebhookType.button_event, should_disable)
+        logger.error(f'Error sending button_event developer webhook: {e}')
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -13768,6 +13768,32 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func postDeveloperButtonEventV1UsersDeveloperButtonEventPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/developer/button-event"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getUserWebhookEndpointV1UsersDeveloperWebhookWtypeGet(client: OmiApiClient, wtype: String, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/users/developer/webhook/\(wtype)"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -16727,5 +16753,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 436 Swift client methods generated.
+  // Total: 437 Swift client methods generated.
 }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -778,6 +778,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarCaptureGap {
   coverage?: string;
   end_time: string;
@@ -4691,6 +4699,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -4725,7 +4734,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4976,6 +4985,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarCaptureGap": CalendarCaptureGap;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
@@ -8827,6 +8837,16 @@ export interface OmiApiPaths {
       operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
       responses: {
         "200": DesktopDailyUsageResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
+      responses: {
+        "200": UserStatusResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16320,6 +16340,27 @@ export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_po
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18586,4 +18627,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 436 client methods generated.
+// Total: 437 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -1279,7 +1279,7 @@
         "type": "object"
       },
       "ActionItemsResponse": {
-        "description": "List envelope; ``truncated`` is set only when the request's list-read\nbudget ended the aggregate scan early (#11831) — such pages may not be a\ncomplete prefix, so ``has_more`` is forced true as well.",
+        "description": "List envelope; ``truncated`` is set only when the request's list-read\nbudget ended the aggregate scan early (#11831) \u2014 such pages may not be a\ncomplete prefix, so ``has_more`` is forced true as well.",
         "properties": {
           "action_items": {
             "items": {
@@ -8011,7 +8011,7 @@
         "type": "object"
       },
       "ConversationProcessingState": {
-        "description": "Why a conversation's ``structured`` holds the §1.7 deterministic minimum.\n\nAbsent (``None``) on every conversation the server enriched itself, and on a\nconversation that already carries a ``client_processing`` projection.\nClients check ``client_processing`` FIRST: a projection that arrives after\nthe terminal persist is stamped by its own ingress mutation and does not\nrewrite this field, so a projected conversation may still read\n``local_pending`` and must render the projection regardless.\n\n- ``local_pending``: a capable client is expected to deliver a projection.\n  Render a spinner with a timeout, not a permanent empty state.\n- ``none``: no projection is coming. Render \"Summary unavailable on the\n  free plan\".",
+        "description": "Why a conversation's ``structured`` holds the \u00a71.7 deterministic minimum.\n\nAbsent (``None``) on every conversation the server enriched itself, and on a\nconversation that already carries a ``client_processing`` projection.\nClients check ``client_processing`` FIRST: a projection that arrives after\nthe terminal persist is stamped by its own ingress mutation and does not\nrewrite this field, so a projected conversation may still read\n``local_pending`` and must render the projection regardless.\n\n- ``local_pending``: a capable client is expected to deliver a projection.\n  Render a spinner with a timeout, not a permanent empty state.\n- ``none``: no projection is coming. Render \"Summary unavailable on the\n  free plan\".",
         "enum": [
           "local_pending",
           "none"
@@ -9087,7 +9087,7 @@
                 "type": "null"
               }
             ],
-            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler: a malformed projection is dropped and the conversation still lands. Display only — never an input to intelligence.",
+            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler: a malformed projection is dropped and the conversation still lands. Display only \u2014 never an input to intelligence.",
             "title": "Client Processing"
           },
           "client_session_id": {
@@ -11439,7 +11439,7 @@
             "$ref": "#/components/schemas/CategoryEnum"
           },
           "emoji": {
-            "default": "🧠",
+            "default": "\ud83e\udde0",
             "title": "Emoji",
             "type": "string"
           },
@@ -12862,7 +12862,7 @@
         "type": "object"
       },
       "FeedbackReason": {
-        "description": "Structured reason for a thumbs-down.\n\nThe first five match the values the mobile client has always sent to\n`POST /v1/users/analytics/chat_message`; keeping them identical means the\nledger and the legacy `analytics` rows stay comparable. The remaining five\nare desktop-only reason chips for proactive-notification cards (focus,\ninsight, task, memory) — a distinct taxonomy from a chat answer's, added\nalongside the mobile five rather than folded into them so neither surface's\ncategories are diluted by the other's.",
+        "description": "Structured reason for a thumbs-down.\n\nThe first five match the values the mobile client has always sent to\n`POST /v1/users/analytics/chat_message`; keeping them identical means the\nledger and the legacy `analytics` rows stay comparable. The remaining five\nare desktop-only reason chips for proactive-notification cards (focus,\ninsight, task, memory) \u2014 a distinct taxonomy from a chat answer's, added\nalongside the mobile five rather than folded into them so neither surface's\ncategories are diluted by the other's.",
         "enum": [
           "too_verbose",
           "incorrect_or_hallucination",
@@ -16218,7 +16218,7 @@
         "type": "object"
       },
       "LearnedMemoryRef": {
-        "description": "One memory the day actually produced, addressed by its canonical id.\n\nThis is the identity `knowledge_nuggets` never had: a client can render a\nnative review card and vote or correct through the existing memory\nendpoints. Review state (`user_review`, `edited`) is deliberately absent —\nclients read it live from the memory so a vote on one device shows on the\nother.",
+        "description": "One memory the day actually produced, addressed by its canonical id.\n\nThis is the identity `knowledge_nuggets` never had: a client can render a\nnative review card and vote or correct through the existing memory\nendpoints. Review state (`user_review`, `edited`) is deliberately absent \u2014\nclients read it live from the memory so a vote on one device shows on the\nother.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -20946,7 +20946,7 @@
                 "type": "null"
               }
             ],
-            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler so a malformed projection cannot 422 a finished recording. Hash-bound to the persisted transcript. Display only — never an input to intelligence.",
+            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler so a malformed projection cannot 422 a finished recording. Hash-bound to the persisted transcript. Display only \u2014 never an input to intelligence.",
             "title": "Client Processing"
           }
         },
@@ -21144,7 +21144,7 @@
             "default": "other"
           },
           "emoji": {
-            "default": "🧠",
+            "default": "\ud83e\udde0",
             "title": "Emoji",
             "type": "string"
           },
@@ -22501,7 +22501,7 @@
       },
       "ScreenFrameGround": {
         "additionalProperties": false,
-        "description": "Gradient stops derived from the canonical bytes at approval time.\n\nBoth clients render the banner from these; neither samples pixels. A\nsigned cross-origin URL cannot be read back from a canvas (no guaranteed\nCORS headers), and two independent extractions (Swift on macOS, JS on\nweb) would drift from each other anyway. Extracted once, server-side,\nfrom the canonical JPEG — see utils/screen_frames/palette.py, a port of\ndesktop/macos/Desktop/Sources/MeetingScreenshots/MeetingBannerPalette.swift.",
+        "description": "Gradient stops derived from the canonical bytes at approval time.\n\nBoth clients render the banner from these; neither samples pixels. A\nsigned cross-origin URL cannot be read back from a canvas (no guaranteed\nCORS headers), and two independent extractions (Swift on macOS, JS on\nweb) would drift from each other anyway. Extracted once, server-side,\nfrom the canonical JPEG \u2014 see utils/screen_frames/palette.py, a port of\ndesktop/macos/Desktop/Sources/MeetingScreenshots/MeetingBannerPalette.swift.",
         "properties": {
           "is_neutral": {
             "title": "Is Neutral",
@@ -22526,7 +22526,7 @@
       },
       "ScreenFrameSettings": {
         "additionalProperties": false,
-        "description": "The account-level setting gating screen-frame egress admission\n(contract §6, setting_key=\"meeting_note_screenshots_enabled\"). Shared and\nauthoritative across every device — desktop, web, a reinstall — because\nit protects the user from themselves (accidentally leaving the feature\non), not third parties from the user; the privacy judge is what protects\npeople appearing in frames. It does not need to be tamper-proof, only\nconsistent, so it is a plain user-profile field, not a signed claim.",
+        "description": "The account-level setting gating screen-frame egress admission\n(contract \u00a76, setting_key=\"meeting_note_screenshots_enabled\"). Shared and\nauthoritative across every device \u2014 desktop, web, a reinstall \u2014 because\nit protects the user from themselves (accidentally leaving the feature\non), not third parties from the user; the privacy judge is what protects\npeople appearing in frames. It does not need to be tamper-proof, only\nconsistent, so it is a plain user-profile field, not a signed claim.",
         "properties": {
           "meeting_note_screenshots_enabled": {
             "title": "Meeting Note Screenshots Enabled",
@@ -23570,7 +23570,7 @@
             "default": "other"
           },
           "emoji": {
-            "default": "🧠",
+            "default": "\ud83e\udde0",
             "title": "Emoji",
             "type": "string"
           },
@@ -24372,7 +24372,7 @@
             "description": "A category for this conversation"
           },
           "emoji": {
-            "default": "🧠",
+            "default": "\ud83e\udde0",
             "description": "An emoji to represent the conversation",
             "title": "Emoji",
             "type": "string"
@@ -28663,6 +28663,11 @@
           "realtime_transcript": {
             "title": "Realtime Transcript",
             "type": "boolean"
+          },
+          "button_event": {
+            "default": false,
+            "title": "Button Event",
+            "type": "boolean"
           }
         },
         "required": [
@@ -28828,7 +28833,8 @@
           "audio_bytes_websocket",
           "realtime_transcript",
           "memory_created",
-          "day_summary"
+          "day_summary",
+          "button_event"
         ],
         "title": "WebhookType",
         "type": "string"
@@ -29729,6 +29735,57 @@
         ],
         "title": "PricingOption",
         "type": "object"
+      },
+      "ButtonEventRequest": {
+        "properties": {
+          "button_event": {
+            "enum": [
+              "single_tap",
+              "double_tap",
+              "long_tap"
+            ],
+            "title": "Button Event",
+            "type": "string"
+          },
+          "device_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Device Id",
+            "type": "string"
+          },
+          "event_id": {
+            "description": "Stable id for the physical gesture across retries",
+            "format": "uuid",
+            "title": "Event Id",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "button_event",
+          "device_id",
+          "event_id",
+          "timestamp"
+        ],
+        "title": "ButtonEventRequest",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -30437,7 +30494,7 @@
     },
     "/v1/action-items/batch-delete": {
       "post": {
-        "description": "Delete multiple action items in one request.\n\nFirestore deletes go through chunked batched commits in the DB layer; the\nvector store delete and the FCM cancellation message both use their batch\nhelpers — no per-id loop on this hot path.",
+        "description": "Delete multiple action items in one request.\n\nFirestore deletes go through chunked batched commits in the DB layer; the\nvector store delete and the FCM cancellation message both use their batch\nhelpers \u2014 no per-id loop on this hot path.",
         "operationId": "batch_delete_action_items_v1_action_items_batch_delete_post",
         "parameters": [
           {
@@ -30525,7 +30582,7 @@
     },
     "/v1/action-items/ids": {
       "get": {
-        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads — the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket. The\n``completed`` bucket is filtered server-side; only documents in that bucket are\nstreamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``\nexclusion is still applied in Python since Firestore equality filters would drop\nundeleted rows that have no ``deleted`` field.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
+        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads \u2014 the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket. The\n``completed`` bucket is filtered server-side; only documents in that bucket are\nstreamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``\nexclusion is still applied in Python since Firestore equality filters would drop\nundeleted rows that have no ``deleted`` field.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
         "operationId": "list_action_item_ids_v1_action_items_ids_get",
         "parameters": [
           {
@@ -31010,7 +31067,7 @@
     },
     "/v1/action-items/shared/{token}": {
       "get": {
-        "description": "Public endpoint — get shared task preview (no auth required).",
+        "description": "Public endpoint \u2014 get shared task preview (no auth required).",
         "operationId": "get_shared_action_items_v1_action_items_shared__token__get",
         "parameters": [
           {
@@ -31675,7 +31732,7 @@
     },
     "/v1/announcements": {
       "post": {
-        "description": "Create a new announcement.\nRequires admin authentication via secret-key header.\n\nContent structure depends on type:\n- changelog: {\"title\": \"...\", \"changes\": [{\"title\": \"...\", \"description\": \"...\", \"icon\": \"🔀\"}, ...]}\n- feature: {\"title\": \"...\", \"steps\": [{\"title\": \"...\", \"description\": \"...\", \"image_url\": \"...\", \"highlight_text\": \"...\"}, ...]}\n- announcement: {\"title\": \"...\", \"body\": \"...\", \"image_url\": \"...\", \"cta\": {\"text\": \"...\", \"action\": \"...\"}}",
+        "description": "Create a new announcement.\nRequires admin authentication via secret-key header.\n\nContent structure depends on type:\n- changelog: {\"title\": \"...\", \"changes\": [{\"title\": \"...\", \"description\": \"...\", \"icon\": \"\ud83d\udd00\"}, ...]}\n- feature: {\"title\": \"...\", \"steps\": [{\"title\": \"...\", \"description\": \"...\", \"image_url\": \"...\", \"highlight_text\": \"...\"}, ...]}\n- announcement: {\"title\": \"...\", \"body\": \"...\", \"image_url\": \"...\", \"cta\": {\"text\": \"...\", \"action\": \"...\"}}",
         "operationId": "create_announcement_endpoint_v1_announcements_post",
         "parameters": [
           {
@@ -38356,7 +38413,7 @@
     },
     "/v1/conversations/from-segments": {
       "post": {
-        "description": "Create a conversation from already-transcribed segments (Firebase-authed).\n\nUsed by clients that transcribe ON-DEVICE (e.g. the macOS desktop app with Parakeet) and need\nthe conversation persisted, processed (memories/summaries), and synced across devices — exactly\nlike a cloud-transcribed conversation, but without the live `/v4/listen` websocket.",
+        "description": "Create a conversation from already-transcribed segments (Firebase-authed).\n\nUsed by clients that transcribe ON-DEVICE (e.g. the macOS desktop app with Parakeet) and need\nthe conversation persisted, processed (memories/summaries), and synced across devices \u2014 exactly\nlike a cloud-transcribed conversation, but without the live `/v4/listen` websocket.",
         "operationId": "create_conversation_from_segments_user_v1_conversations_from_segments_post",
         "parameters": [
           {
@@ -41736,7 +41793,7 @@
     },
     "/v1/conversations/{conversation_id}/shared/screenshots": {
       "get": {
-        "description": "Public, unauthenticated. Returns an empty set unless the conversation\nis currently shareable AND screenshot_sharing_enabled is true — never a\n404, so this route cannot be used to probe whether a conversation_id\nexists (contract §1/§9, and matches the existing\nGET /v1/conversations/{id}/shared 404-avoidance pattern for public\nconversation lookups... except this one specifically must not leak\nexistence via status code, so it always returns 200).",
+        "description": "Public, unauthenticated. Returns an empty set unless the conversation\nis currently shareable AND screenshot_sharing_enabled is true \u2014 never a\n404, so this route cannot be used to probe whether a conversation_id\nexists (contract \u00a71/\u00a79, and matches the existing\nGET /v1/conversations/{id}/shared 404-avoidance pattern for public\nconversation lookups... except this one specifically must not leak\nexistence via status code, so it always returns 200).",
         "operationId": "get_shared_conversation_screenshots_v1_conversations__conversation_id__shared_screenshots_get",
         "parameters": [
           {
@@ -48575,7 +48632,7 @@
     },
     "/v1/integrations/{app_key}": {
       "delete": {
-        "description": "Delete an integration connection.\n\nDeleting a derived integration deletes the grant it rides on — there is no\nseparate token to revoke.",
+        "description": "Delete an integration connection.\n\nDeleting a derived integration deletes the grant it rides on \u2014 there is no\nseparate token to revoke.",
         "operationId": "delete_integration_v1_integrations__app_key__delete",
         "parameters": [
           {
@@ -48656,7 +48713,7 @@
         ]
       },
       "get": {
-        "description": "Get integration connection status for the current user.\n\nGmail has no grant of its own — it rides the Google Calendar OAuth grant and is\nconnected only when that grant actually carries the Gmail scope.",
+        "description": "Get integration connection status for the current user.\n\nGmail has no grant of its own \u2014 it rides the Google Calendar OAuth grant and is\nconnected only when that grant actually carries the Gmail scope.",
         "operationId": "get_integration_v1_integrations__app_key__get",
         "parameters": [
           {
@@ -48841,7 +48898,7 @@
     },
     "/v1/integrations/{app_key}/oauth-url": {
       "get": {
-        "description": "Get OAuth authorization URL for an integration.\nFrontend opens this URL in browser to start OAuth flow.\nUses secure random state tokens to prevent CSRF attacks.\n\nA derived integration (Gmail) authorizes through the grant it rides on, so the\nwhole flow — state, provider config and callback — runs under the source key.",
+        "description": "Get OAuth authorization URL for an integration.\nFrontend opens this URL in browser to start OAuth flow.\nUses secure random state tokens to prevent CSRF attacks.\n\nA derived integration (Gmail) authorizes through the grant it rides on, so the\nwhole flow \u2014 state, provider config and callback \u2014 runs under the source key.",
         "operationId": "get_oauth_url_v1_integrations__app_key__oauth_url_get",
         "parameters": [
           {
@@ -52289,7 +52346,7 @@
     },
     "/v1/payments/overage-info": {
       "get": {
-        "description": "Explain overage billing + return the user's current accrued charge.\n\nPowers the clickable \"What happens past the limit?\" text on the plan page.\nSafe to call on any plan — non-overage plans just get a zero snapshot plus\nthe explainer copy.",
+        "description": "Explain overage billing + return the user's current accrued charge.\n\nPowers the clickable \"What happens past the limit?\" text on the plan page.\nSafe to call on any plan \u2014 non-overage plans just get a zero snapshot plus\nthe explainer copy.",
         "operationId": "get_overage_info_endpoint_v1_payments_overage_info_get",
         "parameters": [
           {
@@ -52521,7 +52578,7 @@
     },
     "/v1/payments/upgrade-subscription": {
       "post": {
-        "description": "Upgrade or change a user's subscription plan.\n\n- Cross-plan changes (e.g. Unlimited→Pro): immediate swap via Subscription.modify(),\n  Stripe prorates automatically. User gets new features right away.\n- Same plan, different interval (e.g. monthly→annual): scheduled via SubscriptionSchedule,\n  takes effect at end of current billing period.",
+        "description": "Upgrade or change a user's subscription plan.\n\n- Cross-plan changes (e.g. Unlimited\u2192Pro): immediate swap via Subscription.modify(),\n  Stripe prorates automatically. User gets new features right away.\n- Same plan, different interval (e.g. monthly\u2192annual): scheduled via SubscriptionSchedule,\n  takes effect at end of current billing period.",
         "operationId": "upgrade_subscription_endpoint_v1_payments_upgrade_subscription_post",
         "parameters": [
           {
@@ -53611,7 +53668,7 @@
     },
     "/v1/screen-frame-egress/settings": {
       "get": {
-        "description": "Account-level, shared across every device (desktop, web, a\nreinstall) — this is the setting the adjudication route's admission\ncheck reads (contract §6). It protects the user from themselves, not\nthird parties from the user (the privacy judge does that), so it lives\nas a plain user-profile field rather than a signed claim.",
+        "description": "Account-level, shared across every device (desktop, web, a\nreinstall) \u2014 this is the setting the adjudication route's admission\ncheck reads (contract \u00a76). It protects the user from themselves, not\nthird parties from the user (the privacy judge does that), so it lives\nas a plain user-profile field rather than a signed claim.",
         "operationId": "get_screen_frame_settings_v1_screen_frame_egress_settings_get",
         "parameters": [
           {
@@ -57117,7 +57174,7 @@
         ]
       },
       "post": {
-        "description": "Generate (or return) a daily summary for a local calendar date.\n\nNo FCM token is required and no push is sent — the caller is looking at the\nscreen. A record already stored for that date is returned without spending\nLLM tokens.",
+        "description": "Generate (or return) a daily summary for a local calendar date.\n\nNo FCM token is required and no push is sent \u2014 the caller is looking at the\nscreen. A record already stored for that date is returned without spending\nLLM tokens.",
         "operationId": "create_user_daily_summary_v1_users_daily_summaries_post",
         "parameters": [
           {
@@ -57383,7 +57440,7 @@
     },
     "/v1/users/daily-summaries/{summary_id}/regenerate": {
       "post": {
-        "description": "Re-run summary generation for the date of an existing daily summary and\noverwrite the same doc in place. No push notification — the user is\nalready looking at the page.",
+        "description": "Re-run summary generation for the date of an existing daily summary and\noverwrite the same doc in place. No push notification \u2014 the user is\nalready looking at the page.",
         "operationId": "regenerate_daily_summary_v1_users_daily_summaries__summary_id__regenerate_post",
         "parameters": [
           {
@@ -59857,7 +59914,7 @@
     },
     "/v1/users/me/trial": {
       "get": {
-        "description": "Structured trial metadata for the calling user.\n\nReturns trial timing info (start, end, remaining seconds, expired flag)\nplus the list of features available during trial and the plan the user\nfalls to after trial expiry. Used by desktop clients to render countdown\nbanners and pre-expiry upgrade nudges.\n\nPaid-plan and BYOK users get `trial_expired=False` with zeroed timing\n(trial is irrelevant to them — they have full access).",
+        "description": "Structured trial metadata for the calling user.\n\nReturns trial timing info (start, end, remaining seconds, expired flag)\nplus the list of features available during trial and the plan the user\nfalls to after trial expiry. Used by desktop clients to render countdown\nbanners and pre-expiry upgrade nudges.\n\nPaid-plan and BYOK users get `trial_expired=False` with zeroed timing\n(trial is irrelevant to them \u2014 they have full access).",
         "operationId": "get_user_trial_status_v1_users_me_trial_get",
         "parameters": [
           {
@@ -62642,7 +62699,7 @@
     },
     "/v1/work-intents": {
       "post": {
-        "description": "Idempotent backend operation behind the “Work on this with Omi” affordance.",
+        "description": "Idempotent backend operation behind the \u201cWork on this with Omi\u201d affordance.",
         "operationId": "resolve_work_intent_v1_work_intents_post",
         "parameters": [
           {
@@ -65423,7 +65480,7 @@
     },
     "/v2/messages/shared/{token}": {
       "get": {
-        "description": "Public endpoint — get shared chat messages (no auth required).",
+        "description": "Public endpoint \u2014 get shared chat messages (no auth required).",
         "operationId": "get_shared_chat_messages_v2_messages_shared__token__get",
         "parameters": [
           {
@@ -65740,7 +65797,7 @@
     },
     "/v2/sync-local-files": {
       "post": {
-        "description": "Async version of sync-local-files. Saves raw files and returns 202\nimmediately, then runs the full pipeline (decode → VAD → STT → LLM) as\nan async background task. The app polls GET /v2/sync-local-files/{job_id}.",
+        "description": "Async version of sync-local-files. Saves raw files and returns 202\nimmediately, then runs the full pipeline (decode \u2192 VAD \u2192 STT \u2192 LLM) as\nan async background task. The app polls GET /v2/sync-local-files/{job_id}.",
         "operationId": "sync_local_files_v2_v2_sync_local_files_post",
         "parameters": [
           {
@@ -66615,7 +66672,7 @@
     },
     "/v3/memories/batch": {
       "delete": {
-        "description": "Delete up to MEMORIES_BATCH_MAX memories in one request.\n\nReplaces the N concurrent DELETE /v3/memories/{id} calls the web UI used to fan out\non bulk selection, which blew through the per-UID rate limiter and 429'd.\n\nAuthorization parity with DELETE /v3/memories/{memory_id}: every requested id is\nvalidated with the SAME business rules as the single-delete path. Validation is\nall-or-nothing — if any id fails, nothing is deleted, so the batch route can never\nbypass the single-delete guardrails (missing/not-owned -> 404, locked paid-plan\nmemory -> 402).",
+        "description": "Delete up to MEMORIES_BATCH_MAX memories in one request.\n\nReplaces the N concurrent DELETE /v3/memories/{id} calls the web UI used to fan out\non bulk selection, which blew through the per-UID rate limiter and 429'd.\n\nAuthorization parity with DELETE /v3/memories/{memory_id}: every requested id is\nvalidated with the SAME business rules as the single-delete path. Validation is\nall-or-nothing \u2014 if any id fails, nothing is deleted, so the batch route can never\nbypass the single-delete guardrails (missing/not-owned -> 404, locked paid-plan\nmemory -> 402).",
         "operationId": "delete_memories_batch_v3_memories_batch_delete",
         "parameters": [
           {
@@ -68430,6 +68487,94 @@
         "summary": "Get Speech Profile",
         "tags": [
           "v3"
+        ]
+      }
+    },
+    "/v1/users/developer/button-event": {
+      "post": {
+        "description": "App \u2192 backend forward of an opt-in hardware button gesture (#11719).",
+        "operationId": "post_developer_button_event_v1_users_developer_button_event_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ButtonEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Post Developer Button Event",
+        "tags": [
+          "v1"
         ]
       }
     }

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -1279,7 +1279,7 @@
         "type": "object"
       },
       "ActionItemsResponse": {
-        "description": "List envelope; ``truncated`` is set only when the request's list-read\nbudget ended the aggregate scan early (#11831) \u2014 such pages may not be a\ncomplete prefix, so ``has_more`` is forced true as well.",
+        "description": "List envelope; ``truncated`` is set only when the request's list-read\nbudget ended the aggregate scan early (#11831) — such pages may not be a\ncomplete prefix, so ``has_more`` is forced true as well.",
         "properties": {
           "action_items": {
             "items": {
@@ -4961,6 +4961,57 @@
         "title": "BulkMoveConversationsResponse",
         "type": "object"
       },
+      "ButtonEventRequest": {
+        "properties": {
+          "button_event": {
+            "enum": [
+              "single_tap",
+              "double_tap",
+              "long_tap"
+            ],
+            "title": "Button Event",
+            "type": "string"
+          },
+          "device_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Device Id",
+            "type": "string"
+          },
+          "event_id": {
+            "description": "Stable id for the physical gesture across retries",
+            "format": "uuid",
+            "title": "Event Id",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "button_event",
+          "device_id",
+          "event_id",
+          "timestamp"
+        ],
+        "title": "ButtonEventRequest",
+        "type": "object"
+      },
       "CalendarCaptureGap": {
         "description": "An accepted calendar event with no overlapping kept conversation.",
         "properties": {
@@ -8011,7 +8062,7 @@
         "type": "object"
       },
       "ConversationProcessingState": {
-        "description": "Why a conversation's ``structured`` holds the \u00a71.7 deterministic minimum.\n\nAbsent (``None``) on every conversation the server enriched itself, and on a\nconversation that already carries a ``client_processing`` projection.\nClients check ``client_processing`` FIRST: a projection that arrives after\nthe terminal persist is stamped by its own ingress mutation and does not\nrewrite this field, so a projected conversation may still read\n``local_pending`` and must render the projection regardless.\n\n- ``local_pending``: a capable client is expected to deliver a projection.\n  Render a spinner with a timeout, not a permanent empty state.\n- ``none``: no projection is coming. Render \"Summary unavailable on the\n  free plan\".",
+        "description": "Why a conversation's ``structured`` holds the §1.7 deterministic minimum.\n\nAbsent (``None``) on every conversation the server enriched itself, and on a\nconversation that already carries a ``client_processing`` projection.\nClients check ``client_processing`` FIRST: a projection that arrives after\nthe terminal persist is stamped by its own ingress mutation and does not\nrewrite this field, so a projected conversation may still read\n``local_pending`` and must render the projection regardless.\n\n- ``local_pending``: a capable client is expected to deliver a projection.\n  Render a spinner with a timeout, not a permanent empty state.\n- ``none``: no projection is coming. Render \"Summary unavailable on the\n  free plan\".",
         "enum": [
           "local_pending",
           "none"
@@ -9087,7 +9138,7 @@
                 "type": "null"
               }
             ],
-            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler: a malformed projection is dropped and the conversation still lands. Display only \u2014 never an input to intelligence.",
+            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler: a malformed projection is dropped and the conversation still lands. Display only — never an input to intelligence.",
             "title": "Client Processing"
           },
           "client_session_id": {
@@ -11439,7 +11490,7 @@
             "$ref": "#/components/schemas/CategoryEnum"
           },
           "emoji": {
-            "default": "\ud83e\udde0",
+            "default": "🧠",
             "title": "Emoji",
             "type": "string"
           },
@@ -12862,7 +12913,7 @@
         "type": "object"
       },
       "FeedbackReason": {
-        "description": "Structured reason for a thumbs-down.\n\nThe first five match the values the mobile client has always sent to\n`POST /v1/users/analytics/chat_message`; keeping them identical means the\nledger and the legacy `analytics` rows stay comparable. The remaining five\nare desktop-only reason chips for proactive-notification cards (focus,\ninsight, task, memory) \u2014 a distinct taxonomy from a chat answer's, added\nalongside the mobile five rather than folded into them so neither surface's\ncategories are diluted by the other's.",
+        "description": "Structured reason for a thumbs-down.\n\nThe first five match the values the mobile client has always sent to\n`POST /v1/users/analytics/chat_message`; keeping them identical means the\nledger and the legacy `analytics` rows stay comparable. The remaining five\nare desktop-only reason chips for proactive-notification cards (focus,\ninsight, task, memory) — a distinct taxonomy from a chat answer's, added\nalongside the mobile five rather than folded into them so neither surface's\ncategories are diluted by the other's.",
         "enum": [
           "too_verbose",
           "incorrect_or_hallucination",
@@ -16218,7 +16269,7 @@
         "type": "object"
       },
       "LearnedMemoryRef": {
-        "description": "One memory the day actually produced, addressed by its canonical id.\n\nThis is the identity `knowledge_nuggets` never had: a client can render a\nnative review card and vote or correct through the existing memory\nendpoints. Review state (`user_review`, `edited`) is deliberately absent \u2014\nclients read it live from the memory so a vote on one device shows on the\nother.",
+        "description": "One memory the day actually produced, addressed by its canonical id.\n\nThis is the identity `knowledge_nuggets` never had: a client can render a\nnative review card and vote or correct through the existing memory\nendpoints. Review state (`user_review`, `edited`) is deliberately absent —\nclients read it live from the memory so a vote on one device shows on the\nother.",
         "properties": {
           "captured_at": {
             "anyOf": [
@@ -20946,7 +20997,7 @@
                 "type": "null"
               }
             ],
-            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler so a malformed projection cannot 422 a finished recording. Hash-bound to the persisted transcript. Display only \u2014 never an input to intelligence.",
+            "description": "Untrusted client-authored display projection. Accepted as a raw payload and validated in the handler so a malformed projection cannot 422 a finished recording. Hash-bound to the persisted transcript. Display only — never an input to intelligence.",
             "title": "Client Processing"
           }
         },
@@ -21144,7 +21195,7 @@
             "default": "other"
           },
           "emoji": {
-            "default": "\ud83e\udde0",
+            "default": "🧠",
             "title": "Emoji",
             "type": "string"
           },
@@ -22501,7 +22552,7 @@
       },
       "ScreenFrameGround": {
         "additionalProperties": false,
-        "description": "Gradient stops derived from the canonical bytes at approval time.\n\nBoth clients render the banner from these; neither samples pixels. A\nsigned cross-origin URL cannot be read back from a canvas (no guaranteed\nCORS headers), and two independent extractions (Swift on macOS, JS on\nweb) would drift from each other anyway. Extracted once, server-side,\nfrom the canonical JPEG \u2014 see utils/screen_frames/palette.py, a port of\ndesktop/macos/Desktop/Sources/MeetingScreenshots/MeetingBannerPalette.swift.",
+        "description": "Gradient stops derived from the canonical bytes at approval time.\n\nBoth clients render the banner from these; neither samples pixels. A\nsigned cross-origin URL cannot be read back from a canvas (no guaranteed\nCORS headers), and two independent extractions (Swift on macOS, JS on\nweb) would drift from each other anyway. Extracted once, server-side,\nfrom the canonical JPEG — see utils/screen_frames/palette.py, a port of\ndesktop/macos/Desktop/Sources/MeetingScreenshots/MeetingBannerPalette.swift.",
         "properties": {
           "is_neutral": {
             "title": "Is Neutral",
@@ -22526,7 +22577,7 @@
       },
       "ScreenFrameSettings": {
         "additionalProperties": false,
-        "description": "The account-level setting gating screen-frame egress admission\n(contract \u00a76, setting_key=\"meeting_note_screenshots_enabled\"). Shared and\nauthoritative across every device \u2014 desktop, web, a reinstall \u2014 because\nit protects the user from themselves (accidentally leaving the feature\non), not third parties from the user; the privacy judge is what protects\npeople appearing in frames. It does not need to be tamper-proof, only\nconsistent, so it is a plain user-profile field, not a signed claim.",
+        "description": "The account-level setting gating screen-frame egress admission\n(contract §6, setting_key=\"meeting_note_screenshots_enabled\"). Shared and\nauthoritative across every device — desktop, web, a reinstall — because\nit protects the user from themselves (accidentally leaving the feature\non), not third parties from the user; the privacy judge is what protects\npeople appearing in frames. It does not need to be tamper-proof, only\nconsistent, so it is a plain user-profile field, not a signed claim.",
         "properties": {
           "meeting_note_screenshots_enabled": {
             "title": "Meeting Note Screenshots Enabled",
@@ -23570,7 +23621,7 @@
             "default": "other"
           },
           "emoji": {
-            "default": "\ud83e\udde0",
+            "default": "🧠",
             "title": "Emoji",
             "type": "string"
           },
@@ -24372,7 +24423,7 @@
             "description": "A category for this conversation"
           },
           "emoji": {
-            "default": "\ud83e\udde0",
+            "default": "🧠",
             "description": "An emoji to represent the conversation",
             "title": "Emoji",
             "type": "string"
@@ -28652,6 +28703,11 @@
             "title": "Audio Bytes",
             "type": "boolean"
           },
+          "button_event": {
+            "default": false,
+            "title": "Button Event",
+            "type": "boolean"
+          },
           "day_summary": {
             "title": "Day Summary",
             "type": "boolean"
@@ -28662,11 +28718,6 @@
           },
           "realtime_transcript": {
             "title": "Realtime Transcript",
-            "type": "boolean"
-          },
-          "button_event": {
-            "default": false,
-            "title": "Button Event",
             "type": "boolean"
           }
         },
@@ -29735,57 +29786,6 @@
         ],
         "title": "PricingOption",
         "type": "object"
-      },
-      "ButtonEventRequest": {
-        "properties": {
-          "button_event": {
-            "enum": [
-              "single_tap",
-              "double_tap",
-              "long_tap"
-            ],
-            "title": "Button Event",
-            "type": "string"
-          },
-          "device_id": {
-            "maxLength": 128,
-            "minLength": 1,
-            "title": "Device Id",
-            "type": "string"
-          },
-          "event_id": {
-            "description": "Stable id for the physical gesture across retries",
-            "format": "uuid",
-            "title": "Event Id",
-            "type": "string"
-          },
-          "session_id": {
-            "anyOf": [
-              {
-                "maxLength": 128,
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Session Id"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
-          }
-        },
-        "required": [
-          "button_event",
-          "device_id",
-          "event_id",
-          "timestamp"
-        ],
-        "title": "ButtonEventRequest",
-        "type": "object"
       }
     },
     "securitySchemes": {
@@ -30494,7 +30494,7 @@
     },
     "/v1/action-items/batch-delete": {
       "post": {
-        "description": "Delete multiple action items in one request.\n\nFirestore deletes go through chunked batched commits in the DB layer; the\nvector store delete and the FCM cancellation message both use their batch\nhelpers \u2014 no per-id loop on this hot path.",
+        "description": "Delete multiple action items in one request.\n\nFirestore deletes go through chunked batched commits in the DB layer; the\nvector store delete and the FCM cancellation message both use their batch\nhelpers — no per-id loop on this hot path.",
         "operationId": "batch_delete_action_items_v1_action_items_batch_delete_post",
         "parameters": [
           {
@@ -30582,7 +30582,7 @@
     },
     "/v1/action-items/ids": {
       "get": {
-        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads \u2014 the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket. The\n``completed`` bucket is filtered server-side; only documents in that bucket are\nstreamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``\nexclusion is still applied in Python since Firestore equality filters would drop\nundeleted rows that have no ``deleted`` field.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
+        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads — the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket. The\n``completed`` bucket is filtered server-side; only documents in that bucket are\nstreamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``\nexclusion is still applied in Python since Firestore equality filters would drop\nundeleted rows that have no ``deleted`` field.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
         "operationId": "list_action_item_ids_v1_action_items_ids_get",
         "parameters": [
           {
@@ -31067,7 +31067,7 @@
     },
     "/v1/action-items/shared/{token}": {
       "get": {
-        "description": "Public endpoint \u2014 get shared task preview (no auth required).",
+        "description": "Public endpoint — get shared task preview (no auth required).",
         "operationId": "get_shared_action_items_v1_action_items_shared__token__get",
         "parameters": [
           {
@@ -31732,7 +31732,7 @@
     },
     "/v1/announcements": {
       "post": {
-        "description": "Create a new announcement.\nRequires admin authentication via secret-key header.\n\nContent structure depends on type:\n- changelog: {\"title\": \"...\", \"changes\": [{\"title\": \"...\", \"description\": \"...\", \"icon\": \"\ud83d\udd00\"}, ...]}\n- feature: {\"title\": \"...\", \"steps\": [{\"title\": \"...\", \"description\": \"...\", \"image_url\": \"...\", \"highlight_text\": \"...\"}, ...]}\n- announcement: {\"title\": \"...\", \"body\": \"...\", \"image_url\": \"...\", \"cta\": {\"text\": \"...\", \"action\": \"...\"}}",
+        "description": "Create a new announcement.\nRequires admin authentication via secret-key header.\n\nContent structure depends on type:\n- changelog: {\"title\": \"...\", \"changes\": [{\"title\": \"...\", \"description\": \"...\", \"icon\": \"🔀\"}, ...]}\n- feature: {\"title\": \"...\", \"steps\": [{\"title\": \"...\", \"description\": \"...\", \"image_url\": \"...\", \"highlight_text\": \"...\"}, ...]}\n- announcement: {\"title\": \"...\", \"body\": \"...\", \"image_url\": \"...\", \"cta\": {\"text\": \"...\", \"action\": \"...\"}}",
         "operationId": "create_announcement_endpoint_v1_announcements_post",
         "parameters": [
           {
@@ -38413,7 +38413,7 @@
     },
     "/v1/conversations/from-segments": {
       "post": {
-        "description": "Create a conversation from already-transcribed segments (Firebase-authed).\n\nUsed by clients that transcribe ON-DEVICE (e.g. the macOS desktop app with Parakeet) and need\nthe conversation persisted, processed (memories/summaries), and synced across devices \u2014 exactly\nlike a cloud-transcribed conversation, but without the live `/v4/listen` websocket.",
+        "description": "Create a conversation from already-transcribed segments (Firebase-authed).\n\nUsed by clients that transcribe ON-DEVICE (e.g. the macOS desktop app with Parakeet) and need\nthe conversation persisted, processed (memories/summaries), and synced across devices — exactly\nlike a cloud-transcribed conversation, but without the live `/v4/listen` websocket.",
         "operationId": "create_conversation_from_segments_user_v1_conversations_from_segments_post",
         "parameters": [
           {
@@ -41793,7 +41793,7 @@
     },
     "/v1/conversations/{conversation_id}/shared/screenshots": {
       "get": {
-        "description": "Public, unauthenticated. Returns an empty set unless the conversation\nis currently shareable AND screenshot_sharing_enabled is true \u2014 never a\n404, so this route cannot be used to probe whether a conversation_id\nexists (contract \u00a71/\u00a79, and matches the existing\nGET /v1/conversations/{id}/shared 404-avoidance pattern for public\nconversation lookups... except this one specifically must not leak\nexistence via status code, so it always returns 200).",
+        "description": "Public, unauthenticated. Returns an empty set unless the conversation\nis currently shareable AND screenshot_sharing_enabled is true — never a\n404, so this route cannot be used to probe whether a conversation_id\nexists (contract §1/§9, and matches the existing\nGET /v1/conversations/{id}/shared 404-avoidance pattern for public\nconversation lookups... except this one specifically must not leak\nexistence via status code, so it always returns 200).",
         "operationId": "get_shared_conversation_screenshots_v1_conversations__conversation_id__shared_screenshots_get",
         "parameters": [
           {
@@ -48632,7 +48632,7 @@
     },
     "/v1/integrations/{app_key}": {
       "delete": {
-        "description": "Delete an integration connection.\n\nDeleting a derived integration deletes the grant it rides on \u2014 there is no\nseparate token to revoke.",
+        "description": "Delete an integration connection.\n\nDeleting a derived integration deletes the grant it rides on — there is no\nseparate token to revoke.",
         "operationId": "delete_integration_v1_integrations__app_key__delete",
         "parameters": [
           {
@@ -48713,7 +48713,7 @@
         ]
       },
       "get": {
-        "description": "Get integration connection status for the current user.\n\nGmail has no grant of its own \u2014 it rides the Google Calendar OAuth grant and is\nconnected only when that grant actually carries the Gmail scope.",
+        "description": "Get integration connection status for the current user.\n\nGmail has no grant of its own — it rides the Google Calendar OAuth grant and is\nconnected only when that grant actually carries the Gmail scope.",
         "operationId": "get_integration_v1_integrations__app_key__get",
         "parameters": [
           {
@@ -48898,7 +48898,7 @@
     },
     "/v1/integrations/{app_key}/oauth-url": {
       "get": {
-        "description": "Get OAuth authorization URL for an integration.\nFrontend opens this URL in browser to start OAuth flow.\nUses secure random state tokens to prevent CSRF attacks.\n\nA derived integration (Gmail) authorizes through the grant it rides on, so the\nwhole flow \u2014 state, provider config and callback \u2014 runs under the source key.",
+        "description": "Get OAuth authorization URL for an integration.\nFrontend opens this URL in browser to start OAuth flow.\nUses secure random state tokens to prevent CSRF attacks.\n\nA derived integration (Gmail) authorizes through the grant it rides on, so the\nwhole flow — state, provider config and callback — runs under the source key.",
         "operationId": "get_oauth_url_v1_integrations__app_key__oauth_url_get",
         "parameters": [
           {
@@ -52346,7 +52346,7 @@
     },
     "/v1/payments/overage-info": {
       "get": {
-        "description": "Explain overage billing + return the user's current accrued charge.\n\nPowers the clickable \"What happens past the limit?\" text on the plan page.\nSafe to call on any plan \u2014 non-overage plans just get a zero snapshot plus\nthe explainer copy.",
+        "description": "Explain overage billing + return the user's current accrued charge.\n\nPowers the clickable \"What happens past the limit?\" text on the plan page.\nSafe to call on any plan — non-overage plans just get a zero snapshot plus\nthe explainer copy.",
         "operationId": "get_overage_info_endpoint_v1_payments_overage_info_get",
         "parameters": [
           {
@@ -52578,7 +52578,7 @@
     },
     "/v1/payments/upgrade-subscription": {
       "post": {
-        "description": "Upgrade or change a user's subscription plan.\n\n- Cross-plan changes (e.g. Unlimited\u2192Pro): immediate swap via Subscription.modify(),\n  Stripe prorates automatically. User gets new features right away.\n- Same plan, different interval (e.g. monthly\u2192annual): scheduled via SubscriptionSchedule,\n  takes effect at end of current billing period.",
+        "description": "Upgrade or change a user's subscription plan.\n\n- Cross-plan changes (e.g. Unlimited→Pro): immediate swap via Subscription.modify(),\n  Stripe prorates automatically. User gets new features right away.\n- Same plan, different interval (e.g. monthly→annual): scheduled via SubscriptionSchedule,\n  takes effect at end of current billing period.",
         "operationId": "upgrade_subscription_endpoint_v1_payments_upgrade_subscription_post",
         "parameters": [
           {
@@ -53668,7 +53668,7 @@
     },
     "/v1/screen-frame-egress/settings": {
       "get": {
-        "description": "Account-level, shared across every device (desktop, web, a\nreinstall) \u2014 this is the setting the adjudication route's admission\ncheck reads (contract \u00a76). It protects the user from themselves, not\nthird parties from the user (the privacy judge does that), so it lives\nas a plain user-profile field rather than a signed claim.",
+        "description": "Account-level, shared across every device (desktop, web, a\nreinstall) — this is the setting the adjudication route's admission\ncheck reads (contract §6). It protects the user from themselves, not\nthird parties from the user (the privacy judge does that), so it lives\nas a plain user-profile field rather than a signed claim.",
         "operationId": "get_screen_frame_settings_v1_screen_frame_egress_settings_get",
         "parameters": [
           {
@@ -57174,7 +57174,7 @@
         ]
       },
       "post": {
-        "description": "Generate (or return) a daily summary for a local calendar date.\n\nNo FCM token is required and no push is sent \u2014 the caller is looking at the\nscreen. A record already stored for that date is returned without spending\nLLM tokens.",
+        "description": "Generate (or return) a daily summary for a local calendar date.\n\nNo FCM token is required and no push is sent — the caller is looking at the\nscreen. A record already stored for that date is returned without spending\nLLM tokens.",
         "operationId": "create_user_daily_summary_v1_users_daily_summaries_post",
         "parameters": [
           {
@@ -57440,7 +57440,7 @@
     },
     "/v1/users/daily-summaries/{summary_id}/regenerate": {
       "post": {
-        "description": "Re-run summary generation for the date of an existing daily summary and\noverwrite the same doc in place. No push notification \u2014 the user is\nalready looking at the page.",
+        "description": "Re-run summary generation for the date of an existing daily summary and\noverwrite the same doc in place. No push notification — the user is\nalready looking at the page.",
         "operationId": "regenerate_daily_summary_v1_users_daily_summaries__summary_id__regenerate_post",
         "parameters": [
           {
@@ -58044,6 +58044,94 @@
           }
         ],
         "summary": "Record Desktop Daily Usage",
+        "tags": [
+          "v1"
+        ]
+      }
+    },
+    "/v1/users/developer/button-event": {
+      "post": {
+        "description": "App → backend forward of an opt-in hardware button gesture (#11719).",
+        "operationId": "post_developer_button_event_v1_users_developer_button_event_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ButtonEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Post Developer Button Event",
         "tags": [
           "v1"
         ]
@@ -59914,7 +60002,7 @@
     },
     "/v1/users/me/trial": {
       "get": {
-        "description": "Structured trial metadata for the calling user.\n\nReturns trial timing info (start, end, remaining seconds, expired flag)\nplus the list of features available during trial and the plan the user\nfalls to after trial expiry. Used by desktop clients to render countdown\nbanners and pre-expiry upgrade nudges.\n\nPaid-plan and BYOK users get `trial_expired=False` with zeroed timing\n(trial is irrelevant to them \u2014 they have full access).",
+        "description": "Structured trial metadata for the calling user.\n\nReturns trial timing info (start, end, remaining seconds, expired flag)\nplus the list of features available during trial and the plan the user\nfalls to after trial expiry. Used by desktop clients to render countdown\nbanners and pre-expiry upgrade nudges.\n\nPaid-plan and BYOK users get `trial_expired=False` with zeroed timing\n(trial is irrelevant to them — they have full access).",
         "operationId": "get_user_trial_status_v1_users_me_trial_get",
         "parameters": [
           {
@@ -62699,7 +62787,7 @@
     },
     "/v1/work-intents": {
       "post": {
-        "description": "Idempotent backend operation behind the \u201cWork on this with Omi\u201d affordance.",
+        "description": "Idempotent backend operation behind the “Work on this with Omi” affordance.",
         "operationId": "resolve_work_intent_v1_work_intents_post",
         "parameters": [
           {
@@ -65480,7 +65568,7 @@
     },
     "/v2/messages/shared/{token}": {
       "get": {
-        "description": "Public endpoint \u2014 get shared chat messages (no auth required).",
+        "description": "Public endpoint — get shared chat messages (no auth required).",
         "operationId": "get_shared_chat_messages_v2_messages_shared__token__get",
         "parameters": [
           {
@@ -65797,7 +65885,7 @@
     },
     "/v2/sync-local-files": {
       "post": {
-        "description": "Async version of sync-local-files. Saves raw files and returns 202\nimmediately, then runs the full pipeline (decode \u2192 VAD \u2192 STT \u2192 LLM) as\nan async background task. The app polls GET /v2/sync-local-files/{job_id}.",
+        "description": "Async version of sync-local-files. Saves raw files and returns 202\nimmediately, then runs the full pipeline (decode → VAD → STT → LLM) as\nan async background task. The app polls GET /v2/sync-local-files/{job_id}.",
         "operationId": "sync_local_files_v2_v2_sync_local_files_post",
         "parameters": [
           {
@@ -66672,7 +66760,7 @@
     },
     "/v3/memories/batch": {
       "delete": {
-        "description": "Delete up to MEMORIES_BATCH_MAX memories in one request.\n\nReplaces the N concurrent DELETE /v3/memories/{id} calls the web UI used to fan out\non bulk selection, which blew through the per-UID rate limiter and 429'd.\n\nAuthorization parity with DELETE /v3/memories/{memory_id}: every requested id is\nvalidated with the SAME business rules as the single-delete path. Validation is\nall-or-nothing \u2014 if any id fails, nothing is deleted, so the batch route can never\nbypass the single-delete guardrails (missing/not-owned -> 404, locked paid-plan\nmemory -> 402).",
+        "description": "Delete up to MEMORIES_BATCH_MAX memories in one request.\n\nReplaces the N concurrent DELETE /v3/memories/{id} calls the web UI used to fan out\non bulk selection, which blew through the per-UID rate limiter and 429'd.\n\nAuthorization parity with DELETE /v3/memories/{memory_id}: every requested id is\nvalidated with the SAME business rules as the single-delete path. Validation is\nall-or-nothing — if any id fails, nothing is deleted, so the batch route can never\nbypass the single-delete guardrails (missing/not-owned -> 404, locked paid-plan\nmemory -> 402).",
         "operationId": "delete_memories_batch_v3_memories_batch_delete",
         "parameters": [
           {
@@ -68487,94 +68575,6 @@
         "summary": "Get Speech Profile",
         "tags": [
           "v3"
-        ]
-      }
-    },
-    "/v1/users/developer/button-event": {
-      "post": {
-        "description": "App \u2192 backend forward of an opt-in hardware button gesture (#11719).",
-        "operationId": "post_developer_button_event_v1_users_developer_button_event_post",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "title": "Authorization",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "X-App-Platform",
-            "required": false,
-            "schema": {
-              "title": "X-App-Platform",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "X-Device-Id-Hash",
-            "required": false,
-            "schema": {
-              "title": "X-Device-Id-Hash",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "X-App-Version",
-            "required": false,
-            "schema": {
-              "title": "X-App-Version",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ButtonEventRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserStatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "401": {
-            "$ref": "#/components/responses/Error401"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "firebaseBearer": []
-          }
-        ],
-        "summary": "Post Developer Button Event",
-        "tags": [
-          "v1"
         ]
       }
     }

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -778,6 +778,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarCaptureGap {
   coverage?: string;
   end_time: string;
@@ -4691,6 +4699,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -4725,7 +4734,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4976,6 +4985,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarCaptureGap": CalendarCaptureGap;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
@@ -8827,6 +8837,16 @@ export interface OmiApiPaths {
       operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
       responses: {
         "200": DesktopDailyUsageResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
+      responses: {
+        "200": UserStatusResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16320,6 +16340,27 @@ export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_po
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18586,4 +18627,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 436 client methods generated.
+// Total: 437 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -778,6 +778,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarCaptureGap {
   coverage?: string;
   end_time: string;
@@ -4691,6 +4699,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -4725,7 +4734,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4976,6 +4985,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarCaptureGap": CalendarCaptureGap;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
@@ -8827,6 +8837,16 @@ export interface OmiApiPaths {
       operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
       responses: {
         "200": DesktopDailyUsageResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
+      responses: {
+        "200": UserStatusResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16320,6 +16340,27 @@ export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_po
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18586,4 +18627,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 436 client methods generated.
+// Total: 437 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -778,6 +778,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarCaptureGap {
   coverage?: string;
   end_time: string;
@@ -4691,6 +4699,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -4725,7 +4734,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4976,6 +4985,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarCaptureGap": CalendarCaptureGap;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
@@ -8827,6 +8837,16 @@ export interface OmiApiPaths {
       operationId: "record_desktop_daily_usage_v1_users_desktop_usage_daily_post";
       responses: {
         "200": DesktopDailyUsageResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
+      responses: {
+        "200": UserStatusResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -16320,6 +16340,27 @@ export async function record_desktop_daily_usage_v1_users_desktop_usage_daily_po
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -18586,4 +18627,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 436 client methods generated.
+// Total: 437 client methods generated.


### PR DESCRIPTION
## Soft-path rebase of #12000

Cherry-picked onto current `main`. Hand-resolved `backend/routers/users.py` imports (kept main Annotated/field_validator/get_byok_key + PR Literal/AwareDatetime/button_event_webhook). OpenAPI regenerated via export_openapi app-client surface.

Original: https://github.com/BasedHardware/omi/pull/12000 (APPROVED; fork push blocked by OAuth `workflow` scope).

### What changed and why
App→backend forward of opt-in hardware button gestures to developer webhook (`button_event`), with per-device serialization and Idempotency via event_id.

### Product invariants affected
none

### How it was verified
`py_compile` on routers/webhooks/models; OpenAPI export + client regen.

### Tests
`backend/tests/unit/test_button_event_webhook.py`

### Failure class (fixes)
Failure-Class: none

Line-Count-Exception: backend/routers/users.py | 2476 -> 2505 | button_event webhook route + status field on existing users developer surface; extract deferred to keep soft-path rebase atomic with #12000

Supersedes #12000.
