### PR TITLE
fix(app): use SharePlus API for chat message share

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1347,7 +1347,9 @@ class _MessageActionBarState extends State<MessageActionBar> {
             onTap: () async {
               if (widget.messageText.isEmpty) return;
               HapticFeedback.lightImpact();
-              await Share.share(widget.messageText, sharePositionOrigin: shareSheetOrigin());
+              await SharePlus.instance.share(
+                ShareParams(text: widget.messageText, sharePositionOrigin: shareSheetOrigin()),
+              );
               PlatformManager.instance.analytics.track(
                 'Chat Message Shared',
                 properties: {'message': widget.messageText},


### PR DESCRIPTION
## Summary
Soft-path of #12619: `Share.share` → `SharePlus.instance.share(ShareParams(...))` for share_plus 11 so chat message Share works.

Supersedes #12619 (original tip had Hygiene/Preflight red on stale base).

## Product invariants affected
None

## Test plan
- [ ] Tap Share on an AI chat message on Android/iOS

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

