### PR TITLE
fix(backend): fall back to user language preference for live speaker-sample verification (#12899)

### DIFF
--- a/backend/tests/unit/test_speaker_identification_language_fallback.py
+++ b/backend/tests/unit/test_speaker_identification_language_fallback.py
@@ -1,0 +1,92 @@
+"""Speaker-sample verification must not silently default to English (#12899).
+
+extract_speaker_samples() runs while the conversation is still live, before
+finalization resolves conversation['language'] — so that field is normally empty
+at sample-extraction time. PR #12901 threaded a language kwarg through to
+Deepgram but sourced it from conversation['language'], which is still empty in
+this live path, so verification kept transcribing in English and rejecting
+every non-English sample. This pins the fallback to the user's app-level
+language preference, the same source chat/memories/process_conversation use.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+import asyncio  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+import utils.speaker_identification as speaker_identification_mod  # noqa: E402
+
+SAMPLE_RATE = 16000
+
+
+def _conversation(language):
+    return {
+        'started_at': 1700000000.0,
+        'transcript_segments': [
+            {'id': 'seg1', 'start': 0.0, 'end': 12.0, 'speaker_id': 0, 'text': 'hello there friend'},
+        ],
+        'audio_files': [{'chunk_timestamps': [1700000000.0]}],
+        'language': language,
+    }
+
+
+def _wire_common_stubs(monkeypatch, conversation, captured):
+    monkeypatch.setattr(speaker_identification_mod.users_db, "get_person", lambda uid, pid: None)
+    monkeypatch.setattr(speaker_identification_mod.users_db, "get_person_speech_samples_count", lambda uid, pid: 0)
+    monkeypatch.setattr(speaker_identification_mod.conversations_db, "get_conversation", lambda uid, cid: conversation)
+    monkeypatch.setattr(
+        speaker_identification_mod, "download_audio_chunks_and_merge", lambda *a, **k: b"\x00" * (SAMPLE_RATE * 12 * 2)
+    )
+    monkeypatch.setattr(
+        speaker_identification_mod, "_trim_pcm_audio", lambda pcm, sr, s, e: b"\x00" * (SAMPLE_RATE * 10 * 2)
+    )
+    monkeypatch.setattr(speaker_identification_mod.users_db, "add_person_speech_sample", lambda *a, **k: True)
+    monkeypatch.setattr(
+        speaker_identification_mod, "upload_person_speech_sample_from_bytes", lambda *a, **k: "people/u1/p1/a.wav"
+    )
+    monkeypatch.setattr(
+        speaker_identification_mod, "extract_embedding_from_bytes", lambda *a, **k: np.zeros((1, 4), dtype=np.float32)
+    )
+    monkeypatch.setattr(speaker_identification_mod.users_db, "set_person_speaker_embedding", lambda *a, **k: True)
+
+    async def fake_verify(wav_bytes, sample_rate, expected_text, language=None):
+        captured['language'] = language
+        return "hello there friend", True, "ok"
+
+    monkeypatch.setattr(speaker_identification_mod, "verify_and_transcribe_sample", fake_verify)
+
+
+def test_falls_back_to_user_language_preference_when_conversation_language_is_empty(monkeypatch):
+    captured: dict = {}
+    _wire_common_stubs(monkeypatch, _conversation(language=None), captured)
+    monkeypatch.setattr(speaker_identification_mod.users_db, "get_user_language_preference", lambda uid: "ja")
+
+    asyncio.run(
+        speaker_identification_mod.extract_speaker_samples(
+            uid="u1", person_id="p1", conversation_id="c1", segment_ids=["seg1"]
+        )
+    )
+
+    assert captured['language'] == "ja"
+
+
+def test_uses_conversation_language_without_consulting_user_preference(monkeypatch):
+    captured: dict = {}
+    _wire_common_stubs(monkeypatch, _conversation(language="de"), captured)
+
+    def _boom(uid):
+        raise AssertionError("should not consult user preference when conversation already has a language")
+
+    monkeypatch.setattr(speaker_identification_mod.users_db, "get_user_language_preference", _boom)
+
+    asyncio.run(
+        speaker_identification_mod.extract_speaker_samples(
+            uid="u1", person_id="p1", conversation_id="c1", segment_ids=["seg1"]
+        )
+    )
+
+    assert captured['language'] == "de"

--- a/backend/utils/speaker_identification.py
+++ b/backend/utils/speaker_identification.py
@@ -352,6 +352,14 @@ async def extract_speaker_samples(
             logger.warning(f"Conversation {conversation_id} not found {uid}")
             return
 
+        # Sample extraction runs live, while the conversation is still processing, so
+        # conversation['language'] (only resolved at finalization) is normally empty here.
+        # Fall back to the user's app-level language preference, same as chat/memories/
+        # process_conversation, instead of silently defaulting to English downstream.
+        sample_language = conversation.get('language') or await run_blocking(
+            db_executor, users_db.get_user_language_preference, uid
+        )
+
         started_at = conversation.get('started_at')
         if not started_at:
             logger.info(f"Conversation {conversation_id} has no started_at {uid}")
@@ -501,7 +509,7 @@ async def extract_speaker_samples(
 
             # Verify sample quality and get transcript using centralized function
             transcript, is_valid, reason = await verify_and_transcribe_sample(
-                wav_bytes, sample_rate, expected_text, language=conversation.get('language')
+                wav_bytes, sample_rate, expected_text, language=sample_language
             )
             if not is_valid:
                 logger.error(f"Sample failed quality check: {reason} {uid} {conversation_id}")


### PR DESCRIPTION
## Bug

Follow-up to #12901 (which fixed the *symptom* PR-preflight caught: non-English
sample verification transcribing as English). The reporter re-tested after that
fix landed and found it's still broken — a controlled experiment (same person,
same device, same tagging procedure, only the app's primary language flipped)
shows a Japanese sample still gets rejected while an English one succeeds.

## Root cause

PR #12901 threaded a `language` kwarg through `verify_and_transcribe_sample()`,
sourced from `conversation.get('language')` in `extract_speaker_samples()`
(`backend/utils/speaker_identification.py`). That field is only resolved during
conversation finalization (`utils/conversations/finalizer.py`'s
`resolved_language = language or getattr(conversation, 'language', None) or 'en'`).
But `extract_speaker_samples()` runs *live*, while the user is still tagging
segments mid-conversation, fed by `pusher.py`'s `process_speaker_sample_queue()`
straight off the in-progress Firestore document. At that point
`conversation['language']` is still unset, so the "fix" received `language=None`
and Deepgram fell back to English exactly as before — the fix was real but its
input source was never populated on the path that actually needed it.

## Fix

Fall back to `users_db.get_user_language_preference(uid)` — the app's primary
language setting, which is exactly the variable the reporter's experiment
identified as controlling the outcome — when `conversation['language']` is
empty. This mirrors the same fallback pattern already used in `chat.py`,
`memories.py`, and `process_conversation.py` for the same reason (per-user
setting available before/without finalization).

## Tested

- Added `backend/tests/unit/test_speaker_identification_language_fallback.py`:
  two tests pinning (1) the fallback to user preference when conversation
  language is empty, and (2) that the user-preference lookup is *not*
  consulted when the conversation already has a language (avoids an extra
  Firestore read on the common finalized-conversation path).
- Verified the new test fails against pre-fix code (reverted the source change,
  reran — `AssertionError: assert None == 'ja'`) and passes with the fix.
- `backend/.venv/bin/python -m pytest tests/unit/test_speaker_identification_language_fallback.py tests/unit/test_speaker_sample.py tests/unit/test_speaker_person_embedding_recovery.py tests/unit/test_speaker_id_pipeline.py tests/unit/test_user_speaker_embedding.py -q` → 165 passed.
- `python scripts/scan_async_blockers.py --dirs routers utils` → 0 blocking findings (the new Firestore read is wrapped in `run_blocking(db_executor, ...)`, matching every other call in this function).

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

