### PR TITLE
fix(backend): count characters, not split() words, for CJK speaker-sample verification

### DIFF
--- a/backend/tests/unit/test_speaker_sample.py
+++ b/backend/tests/unit/test_speaker_sample.py
@@ -455,6 +455,40 @@ def test_the_dominant_ratio_weighs_segments_by_their_words(monkeypatch):
     assert (is_valid, reason) == (True, "ok")
 
 
+def test_cjk_segment_is_counted_by_characters_not_split_as_one_word(monkeypatch):
+    """Regression for #12899: Japanese/Chinese/Thai have no spaces between words, so a whole
+    segment-granular entry (parakeet, Modulate) reads as a single "word" under `.split()` no
+    matter how long it actually is, and gets rejected as insufficient_words regardless of content.
+    """
+    # "Today I met a friend and we had a fun talk." (16 characters, well past MIN_CJK_CHARS).
+    segments = _make_segments(["今日は友達と会って楽しく話しました"], speakers=["SPEAKER_00"])
+
+    monkeypatch.setattr(speaker_sample, "deepgram_prerecorded_from_bytes", lambda *_a, **_k: segments)
+
+    transcript, is_valid, reason = asyncio.run(
+        speaker_sample.verify_and_transcribe_sample(b"audio", 16000, language="ja")
+    )
+
+    assert (is_valid, reason) == (True, "ok")
+    assert transcript == "今日は友達と会って楽しく話しました"
+
+
+def test_cjk_segment_short_of_the_char_floor_is_still_refused(monkeypatch):
+    """The character-counting fix must not remove the floor entirely: a short CJK entry still fails."""
+    monkeypatch.setattr(
+        speaker_sample,
+        "deepgram_prerecorded_from_bytes",
+        lambda *_a, **_k: _make_segments(["こんにちは"]),  # "hello" — 5 characters
+    )
+
+    transcript, is_valid, reason = asyncio.run(
+        speaker_sample.verify_and_transcribe_sample(b"audio", 16000, language="ja")
+    )
+
+    assert (transcript, is_valid) == (None, False)
+    assert reason == f"insufficient_words: 5/{speaker_sample.MIN_CJK_CHARS}"
+
+
 def test_verify_and_transcribe_sample_passes_language_to_transcriber(monkeypatch):
     """A non-English sample must be transcribed in its own language, not silently as English.
 

--- a/backend/utils/speaker_sample.py
+++ b/backend/utils/speaker_sample.py
@@ -9,6 +9,7 @@ Provides functions for:
 
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+from config.stt_provider_policy import normalized_stt_language
 from utils.executors import sync_executor, run_blocking
 from utils.other.storage import delete_speech_profile_blob, download_speech_profile_bytes
 from utils.stt.pre_recorded import prerecorded_from_bytes as deepgram_prerecorded_from_bytes
@@ -17,6 +18,13 @@ from utils.text_utils import compute_text_containment
 MIN_WORDS = 5
 MIN_CONTAINMENT = 0.9
 MIN_DOMINANT_SPEAKER_RATIO = 0.7
+
+# Chinese, Japanese and Thai don't put spaces between words, so `.split()` treats a whole
+# segment-granular entry (Parakeet, Modulate) as a single "word" no matter how long it is.
+# Counting characters instead keeps the same gate meaningful for these languages. 12 chars is
+# a rough parity with MIN_WORDS=5 English words' worth of speech content.
+NON_SPACE_DELIMITED_LANGUAGES = frozenset({'zh', 'ja', 'th'})
+MIN_CJK_CHARS = 12
 
 
 async def verify_and_transcribe_sample(
@@ -29,7 +37,8 @@ async def verify_and_transcribe_sample(
     Transcribe audio and verify quality using PR #4291 rules.
 
     Checks:
-    1. Transcription has at least MIN_WORDS words
+    1. Transcription has at least MIN_WORDS words (MIN_CJK_CHARS characters for
+       non-space-delimited languages, see NON_SPACE_DELIMITED_LANGUAGES)
     2. Dominant speaker accounts for >= MIN_DOMINANT_SPEAKER_RATIO of words (via diarization)
     3. Transcribed text has >= MIN_CONTAINMENT containment in expected text (if provided)
 
@@ -71,13 +80,20 @@ async def verify_and_transcribe_sample(
     # sample was rejected as `insufficient_words` no matter what it contained. The same miscount
     # made the multi-speaker guard inert rather than strict — one entry means ratio 1.0, so a
     # sample carrying two voices passed. Both are unchanged for a word-granular provider.
+    #
+    # For CJK/Thai, `.split()` undercounts even on a word-granular provider, since those
+    # languages don't use whitespace between words at all — count characters instead.
+    count_chars = normalized_stt_language(language) in NON_SPACE_DELIMITED_LANGUAGES
+
     def _words_in(entry: Dict[str, Any]) -> int:
-        return len((entry.get('text') or '').split())
+        text = entry.get('text') or ''
+        return len(text.strip()) if count_chars else len(text.split())
 
     total_words = sum(_words_in(word) for word in words)
+    min_required = MIN_CJK_CHARS if count_chars else MIN_WORDS
 
-    if total_words < MIN_WORDS:
-        return None, False, f"insufficient_words: {total_words}/{MIN_WORDS}"
+    if total_words < min_required:
+        return None, False, f"insufficient_words: {total_words}/{min_required}"
 
     speaker_counts: Dict[str, int] = {}
     for word in words:


### PR DESCRIPTION
## Bug

`verify_and_transcribe_sample()`'s word-count floor uses `.split()` to measure how much
speech a candidate enrollment sample contains. Chinese, Japanese and Thai don't put spaces
between words, so a whole segment-granular entry (Parakeet, Modulate) reads as a single
"word" under `.split()` no matter how long it actually is, and gets rejected as
`insufficient_words` regardless of content.

This is the remaining half of #12899: the primary bug (transcription silently defaulting to
English) was already fixed in #12901, but the reporter's own follow-up in the issue shows a
34-second Japanese segment — far past every duration gate — still produced no sample, which
this word-count gate explains once the language fix is in place.

## Fix

`backend/utils/speaker_sample.py`: when the sample's normalized language is one of
`zh`/`ja`/`th` (`NON_SPACE_DELIMITED_LANGUAGES`), count characters instead of
whitespace-split tokens, against a `MIN_CJK_CHARS = 12` floor instead of `MIN_WORDS = 5`.
This also fixes the dominant-speaker-ratio guard for the same languages, since it reuses the
same per-entry count.

## Tested

`backend/.venv/bin/python -m pytest tests/unit/test_speaker_sample.py
tests/unit/test_speaker_sample_migration.py tests/unit/test_speaker_person_embedding_recovery.py
tests/unit/test_speaker_id_pipeline.py tests/unit/test_speaker_identification_language_fallback.py -q`
→ 201 passed, including two new regression tests:
- a single-entry Japanese segment well past the char floor is now accepted (previously
  rejected as `insufficient_words: 1/5`)
- a short Japanese entry below the char floor is still correctly refused

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

