### PR TITLE
fix(desktop): keep JIT reasoning within the backend contract

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
@@ -114,7 +114,7 @@
         nil,
         ContextProactivityEngine.schema(allowLookup: allowLookup),
         cacheKey,
-        800,
+        ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
         nil)
       let elapsedNanoseconds = DispatchTime.now().uptimeNanoseconds - started
       let latencyMs = min(90_000, Int((Double(elapsedNanoseconds) / 1_000_000).rounded()))

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -612,7 +612,7 @@ actor ContextProactivityEngine {
         imageData: currentFrame.jpegData,
         jsonSchema: Self.schema(allowLookup: retrievalHopEnabled),
         cacheKey: cacheKey,
-        maxCompletionTokens: 800,
+        maxCompletionTokens: ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
         authorizationSnapshot: authorizationSnapshot)
       await ContextProactivityTelemetry.record(result)
       guard
@@ -979,15 +979,11 @@ actor ContextProactivityEngine {
           recentDeliveries: recentDeliveries),
         imageData: currentFrame.jpegData,
         jsonSchema: ContextProactiveCandidateGate.schema,
-        // 400, not 120: the reasoning model bills its thinking into completion
-        // tokens. Measured directly against the same model with this exact
-        // prompt shape: at 120 the call finished with `finish_reason=length`,
-        // 120/120 tokens spent on reasoning, and EMPTY content in 2 of 3
-        // attempts — which parses as malformed and silently suppresses the
-        // candidate. At 400 every attempt finished clean (33-174 reasoning
-        // tokens plus the small JSON body). Live provenance shows the same
-        // degenerate shape (a bare "false" reason) at the old cap.
-        maxCompletionTokens: 400,
+        // The backend-compatible floor applies to every reasoning request. The
+        // reasoning model bills its thinking into completion tokens, so a small
+        // client cap can finish with `finish_reason=length` and empty content,
+        // which parses as malformed and silently suppresses the
+        maxCompletionTokens: ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
         authorizationSnapshot: authorizationSnapshot)
       await ContextProactivityTelemetry.record(result)
       // The gate awaited the model; ownership can be revoked or the visit can
@@ -1224,7 +1220,7 @@ actor ContextProactivityEngine {
         imageData: imageData,
         jsonSchema: Self.schema(allowLookup: true),
         cacheKey: cacheKey,
-        maxCompletionTokens: 800,
+        maxCompletionTokens: ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
         authorizationSnapshot: authorizationSnapshot)
       await ContextProactivityTelemetry.record(result)
       let hopRaw = try JSONDecoder().decode(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -904,7 +904,7 @@ actor ContextWorkstreamReconciler {
       uncachedPrompt: Self.taggingData(batch: batch),
       jsonSchema: ContextWorkstreamTagging.schema,
       cacheKey: ContextPromptCacheKey.reconcilerTagging,
-      maxCompletionTokens: 800,
+      maxCompletionTokens: ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextWorkstreamTagging.parse(result.content) else {
       log("ContextWorkstreamReconciler: tagging response malformed")
@@ -949,7 +949,7 @@ actor ContextWorkstreamReconciler {
       uncachedPrompt: Self.candidateData(groups: eligible),
       jsonSchema: ContextProactiveCandidateWriter.schema,
       cacheKey: ContextPromptCacheKey.reconcilerCandidates,
-      maxCompletionTokens: 800,
+      maxCompletionTokens: ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens,
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextProactiveCandidateWriter.parse(result.content) else {
       log("ContextWorkstreamReconciler: candidate response malformed")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityDelivery.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/JITProactivityDelivery.swift
@@ -582,9 +582,22 @@ actor JITProactivityDelivery {
       await terminalize(deliveryID, failure: "jit_full_turn_budget", state: "suppressed", lane: execution.lane)
       await finish(execution, delivered: false)
     } catch {
-      await terminalize(deliveryID, failure: "jit_execution", state: "failed", lane: execution.lane)
+      let classification = Self.classifyExecutionFailure(error)
+      await terminalize(
+        deliveryID,
+        failure: classification.failure,
+        state: "failed",
+        lane: execution.lane,
+        classification: classification)
       await finish(execution, delivered: false)
     }
+  }
+
+  /// Keep the full-turn ledger useful when a paid JIT attempt fails. The
+  /// classification contains only bounded status/type fields; it never stores
+  /// the agent prompt, response, or raw runtime error text.
+  static func classifyExecutionFailure(_ error: Error) -> ProactiveLaneFailureClassification {
+    ProactiveLaneFailureClassification.classify(error)
   }
 
   func graduateCandidate(
@@ -710,11 +723,17 @@ actor JITProactivityDelivery {
   }
 
   private func terminalize(
-    _ deliveryID: String, failure: String, state: String, lane: JITProactivityLane
+    _ deliveryID: String,
+    failure: String,
+    state: String,
+    lane: JITProactivityLane,
+    classification: ProactiveLaneFailureClassification? = nil
   ) async {
     _ = try? await store.completeDelivery(
       id: deliveryID, decisionType: "silence",
-      provenanceJSON: "{\"failure\":\"\(failure)\"}", message: nil, state: state)
+      provenanceJSON: classification?.provenanceJSON ?? "{\"failure\":\"\(failure)\"}",
+      message: nil,
+      state: state)
     await ContextProactivityTelemetry.recordJITDelivery(
       outcome: state == "failed" ? "delivery_failed" : "delivery_suppressed", reason: failure,
       lane: lane.rawValue, decision: "silence")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -253,6 +253,12 @@ actor ProactiveLaneClient {
   static let defaultQuotaCooldownSeconds = 10 * 60
   static let minQuotaCooldownSeconds = 60
   static let maxQuotaCooldownSeconds = 60 * 60
+  /// Minimum completion budget accepted by the backend for the reasoning lane.
+  /// Reasoning models spend part of this cap on hidden tokens before producing
+  /// the strict JSON body. Keep every director call at this floor so a client
+  /// request cannot be truncated before the backend's compatible budget is
+  /// applied.
+  static let backendCompatibleReasoningMinimumCompletionTokens = 2400
   private let session: URLSession
   private let baseURL: () -> String
   private let authorization: () async throws -> String
@@ -475,6 +481,8 @@ actor ProactiveLaneClient {
         "image_url": ["url": "data:image/jpeg;base64,\(imageData.base64EncodedString())"],
       ])
     }
+    let effectiveMaxCompletionTokens = Self.effectiveMaxCompletionTokens(
+      operation: operation, requested: maxCompletionTokens)
     var body: [String: Any] = [
       "operation": operation,
       "messages": [["role": "user", "content": content]],
@@ -482,7 +490,7 @@ actor ProactiveLaneClient {
         "type": "json_schema",
         "json_schema": ["name": "desktop_proactivity", "strict": true, "schema": jsonSchema],
       ],
-      "max_completion_tokens": maxCompletionTokens,
+      "max_completion_tokens": effectiveMaxCompletionTokens,
     ]
     if let cacheKey { body["cache_key"] = cacheKey }
     let root = baseURL().hasSuffix("/") ? baseURL() : baseURL() + "/"
@@ -553,6 +561,11 @@ actor ProactiveLaneClient {
           failure: ProactiveLaneFailureClassification.classify(error)))
       throw error
     }
+  }
+
+  static func effectiveMaxCompletionTokens(operation: String, requested: Int) -> Int {
+    guard operation == ModelQoS.Proactivity.reasoningOperation else { return requested }
+    return max(requested, backendCompatibleReasoningMinimumCompletionTokens)
   }
 
   private func clearCooldownsIfOwnerChanged(_ owner: String?) {
@@ -795,6 +808,8 @@ enum ContextProactivityTelemetry {
       "attempt_rejected", "jit_trigger_authority_changed", "jit_paid_boundary_invalid",
       "jit_notification_budget", "jit_full_turn_budget", "jit_suppressed",
       "candidate_graduation", "notification_dropped", "jit_execution",
+      "http_error", "invalid_structured_output", "invalid_response", "decode",
+      "network", "quota_cooldown", "plan_gated",
     ])
     let allowedDecisions = Set(["insight", "task_candidate", "focus_nudge", "silence"])
     await MainActor.run {

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -131,9 +131,10 @@ actor RewindOCRService {
   /// Falls back to English when the query fails rather than propagating: an
   /// unavailable capability list must not take OCR down with it.
   static func visionSupportedRecognitionLanguages() -> [String] {
-    (try? VNRecognizeTextRequest.supportedRecognitionLanguages(
-      for: recognitionLevel(),
-      revision: VNRecognizeTextRequest.currentRevision)) ?? ["en-US"]
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = recognitionLevel()
+    request.revision = VNRecognizeTextRequest.currentRevision
+    return (try? request.supportedRecognitionLanguages()) ?? ["en-US"]
   }
 
   /// Picks the recognition languages for a user, in Vision's priority order.

--- a/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
@@ -111,7 +111,9 @@
       // once and never read.
       XCTAssertEqual(captured?.cacheKey, "director:v1")
       XCTAssertEqual(captured?.cacheKey, ContextPromptCacheKey.director)
-      XCTAssertEqual(captured?.maxCompletionTokens, 800)
+      XCTAssertEqual(
+        captured?.maxCompletionTokens,
+        ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens)
       XCTAssertFalse(captured?.authorizationSnapshotWasPresent ?? true)
       XCTAssertEqual(captured?.schemaKeys, Set(["type", "properties", "required", "additionalProperties"]))
       XCTAssertEqual(result["decision"], "suggest")

--- a/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
+++ b/desktop/macos/Desktop/Tests/JITProactivityRuntimeTests.swift
@@ -11,6 +11,30 @@ final class JITProactivityRuntimeTests: XCTestCase {
     return try XCTUnwrap(authority.capture(ownerID: "owner", expectedOwnerID: "owner"))
   }
 
+  func testFullTurnFailureClassificationPreservesBoundedLedgerProvenance() throws {
+    let classification = JITProactivityDelivery.classifyExecutionFailure(
+      ProactiveLaneClientError.http(status: 502, retryAfterSeconds: nil))
+
+    XCTAssertEqual(classification.failure, "http_error")
+    XCTAssertEqual(classification.status, 502)
+    let provenance = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(classification.provenanceJSON.utf8)) as? [String: Any])
+    XCTAssertEqual(provenance["failure"] as? String, "http_error")
+    XCTAssertEqual((provenance["status"] as? NSNumber)?.intValue, 502)
+    XCTAssertNil(provenance["error_type"])
+  }
+
+  func testFullTurnFailureClassificationNeverIncludesRawErrorText() throws {
+    struct SensitiveError: Error, LocalizedError {
+      var errorDescription: String? { "secret prompt and provider response" }
+    }
+
+    let classification = JITProactivityDelivery.classifyExecutionFailure(SensitiveError())
+    XCTAssertFalse(classification.provenanceJSON.contains("secret prompt"))
+    XCTAssertFalse(classification.provenanceJSON.contains("provider response"))
+    XCTAssertEqual(classification.failure, "network")
+  }
+
   func testUnknownAuthorityPreservesLegacyLane() async throws {
     let runtime = JITProactivityRuntime { _ in
       JITProactivityFlags(rollout: .unknown, killSwitch: .unknown)

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -27,6 +27,39 @@ final class ProactiveLaneClientTests: XCTestCase {
     super.tearDown()
   }
 
+  func testReasoningCompletionBudgetUsesBackendCompatibleMinimum() {
+    XCTAssertEqual(
+      ProactiveLaneClient.effectiveMaxCompletionTokens(
+        operation: ModelQoS.Proactivity.reasoningOperation, requested: 800),
+      ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens)
+    XCTAssertEqual(
+      ProactiveLaneClient.effectiveMaxCompletionTokens(
+        operation: ModelQoS.Proactivity.reasoningOperation, requested: 3000),
+      3000)
+    XCTAssertEqual(
+      ProactiveLaneClient.effectiveMaxCompletionTokens(
+        operation: ModelQoS.Proactivity.extractionOperation, requested: 800),
+      800)
+  }
+
+  func testReasoningCompleteForwardsBackendCompatibleMinimum() async throws {
+    ProactiveLaneURLStub.reset()
+    let client = ProactiveLaneClient(
+      session: makeStubSession(), baseURL: { "https://proactive.test" }, authorization: { "Bearer test" })
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200, body: try successEnvelope(operation: ModelQoS.Proactivity.reasoningOperation))
+
+    _ = try await client.complete(
+      operation: ModelQoS.Proactivity.reasoningOperation,
+      prompt: "reason",
+      jsonSchema: ["type": "object"],
+      maxCompletionTokens: 800)
+
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestedMaxCompletionTokens,
+      [ProactiveLaneClient.backendCompatibleReasoningMinimumCompletionTokens])
+  }
+
   func testEnvelopeParsingPreservesGatewayAccounting() throws {
     let data = try JSONSerialization.data(withJSONObject: [
       "operation": "proactive_reasoning",
@@ -1108,6 +1141,7 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
   private nonisolated(unsafe) static var responses: [StubResponse] = []
   private nonisolated(unsafe) static var served = 0
   private nonisolated(unsafe) static var operations: [String] = []
+  private nonisolated(unsafe) static var maxCompletionTokenBudgets: [Int] = []
   private nonisolated(unsafe) static var paths: [String] = []
   /// How many requests must be in flight before any of them is answered, if the caller asked for
   /// that. Nil is the ordinary case: answer each request as it arrives.
@@ -1127,6 +1161,12 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     return operations
   }
 
+  static var requestedMaxCompletionTokens: [Int] {
+    lock.lock()
+    defer { lock.unlock() }
+    return maxCompletionTokenBudgets
+  }
+
   /// Request URL paths in issue order, for asserting which authority routes a
   /// caller actually reached.
   static var requestedPaths: [String] {
@@ -1140,6 +1180,7 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     responses = []
     served = 0
     operations = []
+    maxCompletionTokenBudgets = []
     paths = []
     holdThreshold = nil
     holdReached = nil
@@ -1184,8 +1225,10 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
       return
     }
     let operation = Self.operation(from: request)
+    let maxCompletionTokens = Self.maxCompletionTokens(from: request)
     Self.lock.lock()
     Self.operations.append(operation)
+    if let maxCompletionTokens { Self.maxCompletionTokenBudgets.append(maxCompletionTokens) }
     Self.paths.append(url.path)
     let stub = Self.responses.isEmpty ? nil : Self.responses.removeFirst()
     Self.served += 1
@@ -1226,6 +1269,13 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
       let operation = object["operation"] as? String
     else { return "" }
     return operation
+  }
+
+  private static func maxCompletionTokens(from request: URLRequest) -> Int? {
+    guard let data = bodyData(from: request),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    return object["max_completion_tokens"] as? Int
   }
 
   private static func bodyData(from request: URLRequest) -> Data? {

--- a/desktop/macos/changelog/unreleased/20260907-jit-proactive-reliability.json
+++ b/desktop/macos/changelog/unreleased/20260907-jit-proactive-reliability.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved proactive JIT notifications so reasoning requests stay within the backend budget and failures retain actionable diagnostics"
+}


### PR DESCRIPTION
## What changed and why

Proactive JIT reasoning requests could be rejected by the QA backend because the desktop client asked for fewer completion tokens than the reasoning contract requires, and delivery telemetry reduced typed HTTP, decode, and transport failures to a generic `jit_execution` marker. This change enforces the backend-compatible reasoning floor for every proactive reasoning call and persists bounded typed failure provenance so QA can distinguish contract, provider, and network failures.

## Product invariants affected

none

## How it was verified

- `backend/.venv` equivalent: `/Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python -m pytest backend/tests/unit/test_desktop_proactivity.py -q` (55 passed)
- `xcrun swift test -c debug --package-path Desktop --filter 'ContextBucketDirectorProbeTests|ContextProactivityEngineTests|JITProactivityRuntimeTests|ContextWorkstreamReconcilerTests|ProactiveLaneClientTests'` (134 passed on the repair branch)
- `xcrun swift test -c debug --package-path Desktop --filter RewindOCRQualityTests` (11 passed; full package/test target compiled after the Vision API compatibility fix)
- Current QA app remains in dev/beta with JIT allowlist and notification permission enabled; no production flags or deployments were changed

## Tests

Regression coverage verifies the 2400-token reasoning floor, all proactive call sites, and typed delivery failure classification/provenance.

## Failure class (fixes)

Failure-Class: FC-typed-failure-collapsed-to-generic
