### PR TITLE
fix(jit): harden agent state storage permissions

### DIFF
--- a/.github/failure-classes/FC-private-runtime-state-permissions.json
+++ b/.github/failure-classes/FC-private-runtime-state-permissions.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-private-runtime-state-permissions",
+  "violated_contract": "Owner-scoped agent runtime state that can contain prompt material must be created and retained with owner-only directory, database, and SQLite sidecar permissions before the state is admitted to a JIT source projection.",
+  "canonical_prevention": "Set a private process umask before SQLite opens, reject symlinked state paths, and enforce 0700 for the state directory and 0600 for the database and WAL/SHM sidecars on every open, with a regression test over newly created and existing state.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/src/runtime/sqlite-store.ts",
+    "desktop/macos/agent/tests/sqlite-store.test.ts"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/agent/src/runtime/**",
+    "desktop/macos/agent/tests/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { chmodSync, lstatSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { DatabaseSync, type SQLInputValue, type SQLOutputValue } from "node:sqlite";
@@ -429,9 +429,29 @@ export class SqliteAgentStore implements AgentStore {
 
   constructor(options: SqliteAgentStoreOptions = {}) {
     const databasePath = options.databasePath ?? databasePathForStateDir(requiredStateDir(options.stateDir));
-    mkdirSync(dirname(databasePath), { recursive: true });
+    // The Swift JIT source projection preflight requires the agent state and
+    // SQLite files to be owner-only because the database can contain prompt
+    // material.  The default process umask on a developer Mac is commonly
+    // 022, which otherwise leaves new directories at 0755 and SQLite files at
+    // 0644.  Set a private umask before SQLite creates its WAL/SHM sidecars,
+    // and repair the existing directory/file modes on every open.
+    process.umask(0o077);
+    const isInMemory = databasePath === ":memory:";
+    if (!isInMemory) {
+      const stateDirectory = dirname(databasePath);
+      mkdirSync(stateDirectory, { recursive: true, mode: 0o700 });
+      hardenOwnerOnlyDirectory(stateDirectory);
+      rejectSymlink(databasePath, "database");
+    }
     const Database = options.databaseFactory ?? DatabaseSync;
     this.db = new Database(databasePath) as DatabaseSync;
+    if (!isInMemory) {
+      hardenOwnerOnlyFile(databasePath, "database");
+      for (const suffix of ["-wal", "-shm"]) {
+        const sidecarPath = `${databasePath}${suffix}`;
+        if (pathExists(sidecarPath)) hardenOwnerOnlyFile(sidecarPath, `database ${suffix} sidecar`);
+      }
+    }
     this.nowMs = options.nowMs ?? Date.now;
 
     applyConnectionPragmas(this.db);
@@ -1676,6 +1696,44 @@ export class SqliteAgentStore implements AgentStore {
       payloadJson: input.payloadJson ?? "{}",
       createdAtMs: input.createdAtMs ?? this.nowMs(),
     };
+  }
+}
+
+function hardenOwnerOnlyDirectory(path: string): void {
+  const attributes = lstatSync(path);
+  if (!attributes.isDirectory() || attributes.isSymbolicLink()) {
+    throw new Error(`SqliteAgentStore state directory must be a real directory: ${path}`);
+  }
+  chmodSync(path, 0o700);
+}
+
+function hardenOwnerOnlyFile(path: string, label: string): void {
+  const attributes = lstatSync(path);
+  if (!attributes.isFile() || attributes.isSymbolicLink()) {
+    throw new Error(`SqliteAgentStore ${label} must be a real file: ${path}`);
+  }
+  chmodSync(path, 0o600);
+}
+
+function rejectSymlink(path: string, label: string): void {
+  try {
+    const attributes = lstatSync(path);
+    if (attributes.isSymbolicLink()) {
+      throw new Error(`SqliteAgentStore ${label} cannot be a symbolic link: ${path}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+}
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
   }
 }
 

--- a/desktop/macos/agent/tests/sqlite-store.test.ts
+++ b/desktop/macos/agent/tests/sqlite-store.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
@@ -15,6 +15,17 @@ afterEach(() => {
 });
 
 describe("SqliteAgentStore", () => {
+  it("keeps the runtime state directory and database owner-only", () => {
+    const databasePath = newDatabasePath();
+    const stateDir = dirname(databasePath);
+    chmodSync(stateDir, 0o755);
+
+    const store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false });
+    expect(statSync(stateDir).mode & 0o777).toBe(0o700);
+    expect(statSync(databasePath).mode & 0o777).toBe(0o600);
+    store.close();
+  });
+
   it("runs runtime and desktop coordinator migrations idempotently", () => {
     const store = newStore({ reconcileOnOpen: false });
 

--- a/desktop/macos/changelog/unreleased/20260907-jit-runtime-state-permissions.json
+++ b/desktop/macos/changelog/unreleased/20260907-jit-runtime-state-permissions.json
@@ -1,0 +1,3 @@
+{
+  "change": "Hardened the local agent runtime state used by proactive JIT processing"
+}


### PR DESCRIPTION
## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

## Failure class (fixes)

Failure-Class: new

## Summary

The JIT source projection preflight rejects the QA runtime when Node creates its state directory and SQLite WAL files with the normal 0755/0644 modes. Harden the runtime state directory, database, and existing SQLite sidecars to owner-only permissions, and set a private umask before SQLite creates new sidecars. Keep in-memory test databases exempt.

## Validation

- `npm test -- sqlite-store.test.ts`
- `npm run build`
- `npm test` (on the preceding repair worktree: 816 tests passed; unrelated generated-output and MCP timing failures are pre-existing on a fresh main checkout)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

