### PR TITLE
perf(ios): reduce repeated work during native batch recording

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -314,6 +314,12 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "iOS BLE diagnostics must not poll RSSI while closed, and frequent battery notifications must not rewrite the complete history on every packet"
+  - id: ios-batch-audio-energy
+    command: ["ruby", "app/ios/test/batch_audio_energy_test.rb"]
+    triggers: ["app/ios/Runner/Batch/*.swift", "app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift", "app/ios/test/batch_audio_energy_test.*", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "c04b703719 writes each native batch frame in two calls; 370b1045a0 rereads saved phone location each append; exercise those production writers while preserving frame durability and metadata freshness"
   - id: deferred-work-markers
     command: ["python3", ".github/scripts/deferred-work-marker-count.py", "--changed-files", "{changed_files}", "--base", "{base}", "--check-new"]
     triggers: ["all"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -316,7 +316,7 @@ checks:
     reason: "iOS BLE diagnostics must not poll RSSI while closed, and frequent battery notifications must not rewrite the complete history on every packet"
   - id: ios-batch-audio-energy
     command: ["ruby", "app/ios/test/batch_audio_energy_test.rb"]
-    triggers: ["app/ios/Runner/Batch/*.swift", "app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift", "app/ios/test/batch_audio_energy_test.*", ".github/checks-manifest.yaml"]
+    triggers: ["app/ios/Runner/Batch/BaseBatchAudioWriter.swift", "app/ios/Runner/Batch/BatchAudioWriter.swift", "app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift", "app/ios/test/batch_audio_energy_test.*", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "c04b703719 writes each native batch frame in two calls; 370b1045a0 rereads saved phone location each append; exercise those production writers while preserving frame durability and metadata freshness"

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -93,6 +93,8 @@ flutter test test/unit/  # specific directory
 
 `bash test.sh` bootstraps missing local generated files with an empty `API_BASE_URL` so `test/` stays hermetic.
 
+Native batch contracts: `ruby ios/test/batch_audio_energy_test.rb` runs production Swift writers for frame durability, preference freshness, and location snapshots (macOS manifest, local + CI).
+
 PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.sh`) — analyzer errors always fail; new info/warning lint occurrences above `app/analysis_baseline.json` fail. Run the script locally before committing app Dart changes. Deliberate lint acceptances/improvements update the baseline via `--update-baseline` in the same PR.
 
 ### Test Patterns

--- a/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
+++ b/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
@@ -19,6 +19,7 @@ class BaseBatchAudioWriter {
     let queue: DispatchQueue
     private let tag: String
     private let recoveryPrefix: String
+    private let writeData: (FileHandle, Data) throws -> Void
 
     // Active-file state (only touched on `queue`).
     private var fileHandle: FileHandle?
@@ -39,10 +40,14 @@ class BaseBatchAudioWriter {
     /// the phone-mic writer runs on the controller's audio queue so encode+write
     /// stay on a single queue and `audioQueue.sync {}` genuinely drains pending
     /// writes. When nil (the BLE subclasses) the writer creates its own.
-    init(tag: String, queueLabel: String, recoveryPrefix: String, queue: DispatchQueue? = nil) {
+    init(
+        tag: String, queueLabel: String, recoveryPrefix: String, queue: DispatchQueue? = nil,
+        writeData: @escaping (FileHandle, Data) throws -> Void = { try $0.write(contentsOf: $1) }
+    ) {
         self.tag = tag
         self.queue = queue ?? DispatchQueue(label: queueLabel)
         self.recoveryPrefix = recoveryPrefix
+        self.writeData = writeData
     }
 
     /// Whether a part file is currently open (only meaningful on `queue`).
@@ -111,9 +116,12 @@ class BaseBatchAudioWriter {
         do {
             for frame in frames {
                 var len = UInt32(frame.count).littleEndian
-                let header = Data(bytes: &len, count: 4)
-                try fh.write(contentsOf: header)
-                try fh.write(contentsOf: frame)
+                // Keep the existing per-frame commit boundary while issuing one
+                // write for bytes already available. Never buffer across callbacks.
+                var record = Data(capacity: 4 + frame.count)
+                withUnsafeBytes(of: &len) { record.append(contentsOf: $0) }
+                record.append(frame)
+                try writeData(fh, record)
                 currentBytes += Int64(4 + frame.count)
                 currentFrames += 1
             }
@@ -214,24 +222,28 @@ class BaseBatchAudioWriter {
 
     /// Persist a bounded recording-owned location snapshot beside the audio file.
     /// The sidecar is written atomically so a native crash cannot leave a partial
-    /// JSON file for the Dart scanner to ingest.
-    func persistRecordingGeolocationSidecar(rawGeolocation: String?, audioURL: URL) {
+    /// JSON file for the Dart scanner to ingest. True confirms a saved/existing
+    /// snapshot; false lets callers retry missing metadata or a failed write.
+    @discardableResult
+    func persistRecordingGeolocationSidecar(rawGeolocation: String?, audioURL: URL) -> Bool {
         guard let rawGeolocation,
               let data = rawGeolocation.data(using: .utf8),
               !data.isEmpty,
               data.count <= 4_096,
-              (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else { return }
+              (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else { return false }
 
         let sidecarURL = URL(fileURLWithPath: audioURL.path + ".geolocation.json")
         // A same-name part file can be reopened after a native restart. Its
         // location belongs to that recording, so never replace an existing
         // snapshot with the next session's config.
-        if FileManager.default.fileExists(atPath: sidecarURL.path) { return }
+        if FileManager.default.fileExists(atPath: sidecarURL.path) { return true }
         do {
             try data.write(to: sidecarURL, options: .atomic)
+            return true
         } catch {
             // Location is optional: never interrupt or discard audio capture.
             NSLog("[\(tag)] failed to persist bounded recording location sidecar: \(type(of: error))")
+            return false
         }
     }
 

--- a/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
+++ b/app/ios/Runner/Batch/BaseBatchAudioWriter.swift
@@ -224,19 +224,21 @@ class BaseBatchAudioWriter {
     /// The sidecar is written atomically so a native crash cannot leave a partial
     /// JSON file for the Dart scanner to ingest. True confirms a saved/existing
     /// snapshot; false lets callers retry missing metadata or a failed write.
+    /// The existing-snapshot check deliberately runs before input validation: a
+    /// reopened recording keeps its original location even when the current
+    /// preference is missing or has become invalid.
     @discardableResult
     func persistRecordingGeolocationSidecar(rawGeolocation: String?, audioURL: URL) -> Bool {
-        guard let rawGeolocation,
-              let data = rawGeolocation.data(using: .utf8),
-              !data.isEmpty,
-              data.count <= 4_096,
-              (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else { return false }
-
         let sidecarURL = URL(fileURLWithPath: audioURL.path + ".geolocation.json")
         // A same-name part file can be reopened after a native restart. Its
         // location belongs to that recording, so never replace an existing
         // snapshot with the next session's config.
         if FileManager.default.fileExists(atPath: sidecarURL.path) { return true }
+        guard let rawGeolocation,
+              let data = rawGeolocation.data(using: .utf8),
+              !data.isEmpty,
+              data.count <= 4_096,
+              (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else { return false }
         do {
             try data.write(to: sidecarURL, options: .atomic)
             return true

--- a/app/ios/Runner/Batch/BatchAudioWriter.swift
+++ b/app/ios/Runner/Batch/BatchAudioWriter.swift
@@ -19,7 +19,15 @@ import Foundation
 /// per-device frame extraction, silence-gap finalize and wall-clock rotation.
 final class OmiBatchAudioWriter: BaseBatchAudioWriter {
     static let shared = OmiBatchAudioWriter()
-    private init() {
+    private let defaults: UserDefaults
+    private let decodeJSON: (Data) throws -> Any
+
+    init(
+        defaults: UserDefaults = .standard,
+        decodeJSON: @escaping (Data) throws -> Any = { try JSONSerialization.jsonObject(with: $0) }
+    ) {
+        self.defaults = defaults
+        self.decodeJSON = decodeJSON
         super.init(tag: "BatchWriter", queueLabel: "com.omi.batchAudioWriter", recoveryPrefix: "audio_omibatch_")
     }
 
@@ -28,6 +36,11 @@ final class OmiBatchAudioWriter: BaseBatchAudioWriter {
     private var lastFrameMs: Int64 = 0
     private var wasEnabled = false
     private var diagLoggedMatch = false
+    // BLE callback-thread confined, like wasEnabled. Read preferences each time
+    // so setting changes apply immediately; decode only when their values change.
+    private var cachedRawConfig: String?
+    private var cachedDirectory: String?
+    private var cachedConfig: Config?
 
     private let maxFileBytes: Int64 = 32 * 1024 * 1024 // ~32 MB per file
     private let maxFileSeconds: Int64 = 900 // 15 min per file
@@ -58,7 +71,7 @@ final class OmiBatchAudioWriter: BaseBatchAudioWriter {
         }
         wasEnabled = true
         guard config.deviceType != "limitless" else { return false } // LimitlessFlashDrainEngine owns that device
-        guard config.deviceId.lowercased() == peripheralUuid.lowercased() else { return false }
+        guard config.deviceId == peripheralUuid.lowercased() else { return false }
         guard config.serviceUuid == serviceUuid.lowercased(),
             config.characteristicUuid == characteristicUuid.lowercased() else { return false }
 
@@ -67,7 +80,7 @@ final class OmiBatchAudioWriter: BaseBatchAudioWriter {
             NSLog("[BatchWriter] matched audio characteristic — batch capture active (device=\(peripheralUuid), dir=\(config.dir))")
         }
 
-        let d = UserDefaults.standard
+        let d = defaults
         // Muted: drop the packet but keep the open file's gap timer alive so unmute
         // resumes the same recording instead of starting a new one.
         if d.bool(forKey: "flutter.batchMuted") {
@@ -166,17 +179,21 @@ final class OmiBatchAudioWriter: BaseBatchAudioWriter {
     // MARK: - Config
 
     private func loadConfig() -> Config? {
-        let d = UserDefaults.standard
+        let d = defaults
         guard d.bool(forKey: "flutter.batchModeEnabled") else { return nil }
         guard let dir = d.string(forKey: "flutter.batchAudioDir"), !dir.isEmpty else { return nil }
-        guard let raw = d.string(forKey: "flutter.nativeBleStreamConfig"),
-            let data = raw.data(using: .utf8),
-            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let raw = d.string(forKey: "flutter.nativeBleStreamConfig") else { return nil }
+        if raw == cachedRawConfig, dir == cachedDirectory { return cachedConfig }
+        cachedRawConfig = raw
+        cachedDirectory = dir
+        cachedConfig = nil // Invalid replacements must never reuse a previous route.
+        guard let data = raw.data(using: .utf8),
+            let json = try? decodeJSON(data) as? [String: Any] else { return nil }
         guard let deviceId = json["deviceId"] as? String, !deviceId.isEmpty,
             let serviceUuid = json["serviceUuid"] as? String, !serviceUuid.isEmpty,
             let charUuid = json["characteristicUuid"] as? String, !charUuid.isEmpty else { return nil }
-        return Config(
-            deviceId: deviceId,
+        let config = Config(
+            deviceId: deviceId.lowercased(),
             codec: (json["codec"] as? String) ?? "opus",
             sampleRate: (json["sampleRate"] as? Int) ?? 16000,
             serviceUuid: serviceUuid.lowercased(),
@@ -184,5 +201,7 @@ final class OmiBatchAudioWriter: BaseBatchAudioWriter {
             deviceType: (json["deviceType"] as? String) ?? "omi",
             dir: dir
         )
+        cachedConfig = config
+        return config
     }
 }

--- a/app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift
+++ b/app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift
@@ -14,6 +14,7 @@ import Foundation
 /// from the tap's audioQueue block and close from `audioQueue.sync`).
 final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
     private let dir: String
+    private let defaults: UserDefaults
 
     private let maxFileBytes: Int64 = 32 * 1024 * 1024 // ~32 MB per file
     private let maxFileSeconds: Int64 = 900 // 15 min per file
@@ -21,6 +22,7 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
 
     private var lastAppendMs: Int64 = 0
     private var currentAudioURL: URL?
+    private var geolocationSidecarPersisted = false
     /// Session total of frames durably written (each = one 20ms opus packet). Drives
     /// onBatchProgress; muted/interrupted/storage-full periods never advance it.
     private(set) var sessionFramesWritten: Int64 = 0
@@ -31,18 +33,16 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
 
     override func onOpenedLocked(_ partURL: URL) {
         currentAudioURL = partURL.deletingPathExtension()
+        geolocationSidecarPersisted = false
         persistCurrentGeolocationSidecar()
     }
 
     private func persistCurrentGeolocationSidecar() {
-        guard let currentAudioURL,
-              let raw = UserDefaults.standard.string(forKey: "flutter.phoneBatchGeolocation"),
-              let data = raw.data(using: .utf8),
-              (try? JSONSerialization.jsonObject(with: data)) is [String: Any]
-        else { return }
-
-        persistRecordingGeolocationSidecar(
-            rawGeolocation: raw,
+        guard !geolocationSidecarPersisted, let currentAudioURL else { return }
+        // Location can arrive after capture starts. Retry absent/invalid metadata
+        // and failed writes, but stop rereading it once this recording owns a snapshot.
+        geolocationSidecarPersisted = persistRecordingGeolocationSidecar(
+            rawGeolocation: defaults.string(forKey: "flutter.phoneBatchGeolocation"),
             audioURL: currentAudioURL
         )
     }
@@ -52,8 +52,9 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
     /// so it is never re-checked per append. The recovery prefix `audio_omibatchphone`
     /// intentionally matches both the manual (`omibatchphone`) and auto
     /// (`omibatchphoneauto`) markers, and nothing else.
-    init(dir: String, queue: DispatchQueue) {
+    init(dir: String, queue: DispatchQueue, defaults: UserDefaults = .standard) {
         self.dir = dir
+        self.defaults = defaults
         super.init(
             tag: "PhoneBatchWriter",
             queueLabel: "com.omi.phoneBatchWriter",
@@ -69,7 +70,7 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
     /// (`omibatchphone` / `omibatchphoneauto`) and only shapes the file name.
     func append(opusPackets: [Data], marker: String) {
         if opusPackets.isEmpty { return }
-        let d = UserDefaults.standard
+        let d = defaults
         let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
 
         // Muted: drop packets but keep the open file's gap timer fresh so unmute
@@ -146,7 +147,7 @@ final class PhoneMicBatchAudioWriter: BaseBatchAudioWriter {
         // The base sets flutter.batchStorageFull when the free-space guard trips;
         // read it back to distinguish a storage-full refusal from a transient open
         // failure, and latch only the false->true edge.
-        if UserDefaults.standard.bool(forKey: "flutter.batchStorageFull"), !wasStorageFull {
+        if defaults.bool(forKey: "flutter.batchStorageFull"), !wasStorageFull {
             wasStorageFull = true
             pendingStorageFullReport = true
         }

--- a/app/ios/test/batch_audio_energy_test.rb
+++ b/app/ios/test/batch_audio_energy_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+
+class BatchAudioEnergyTest < Minitest::Test
+  def test_native_batch_writes_settings_and_location
+    ios_root = File.expand_path('..', __dir__)
+    sources = %w[
+      Runner/Batch/BaseBatchAudioWriter.swift
+      Runner/Batch/BatchAudioWriter.swift
+      Runner/PhoneMic/PhoneMicBatchAudioWriter.swift
+      test/batch_audio_energy_test.swift
+    ].map { |path| File.join(ios_root, path) }
+    Dir.mktmpdir('omi-batch-energy') do |directory|
+      binary = File.join(directory, 'batch-energy-test')
+      stdout, stderr, status = Open3.capture3('swiftc', '-parse-as-library', *sources, '-o', binary)
+      assert status.success?, "swiftc failed:\n#{stdout}\n#{stderr}"
+      stdout, stderr, status = Open3.capture3(binary)
+      assert status.success?, "native batch assertions failed:\n#{stdout}\n#{stderr}"
+    end
+  end
+end

--- a/app/ios/test/batch_audio_energy_test.swift
+++ b/app/ios/test/batch_audio_energy_test.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+// Stub only the Flutter delivery boundary; compile and execute the real writers.
+final class OmiBleManager {
+    static let shared = OmiBleManager()
+    var flutterApi: TestFlutterApi?
+}
+final class TestFlutterApi {
+    func onBatchRecordingFinalized(fileName: String, completion: (Bool) -> Void) {}
+}
+final class CountingDefaults: UserDefaults {
+    var locationReads = 0
+    override func string(forKey key: String) -> String? {
+        if key == "flutter.phoneBatchGeolocation" { locationReads += 1 }
+        return super.string(forKey: key)
+    }
+}
+
+@main
+struct BatchAudioEnergyTests {
+    static func check(_ condition: Bool) { precondition(condition) }
+
+    static func directory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    static func main() throws {
+        try testFrameWrites()
+        try testConfigChanges()
+        try testLocationSnapshot()
+        print("PASS: single writes, partial failures, config changes, and location lifecycle")
+    }
+
+    static func testFrameWrites() throws {
+        let dir = try directory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        var writes: [Data] = []
+        var tearAt: Int?
+        let writer = BaseBatchAudioWriter(tag: "test", queueLabel: "test", recoveryPrefix: "test_", writeData: { fh, data in
+            writes.append(data)
+            if let tearAt {
+                try fh.write(contentsOf: data.prefix(tearAt))
+                throw NSError(domain: "injected-write-failure", code: 1)
+            }
+            try fh.write(contentsOf: data)
+        })
+        try writer.queue.sync {
+            precondition(!writer.writeFramesLocked([Data([1])]))
+            precondition(writer.openLocked(dirPath: dir.path, fileName: "test_normal.bin.part", startSec: 1, nowMs: 0))
+            let frames = [Data([0xaa, 0xbb]), Data(), Data(repeating: 0xcc, count: 320)]
+            precondition(writer.writeFramesLocked(frames))
+            precondition(writes.count == frames.count) // old code performed two writes per frame
+            precondition(writes[0] == Data([2, 0, 0, 0, 0xaa, 0xbb]))
+            precondition(writes[1] == Data([0, 0, 0, 0]))
+            precondition(writes[2].prefix(4) == Data([0x40, 1, 0, 0]))
+            precondition(writer.currentFrames == 3 && writer.currentBytes == 334)
+            let expected = writes.reduce(into: Data()) { $0.append($1) }
+            check(try Data(contentsOf: dir.appendingPathComponent("test_normal.bin.part")) == expected)
+            precondition(writer.fsyncLocked())
+            writer.closeCurrentLocked("test")
+            check(try Data(contentsOf: dir.appendingPathComponent("test_normal.bin")) == expected)
+
+            // Fail inside the header, at its boundary, and inside the payload.
+            // Every failure must publish only the previously completed frame.
+            for offset in [0, 2, 4, 5] {
+                tearAt = nil
+                let name = "test_torn_\(offset).bin"
+                precondition(writer.openLocked(dirPath: dir.path, fileName: name + ".part", startSec: 2, nowMs: 0))
+                precondition(writer.writeFramesLocked([Data([0x11])]))
+                tearAt = offset
+                precondition(!writer.writeFramesLocked([Data([0x22, 0x33]), Data([0x44])]))
+                precondition(!writer.isOpen)
+                check(try Data(contentsOf: dir.appendingPathComponent(name)) == Data([1, 0, 0, 0, 0x11]))
+                precondition(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(name + ".part").path))
+            }
+            // Failure in the first frame leaves no ingestable placeholder.
+            precondition(writer.openLocked(dirPath: dir.path, fileName: "test_empty.bin.part", startSec: 3, nowMs: 0))
+            precondition(!writer.writeFramesLocked([Data([1, 2])]))
+            precondition(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("test_empty.bin").path))
+        }
+    }
+
+    static func testConfigChanges() throws {
+        let suite = "omi.batch.config.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        var decodes = 0
+        let writer = OmiBatchAudioWriter(defaults: defaults, decodeJSON: { data in
+            decodes += 1
+            return try JSONSerialization.jsonObject(with: data)
+        })
+        func config(_ device: String) -> String {
+            "{\"deviceId\":\"\(device)\",\"serviceUuid\":\"SERVICE\",\"characteristicUuid\":\"CHAR\"}"
+        }
+        func handle(_ device: String = "DEVICE") -> Bool {
+            // Header-only packets exercise routing without creating files.
+            writer.handle(peripheralUuid: device, serviceUuid: "service", characteristicUuid: "char", value: Data([1, 2, 3]))
+        }
+        defaults.set(true, forKey: "flutter.batchModeEnabled")
+        defaults.set("/unused", forKey: "flutter.batchAudioDir")
+        defaults.set(config("device"), forKey: "flutter.nativeBleStreamConfig")
+        for _ in 0..<1_000 { precondition(handle()) }
+        precondition(decodes == 1)
+        defaults.set(true, forKey: "flutter.batchMuted")
+        defaults.set(true, forKey: "flutter.batchCutRequested")
+        precondition(handle())
+        precondition(defaults.bool(forKey: "flutter.batchCutRequested"))
+        defaults.set(false, forKey: "flutter.batchMuted")
+        precondition(handle())
+        precondition(!defaults.bool(forKey: "flutter.batchCutRequested"))
+        defaults.set(config("other"), forKey: "flutter.nativeBleStreamConfig")
+        precondition(!handle() && handle("other") && decodes == 2)
+        defaults.set("{broken", forKey: "flutter.nativeBleStreamConfig")
+        for _ in 0..<10 { precondition(!handle()) }
+        precondition(decodes == 3)
+        defaults.set(config("device"), forKey: "flutter.nativeBleStreamConfig")
+        precondition(handle() && decodes == 4)
+        defaults.set("/other", forKey: "flutter.batchAudioDir")
+        precondition(handle() && decodes == 5)
+        defaults.set(false, forKey: "flutter.batchModeEnabled")
+        precondition(!handle())
+        defaults.set(true, forKey: "flutter.batchModeEnabled")
+        precondition(handle())
+        defaults.removeObject(forKey: "flutter.nativeBleStreamConfig")
+        precondition(!handle())
+        defaults.set(config("device"), forKey: "flutter.nativeBleStreamConfig")
+        defaults.set("", forKey: "flutter.batchAudioDir")
+        precondition(!handle())
+        writer.queue.sync {} // drain disable finalization before teardown
+
+        // Exercise real bytes after a cache hit, including mute and manual cut.
+        let dir = try directory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        defaults.set(dir.path, forKey: "flutter.batchAudioDir")
+        precondition(handle()) // populate the exact config cache used by audio below
+        let beforeAudioDecodes = decodes
+        func audio(_ byte: UInt8) {
+            precondition(writer.handle(peripheralUuid: "device", serviceUuid: "service", characteristicUuid: "char", value: Data([0, 0, 0, byte])))
+            writer.queue.sync {}
+        }
+        audio(0x11)
+        defaults.set(true, forKey: "flutter.batchMuted")
+        audio(0x22)
+        defaults.set(true, forKey: "flutter.batchCutRequested")
+        defaults.set(false, forKey: "flutter.batchMuted")
+        audio(0x33)
+        precondition(decodes == beforeAudioDecodes)
+        precondition(!defaults.bool(forKey: "flutter.batchCutRequested"))
+        let files = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        let finalized = files.filter { $0.path.hasSuffix(".bin") }
+        let active = files.filter { $0.path.hasSuffix(".bin.part") }
+        precondition(finalized.count == 1 && active.count == 1)
+        check(try Data(contentsOf: finalized[0]) == Data([1, 0, 0, 0, 0x11]))
+        check(try Data(contentsOf: active[0]) == Data([1, 0, 0, 0, 0x33]))
+        defaults.set(false, forKey: "flutter.batchModeEnabled")
+        precondition(!handle())
+        writer.queue.sync {}
+    }
+
+    static func testLocationSnapshot() throws {
+        let dir = try directory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let suite = "omi.batch.location.test.\(UUID().uuidString)"
+        let defaults = CountingDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let queue = DispatchQueue(label: "test.phone")
+        let writer = PhoneMicBatchAudioWriter(dir: dir.path, queue: queue, defaults: defaults)
+        let location = "{\"latitude\":1,\"longitude\":2}"
+        try queue.sync {
+            func append() { writer.append(opusPackets: [Data([1, 2])], marker: "omibatchphone") }
+            append() // no initial location: keep trying
+            defaults.set("broken", forKey: "flutter.phoneBatchGeolocation")
+            append()
+            defaults.set(location, forKey: "flutter.phoneBatchGeolocation")
+            // The audio handle stays valid across a directory rename, but the
+            // sidecar path becomes temporarily unwritable. Restore it to prove
+            // the phone writer does not latch failure and retries the next chunk.
+            let relocated = dir.appendingPathExtension("temporarily-moved")
+            try FileManager.default.moveItem(at: dir, to: relocated)
+            append()
+            let readsAfterFailure = defaults.locationReads
+            try FileManager.default.moveItem(at: relocated, to: dir)
+            append()
+            precondition(defaults.locationReads == readsAfterFailure + 1)
+            let readsAfterSave = defaults.locationReads
+            defaults.set("{\"latitude\":3}", forKey: "flutter.phoneBatchGeolocation")
+            for _ in 0..<100 { append() }
+            precondition(defaults.locationReads == readsAfterSave)
+            let sidecars = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil).filter { $0.path.hasSuffix(".geolocation.json") }
+            precondition(sidecars.count == 1)
+            check(try String(contentsOf: sidecars[0], encoding: .utf8) == location)
+            writer.closeNowLocked("test")
+            append() // new recording gets the new location and resets its latch
+            precondition(defaults.locationReads > readsAfterSave)
+            writer.closeNowLocked("test")
+
+            // Existing snapshots are immutable, and failed writes remain retryable.
+            let base = BaseBatchAudioWriter(tag: "test", queueLabel: "unused", recoveryPrefix: "test_")
+            precondition(base.persistRecordingGeolocationSidecar(rawGeolocation: "{\"latitude\":9}", audioURL: URL(fileURLWithPath: String(sidecars[0].path.dropLast(".geolocation.json".count)))))
+            check(try String(contentsOf: sidecars[0], encoding: .utf8) == location)
+            let missingDir = dir.appendingPathComponent("missing")
+            let audio = missingDir.appendingPathComponent("recording.bin")
+            precondition(!base.persistRecordingGeolocationSidecar(rawGeolocation: location, audioURL: audio))
+            try FileManager.default.createDirectory(at: missingDir, withIntermediateDirectories: true)
+            precondition(base.persistRecordingGeolocationSidecar(rawGeolocation: location, audioURL: audio))
+        }
+    }
+}

--- a/app/ios/test/batch_audio_energy_test.swift
+++ b/app/ios/test/batch_audio_energy_test.swift
@@ -76,6 +76,7 @@ struct BatchAudioEnergyTests {
                 precondition(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(name + ".part").path))
             }
             // Failure in the first frame leaves no ingestable placeholder.
+            tearAt = 5 // inject the failure explicitly; don't rely on loop leftovers
             precondition(writer.openLocked(dirPath: dir.path, fileName: "test_empty.bin.part", startSec: 3, nowMs: 0))
             precondition(!writer.writeFramesLocked([Data([1, 2])]))
             precondition(!FileManager.default.fileExists(atPath: dir.appendingPathComponent("test_empty.bin").path))
@@ -199,6 +200,10 @@ struct BatchAudioEnergyTests {
             // Existing snapshots are immutable, and failed writes remain retryable.
             let base = BaseBatchAudioWriter(tag: "test", queueLabel: "unused", recoveryPrefix: "test_")
             precondition(base.persistRecordingGeolocationSidecar(rawGeolocation: "{\"latitude\":9}", audioURL: URL(fileURLWithPath: String(sidecars[0].path.dropLast(".geolocation.json".count)))))
+            // An existing snapshot wins even when the current preference is invalid:
+            // the caller must latch instead of rereading defaults on every append.
+            precondition(base.persistRecordingGeolocationSidecar(rawGeolocation: "broken", audioURL: URL(fileURLWithPath: String(sidecars[0].path.dropLast(".geolocation.json".count)))))
+            precondition(base.persistRecordingGeolocationSidecar(rawGeolocation: nil, audioURL: URL(fileURLWithPath: String(sidecars[0].path.dropLast(".geolocation.json".count)))))
             check(try String(contentsOf: sidecars[0], encoding: .utf8) == location)
             let missingDir = dir.appendingPathComponent("missing")
             let audio = missingDir.appendingPathComponent("recording.bin")


### PR DESCRIPTION
Native iOS batch capture wrote each frame header and payload separately, decoded the same BLE configuration on every notification, and reread phone location after its recording already had a saved snapshot. Reduce that repeated work while preserving capture behavior:

- Append each frame's existing header and payload in one FileHandle call. Preserve the successful-frame boundary, torn-tail truncation, and existing fsync cadence; no buffering across callbacks.
- Cache decoded BLE configuration by its exact JSON and directory values. Continue reading preferences on each callback so enable, mute, cut, device, and routing changes take effect immediately, including invalid replacements.
- Stop rereading phone location after its current file has a saved/existing sidecar. Reset for every opened recording and keep retrying late metadata and failed writes.

The native behavioral harness compiles the production writers with only Flutter notification delivery stubbed. It covers exact bytes, partial writes, real audio across mute/cut, config invalidation, delayed location, a failed phone-sidecar write followed by recovery, and immutable recording snapshots. This is a writer-specific durability/metadata contract, not a new shared primitive; it exercises the original writer behavior in c04b703719 and location behavior in 370b1045a0. The existing macOS manifest runs it locally and in CI.

Validation on BasedHardware/omi, branch codex/ios-battery-efficiency at 8b9d55d658, base 763bf0f8c4fb:

- `bash app/test.sh`: 1,813 passed, 5 skipped.
- Every `app/ios/test/*_test.rb`: passed (36 Ruby test cases), including the new production-writer harness.
- New harness measures one FileHandle call per frame, one decode across 1,000 unchanged config callbacks, and zero location preference reads over 100 further appends after persistence. Three negative controls restoring the repeated work each fail as expected.
- `xcrun swiftc -typecheck -target arm64-apple-ios15.0-simulator -sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)" app/ios/Runner/Batch/{BaseBatchAudioWriter,BatchAudioWriter,LimitlessBatchAudioWriter}.swift app/ios/Runner/PhoneMic/PhoneMicBatchAudioWriter.swift app/ios/test/batch_audio_energy_test.swift`: passed.
- `flutter build ios --simulator --debug --flavor dev --no-pub`: blocked before compilation because Xcode has no installed iOS Simulator runtime (`simctl list runtimes` is empty; no eligible build destination). A prior missing Intercom spec was resolved with `pod install --repo-update`. Task-generated Package.swift/Podfile.lock drift was restored.
- `make preflight` and `scripts/pr-preflight --pr-body-file /tmp/omi-ios-battery-pr.md`: each passed, 121 checks. `scripts/failure-class validate --pr-body-file /tmp/omi-ios-battery-pr.md --format text`: passed.

Parent review: independently inspected every changed production, test, documentation, and manifest file and reran the expanded production-writer harness; no remaining actionable findings.

These are native behavior and operation-count checks. Physical-device microphone/BLE capture and battery consumption were not measured. The change does not claim a quantified battery-life improvement.

Product invariants: `scripts/pr-preflight --suggest` reports no matched invariant paths.
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

