### PR TITLE
perf(macos): smooth chat rendering and unify composer controls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
@@ -107,7 +107,7 @@ struct ChatInputView: View {
   /// Padding used for both the NSTextView (via textContainerInset) and the
   /// placeholder overlay — guaranteeing the cursor and placeholder align.
   private let inputPaddingH: CGFloat = 12
-  private let inputPaddingV: CGFloat = 12
+  private let inputPaddingV: CGFloat = 8
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.sm) {
@@ -126,11 +126,11 @@ struct ChatInputView: View {
         )
       }
 
-      HStack(alignment: .center, spacing: OmiSpacing.sm) {
+      HStack(alignment: .bottom, spacing: OmiSpacing.sm) {
         if attachmentsEnabled {
           Button(action: pickFiles) {
             Image(systemName: "paperclip")
-              .scaledFont(size: OmiType.heading, weight: .medium)
+              .scaledFont(size: OmiType.body, weight: .medium)
               .foregroundColor(Ink.secondary)
               .frame(width: 32, height: 32)
           }
@@ -140,7 +140,7 @@ struct ChatInputView: View {
         }
 
         if showsPushToTalk {
-          PushToTalkMicButton()
+          PushToTalkMicButton(glyphSize: OmiType.body)
         }
 
         // Input field with floating toggle
@@ -184,10 +184,6 @@ struct ChatInputView: View {
             }
             .frame(maxHeight: 200)
             .clipped()
-            // The well is one step up from the shell it sits in, so the two stay distinguishable
-            // without either painting an opaque ground over the glass.
-            .background(Ink.rowFillHover)
-            .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous))
 
           // Floating Ask/Act toggle (top-right, inside the input area)
           if askModeEnabled {
@@ -197,29 +193,28 @@ struct ChatInputView: View {
           }
         }
 
-        // Send/Stop button — inline to the right of the input
-        if isSending {
-          if isStopping {
-            ProgressView()
-              .controlSize(.small)
-              .frame(width: 24, height: 24)
-          } else {
-            Button(action: { onStop?() }) {
-              Image(systemName: "stop.circle.fill")
-                .scaledFont(size: 24)
-                .foregroundColor(.red.opacity(0.8))
+        // One stable target keeps the composer still as Send becomes Stop.
+        Button(action: {
+          if isSending { onStop?() } else { handleSubmit() }
+        }) {
+          ZStack {
+            if isStopping {
+              ProgressView()
+                .controlSize(.small)
+                .environment(\.colorScheme, .dark)
+            } else {
+              Image(systemName: isSending ? "stop.fill" : "arrow.up")
+                .scaledFont(size: 14, weight: .semibold)
             }
-            .buttonStyle(.plain)
           }
-        } else {
-          Button(action: handleSubmit) {
-            Image(systemName: "arrow.up.circle.fill")
-              .scaledFont(size: 24)
-              .foregroundColor(canSend ? Ink.accent : Ink.secondary)
-          }
-          .buttonStyle(.plain)
-          .disabled(!canSend)
+          .frame(width: 32, height: 32)
+          .contentShape(Circle())
         }
+        .buttonStyle(ChatComposerActionStyle(isBusy: isStopping))
+        .disabled(isStopping || (isSending ? onStop == nil : !canSend))
+        .accessibilityLabel(isStopping ? "Stopping response" : isSending ? "Stop response" : "Send message")
+        .help(isSending ? "Stop response" : "Send message (Return)")
+
       }
     }
     .chatComposerShell(fill: isDropTargeted ? Ink.rowFillHover : Ink.rowFill)
@@ -555,5 +550,18 @@ struct ChatModeToggle: View {
         .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous))
     }
     .buttonStyle(.plain)
+  }
+}
+
+/// Neutral, tactile chrome shared by the composer's mutually exclusive actions.
+struct ChatComposerActionStyle: ButtonStyle {
+  var isBusy = false
+  @Environment(\.isEnabled) private var isEnabled
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .foregroundStyle(Ink.surface)
+      .background(Circle().fill(Ink.primary))
+      .opacity(isEnabled || isBusy ? (configuration.isPressed ? 0.65 : 1) : 0.4)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatProseRenderCache.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatProseRenderCache.swift
@@ -44,10 +44,10 @@ enum ChatProseRenderCache {
     }
   }
 
-  private static var entries: [Key: Entry] = [:]
-  private static var lruOrder: [Key] = []
-  /// A full transcript window plus headroom for the streaming row's turnover.
-  private static let maximumEntries = 192
+  // Two prose blocks per fully expanded 500-row transcript, plus a streaming
+  // tail. The former 192-entry cache evicted rows before the next render pass.
+  static let maximumEntries = 1_024
+  private static let entries = ChatRenderLRU<Key, Entry>(capacity: maximumEntries)
   /// A window resize proposes a new width per block per frame of the drag.
   /// Old widths are dead once the window settles at its new size, so the map
   /// is dropped wholesale at the bound rather than curated.
@@ -57,16 +57,10 @@ enum ChatProseRenderCache {
   /// cannot be represented as AppKit prose (a table, a fenced block) — those
   /// keep their SwiftUI renderers and are never cached.
   static func entry(for key: Key, produce: () -> NSAttributedString?) -> Entry? {
-    if let hit = entries[key] {
-      touch(key)
-      return hit
+    entries.value(for: key) {
+      guard let attributed = produce() else { return nil }
+      return Entry(attributed: attributed)
     }
-    guard let attributed = produce() else { return nil }
-    let entry = Entry(attributed: attributed)
-    entries[key] = entry
-    lruOrder.append(key)
-    evictIfNeeded()
-    return entry
   }
 
   /// Memoized TextKit height for the width the transcript proposed. The width
@@ -85,20 +79,8 @@ enum ChatProseRenderCache {
   /// asserts on its population needs a way to start from empty.
   static func removeAll() {
     entries.removeAll()
-    lruOrder.removeAll()
   }
 
   /// Population, for tests that pin the eviction bound.
   static var entryCount: Int { entries.count }
-
-  private static func touch(_ key: Key) {
-    lruOrder.removeAll { $0 == key }
-    lruOrder.append(key)
-  }
-
-  private static func evictIfNeeded() {
-    while lruOrder.count > maximumEntries {
-      entries[lruOrder.removeFirst()] = nil
-    }
-  }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRenderLRU.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRenderLRU.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Bounded memo for immutable render results. Hits relink one node instead of
+/// comparing every cached Markdown string during each streaming frame.
+@MainActor
+final class ChatRenderLRU<Key: Hashable, Value> {
+  private final class Node {
+    let key: Key
+    let value: Value
+    weak var previous: Node?
+    var next: Node?
+
+    init(key: Key, value: Value) {
+      self.key = key
+      self.value = value
+    }
+  }
+
+  private let capacity: Int
+  private var nodes: [Key: Node] = [:]
+  private var oldest: Node?
+  private var newest: Node?
+
+  init(capacity: Int) {
+    precondition(capacity > 0)
+    self.capacity = capacity
+  }
+
+  var count: Int { nodes.count }
+
+  func value(for key: Key, produce: () -> Value?) -> Value? {
+    if let node = nodes[key] {
+      if node !== newest {
+        unlink(node)
+        append(node)
+      }
+      return node.value
+    }
+    guard let value = produce() else { return nil }
+    let node = Node(key: key, value: value)
+    nodes[key] = node
+    append(node)
+    if nodes.count > capacity, let victim = oldest {
+      unlink(victim)
+      nodes[victim.key] = nil
+    }
+    return value
+  }
+
+  func removeAll() {
+    // Detach iteratively so a full cache does not recursively destroy its chain.
+    while let node = oldest { unlink(node) }
+    nodes.removeAll()
+  }
+
+  private func unlink(_ node: Node) {
+    if let previous = node.previous { previous.next = node.next } else { oldest = node.next }
+    if let next = node.next { next.previous = node.previous } else { newest = node.previous }
+    node.previous = nil
+    node.next = nil
+  }
+
+  private func append(_ node: Node) {
+    node.previous = newest
+    newest?.next = node
+    if oldest == nil { oldest = node }
+    newest = node
+  }
+}
+
+/// Rebuilding parent chrome must not reparse every unchanged answer. Keep the
+/// parser pure, and memoize at the UI boundary where its output is consumed.
+@MainActor
+enum ChatMarkdownRenderCache {
+  private static let documents = ChatRenderLRU<String, OmiMarkdownDocument>(capacity: 1_024)
+
+  static func document(for text: String) -> OmiMarkdownDocument {
+    if let cached = documents.value(for: text, produce: { nil }) { return cached }
+    let document = OmiMarkdownDocument(markdown: text)
+    _ = documents.value(for: text) { document }
+    return document
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
@@ -111,7 +111,6 @@ struct OmiMarkdownContent: View, Equatable {
   let text: String
   let style: OmiMarkdown.Style
   let fontScale: CGFloat
-  let document: OmiMarkdownDocument
   let citations: [ChatCitationReference]
   let onOpenCitation: ((ChatCitationReference) -> Void)?
   let appKitProseSelection: Bool
@@ -127,7 +126,6 @@ struct OmiMarkdownContent: View, Equatable {
     self.text = text
     self.style = style
     self.fontScale = fontScale
-    self.document = OmiMarkdownDocument(markdown: text)
     self.citations = citations
     self.onOpenCitation = onOpenCitation
     self.appKitProseSelection = appKitProseSelection
@@ -139,6 +137,7 @@ struct OmiMarkdownContent: View, Equatable {
   }
 
   var body: some View {
+    let document = ChatMarkdownRenderCache.document(for: text)
     Group {
       if document.blocks.count == 1, case .text(let content) = document.blocks[0].kind {
         // Single text segment — no VStack overhead

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
@@ -318,18 +318,24 @@ struct QueryHeroBar: View {
     action: @escaping () -> Void
   ) -> some View {
     Button(action: action) {
-      Image(systemName: systemImage)
-        .scaledFont(size: glyphSize, weight: .semibold)
-        .foregroundStyle(Ink.surface)
-        .frame(width: diameter, height: diameter)
-        .background(Circle().fill(Ink.primary))
-        .contentShape(Circle())
+      ZStack {
+        if isStopping {
+          ProgressView()
+            .controlSize(.small)
+            .environment(\.colorScheme, .dark)
+        } else {
+          Image(systemName: systemImage)
+            .scaledFont(size: glyphSize, weight: .semibold)
+        }
+      }
+      .frame(width: diameter, height: diameter)
+      .contentShape(Circle())
     }
-    .buttonStyle(.plain)
+    .buttonStyle(ChatComposerActionStyle(isBusy: isStopping))
     // Never `.disabled` on an empty field: `⌘⏎` is this button's `keyboardShortcut`, and a disabled
     // button swallows it — the key would stop resolving through `QueryShellSubmission` at all.
     // Dimmed instead, which is what "nothing to send yet" actually looks like.
-    .opacity(isProminent ? 1 : 0.4)
+    .opacity(isProminent || isStopping ? 1 : 0.4)
     .animation(InkReduceMotion.animation(.easeOut(duration: InkMotion.press)), value: isProminent)
   }
 

--- a/desktop/macos/Desktop/Tests/ChatProseRenderCacheTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatProseRenderCacheTests.swift
@@ -97,7 +97,7 @@ final class ChatProseRenderCacheTests: XCTestCase {
 
   func testEvictionHoldsTheBoundAndTurnsOldestKeysOver() {
     beginFresh()
-    let capacity = 192
+    let capacity = ChatProseRenderCache.maximumEntries
     var produced = Set<String>()
     func produce(_ text: String) -> NSAttributedString {
       produced.insert(text)
@@ -126,6 +126,23 @@ final class ChatProseRenderCacheTests: XCTestCase {
     XCTAssertTrue(produced.isEmpty, "a recently inserted key must not be evicted by later inserts")
     XCTAssertNotNil(newest)
     XCTAssertEqual(ChatProseRenderCache.entryCount, capacity)
+  }
+
+  func testExpandedTranscriptStaysWarmAcrossStreamingFrames() {
+    beginFresh()
+    var productions = 0
+    for frame in 0..<8 {
+      for row in 0..<500 {
+        _ = ChatProseRenderCache.entry(for: Self.key(markdown: "settled row \(row)")) {
+          productions += 1
+          return NSAttributedString(string: "settled row \(row)")
+        }
+      }
+      _ = ChatProseRenderCache.entry(for: Self.key(markdown: "stream frame \(frame)")) {
+        NSAttributedString(string: "stream frame \(frame)")
+      }
+    }
+    XCTAssertEqual(productions, 500, "Streaming must not evict and reparse the mounted history")
   }
 
   // MARK: - Height memo

--- a/desktop/macos/Desktop/Tests/ChatRenderLRUTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatRenderLRUTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ChatRenderLRUTests: XCTestCase {
+  func testHitPromotesEntryAndEvictsOnlyLeastRecentlyUsed() {
+    let cache = ChatRenderLRU<String, String>(capacity: 2)
+    XCTAssertEqual(cache.value(for: "a") { "A" }, "A")
+    XCTAssertEqual(cache.value(for: "b") { "B" }, "B")
+    XCTAssertEqual(
+      cache.value(for: "a") {
+        XCTFail("must hit")
+        return nil
+      }, "A")
+    XCTAssertEqual(cache.value(for: "c") { "C" }, "C")
+    XCTAssertEqual(cache.count, 2)
+    XCTAssertNil(cache.value(for: "b") { nil })
+    XCTAssertEqual(cache.value(for: "a") { nil }, "A")
+    XCTAssertEqual(cache.value(for: "c") { nil }, "C")
+  }
+
+  func testSingleEntryReplacementAndClearReleaseValues() {
+    final class Value {}
+    let cache = ChatRenderLRU<Int, Value>(capacity: 1)
+    weak var first: Value?
+    first = cache.value(for: 1) { Value() }
+    XCTAssertNotNil(first)
+    weak var second: Value?
+    second = cache.value(for: 2) { Value() }
+    XCTAssertNil(first)
+    XCTAssertNotNil(second)
+    cache.removeAll()
+    XCTAssertNil(second)
+    XCTAssertEqual(cache.count, 0)
+    XCTAssertNotNil(cache.value(for: 3) { Value() })
+  }
+
+  func testFailedProductionDoesNotEvictUsefulContent() {
+    let cache = ChatRenderLRU<Int, String>(capacity: 1)
+    _ = cache.value(for: 1) { "kept" }
+    XCTAssertNil(cache.value(for: 2) { nil })
+    XCTAssertEqual(cache.value(for: 1) { nil }, "kept")
+  }
+
+  func testCachedMarkdownMatchesParserAcrossPartialAndCompleteRichText() {
+    let answer = "A **bold** answer\n\n```swift\nlet x = 1\n```\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\n---\nDone."
+    for length in 0...answer.count {
+      let partial = String(answer.prefix(length))
+      XCTAssertEqual(ChatMarkdownRenderCache.document(for: partial), OmiMarkdownDocument(markdown: partial))
+      XCTAssertEqual(ChatMarkdownRenderCache.document(for: partial), OmiMarkdownDocument(markdown: partial))
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/QueryComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryComposerTests.swift
@@ -297,6 +297,26 @@ final class QueryComposerTests: XCTestCase {
     XCTAssertEqual(QueryShellSubmit.resolve(text: "  "), .none)
   }
 
+  func testSendStopAndStoppingKeepTheDraftAndComposerGeometry() throws {
+    for mode in [QueryShellMode.answer, .results] {
+      let composer = try Composer(mode: mode)
+      defer { composer.tearDown() }
+      composer.type("A draft for the next question\nwith a second line")
+      let draft = composer.visibleText
+      let height = composer.barHeight
+      composer.surface.isWorking = true
+      XCTAssertEqual(composer.visibleText, draft)
+      XCTAssertEqual(composer.barHeight, height, accuracy: 0.5)
+      composer.surface.isStopping = true
+      XCTAssertEqual(composer.visibleText, draft)
+      XCTAssertEqual(composer.barHeight, height, accuracy: 0.5)
+      composer.surface.isStopping = false
+      composer.surface.isWorking = false
+      XCTAssertEqual(composer.visibleText, draft)
+      XCTAssertEqual(composer.barHeight, height, accuracy: 0.5)
+    }
+  }
+
   // MARK: - Harness
 
   /// The real `QueryHeroBar` over the real `ChatComposerDraft`, in a window, with the `NSTextView`
@@ -468,7 +488,8 @@ final class QueryComposerTests: XCTestCase {
         QueryHeroBar(
           text: draft,
           caretClaim: surface.caretClaims,
-          isWorking: false,
+          isWorking: surface.isWorking,
+          isStopping: surface.isStopping,
           mode: mode,
           onAsk: { surface.asks += 1 }
         )
@@ -494,6 +515,8 @@ final class QueryComposerTests: XCTestCase {
   @MainActor
   private final class Surface: ObservableObject {
     @Published var caretClaims = 0
+    @Published var isWorking = false
+    @Published var isStopping = false
     var asks = 0
   }
 }

--- a/desktop/macos/changelog/unreleased/20260907-chat-response-polish.json
+++ b/desktop/macos/changelog/unreleased/20260907-chat-response-polish.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat responsiveness with reusable Markdown rendering and a more compact composer with consistent Send and Stop controls"
+}

--- a/desktop/macos/e2e/flows/chat-first-cohesive.yaml
+++ b/desktop/macos/e2e/flows/chat-first-cohesive.yaml
@@ -48,6 +48,7 @@ covers:
   # The prose parse and measured height this file caches are exercised by the
   # same mounts the flow drives; the cache changes no visible behaviour.
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatProseRenderCache.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatRenderLRU.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/StableChatCardHeader.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatConversationReferencePill.swift
   # S8 drives the Tasks-page closure, including its bounded attempt/terminal telemetry.


### PR DESCRIPTION
## What changed and why

Long transcripts repeatedly evicted rendered prose and reparsed unchanged Markdown as chat updated. Cache immutable Markdown at the rendering boundary and use constant-time LRU bookkeeping with room for the 500-row transcript window. The prose cache grows from 192 to 1,024 entries, trading bounded additional memory for fewer repeated parses. Unify Send/Stop controls across chat composers, reduce nested chrome and spacing, and keep the stopping indicator and draft geometry stable.

## Product invariants affected

INV-CHAT-1. Existing streaming reveal and reader-controlled scrolling behavior is preserved.

## How it was verified

- Native mounted chat/composer views visually inspected with synthetic settled, streaming, and stopping states. Scroll/streaming/cache focused run: 54 tests passed, including 21 transcript gesture tests. Expanded cache/composer/shell/drift run: 86 passed.
- Isolated optimized render-cache benchmark, 500 rows across eight passes: 4,000 to 500 Markdown parses; 3.09s to 0.40s. This measures the cache workload, not end-to-end app latency.
- Cross-surface smoke passed, including 72 Swift tests and Node/Python contracts. Desktop Python tests: 240 passed. Launcher/formatter fixture checks passed; worktree fixtures used the approved scratch root.
- Named ad-hoc dev bundle built and launched. Development health returned 200; API and auth routing explicitly target development. Authenticated dev-provider chat was not exercised because no usable dev session was available.
- Broad Swift verification: all 801 parallel suites passed; all 22 auth/state suites passed via the same runner in separate processes with fresh runtime homes. The full wrapper stopped on a transient build-cache copy race after 804 passes; the entire serial group was completed separately, with one build-lock collision retried after the push compile finished. No test assertion failures remained.
- Final composer run: 18 passed; final native visual probe passed. `OMI_PR_BODY_FILE=/tmp/omi-chat-polish-pr.md make preflight`: all 24 checks passed. Required pre-push checks and desktop debug compilation passed; formatting and SwiftLint passed.

## Tests

Added regression coverage for 500-row cache reuse, LRU eviction and release, partial rich Markdown equivalence, and draft/geometry preservation through Send/Stop/Stopping. Existing mounted gesture tests cover reading older messages during streaming, following the live edge, and preserving anchors while loading history.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

