### PR TITLE
fix(firmware): sleep idle button and SD workers until events or deadlines

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: firmware-idle-wake-tests
+    command: ["bash", "omi/firmware/omi/tests/host/run.sh"]
+    triggers: ["omi/firmware/omi/src/lib/core/button*", "omi/firmware/omi/src/lib/core/sd_worker_wait.h", "omi/firmware/omi/src/sd_card.c", "omi/firmware/omi/tests/host/**", "omi/firmware/omi/CMakeLists.txt"]
+    lanes: ["local", "ci"]
+    reason: "shipped button work woke every 40ms and measured holds in worker ticks; SD queue polling delayed priority requests and woke idle storage every 50/250ms. Exercise production deadline and queue ownership with a controllable clock and kernel seam"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/omi/firmware/AGENTS.md
+++ b/omi/firmware/AGENTS.md
@@ -18,24 +18,5 @@ C/C++ files: `clang-format -i <files>` (the repo pre-commit hook covers this).
 
 ## Local verification
 
-Run `bash omi/firmware/omi/tests/host/run.sh` from the repository root for the
-button edge/deadline controller and SD worker queue/wait contract tests. They
-compile production code against a controllable host kernel seam with ASan and
-UBSan, requiring a C compiler; the existing checks manifest runs them locally
-and in CI. This verifies timing, idle scheduling, and queue wakeup behavior,
-not Zephyr integration or physical battery consumption.
-
-The button retains GPIO edge timestamps while the system workqueue is busy,
-uses 40 ms debounce, and schedules only active gesture deadlines (300 ms tap,
-600 ms release-to-release double window, 3 s hold). A single tap is decided at
-300 ms after press unless a second press is underway; release follows after
-40 ms. An idle released button has no timer. SD request producers notify a
-shared semaphore after publication; the worker checks the connect-flush flag,
-priority queue, inactivity flush deadline, then normal writes. Keep all queue
-puts routed through `enqueue_sd_request` so neither queue can strand an idle
-worker. Power-off write draining and remount sequencing remain owned by
-`sd_card.c`.
-
-Use the NCS 2.9.0 sysbuild lane above for target compilation. Hardware validation
-must separately measure idle/AAD-sleep current and exercise button gestures,
-recording/sync, and SD sleep/wake with buffered audio before release.
+Run `bash omi/firmware/omi/tests/host/run.sh` for the sanitized host timing and
+queue tests. See [test scope and hardware checks](omi/tests/host/README.md).

--- a/omi/firmware/AGENTS.md
+++ b/omi/firmware/AGENTS.md
@@ -15,3 +15,27 @@ Build logic lives in `omi/firmware/scripts/ci/`.
 ## Formatting
 
 C/C++ files: `clang-format -i <files>` (the repo pre-commit hook covers this).
+
+## Local verification
+
+Run `bash omi/firmware/omi/tests/host/run.sh` from the repository root for the
+button edge/deadline controller and SD worker queue/wait contract tests. They
+compile production code against a controllable host kernel seam with ASan and
+UBSan, requiring a C compiler; the existing checks manifest runs them locally
+and in CI. This verifies timing, idle scheduling, and queue wakeup behavior,
+not Zephyr integration or physical battery consumption.
+
+The button retains GPIO edge timestamps while the system workqueue is busy,
+uses 40 ms debounce, and schedules only active gesture deadlines (300 ms tap,
+600 ms release-to-release double window, 3 s hold). A single tap is decided at
+300 ms after press unless a second press is underway; release follows after
+40 ms. An idle released button has no timer. SD request producers notify a
+shared semaphore after publication; the worker checks the connect-flush flag,
+priority queue, inactivity flush deadline, then normal writes. Keep all queue
+puts routed through `enqueue_sd_request` so neither queue can strand an idle
+worker. Power-off write draining and remount sequencing remain owned by
+`sd_card.c`.
+
+Use the NCS 2.9.0 sysbuild lane above for target compilation. Hardware validation
+must separately measure idle/AAD-sleep current and exercise button gestures,
+recording/sync, and SD sleep/wake with buffered audio before release.

--- a/omi/firmware/omi/CMakeLists.txt
+++ b/omi/firmware/omi/CMakeLists.txt
@@ -28,6 +28,7 @@ file(GLOB core_sources
     src/lib/core/codec.c
     src/lib/core/transport.c
     src/lib/core/button.c
+    src/lib/core/button_input.c
     src/lib/core/monitor.c
 )
 

--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -12,6 +12,7 @@
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/poweroff.h>
 
+#include "button_input.h"
 #include "haptic.h"
 #include "imu.h"
 #include "led.h"
@@ -65,45 +66,12 @@ static void button_ccc_config_changed_handler(const struct bt_gatt_attr *attr, u
 static const struct device *const buttons = DEVICE_DT_GET(DT_ALIAS(buttons));
 static const struct gpio_dt_spec usr_btn = GPIO_DT_SPEC_GET_OR(DT_NODELABEL(usr_btn), gpios, {0});
 
-static bool was_pressed = false;
-
-// Using GPIO callback due to the lower priority of the input subsystem vs. storage.c's thread that prevents the
-// callback from working properly.
-#define BUTTON_CHECK_INTERVAL 40 // 0.04 seconds, 25 Hz
-
-void check_button_level(struct k_work *work_item);
-
-K_WORK_DELAYABLE_DEFINE(button_work, check_button_level);
-
-#define DEFAULT_STATE 0
 #define SINGLE_TAP 1
 #define DOUBLE_TAP 2
-#define LONG_TAP 3
-#define BUTTON_PRESS 4
 #define BUTTON_RELEASE 5
 
-// 4 is button down, 5 is button up
 static FSM_STATE_T current_button_state = IDLE;
-static uint32_t inc_count_1 = 0;
-static uint32_t inc_count_0 = 0;
-
 static int final_button_state[2] = {0, 0};
-const static int threshold = 10;
-
-static void reset_count()
-{
-    inc_count_0 = 0;
-    inc_count_1 = 0;
-}
-static inline void notify_press()
-{
-    final_button_state[0] = BUTTON_PRESS;
-    LOG_INF("Button pressed");
-    struct bt_conn *conn = get_current_connection();
-    if (conn != NULL) {
-        bt_gatt_notify(conn, &button_service.attrs[1], &final_button_state, sizeof(final_button_state));
-    }
-}
 
 static inline void notify_unpress()
 {
@@ -135,125 +103,23 @@ static inline void notify_double_tap()
     }
 }
 
-static inline void notify_long_tap()
+static void handle_button_event(enum button_input_event event)
 {
-    final_button_state[0] = LONG_TAP; // button press
-    LOG_INF("Button long tap");
-    struct bt_conn *conn = get_current_connection();
-    if (conn != NULL) {
-        bt_gatt_notify(conn, &button_service.attrs[1], &final_button_state, sizeof(final_button_state));
-    }
-}
-
-#define BUTTON_PRESSED 1
-#define BUTTON_RELEASED 0
-
-#define TAP_THRESHOLD 300     // 300 ms for single tap
-#define DOUBLE_TAP_WINDOW 600 // 600 ms maximum for double-tap
-#define LONG_PRESS_TIME 3000  // 3000 ms for long press (power off)
-
-typedef enum {
-    BUTTON_EVENT_NONE,
-    BUTTON_EVENT_SINGLE_TAP,
-    BUTTON_EVENT_DOUBLE_TAP,
-    BUTTON_EVENT_LONG_PRESS,
-    BUTTON_EVENT_RELEASE
-} ButtonEvent;
-
-static uint32_t current_time = 0;
-static uint32_t btn_press_start_time;
-static uint32_t btn_release_time;
-static uint32_t btn_last_tap_time;
-static bool btn_is_pressed;
-
-static u_int8_t btn_last_event = BUTTON_EVENT_NONE;
-
-void check_button_level(struct k_work *work_item)
-{
-    current_time = current_time + 1;
-
-    u_int8_t btn_state = was_pressed ? BUTTON_PRESSED : BUTTON_RELEASED;
-
-    ButtonEvent event = BUTTON_EVENT_NONE;
-
-    // Debouncing pressed state
-    if (btn_state == BUTTON_PRESSED && !btn_is_pressed) {
-        btn_is_pressed = true;
-        btn_press_start_time = current_time;
-    } else if (btn_state == BUTTON_RELEASED && btn_is_pressed) {
-        btn_is_pressed = false;
-        btn_release_time = current_time;
-
-        // Check for double tap
-        uint32_t press_duration = (btn_release_time - btn_press_start_time) * BUTTON_CHECK_INTERVAL;
-        if (press_duration < TAP_THRESHOLD) {
-            if (btn_last_tap_time > 0 &&
-                (current_time - btn_last_tap_time) * BUTTON_CHECK_INTERVAL < DOUBLE_TAP_WINDOW) {
-                event = BUTTON_EVENT_DOUBLE_TAP;
-                btn_last_tap_time = 0; // Reset double-tap / single-tap detection
-            } else {
-                btn_last_tap_time = current_time;
-            }
-        }
-    }
-
-    // Check for single tap
-    if (btn_state == BUTTON_RELEASED && !btn_is_pressed) {
-        uint32_t press_duration = (btn_release_time - btn_press_start_time) * BUTTON_CHECK_INTERVAL;
-        if (press_duration < TAP_THRESHOLD && btn_last_tap_time > 0 &&
-            (current_time - btn_press_start_time) * BUTTON_CHECK_INTERVAL > TAP_THRESHOLD) {
-            event = BUTTON_EVENT_SINGLE_TAP;
-            btn_last_tap_time = 0;
-        } else if ((current_time - btn_press_start_time) * BUTTON_CHECK_INTERVAL > TAP_THRESHOLD) {
-            event = BUTTON_EVENT_RELEASE;
-        }
-    }
-
-    // Check for long press
-    if (btn_is_pressed && (current_time - btn_press_start_time) * BUTTON_CHECK_INTERVAL >= LONG_PRESS_TIME) {
-        event = BUTTON_EVENT_LONG_PRESS;
-    }
-
-    // Single tap
-    if (event == BUTTON_EVENT_SINGLE_TAP) {
-        LOG_INF("single tap detected\n");
-        btn_last_event = event;
-
+    switch (event) {
+    case BUTTON_INPUT_SINGLE:
         notify_tap();
-    }
-
-    // Double tap
-    if (event == BUTTON_EVENT_DOUBLE_TAP) {
-        LOG_INF("double tap detected\n");
-        btn_last_event = event;
+        break;
+    case BUTTON_INPUT_DOUBLE:
         notify_double_tap();
-    }
-
-    // Long press, one time event
-    if (event == BUTTON_EVENT_LONG_PRESS && btn_last_event != BUTTON_EVENT_LONG_PRESS) {
-        LOG_INF("long press detected\n");
-        btn_last_event = event;
+        break;
+    case BUTTON_INPUT_LONG:
         turnoff_all();
-    }
-
-    // Releases, one time event
-    if (event == BUTTON_EVENT_RELEASE && btn_last_event != BUTTON_EVENT_RELEASE) {
-        LOG_PRINTK("release detected\n");
-        btn_last_event = event;
+        break;
+    case BUTTON_INPUT_RELEASE:
         notify_unpress();
-
-        // Reset
-        current_time = 0;
-        btn_press_start_time = 0;
-        btn_release_time = 0;
-        btn_last_tap_time = 0;
-    }
-    if (event == BUTTON_EVENT_RELEASE) {
         current_button_state = GRACE;
+        break;
     }
-
-    k_work_reschedule(&button_work, K_MSEC(BUTTON_CHECK_INTERVAL));
-    return 0;
 }
 
 static ssize_t button_data_read_characteristic(struct bt_conn *conn,
@@ -271,8 +137,10 @@ static struct gpio_callback button_cb_data;
 
 static void button_gpio_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
-    was_pressed = (gpio_pin_get_dt(&usr_btn) == 1);
-    LOG_INF("Button %s (GPIO callback)", was_pressed ? "pressed" : "released");
+    int level = gpio_pin_get_dt(&usr_btn);
+    if (level >= 0) {
+        button_input_edge(level == 1);
+    }
 }
 
 int button_regist_callback()
@@ -329,9 +197,14 @@ int button_init()
     return 0;
 }
 
+static int read_button_level(void)
+{
+    return gpio_pin_get_dt(&usr_btn);
+}
+
 void activate_button_work()
 {
-    k_work_schedule(&button_work, K_MSEC(BUTTON_CHECK_INTERVAL));
+    button_input_start(handle_button_event, read_button_level);
 }
 
 void register_button_service()

--- a/omi/firmware/omi/src/lib/core/button_input.c
+++ b/omi/firmware/omi/src/lib/core/button_input.c
@@ -1,0 +1,181 @@
+#include "button_input.h"
+
+#include <stdint.h>
+#include <zephyr/kernel.h>
+
+#define DEBOUNCE_MS 40
+#define TAP_MS 300
+#define DOUBLE_MS 600
+#define LONG_MS 3000
+#define EDGE_CAPACITY 32
+#define NO_DEADLINE INT64_MAX
+
+struct button_edge {
+    int64_t at;
+    bool pressed;
+};
+
+static struct {
+    bool raw_pressed;
+    bool pressed;
+    bool tap_pending;
+    bool release_pending;
+    bool long_reported;
+    int64_t raw_since;
+    int64_t pressed_at;
+    int64_t last_tap_at;
+    int64_t release_at;
+} gesture;
+
+static struct k_spinlock input_lock;
+static struct button_edge edges[EDGE_CAPACITY];
+static unsigned edge_count;
+static bool overflowed;
+static bool started;
+static int64_t work_at = NO_DEADLINE;
+static void (*notify_event)(enum button_input_event);
+
+/* The lock covers edge capture, deadline selection and scheduling. Notifications
+ * happen after unlocking: Bluetooth and shutdown may block for a long time. */
+static enum button_input_event events[EDGE_CAPACITY * 2 + 2];
+static unsigned event_count;
+
+static void emit(enum button_input_event event)
+{
+    events[event_count++] = event;
+}
+
+static int64_t next_deadline(void)
+{
+    if (gesture.raw_pressed != gesture.pressed) {
+        return gesture.raw_since + DEBOUNCE_MS;
+    }
+    if (gesture.pressed) {
+        return gesture.long_reported ? NO_DEADLINE : gesture.pressed_at + LONG_MS;
+    }
+    return gesture.release_pending ? gesture.release_at : NO_DEADLINE;
+}
+
+static void advance(int64_t now)
+{
+    int64_t deadline;
+    while ((deadline = next_deadline()) != NO_DEADLINE && deadline <= now) {
+        if (gesture.raw_pressed != gesture.pressed) {
+            gesture.pressed = gesture.raw_pressed;
+            if (gesture.pressed) {
+                gesture.pressed_at = gesture.raw_since;
+                gesture.long_reported = false;
+            } else {
+                int64_t duration = gesture.raw_since - gesture.pressed_at;
+                gesture.release_pending = true;
+                gesture.release_at = gesture.pressed_at + TAP_MS;
+                if (duration < TAP_MS) {
+                    if (gesture.tap_pending && gesture.raw_since - gesture.last_tap_at < DOUBLE_MS) {
+                        emit(BUTTON_INPUT_DOUBLE);
+                        gesture.tap_pending = false;
+                    } else {
+                        gesture.tap_pending = true;
+                        gesture.last_tap_at = gesture.raw_since;
+                    }
+                } else {
+                    gesture.tap_pending = false;
+                }
+                /* A deadline cannot precede the release becoming stable. */
+                if (gesture.release_at < deadline) {
+                    gesture.release_at = deadline;
+                }
+            }
+        } else if (gesture.pressed) {
+            emit(BUTTON_INPUT_LONG);
+            gesture.long_reported = true;
+        } else if (gesture.tap_pending) {
+            emit(BUTTON_INPUT_SINGLE);
+            gesture.tap_pending = false;
+            gesture.release_at = deadline + DEBOUNCE_MS;
+        } else {
+            emit(BUTTON_INPUT_RELEASE);
+            gesture.release_pending = false;
+        }
+    }
+}
+
+static void reset_gesture(bool pressed, int64_t now)
+{
+    gesture = (typeof(gesture)) {.raw_pressed = pressed, .raw_since = now};
+}
+
+static void process_input(struct k_work *work);
+K_WORK_DELAYABLE_DEFINE(input_work, process_input);
+
+static void process_input(struct k_work *work)
+{
+    ARG_UNUSED(work);
+    k_spinlock_key_t key = k_spin_lock(&input_lock);
+    work_at = NO_DEADLINE;
+    event_count = 0;
+    if (overflowed) {
+        /* Excessive bounce must not turn a dropped release into a power-off.
+         * Restart from the latest physical level, without inventing a tap. */
+        reset_gesture(edges[edge_count - 1].pressed, edges[edge_count - 1].at);
+        overflowed = false;
+    } else {
+        for (unsigned i = 0; i < edge_count; ++i) {
+            advance(edges[i].at);
+            if (gesture.raw_pressed != edges[i].pressed) {
+                gesture.raw_pressed = edges[i].pressed;
+                gesture.raw_since = edges[i].at;
+            }
+        }
+    }
+    edge_count = 0;
+    int64_t now = k_uptime_get();
+    advance(now);
+    int64_t deadline = next_deadline();
+    if (deadline != NO_DEADLINE) {
+        work_at = deadline;
+        k_work_reschedule(&input_work, K_MSEC(deadline - now));
+    }
+    k_spin_unlock(&input_lock, key);
+
+    for (unsigned i = 0; i < event_count; ++i) {
+        notify_event(events[i]);
+    }
+}
+
+void button_input_start(void (*notify)(enum button_input_event), int (*read_level)(void))
+{
+    k_spinlock_key_t key = k_spin_lock(&input_lock);
+    if (!started) {
+        notify_event = notify;
+        started = true;
+        /* Sample under the same lock as ISR capture: an edge between an initial
+         * GPIO read and enabling capture must not strand a stale held level. */
+        bool pressed = read_level() == 1;
+        reset_gesture(pressed, k_uptime_get());
+        if (pressed) {
+            work_at = k_uptime_get() + DEBOUNCE_MS;
+            k_work_reschedule(&input_work, K_MSEC(DEBOUNCE_MS));
+        }
+    }
+    k_spin_unlock(&input_lock, key);
+}
+
+void button_input_edge(bool pressed)
+{
+    k_spinlock_key_t key = k_spin_lock(&input_lock);
+    if (started) {
+        if (edge_count == EDGE_CAPACITY) {
+            overflowed = true;
+            --edge_count;
+        }
+        int64_t now = k_uptime_get();
+        edges[edge_count++] = (struct button_edge) {.at = now, .pressed = pressed};
+        /* Bring a distant hold deadline forward for a release, but preserve an
+         * earlier deadline and bound wakeups during bouncing edges. */
+        if (now + DEBOUNCE_MS < work_at) {
+            work_at = now + DEBOUNCE_MS;
+            k_work_reschedule(&input_work, K_MSEC(DEBOUNCE_MS));
+        }
+    }
+    k_spin_unlock(&input_lock, key);
+}

--- a/omi/firmware/omi/src/lib/core/button_input.c
+++ b/omi/firmware/omi/src/lib/core/button_input.c
@@ -103,7 +103,7 @@ static void advance(int64_t now)
 
 static void reset_gesture(bool pressed, int64_t now)
 {
-    gesture = (struct button_gesture) {.raw_pressed = pressed, .raw_since = now};
+    gesture = (struct button_gesture){.raw_pressed = pressed, .raw_since = now};
 }
 
 static void process_input(struct k_work *work);
@@ -171,7 +171,7 @@ void button_input_edge(bool pressed)
             --edge_count;
         }
         int64_t now = k_uptime_get();
-        edges[edge_count++] = (struct button_edge) {.at = now, .pressed = pressed};
+        edges[edge_count++] = (struct button_edge){.at = now, .pressed = pressed};
         /* Bring a distant hold deadline forward for a release, but preserve an
          * earlier deadline and bound wakeups during bouncing edges. */
         if (now + DEBOUNCE_MS < work_at) {

--- a/omi/firmware/omi/src/lib/core/button_input.c
+++ b/omi/firmware/omi/src/lib/core/button_input.c
@@ -15,7 +15,7 @@ struct button_edge {
     bool pressed;
 };
 
-static struct {
+struct button_gesture {
     bool raw_pressed;
     bool pressed;
     bool tap_pending;
@@ -25,7 +25,9 @@ static struct {
     int64_t pressed_at;
     int64_t last_tap_at;
     int64_t release_at;
-} gesture;
+};
+
+static struct button_gesture gesture;
 
 static struct k_spinlock input_lock;
 static struct button_edge edges[EDGE_CAPACITY];
@@ -101,7 +103,7 @@ static void advance(int64_t now)
 
 static void reset_gesture(bool pressed, int64_t now)
 {
-    gesture = (typeof(gesture)) {.raw_pressed = pressed, .raw_since = now};
+    gesture = (struct button_gesture) {.raw_pressed = pressed, .raw_since = now};
 }
 
 static void process_input(struct k_work *work);

--- a/omi/firmware/omi/src/lib/core/button_input.h
+++ b/omi/firmware/omi/src/lib/core/button_input.h
@@ -1,0 +1,12 @@
+#ifndef OMI_BUTTON_INPUT_H
+#define OMI_BUTTON_INPUT_H
+
+#include <stdbool.h>
+
+enum button_input_event { BUTTON_INPUT_SINGLE, BUTTON_INPUT_DOUBLE, BUTTON_INPUT_LONG, BUTTON_INPUT_RELEASE };
+
+/* Events are delivered in workqueue context; edge capture is safe in the GPIO ISR. */
+void button_input_start(void (*notify)(enum button_input_event), int (*read_level)(void));
+void button_input_edge(bool pressed);
+
+#endif

--- a/omi/firmware/omi/src/lib/core/sd_worker_wait.h
+++ b/omi/firmware/omi/src/lib/core/sd_worker_wait.h
@@ -1,0 +1,56 @@
+#ifndef OMI_SD_WORKER_WAIT_H
+#define OMI_SD_WORKER_WAIT_H
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/atomic.h>
+
+enum sd_worker_event { SD_WORKER_REQUEST, SD_WORKER_FLUSH_DUE, SD_WORKER_CONNECT_FLUSH };
+
+/* A binary notification covers both queues and the out-of-band connect flush.
+ * Give after publishing: an arrival between the empty checks and the wait is
+ * retained by the semaphore. Queue contents remain the authority for ordering. */
+static inline int sd_worker_enqueue(struct k_msgq *queue, const void *request, k_timeout_t timeout, struct k_sem *wake)
+{
+    int ret = k_msgq_put(queue, request, timeout);
+    if (ret == 0) {
+        k_sem_give(wake);
+    }
+    return ret;
+}
+
+static inline enum sd_worker_event sd_worker_next(struct k_msgq *priority,
+                                                  struct k_msgq *normal,
+                                                  struct k_sem *wake,
+                                                  atomic_t *connect_flush,
+                                                  void *request,
+                                                  int64_t flush_at)
+{
+    for (;;) {
+        if (atomic_cas(connect_flush, 1, 0)) {
+            return SD_WORKER_CONNECT_FLUSH;
+        }
+        if (k_msgq_get(priority, request, K_NO_WAIT) == 0) {
+            return SD_WORKER_REQUEST;
+        }
+        int64_t remaining = flush_at < 0 ? -1 : flush_at - k_uptime_get();
+        if (flush_at >= 0 && remaining <= 0) {
+            return SD_WORKER_FLUSH_DUE;
+        }
+        if (k_msgq_get(normal, request, K_NO_WAIT) == 0) {
+            return SD_WORKER_REQUEST;
+        }
+        (void) k_sem_take(wake, flush_at < 0 ? K_FOREVER : K_MSEC(remaining));
+    }
+}
+
+static inline int64_t
+sd_worker_flush_deadline(bool mounted, bool dirty, int64_t last_activity, int64_t retry_at, int64_t interval)
+{
+    if (!mounted || !dirty) {
+        return -1;
+    }
+    int64_t deadline = last_activity + interval;
+    return deadline > retry_at ? deadline : retry_at;
+}
+
+#endif

--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -13,6 +13,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
 
+#include "lib/core/sd_worker_wait.h"
 #include "rtc.h"
 
 LOG_MODULE_REGISTER(sd_card, CONFIG_LOG_DEFAULT_LEVEL);
@@ -149,6 +150,12 @@ static const struct gpio_dt_spec sd_en = GPIO_DT_SPEC_GET_OR(DT_NODELABEL(sdcard
 
 K_MSGQ_DEFINE(sd_msgq, sizeof(sd_req_t), SD_REQ_QUEUE_MSGS, 4);
 K_MSGQ_DEFINE(sd_prio_msgq, sizeof(sd_req_t), SD_PRIO_QUEUE_MSGS, 4);
+K_SEM_DEFINE(sd_worker_wake, 0, 1);
+
+static int enqueue_sd_request(struct k_msgq *queue, const sd_req_t *request, k_timeout_t timeout)
+{
+    return sd_worker_enqueue(queue, request, timeout, &sd_worker_wake);
+}
 
 #define SD_WORKER_STACK_SIZE 8192
 #define SD_WORKER_PRIORITY 7
@@ -911,6 +918,7 @@ static int get_packet_name_for_seq(uint64_t seq, char *buf, size_t buf_size)
 void sd_worker_thread(void)
 {
     sd_req_t req;
+    int64_t flush_retry_at = 0;
 
     int res = sd_mount();
     if (res != 0) {
@@ -924,27 +932,23 @@ void sd_worker_thread(void)
     sd_set_io_low_power(true);
 
     while (1) {
-        if (atomic_cas(&pending_flush_on_ble_connect, 1, 0)) {
+        int64_t flush_at = sd_worker_flush_deadline(
+            is_mounted, current_batch_dirty, last_batch_activity_ms, flush_retry_at, RAW_FLUSH_INTERVAL_MS);
+        enum sd_worker_event event =
+            sd_worker_next(&sd_prio_msgq, &sd_msgq, &sd_worker_wake, &pending_flush_on_ble_connect, &req, flush_at);
+        if (event == SD_WORKER_CONNECT_FLUSH) {
             req.type = REQ_FLUSH;
             req.u.status.resp = NULL;
-            goto handle_req;
-        }
-
-        if (k_msgq_get(&sd_prio_msgq, &req, K_NO_WAIT) == 0) {
-            goto handle_req;
-        }
-
-        k_timeout_t write_wait = ble_connected ? K_MSEC(50) : K_MSEC(250);
-        if (k_msgq_get(&sd_msgq, &req, write_wait) != 0) {
-            if (current_batch_dirty && (k_uptime_get() - last_batch_activity_ms) >= RAW_FLUSH_INTERVAL_MS) {
-                sd_set_io_low_power(false);
-                (void) flush_current_batch(false);
-                sd_set_io_low_power(true);
-            }
+        } else if (event == SD_WORKER_FLUSH_DUE) {
+            sd_set_io_low_power(false);
+            int ret = flush_current_batch(false);
+            sd_set_io_low_power(true);
+            /* A failed flush leaves the batch dirty. Retry after an interval,
+             * rather than spinning on an already-expired deadline. */
+            flush_retry_at = ret < 0 ? k_uptime_get() + RAW_FLUSH_INTERVAL_MS : 0;
             continue;
         }
 
-    handle_req:
         if (req.type != REQ_WRITE_DATA) {
             sd_set_io_low_power(false);
         }
@@ -1120,7 +1124,7 @@ int app_sd_off(void)
         req.type = REQ_UNMOUNT;
         req.u.status.resp = &resp;
 
-        int qret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(2000));
+        int qret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(2000));
         if (qret == 0) {
             if (k_sem_take(&resp.sem, K_MSEC(45000)) == 0 && resp.res >= 0) {
                 unmount_completed = true;
@@ -1179,7 +1183,7 @@ void sd_request_power(bool on)
     /* Queue with a timeout and check the result (like the other prio-queue
      * callers). A silently dropped REQ_POWER_ON would leave sd_enabled=true with
      * no remount -> subsequent writes lost. */
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         LOG_ERR("sd_request_power(%s) failed to queue: %d", on ? "on" : "off", ret);
         return;
@@ -1206,9 +1210,10 @@ void sd_notify_ble_state(bool connected)
         sd_req_t req = {0};
         req.type = REQ_FLUSH;
         req.u.status.resp = NULL;
-        int ret = k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
+        int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_NO_WAIT);
         if (ret != 0) {
             atomic_set(&pending_flush_on_ble_connect, 1);
+            k_sem_give(&sd_worker_wake);
         }
     }
 
@@ -1257,9 +1262,9 @@ uint32_t write_to_file(uint8_t *data, uint32_t length)
     memcpy(req.u.write.buf, data, length);
     req.u.write.len = length;
 
-    int ret = k_msgq_put(&sd_msgq, &req, K_NO_WAIT);
+    int ret = enqueue_sd_request(&sd_msgq, &req, K_NO_WAIT);
     if (ret != 0) {
-        ret = k_msgq_put(&sd_msgq, &req, ble_connected ? K_MSEC(1) : K_MSEC(5));
+        ret = enqueue_sd_request(&sd_msgq, &req, ble_connected ? K_MSEC(1) : K_MSEC(5));
     }
 
     if (ret != 0) {
@@ -1299,7 +1304,7 @@ int sd_ring_get_info(sd_ring_info_t *info)
     req.type = REQ_GET_RING_INFO;
     req.u.info.resp = &resp;
 
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         resp.busy_flag = NULL;
         atomic_clear(&info_in_flight);
@@ -1340,7 +1345,7 @@ int sd_ring_read(uint64_t start_seq, uint8_t *buf, uint32_t max_bytes, uint32_t 
     req.u.read.out_buf = buf;
     req.u.read.resp = &resp;
 
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         resp.busy_flag = NULL;
         atomic_clear(&read_in_flight);
@@ -1374,7 +1379,7 @@ int sd_ring_advance(uint64_t new_read_seq)
     req.u.advance.new_read_seq = new_read_seq;
     req.u.advance.resp = &resp;
 
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         resp.busy_flag = NULL;
         atomic_clear(&advance_in_flight);
@@ -1399,7 +1404,7 @@ int sd_ring_advance_async(uint64_t new_read_seq)
     req.type = REQ_ADVANCE_READ;
     req.u.advance.new_read_seq = new_read_seq;
     req.u.advance.resp = NULL;
-    return k_msgq_put(&sd_prio_msgq, &req, K_NO_WAIT);
+    return enqueue_sd_request(&sd_prio_msgq, &req, K_NO_WAIT);
 }
 
 int sd_ring_clear(void)
@@ -1418,7 +1423,7 @@ int sd_ring_clear(void)
     req.type = REQ_CLEAR_RING;
     req.u.status.resp = &resp;
 
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         resp.busy_flag = NULL;
         atomic_clear(&clear_in_flight);
@@ -1449,7 +1454,7 @@ int sd_flush_current_file(void)
     req.type = REQ_FLUSH;
     req.u.status.resp = &resp;
 
-    int ret = k_msgq_put(&sd_prio_msgq, &req, K_MSEC(500));
+    int ret = enqueue_sd_request(&sd_prio_msgq, &req, K_MSEC(500));
     if (ret != 0) {
         resp.busy_flag = NULL;
         atomic_clear(&flush_in_flight);

--- a/omi/firmware/omi/tests/host/README.md
+++ b/omi/firmware/omi/tests/host/README.md
@@ -2,8 +2,8 @@
 
 Run `bash omi/firmware/omi/tests/host/run.sh` from the repository root for the
 button edge/deadline controller and SD worker queue/wait contract tests. They
-compile production code against a controllable host kernel seam with ASan and
-UBSan, requiring a C compiler; the existing checks manifest runs them locally
+compile production code as C99 (matching the NCS 2.9.0 target flags) against a
+controllable host kernel seam with ASan and UBSan, requiring a C compiler; the existing checks manifest runs them locally
 and in CI. This verifies timing, idle scheduling, and queue wakeup behavior,
 not Zephyr integration or physical battery consumption.
 

--- a/omi/firmware/omi/tests/host/README.md
+++ b/omi/firmware/omi/tests/host/README.md
@@ -18,6 +18,6 @@ puts routed through `enqueue_sd_request` so neither queue can strand an idle
 worker. Power-off write draining and remount sequencing remain owned by
 `sd_card.c`.
 
-Use the NCS 2.9.0 sysbuild lane above for target compilation. Hardware validation
-must separately measure idle/AAD-sleep current and exercise button gestures,
+Use the [NCS 2.9.0 sysbuild lane](../../../scripts/ci/README.md) for target
+compilation. Hardware validation must separately measure idle/AAD-sleep current and exercise button gestures,
 recording/sync, and SD sleep/wake with buffered audio before release.

--- a/omi/firmware/omi/tests/host/README.md
+++ b/omi/firmware/omi/tests/host/README.md
@@ -1,0 +1,23 @@
+# Firmware timing and queue tests
+
+Run `bash omi/firmware/omi/tests/host/run.sh` from the repository root for the
+button edge/deadline controller and SD worker queue/wait contract tests. They
+compile production code against a controllable host kernel seam with ASan and
+UBSan, requiring a C compiler; the existing checks manifest runs them locally
+and in CI. This verifies timing, idle scheduling, and queue wakeup behavior,
+not Zephyr integration or physical battery consumption.
+
+The button retains GPIO edge timestamps while the system workqueue is busy,
+uses 40 ms debounce, and schedules only active gesture deadlines (300 ms tap,
+600 ms release-to-release double window, 3 s hold). A single tap is decided at
+300 ms after press unless a second press is underway; release follows after
+40 ms. An idle released button has no timer. SD request producers notify a
+shared semaphore after publication; the worker checks the connect-flush flag,
+priority queue, inactivity flush deadline, then normal writes. Keep all queue
+puts routed through `enqueue_sd_request` so neither queue can strand an idle
+worker. Power-off write draining and remount sequencing remain owned by
+`sd_card.c`.
+
+Use the NCS 2.9.0 sysbuild lane above for target compilation. Hardware validation
+must separately measure idle/AAD-sleep current and exercise button gestures,
+recording/sync, and SD sleep/wake with buffered audio before release.

--- a/omi/firmware/omi/tests/host/include/zephyr/kernel.h
+++ b/omi/firmware/omi/tests/host/include/zephyr/kernel.h
@@ -1,0 +1,79 @@
+#ifndef TEST_ZEPHYR_KERNEL_H
+#define TEST_ZEPHYR_KERNEL_H
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef int64_t k_timeout_t;
+#define K_NO_WAIT 0
+#define K_FOREVER -1
+#define K_MSEC(ms) (ms)
+#define ARG_UNUSED(value) ((void) (value))
+struct k_work {
+    int unused;
+};
+struct k_work_delayable {
+    struct k_work work;
+    void (*handler)(struct k_work *);
+    int64_t due;
+};
+#define K_WORK_DELAYABLE_DEFINE(name, fn) struct k_work_delayable name = {.handler = fn, .due = INT64_MAX}
+struct k_spinlock {
+    int locked;
+};
+typedef int k_spinlock_key_t;
+static inline k_spinlock_key_t k_spin_lock(struct k_spinlock *lock)
+{
+    assert(!lock->locked);
+    lock->locked = 1;
+    return 0;
+}
+static inline void k_spin_unlock(struct k_spinlock *lock, k_spinlock_key_t key)
+{
+    (void) key;
+    assert(lock->locked);
+    lock->locked = 0;
+}
+extern int64_t fake_now;
+static inline int64_t k_uptime_get(void)
+{
+    return fake_now;
+}
+static inline int k_work_reschedule(struct k_work_delayable *work, k_timeout_t delay)
+{
+    assert(delay >= 0);
+    work->due = fake_now + delay;
+    return 1;
+}
+struct k_sem {
+    unsigned count;
+};
+struct k_msgq {
+    int items[16];
+    unsigned head, count;
+};
+static inline int k_msgq_put(struct k_msgq *q, const void *item, k_timeout_t timeout)
+{
+    (void) timeout;
+    if (q->count == 16)
+        return -ENOMSG;
+    q->items[(q->head + q->count++) % 16] = *(const int *) item;
+    return 0;
+}
+static inline int k_msgq_get(struct k_msgq *q, void *item, k_timeout_t timeout)
+{
+    assert(timeout == K_NO_WAIT);
+    if (!q->count)
+        return -ENOMSG;
+    *(int *) item = q->items[q->head++ % 16];
+    --q->count;
+    return 0;
+}
+static inline void k_sem_give(struct k_sem *sem)
+{
+    sem->count = 1;
+}
+int k_sem_take(struct k_sem *sem, k_timeout_t timeout);
+#endif

--- a/omi/firmware/omi/tests/host/include/zephyr/sys/atomic.h
+++ b/omi/firmware/omi/tests/host/include/zephyr/sys/atomic.h
@@ -1,0 +1,12 @@
+#ifndef TEST_ZEPHYR_ATOMIC_H
+#define TEST_ZEPHYR_ATOMIC_H
+#include <stdbool.h>
+typedef int atomic_t;
+static inline bool atomic_cas(atomic_t *value, int old, int next)
+{
+    if (*value != old)
+        return false;
+    *value = next;
+    return true;
+}
+#endif

--- a/omi/firmware/omi/tests/host/run.sh
+++ b/omi/firmware/omi/tests/host/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TEST_ROOT=$(cd "$(dirname "$0")" && pwd)
+TEST_BUILD=$(mktemp -d "${TMPDIR:-/tmp}/omi-firmware-host.XXXXXX")
+trap 'rm -rf "$TEST_BUILD"' EXIT
+for name in button_input sd_worker_wait; do
+    "${CC:-cc}" -std=gnu11 -Wall -Wextra -Werror -g \
+        -fsanitize=address,undefined -fno-omit-frame-pointer \
+        -I "$TEST_ROOT/include" "$TEST_ROOT/test_$name.c" -o "$TEST_BUILD/test_$name"
+    "$TEST_BUILD/test_$name"
+done

--- a/omi/firmware/omi/tests/host/run.sh
+++ b/omi/firmware/omi/tests/host/run.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 TEST_ROOT=$(cd "$(dirname "$0")" && pwd)
 TEST_BUILD=$(mktemp -d "${TMPDIR:-/tmp}/omi-firmware-host.XXXXXX")
 trap 'rm -rf "$TEST_BUILD"' EXIT
+# Match the NCS 2.9.0 application compile dialect (arm-zephyr-eabi-gcc -std=c99).
 for name in button_input sd_worker_wait; do
-    "${CC:-cc}" -std=gnu11 -Wall -Wextra -Werror -g \
+    "${CC:-cc}" -std=c99 -Wall -Wextra -Werror -g \
         -fsanitize=address,undefined -fno-omit-frame-pointer \
         -I "$TEST_ROOT/include" "$TEST_ROOT/test_$name.c" -o "$TEST_BUILD/test_$name"
     "$TEST_BUILD/test_$name"

--- a/omi/firmware/omi/tests/host/test_button_input.c
+++ b/omi/firmware/omi/tests/host/test_button_input.c
@@ -21,7 +21,7 @@ static void record_event(enum button_input_event event)
 
 static void reset(bool initially_pressed)
 {
-    gesture = (struct button_gesture) {0};
+    gesture = (struct button_gesture){0};
     input_work.due = INT64_MAX;
     work_at = NO_DEADLINE;
     edge_count = 0;

--- a/omi/firmware/omi/tests/host/test_button_input.c
+++ b/omi/firmware/omi/tests/host/test_button_input.c
@@ -1,0 +1,185 @@
+#include <stdio.h>
+
+#include "../../src/lib/core/button_input.c"
+
+int64_t fake_now;
+static enum button_input_event received[100];
+static unsigned received_count;
+static bool initial_level;
+
+static int read_level(void)
+{
+    assert(input_lock.locked);
+    return initial_level;
+}
+
+static void record_event(enum button_input_event event)
+{
+    assert(!input_lock.locked);
+    received[received_count++] = event;
+}
+
+static void reset(bool initially_pressed)
+{
+    gesture = (typeof(gesture)) {0};
+    input_work.due = INT64_MAX;
+    work_at = NO_DEADLINE;
+    edge_count = 0;
+    overflowed = started = false;
+    received_count = 0;
+    fake_now = 0;
+    initial_level = initially_pressed;
+    button_input_start(record_event, read_level);
+}
+
+static void run_to(int64_t time)
+{
+    assert(time >= fake_now);
+    unsigned runs = 0;
+    while (input_work.due <= time) {
+        assert(++runs < 100);
+        fake_now = input_work.due;
+        input_work.due = INT64_MAX;
+        input_work.handler(&input_work.work);
+    }
+    fake_now = time;
+}
+
+static void edge(int64_t time, bool pressed)
+{
+    run_to(time);
+    button_input_edge(pressed);
+}
+
+static void expect_idle(void)
+{
+    assert(input_work.due == INT64_MAX);
+    unsigned count = received_count;
+    run_to(fake_now + 100000);
+    assert(received_count == count);
+}
+
+int main(void)
+{
+    reset(false);
+    expect_idle();
+    assert(received_count == 0);
+
+    reset(false);
+    edge(0, true);
+    edge(100, false);
+    run_to(299);
+    assert(received_count == 0);
+    run_to(300);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_SINGLE);
+    run_to(340);
+    assert(received_count == 2 && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    reset(false);
+    edge(0, true);
+    edge(80, false);
+    edge(200, true);
+    edge(280, false);
+    run_to(500);
+    assert(received_count == 2 && received[0] == BUTTON_INPUT_DOUBLE && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    /* A second held press suppresses the first single, as in the shipped FSM. */
+    reset(false);
+    edge(0, true);
+    edge(80, false);
+    edge(250, true);
+    edge(540, false);
+    run_to(580);
+    assert(received_count == 2 && received[0] == BUTTON_INPUT_DOUBLE && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    /* A medium press emits only release; the tap boundary is strictly <300ms. */
+    reset(false);
+    edge(0, true);
+    edge(300, false);
+    run_to(340);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    reset(true);
+    button_input_start(record_event, read_level); /* reconnect activation is idempotent */
+    run_to(2999);
+    assert(received_count == 0);
+    run_to(3000);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_LONG);
+    expect_idle(); /* no repeat work while a long press remains held */
+    edge(fake_now, false);
+    run_to(fake_now + 40);
+    assert(received_count == 2 && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    reset(false);
+    edge(0, true);
+    edge(2999, false);
+    run_to(3040);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    /* Mechanical bounce and sub-debounce pulses produce no synthetic gesture. */
+    reset(false);
+    edge(0, true);
+    edge(5, false);
+    edge(10, true);
+    edge(15, false);
+    run_to(100);
+    assert(received_count == 0);
+    expect_idle();
+
+    /* SD contention stalls work, but ISR timestamps preserve both complete taps. */
+    reset(false);
+    fake_now = 1000;
+    button_input_edge(true);
+    fake_now = 1080;
+    button_input_edge(false);
+    fake_now = 1200;
+    button_input_edge(true);
+    fake_now = 1280;
+    button_input_edge(false);
+    fake_now = 8000;
+    input_work.due = INT64_MAX;
+    input_work.handler(&input_work.work);
+    assert(received_count == 2 && received[0] == BUTTON_INPUT_DOUBLE && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    /* A delayed worker must not turn a completed 2999ms press into power-off. */
+    reset(false);
+    fake_now = 0;
+    button_input_edge(true);
+    fake_now = 2999;
+    button_input_edge(false);
+    fake_now = 9000;
+    input_work.due = INT64_MAX;
+    input_work.handler(&input_work.work);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    /* Overflow resynchronizes from the latest release, never a stale held level. */
+    reset(false);
+    for (unsigned i = 0; i < EDGE_CAPACITY + 10; ++i) {
+        fake_now = i;
+        button_input_edge(i % 2 == 0);
+    }
+    fake_now = 10000;
+    input_work.due = INT64_MAX;
+    input_work.handler(&input_work.work);
+    assert(received_count == 0);
+    expect_idle();
+
+    reset(false);
+    int64_t base = (int64_t) UINT32_MAX + 5000;
+    edge(base, true);
+    edge(base + 100, false);
+    run_to(base + 340);
+    assert(received_count == 2 && received[0] == BUTTON_INPUT_SINGLE && received[1] == BUTTON_INPUT_RELEASE);
+    expect_idle();
+
+    puts("button input: idle, gestures, debounce, delayed ISR edges, overflow, uptime passed");
+    return 0;
+}

--- a/omi/firmware/omi/tests/host/test_button_input.c
+++ b/omi/firmware/omi/tests/host/test_button_input.c
@@ -148,6 +148,16 @@ int main(void)
     assert(received_count == 2 && received[0] == BUTTON_INPUT_DOUBLE && received[1] == BUTTON_INPUT_RELEASE);
     expect_idle();
 
+    /* A hold already past 3s is delivered immediately when contention clears. */
+    reset(false);
+    fake_now = 1000;
+    button_input_edge(true);
+    fake_now = 4100;
+    input_work.due = INT64_MAX;
+    input_work.handler(&input_work.work);
+    assert(received_count == 1 && received[0] == BUTTON_INPUT_LONG);
+    expect_idle();
+
     /* A delayed worker must not turn a completed 2999ms press into power-off. */
     reset(false);
     fake_now = 0;

--- a/omi/firmware/omi/tests/host/test_button_input.c
+++ b/omi/firmware/omi/tests/host/test_button_input.c
@@ -21,7 +21,7 @@ static void record_event(enum button_input_event event)
 
 static void reset(bool initially_pressed)
 {
-    gesture = (typeof(gesture)) {0};
+    gesture = (struct button_gesture) {0};
     input_work.due = INT64_MAX;
     work_at = NO_DEADLINE;
     edge_count = 0;

--- a/omi/firmware/omi/tests/host/test_sd_worker_wait.c
+++ b/omi/firmware/omi/tests/host/test_sd_worker_wait.c
@@ -1,0 +1,143 @@
+#include <stdio.h>
+
+#include "../../src/lib/core/sd_worker_wait.h"
+
+int64_t fake_now;
+static struct k_msgq priority, normal;
+static struct k_sem wake;
+static atomic_t connect_flush;
+static unsigned waits;
+static k_timeout_t observed_wait;
+static void (*during_wait)(void);
+
+int k_sem_take(struct k_sem *sem, k_timeout_t timeout)
+{
+    ++waits;
+    observed_wait = timeout;
+    if (sem->count) {
+        sem->count = 0;
+        return 0;
+    }
+    if (during_wait) {
+        void (*hook)(void) = during_wait;
+        during_wait = NULL;
+        hook();
+    }
+    if (sem->count) {
+        sem->count = 0;
+        return 0;
+    }
+    assert(timeout != K_FOREVER); /* an unnotified request would hang production */
+    fake_now += timeout;
+    return -EAGAIN;
+}
+
+static void reset(void)
+{
+    priority = normal = (struct k_msgq) {0};
+    wake = (struct k_sem) {0};
+    connect_flush = 0;
+    fake_now = 0;
+    waits = 0;
+    during_wait = NULL;
+}
+
+static void put_normal(void)
+{
+    int request = 42;
+    assert(sd_worker_enqueue(&normal, &request, K_NO_WAIT, &wake) == 0);
+}
+
+static void put_power_request(void)
+{
+    int request = 99;
+    assert(sd_worker_enqueue(&priority, &request, K_NO_WAIT, &wake) == 0);
+}
+
+static void put_connect_flush(void)
+{
+    connect_flush = 1;
+    k_sem_give(&wake);
+}
+
+static enum sd_worker_event next(int *request, int64_t deadline)
+{
+    return sd_worker_next(&priority, &normal, &wake, &connect_flush, request, deadline);
+}
+
+int main(void)
+{
+    int request;
+    reset();
+    assert(sd_worker_flush_deadline(true, false, 0, 0, 1000) == -1);
+    assert(sd_worker_flush_deadline(false, true, 0, 0, 1000) == -1);
+    during_wait = put_normal;
+    assert(next(&request, -1) == SD_WORKER_REQUEST && request == 42);
+    assert(waits == 1 && observed_wait == K_FOREVER);
+
+    /* Priority power/read requests wake an otherwise indefinitely idle worker. */
+    reset();
+    during_wait = put_power_request;
+    assert(next(&request, -1) == SD_WORKER_REQUEST && request == 99);
+    assert(waits == 1 && observed_wait == K_FOREVER);
+
+    /* Both queues were published before waiting: priority wins, normal stays FIFO. */
+    reset();
+    for (int i = 0; i < 3; ++i) {
+        assert(sd_worker_enqueue(&normal, &i, K_NO_WAIT, &wake) == 0);
+    }
+    put_power_request();
+    assert(next(&request, -1) == SD_WORKER_REQUEST && request == 99);
+    for (int i = 0; i < 3; ++i) {
+        assert(next(&request, -1) == SD_WORKER_REQUEST && request == i);
+    }
+    assert(waits == 0);
+    /* A coalesced notification is consumed once; it cannot cause periodic wakes. */
+    during_wait = put_power_request;
+    assert(next(&request, -1) == SD_WORKER_REQUEST && request == 99);
+    assert(waits == 2 && observed_wait == K_FOREVER);
+
+    /* The hook publishes precisely between empty checks and blocking: no lost wake. */
+    reset();
+    during_wait = put_normal;
+    assert(next(&request, 1000) == SD_WORKER_REQUEST && request == 42);
+    assert(fake_now == 0 && observed_wait == 1000);
+
+    reset();
+    fake_now = 400;
+    int64_t deadline = sd_worker_flush_deadline(true, true, 250, 0, 1000);
+    assert(deadline == 1250);
+    assert(next(&request, deadline) == SD_WORKER_FLUSH_DUE);
+    assert(waits == 1 && observed_wait == 850 && fake_now == 1250);
+    /* A failed media flush leaves dirty state but cannot spin at the old deadline. */
+    deadline = sd_worker_flush_deadline(true, true, 250, fake_now + 1000, 1000);
+    assert(next(&request, deadline) == SD_WORKER_FLUSH_DUE);
+    assert(observed_wait == 1000 && fake_now == 2250);
+
+    /* Expired inactivity flush is not postponed by a newly queued normal write. */
+    reset();
+    put_normal();
+    fake_now = 1001;
+    assert(next(&request, 1000) == SD_WORKER_FLUSH_DUE && normal.count == 1);
+    assert(next(&request, -1) == SD_WORKER_REQUEST && request == 42);
+
+    /* A failed full-queue connect enqueue still has a retained out-of-band wake. */
+    reset();
+    for (int i = 0; i < 16; ++i) {
+        assert(sd_worker_enqueue(&priority, &i, K_NO_WAIT, &wake) == 0);
+    }
+    assert(sd_worker_enqueue(&priority, &request, K_NO_WAIT, &wake) != 0);
+    put_connect_flush();
+    assert(next(&request, -1) == SD_WORKER_CONNECT_FLUSH);
+    assert(priority.count == 16);
+    for (int i = 0; i < 16; ++i) {
+        assert(next(&request, -1) == SD_WORKER_REQUEST && request == i);
+    }
+    wake.count = 0;
+    during_wait = put_connect_flush;
+    assert(next(&request, -1) == SD_WORKER_CONNECT_FLUSH);
+    assert(observed_wait == K_FOREVER);
+
+    puts("SD wait: both queues, priority/FIFO, deadlines, retry bound, retained wake passed");
+    return 0;
+}

--- a/omi/firmware/omi/tests/host/test_sd_worker_wait.c
+++ b/omi/firmware/omi/tests/host/test_sd_worker_wait.c
@@ -34,8 +34,8 @@ int k_sem_take(struct k_sem *sem, k_timeout_t timeout)
 
 static void reset(void)
 {
-    priority = normal = (struct k_msgq) {0};
-    wake = (struct k_sem) {0};
+    priority = normal = (struct k_msgq){0};
+    wake = (struct k_sem){0};
     connect_flush = 0;
     fake_now = 0;
     waits = 0;


### PR DESCRIPTION
The CV1 button worker woke every 40 ms even with no gesture underway, and counted worker executions to time holds. The SD worker woke every 50/250 ms to inspect its other queue. This replaces both idle polling loops with GPIO/request notifications and actual uptime deadlines.

- Retain timestamped GPIO edges while the system workqueue is busy; preserve single/double-tap notification codes, the existing nominal 300 ms tap decision and 600 ms release-to-release double window, and one shutdown per 3 s hold. Debounce uses a 40 ms stable-level window. Idle and completed holds have no scheduled work. Remove unreachable press/long-notification helpers and tick counters.
- Publish SD requests through one notification helper, preserve priority and per-queue FIFO order, flush dirty batches after the existing 1 s inactivity deadline, and rate-limit failed flush attempts. Preserve power-off write draining, direct wake-race remount, and asynchronous advance handling from b49faed668 / 27492ba70f.
- Run the production button controller and SD request/wait helpers through a controllable C99 host kernel seam with sanitizers, matching the NCS target dialect. Register the tests in the existing local/CI checks manifest and document their measured layer.

Verification (BasedHardware/omi, codex/firmware-battery-efficiency, base 763bf0f8c4fb):
- `bash omi/firmware/omi/tests/host/run.sh` — passes with AddressSanitizer and UndefinedBehaviorSanitizer: idle scheduling; single/double/medium/long gestures; debounce; initial held button and repeat activation; delayed ISR edge sequences; overflow recovery; uptime beyond 32-bit; both queues, priority/FIFO, deadline timeout, failed-flush retry bound, and arrivals at the empty-check/wait boundary.
- `make setup` — passed (linked-worktree hooks and prerequisites).
- `OMI_PR_BODY_FILE=/tmp/omi-firmware-battery-pr.md make preflight` — passed all 121 selected local checks on 82d0ec6886 (17.56 s).
- `scripts/pr-preflight --pr-body-file /tmp/omi-firmware-battery-pr.md` — passed all 121 selected CI-lane checks on the final commit.
- `scripts/failure-class validate --pr-body-file /tmp/omi-firmware-battery-pr.md --format text` — passed (`Failure-Class: none`); `scripts/pr-preflight --suggest` reports no matched product invariants.
- Full CV1 NCS 2.9.0 sysbuild passed using the pinned CI container `ghcr.io/zephyrproject-rtos/ci:v0.26.13@sha256:b0ac6334d1926cd0971a0a444f7adc6dd020e88ee3ce865aa070b6475a3ac4eb`. Initialized/configured with `bash /omi/firmware/scripts/ci/build-cv1.sh`, then completed final C99 sources using `cmake --build /omi/firmware/v2.9.0/build`. Verified nonempty `dfu_application.zip`, `merged.hex`, and `merged_CPUNET.hex`; final log `/tmp/omi-firmware-battery-build-final.log`.
- Parent independently reviewed all changed files and reran both C99 host suites with sanitizers; passed. The host runner now matches the target dialect and reproduced the target compile failure before its named-struct fix.

The new expectations use the existing firmware's TAP_THRESHOLD=300, DOUBLE_TAP_WINDOW=600, LONG_PRESS_TIME=3000 and RAW_FLUSH_INTERVAL_MS=1000. Removing tick quantization means exact deadlines replace scheduling-dependent 40 ms rounding. Initialization no longer emits a synthetic release notification for an untouched button. The tests execute production control code, not mirrored source assertions; these seams are firmware-specific owners of GPIO and SD request timing, not a new cross-component primitive. The motivating instance is the shipped loops audited at 763bf0f8c4fb; prior SD durability fixes cited above constrain ordering.

No physical CV1 was exercised and no battery-life percentage is claimed. Hardware review still needs idle/AAD-sleep current measurements plus button, recording/sync, and SD sleep/wake checks with buffered audio before firmware release. No release, flash, Bluetooth radio tuning, AAD sensitivity, SD power lifecycle, LED, or battery sampling change is included.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

