### PR TITLE
fix(sdks/python): preserve callable transcribe package export

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -10,6 +10,11 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["linux", "macos"]
     reason: "Parakeet readiness is written by the WebSocket reader and read by PCM submission; execute the in-memory handshake with the race detector"
+  - id: python-sdk-public-api
+    command: ["python3", "sdks/python/tests/test_public_api.py"]
+    triggers: ["sdks/python/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#12950: the documented transcribe import returned its same-named submodule rather than the callable; fresh-process public API tests execute transcript delivery without optional packages"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/sdks/python/omi/__init__.py
+++ b/sdks/python/omi/__init__.py
@@ -17,6 +17,8 @@ from .constants import (
     PACKET_HEADER_BYTES,
     PCM_SAMPLE_RATE_HZ,
 )
+# Bind explicitly so loading the same-named submodule cannot replace the API.
+from .transcribe import transcribe
 
 __all__ = [
     "constants",
@@ -52,8 +54,4 @@ def __getattr__(name: str):
         from .decoder import OmiOpusDecoder
 
         return OmiOpusDecoder
-    if name == "transcribe":
-        from .transcribe import transcribe
-
-        return transcribe
     raise AttributeError(name)

--- a/sdks/python/tests/test_public_api.py
+++ b/sdks/python/tests/test_public_api.py
@@ -1,0 +1,78 @@
+"""Exercise public imports in fresh interpreters, without optional STT packages."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+class TestTranscribeExport(unittest.TestCase):
+    def run_example(self, imports):
+        source = imports + textwrap.dedent(
+            r"""
+            import asyncio
+            import sys
+
+            assert callable(transcribe), type(transcribe)
+            assert not ({'bleak', 'opuslib', 'whisper', 'websockets'} & sys.modules.keys())
+
+            class TranscriptReceived(Exception):
+                pass
+
+            async def main():
+                audio = asyncio.Queue()
+                pcm = b'\x00\x00' * (16000 * 5)
+                audio.put_nowait(pcm)
+                received = []
+
+                def runner(data):
+                    assert data == pcm
+                    return 'local transcript'
+
+                def on_transcript(text):
+                    received.append(text)
+                    raise TranscriptReceived
+
+                try:
+                    await transcribe(audio, '', on_transcript, engine='whisper', runner=runner)
+                except TranscriptReceived:
+                    pass
+                assert received == ['local transcript'], received
+
+            asyncio.run(main())
+            """
+        )
+        env = dict(os.environ)
+        env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1])
+        result = subprocess.run(
+            [sys.executable, '-S', '-c', source],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_documented_from_import(self):
+        self.run_example('from omi import transcribe\n')
+
+    def test_repeated_package_attribute_access(self):
+        self.run_example(
+            'import omi\n'
+            'first = omi.transcribe\n'
+            'transcribe = omi.transcribe\n'
+            'assert first is transcribe\n'
+        )
+
+    def test_submodule_import_before_public_import(self):
+        self.run_example(
+            'from omi.transcribe import transcribe as direct\n'
+            'from omi import transcribe\n'
+            'assert transcribe is direct\n'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem and change

The documented `from omi import transcribe` resolves to a module because importing the same-named submodule inside `__getattr__` writes that module onto the package. Bind the lightweight public function during package initialization so the documented import, repeated attribute access, and submodule-first imports consistently expose the async function.

Closes #12950.

## Verification

- Three fresh-interpreter regression cases fail on the original source and pass with the patch.
- Each case exercises the public async transcription call with synthetic PCM and Whisper's injected runner, verifying transcript delivery with site packages disabled (`python -S`). No model, Bluetooth hardware, provider credentials, or network service is involved.
- Python SDK test directory: 27 passed on Python 3.12.14 / Windows.
- Shared manifest public-API check and manifest contract tests pass.
- PR metadata and local manifest preflight passed (16 executed checks); the repository pre-push gate also passed. The history-based failure-class guard reported a shallow-history skip; platform-specific checks remain subject to upstream CI.

Rebased onto current main after collaborator approval, preserving both the new upstream Go SDK check and the Python public API check in the manifest. The Python implementation and regression tests are unchanged. Local validation uses Python 3.12.14, websockets 17.1, GNU Make 4.4.1 and UTF-8 mode; history-based and platform-specific limitations remain as noted above.

## Product invariants affected

none

Failure-Class: none

This is an isolated Python package export collision; no existing registry class matches it. The regression belongs at the package's public import boundary and runs in both local and CI lanes. It tests the real public operation rather than source strings. No separate runtime guard or compatibility wrapper is introduced.

AI-assisted implementation and tests. Bounty requested in #12950; no reward or payment has been approved.




