### PR TITLE
fix: preserve literal API data in CLI output

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -59,6 +59,10 @@ machine-readable output, ready for `jq`, agent harnesses, or whatever else:
 omi --json memory list | jq '.[] | {id, content}'
 ```
 
+Pretty output displays returned text literally, including square brackets and
+emoji-like codes such as `:warning:`. Styling applies to the table layout, not
+to the contents of your memories or conversations.
+
 ## Auth
 
 Two auth methods, both fully wired:

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -102,7 +102,7 @@ class Renderer:
 
         table = Table(title=title, show_lines=False, header_style="bold")
         for col in cols:
-            table.add_column(Text(col))
+            table.add_column(Text(col, style="bold"))
         for row in rows:
             table.add_row(*[Text(_stringify(row.get(c))) for c in cols])
         self._stdout.print(table)

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -22,6 +22,7 @@ from typing import Any, Iterable, Mapping, Optional, Sequence
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
+from rich.text import Text
 
 
 def _no_color_env() -> bool:
@@ -77,7 +78,7 @@ class Renderer:
             self._emit_mapping(data, title=title)
         else:
             # Scalars or anything else — just print.
-            self._stdout.print(data)
+            self._stdout.print(Text(data) if isinstance(data, str) else data)
 
     def _emit_json(self, data: Any) -> None:
         # Use sys.stdout directly to avoid Rich coloring/wrapping the JSON.
@@ -101,9 +102,9 @@ class Renderer:
 
         table = Table(title=title, show_lines=False, header_style="bold")
         for col in cols:
-            table.add_column(col)
+            table.add_column(Text(col))
         for row in rows:
-            table.add_row(*[_stringify(row.get(c)) for c in cols])
+            table.add_row(*[Text(_stringify(row.get(c))) for c in cols])
         self._stdout.print(table)
 
     def _emit_mapping(self, mapping: Mapping[str, Any], *, title: Optional[str]) -> None:
@@ -111,7 +112,7 @@ class Renderer:
         table.add_column("field", style="bold")
         table.add_column("value")
         for k, v in mapping.items():
-            table.add_row(k, _stringify(v))
+            table.add_row(Text(k), Text(_stringify(v)))
         self._stdout.print(table)
 
     # ------------------------------------------------------------------

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from omi_cli.main import app
 
 
@@ -125,3 +127,13 @@ def test_memory_get_found_in_later_page(authed_profile, respx_mock, cli_runner) 
     )
     result = cli_runner.invoke(app, ["--json", "memory", "get", "target"])
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("command", [["memory", "list"], ["memory", "get", "m1"]])
+def test_memory_pretty_preserves_markup_like_content(authed_profile, respx_mock, cli_runner, command) -> None:
+    respx_mock.get("/v1/dev/user/memories").respond(
+        json=[{"id": "m1", "content": "[draft] literal [/bold] :warning:", "tags": []}]
+    )
+    result = cli_runner.invoke(app, ["--no-color", *command])
+    assert result.exit_code == 0, result.output
+    assert "[draft] literal [/bold] :warning:" in result.stdout

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from omi_cli.output import Renderer, coalesce_rows, shorten
 
 
@@ -89,3 +91,26 @@ def test_no_color_env_disables_color(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     # No ANSI codes when NO_COLOR is set.
     assert "\x1b[" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        [{"content": "[draft] literal [/bold] :warning:"}],
+        {"content": "[draft] literal [/bold] :warning:"},
+        "[draft] literal [/bold] :warning:",
+    ],
+)
+def test_pretty_data_is_literal(data, capsys) -> None:
+    Renderer(no_color=True).emit(data)
+    assert "[draft] literal [/bold] :warning:" in capsys.readouterr().out
+
+
+def test_pretty_data_keys_and_matched_tags_are_literal(capsys) -> None:
+    renderer = Renderer(no_color=True)
+    data = {"[key]": "[bold]keep tags[/bold] :warning:"}
+    renderer.emit(data)
+    renderer.emit([data])
+    output = capsys.readouterr().out
+    assert output.count("[key]") == 2
+    assert output.count("[bold]keep tags[/bold] :warning:") == 2


### PR DESCRIPTION
Memory content such as `[draft] literal [/bold] :warning:` currently makes `omi memory list` and `omi memory get` raise `MarkupError`. Matched tags can also disappear from the displayed content. Render API data with Rich's literal `Text` type across scalar, table and mapping output so data is not interpreted as presentation markup.

Fixes #12960. This contribution is AI-assisted. Bounty consideration was requested separately; no award is assumed.

Validation: five new regression cases failed before the fix. The final CLI suite passes on macOS/Python 3.14: 134 passed, 1 skipped, including an additional matched-tag and key test. Tests exercise the actual memory commands and HTTP client with synthetic respx responses; no live Omi service or hardware was used. Output expectations follow https://rich.readthedocs.io/en/stable/markup.html. The patch uses Rich's existing literal text primitive rather than a new guard or string sanitizer.

## Product invariants affected

none

Failure-Class: none

Root cause: API text crossed the shared data renderer as markup-bearing strings. The renderer owns this boundary; regression tests cover table, mapping and scalar output and the two affected memory commands. No matching existing failure class was found for CLI Rich data interpretation.

Repository validation: `make preflight` and `scripts/pr-preflight --pr-body-file` passed for the four changed files (12 selected checks). The history-based failure-class ratchet explicitly skipped in the shallow local clone; upstream CI remains authoritative for that check. The published tree matches the locally tested tree exactly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

