### PR TITLE
fix(cli): preserve Unicode when importing transcript JSON

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -228,6 +228,9 @@ omi
     └── delete <id> [-y]
 ```
 
+`conversation from-segments` reads JSON files as UTF-8 (with or without a BOM),
+UTF-16, or UTF-32, independently of the system's default text encoding.
+
 ## Global flags
 
 ```text

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -142,8 +142,8 @@ def from_segments(
     if not segments_file.exists():
         raise UsageError(message=f"File not found: {segments_file}")
     try:
-        payload = json.loads(segments_file.read_text())
-    except json.JSONDecodeError as exc:
+        payload = json.loads(segments_file.read_bytes())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise UsageError(message=f"Invalid JSON in {segments_file}", detail=str(exc))
 
     segments = payload.get("transcript_segments") if isinstance(payload, dict) else payload

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from omi_cli.main import app
 
 
@@ -76,3 +78,31 @@ def test_conversation_from_segments_reads_file(authed_profile, respx_mock, cli_r
     body = json.loads(route.calls.last.request.content)
     assert len(body["transcript_segments"]) == 2
     assert body["source"] == "phone"
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-8-sig", "utf-16", "utf-32"])
+def test_conversation_from_segments_preserves_unicode(
+    authed_profile, respx_mock, cli_runner, tmp_path, encoding
+) -> None:
+    segments = [{"text": "Caf\u00e9, \u65e5\u672c\u8a9e \U0001f642", "start": 0.0, "end": 1.0}]
+    source = tmp_path / "segments.json"
+    source.write_bytes(json.dumps(segments, ensure_ascii=False).encode(encoding))
+    route = respx_mock.post("/v1/dev/user/conversations/from-segments").respond(
+        json={"id": "c1", "status": "completed", "discarded": False}
+    )
+
+    result = cli_runner.invoke(app, ["--json", "conversation", "from-segments", str(source)])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content)["transcript_segments"] == segments
+
+
+def test_conversation_from_segments_rejects_invalid_unicode(config_path, respx_mock, cli_runner, tmp_path) -> None:
+    source = tmp_path / "segments.json"
+    source.write_bytes(b'[{"text": "\xff", "start": 0, "end": 1}]')
+
+    result = cli_runner.invoke(app, ["--json", "conversation", "from-segments", str(source)])
+
+    assert result.exit_code == 1
+    assert "Invalid JSON" in result.stderr
+    assert not respx_mock.calls


### PR DESCRIPTION
Fixes #12958.

On Windows with a cp1252 process locale, importing a UTF-8 transcript could report success while sending corrupted accented, Japanese and emoji text. The command now passes file bytes to Python's JSON decoder, preserving UTF-8 (including BOM), UTF-16 and UTF-32 independently of the host locale. Invalid Unicode receives the existing invalid-JSON error before any HTTP request.

Five regression cases exercise the actual command and inspect the outgoing request or absence of a request. The CLI README documents the accepted encodings. No live account, recordings or hardware were used.

Validation:
- `python -X utf8=0 -m pytest sdks/python-cli/tests -o addopts='' -q`: **134 passed**, two upstream Typer/Click deprecation warnings, on Windows / Python 3.12.
- Fresh CLI processes against a loopback HTTP capture server: the original code returned success but changed UTF-8 transcript text; it rejected BOM/UTF-16/UTF-32. The patched command preserved the exact request text in all four cases. Invalid Unicode now exits before sending a request.
- `black --check` on the changed Python files and `git diff --check` passed.
- Repository setup targets were run directly through Git Bash (GNU Make is unavailable): refresh main, install hooks, sync pinned backend dependencies. The commit ran the installed pre-commit hook.
- The local PR preflight passed all 12 selected checks against this three-file diff and this PR body. Its historical failure-class recurrence check explicitly skipped because this is a shallow clone; full-history enforcement remains for CI.

Failure-Class: FC-repository-text-io-inherits-host-locale

The same host-locale text-decoding boundary applies here to imported transcript JSON. The standard JSON decoder owns encoding detection; the behavioral request tests guard the user-visible boundary. No product-invariant path globs match these files.

AI-assisted contribution for EAVENS93. The optional bounty proposal is tracked separately in #12958; no reward has been approved or claimed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

