### PR TITLE
fix: preserve in-flight Whisper transcripts after stop

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: typescript-device-sdk-tests
+    command: ["bun", "test", "sdks/device/typescript"]
+    triggers: ["sdks/device/typescript/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#12964: stopping Whisper discarded accepted full-batch transcripts while delivering only the buffered tail; exercise the production transcriber lifecycle with deterministic runners"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/sdks/device/typescript/README.md
+++ b/sdks/device/typescript/README.md
@@ -8,3 +8,10 @@ Shared Omi device BLE constants + packet framing.
 ```ts
 import { AUDIO_DATA_UUID, stripPacketHeader, OmiDeviceSession } from '@basedhardware/omi-device';
 ```
+
+For the local Whisper transcriber, `stop()` stops accepting new audio and
+flushes any buffered tail. Transcription already in progress still delivers its
+result through `onTranscript`, so callbacks may occur after `stop()` returns.
+
+Run `bun test` in this directory for the SDK's hardware-free unit tests. The same
+suite runs through the repository's shared preflight manifest locally and in CI.

--- a/sdks/device/typescript/README.md
+++ b/sdks/device/typescript/README.md
@@ -11,7 +11,8 @@ import { AUDIO_DATA_UUID, stripPacketHeader, OmiDeviceSession } from '@basedhard
 
 For the local Whisper transcriber, `stop()` stops accepting new audio and
 flushes any buffered tail. Transcription already in progress still delivers its
-result through `onTranscript`, so callbacks may occur after `stop()` returns.
+result through `onTranscript` in audio input order, even if runners finish out of
+order. Callbacks may occur after `stop()` returns.
 
 Run `bun test` in this directory for the SDK's hardware-free unit tests. The same
 suite runs through the repository's shared preflight manifest locally and in CI.

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -133,6 +133,34 @@ describe('createWhisperTranscriber', () => {
     expect(transcripts).toEqual(['full batch', 'tail']);
   });
 
+  test('keeps input order when the tail completes before earlier batches', async () => {
+    const transcripts: string[] = [];
+    const completions: ((text: string) => void)[] = [];
+    const pending: Promise<string>[] = [];
+    const transcriber = createWhisperTranscriber({
+      runner: () => {
+        const result = new Promise<string>((resolve) => completions.push(resolve));
+        pending.push(result);
+        return result;
+      },
+      onTranscript: (text) => transcripts.push(text),
+      batchSeconds: 1,
+    });
+
+    transcriber.appendPcm(new Uint8Array(32000));
+    transcriber.appendPcm(new Uint8Array(32000));
+    transcriber.appendPcm(new Uint8Array(2));
+    transcriber.stop();
+    completions[2]('tail');
+    await pending[2];
+    completions[1]('');
+    await pending[1];
+    expect(transcripts).toEqual([]);
+    completions[0]('first batch');
+    await pending[0];
+    expect(transcripts).toEqual(['first batch', 'tail']);
+  });
+
   test('delivers buffered audio transcript when stopped before a batch fills', async () => {
     const transcripts: string[] = [];
     const transcriber = createWhisperTranscriber({

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -85,6 +85,54 @@ describe('createDeepgramTranscriber', () => {
 });
 
 describe('createWhisperTranscriber', () => {
+  test('delivers an in-flight full batch after stop and ignores later audio', async () => {
+    const transcripts: string[] = [];
+    const batches: Uint8Array[] = [];
+    let finish!: (text: string) => void;
+    const pending = new Promise<string>((resolve) => { finish = resolve; });
+    const transcriber = createWhisperTranscriber({
+      runner: (pcm) => { batches.push(pcm); return pending; },
+      onTranscript: (text) => transcripts.push(text),
+      batchSeconds: 1,
+    });
+
+    transcriber.appendPcm(new Uint8Array(32000).fill(7));
+    transcriber.stop();
+    transcriber.stop();
+    transcriber.appendPcm(new Uint8Array(32000).fill(9));
+    finish('accepted audio');
+    await pending;
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(new Uint8Array(32000).fill(7));
+    expect(transcripts).toEqual(['accepted audio']);
+  });
+
+  test('delivers both an in-flight batch and the buffered tail on stop', async () => {
+    const transcripts: string[] = [];
+    const completions: ((text: string) => void)[] = [];
+    const pending: Promise<string>[] = [];
+    const transcriber = createWhisperTranscriber({
+      runner: () => {
+        const result = new Promise<string>((resolve) => completions.push(resolve));
+        pending.push(result);
+        return result;
+      },
+      onTranscript: (text) => transcripts.push(text),
+      batchSeconds: 1,
+    });
+
+    transcriber.appendPcm(new Uint8Array(32000));
+    transcriber.appendPcm(new Uint8Array(2));
+    transcriber.stop();
+    completions[0]('full batch');
+    await pending[0];
+    completions[1]('tail');
+    await pending[1];
+
+    expect(transcripts).toEqual(['full batch', 'tail']);
+  });
+
   test('delivers buffered audio transcript when stopped before a batch fills', async () => {
     const transcripts: string[] = [];
     const transcriber = createWhisperTranscriber({

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -92,12 +92,12 @@ export function createWhisperTranscriber(opts: {
   const batchBytes = (opts.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
-  async function flush(deliverWhenStopped = false) {
+  async function flush() {
     if (!buffer.byteLength) return;
     const pcm = buffer;
     buffer = new Uint8Array(0);
     const text = await opts.runner(pcm);
-    if (text && (!stopped || deliverWhenStopped)) opts.onTranscript(text);
+    if (text) opts.onTranscript(text);
   }
   return {
     appendPcm(chunk) {
@@ -111,7 +111,7 @@ export function createWhisperTranscriber(opts: {
     },
     stop() {
       stopped = true;
-      void flush(true);
+      void flush();
     },
   };
 }

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -92,12 +92,26 @@ export function createWhisperTranscriber(opts: {
   const batchBytes = (opts.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
+  let nextBatch = 0;
+  let nextDelivery = 0;
+  const completed = new Map<number, string>();
   async function flush() {
     if (!buffer.byteLength) return;
     const pcm = buffer;
     buffer = new Uint8Array(0);
-    const text = await opts.runner(pcm);
-    if (text) opts.onTranscript(text);
+    const batch = nextBatch++;
+    let text = '';
+    try {
+      text = await opts.runner(pcm);
+    } finally {
+      // A failed or empty batch must not prevent later accepted audio delivery.
+      completed.set(batch, text);
+      while (completed.has(nextDelivery)) {
+        const result = completed.get(nextDelivery);
+        completed.delete(nextDelivery++);
+        if (result) opts.onTranscript(result);
+      }
+    }
   }
   return {
     appendPcm(chunk) {


### PR DESCRIPTION
## What changed and why

Fixes #12964. If `stop()` is called while a full Whisper batch is still being transcribed, its result is currently discarded even though a buffered tail is delivered. Deliver results for all accepted audio in input order even when runners finish out of order, continue ignoring audio appended after stopping, and document that completion callbacks can occur after `stop()` returns.

This is an AI-assisted contribution. The optional US$10 bounty proposed in the issue has not been approved; this PR does not claim an existing reward.

## Product invariants affected

none

## How it was verified

- `bun test sdks/device/typescript`: 15 tests passed, 33 assertions across 3 files. The two stop regressions failed before the original fix; the additional reversed-completion regression failed before the ordering fix. All pass now.
- TypeScript source type-check with `tsc -p sdks/device/typescript` and isolated Node type definitions: passed.
- Exercised the exported production transcriber with a controllable asynchronous runner, including repeated stops and audio arriving after stop. No live Whisper model or BLE hardware was exercised.
- `make setup`: completed with locked backend development dependencies.
- Shared manifest checks for the changed files and `git diff --check`: passed.

## Tests

`sdks/device/typescript/src/stt/index.test.ts` adds regressions for an in-flight full batch at stop and for a full batch plus a buffered tail. The existing tail-flush test remains unchanged. The SDK suite is registered in the existing shared local/CI check manifest.

## Failure class (fixes)

Failure-Class: none

The failed boundary is acceptance versus completion of SDK audio: stopping closes input but should preserve completion of already accepted work, consistent with the existing tail-flush behavior. The existing proactive-evaluation and voice-owner failure classes have narrower subsystem contracts.

## New guards

The manifest runs the existing SDK suite, including deterministic behavioral regressions for the reproduced incident in #12964. This is component lifecycle coverage through the production runner seam; it does not introduce a new shared runtime primitive.
