### PR TITLE
fix(python-sdk): require compatible websockets handshake API

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: python-device-sdk-tests
+    command: ["bash", "sdks/python/test.sh"]
+    triggers: ["sdks/python/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the Python SDK's Deepgram handshake uses the websockets 14 API; exercise the actual client at the minimum supported version so an incompatible dependency floor cannot silently disable transcription"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -205,7 +205,7 @@ version and is also selected by the shared local/CI check manifest.
     Make sure your Omi device is powered on and nearby. Try running `omi-scan` to verify it's discoverable.
   </Accordion>
   <Accordion title="WebSocket issues" icon="plug">
-    The SDK uses `websockets>=11.0`. Try upgrading: `pip install --upgrade websockets`
+    The SDK requires `websockets>=14.0`. Try upgrading: `pip install --upgrade "websockets>=14.0"`
   </Accordion>
 </AccordionGroup>
 

--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -8,6 +8,8 @@ description: "Connect to Omi devices over Bluetooth, decode Opus audio, and tran
 
 A pip-installable Python SDK for connecting to Omi wearable devices over Bluetooth, decoding Opus-encoded audio, and transcribing it in real time using Deepgram.
 
+Deepgram transcription requires `websockets` 14.0 or newer. The SDK's dependency declarations enforce this minimum for its authenticated WebSocket handshake.
+
 <CardGroup cols={3}>
   <Card title="Bluetooth Connection" icon="bluetooth">
     Connect to any Omi device
@@ -180,6 +182,10 @@ pip install -e .
 # Install dev dependencies
 pip install -e ".[dev]"
 ```
+
+Run the SDK's hardware-free regression suite with `bash test.sh`. It uses the
+repository's `uv` environment manager to test the minimum supported `websockets`
+version and is also selected by the shared local/CI check manifest.
 
 ---
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "sniffio==1.3.1",
     "typing-inspect==0.9.0",
     "typing_extensions==4.12.2",
-    "websockets>=10.0",
+    "websockets>=14.0",
     "yarl==1.18.3",
 ]
 

--- a/sdks/python/requirements.txt
+++ b/sdks/python/requirements.txt
@@ -30,5 +30,5 @@ pyobjc-framework-libdispatch==10.3.2
 sniffio==1.3.1
 typing-inspect==0.9.0
 typing_extensions==4.12.2
-websockets>=10.0
+websockets>=14.0
 yarl==1.18.3

--- a/sdks/python/test.sh
+++ b/sdks/python/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Manifest-owned, network-free SDK tests against the minimum WebSocket API.
+# uv only provisions test dependencies; no Bluetooth/audio/provider setup is needed.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Python SDK tests require uv (the repository's Python environment manager)." >&2
+  exit 1
+fi
+
+minimum_websockets="$(sed -n 's/^websockets>=\([0-9][0-9.]*\)$/\1/p' requirements.txt)"
+if [[ ! "$minimum_websockets" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+  echo "Expected one websockets>=VERSION requirement to select the minimum-version test environment." >&2
+  exit 1
+fi
+
+exec uv run --no-project --python 3.11 \
+  --with 'pytest==8.4.1' \
+  --with "websockets==$minimum_websockets" \
+  python -m pytest tests -q

--- a/sdks/python/tests/test_deepgram_handshake.py
+++ b/sdks/python/tests/test_deepgram_handshake.py
@@ -1,0 +1,62 @@
+"""Exercise the SDK with the installed websockets API, without network I/O."""
+
+import asyncio
+import json
+import urllib.request
+
+from omi.stt.deepgram import DeepgramTranscriber
+
+
+def test_deepgram_authorization_is_a_handshake_header(monkeypatch):
+    async def scenario():
+        received = asyncio.Event()
+        headers = []
+        transcripts = []
+
+        class Connection:
+            async def handshake(self, additional_headers, user_agent_header):
+                headers.append(dict(additional_headers))
+
+            def start_keepalive(self):
+                pass
+
+            async def close(self):
+                pass
+
+            async def send(self, message):
+                raise AssertionError("the empty input queue must not send audio")
+
+            async def messages(self):
+                yield json.dumps({"channel": {"alternatives": [{"transcript": "test transcript"}]}})
+                await asyncio.Future()
+
+            def __aiter__(self):
+                return self.messages()
+
+        # Deliberately keep asyncio's TCP argument boundary: HTTP handshake
+        # headers must be consumed by websockets, never forwarded to this call.
+        async def connect_tcp(protocol_factory, host=None, port=None, *, ssl=None, server_hostname=None):
+            assert host == "api.deepgram.com"
+            assert port == 443
+            assert ssl is True
+            assert server_hostname == "api.deepgram.com"
+            return object(), Connection()
+
+        def on_transcript(text):
+            transcripts.append(text)
+            received.set()
+
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(urllib.request, "getproxies", lambda: {})
+        monkeypatch.setattr(loop, "create_connection", connect_tcp)
+        worker = asyncio.create_task(DeepgramTranscriber("test-key").run(asyncio.Queue(), on_transcript))
+        try:
+            await asyncio.wait_for(received.wait(), timeout=1)
+        finally:
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+
+        assert headers == [{"Authorization": "Token test-key"}]
+        assert transcripts == ["test transcript"]
+
+    asyncio.run(scenario())

--- a/sdks/python/tests/test_deepgram_handshake.py
+++ b/sdks/python/tests/test_deepgram_handshake.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 import urllib.request
 
 from omi.stt.deepgram import DeepgramTranscriber
@@ -10,8 +11,11 @@ from omi.stt.deepgram import DeepgramTranscriber
 def test_deepgram_authorization_is_a_handshake_header(monkeypatch):
     async def scenario():
         received = asyncio.Event()
+        audio_sent = asyncio.Event()
         headers = []
+        sent_audio = []
         transcripts = []
+        pcm = b"\x00\x00" * 80
 
         class Connection:
             async def handshake(self, additional_headers, user_agent_header):
@@ -24,9 +28,11 @@ def test_deepgram_authorization_is_a_handshake_header(monkeypatch):
                 pass
 
             async def send(self, message):
-                raise AssertionError("the empty input queue must not send audio")
+                sent_audio.append(message)
+                audio_sent.set()
 
             async def messages(self):
+                await audio_sent.wait()
                 yield json.dumps({"channel": {"alternatives": [{"transcript": "test transcript"}]}})
                 await asyncio.Future()
 
@@ -46,17 +52,33 @@ def test_deepgram_authorization_is_a_handshake_header(monkeypatch):
             transcripts.append(text)
             received.set()
 
+        async def fail_on_retry(_delay):
+            # run() calls sleep from its exception handler. Preserve that
+            # original error instead of hiding a broken mock behind retries.
+            error = sys.exc_info()[1]
+            assert error is not None, "retry sleep must have an active exception"
+            raise error
+
         loop = asyncio.get_running_loop()
         monkeypatch.setattr(urllib.request, "getproxies", lambda: {})
         monkeypatch.setattr(loop, "create_connection", connect_tcp)
-        worker = asyncio.create_task(DeepgramTranscriber("test-key").run(asyncio.Queue(), on_transcript))
+        monkeypatch.setattr(asyncio, "sleep", fail_on_retry)
+        audio_queue = asyncio.Queue()
+        audio_queue.put_nowait(pcm)
+        worker = asyncio.create_task(DeepgramTranscriber("test-key").run(audio_queue, on_transcript))
+        completed = asyncio.create_task(received.wait())
         try:
-            await asyncio.wait_for(received.wait(), timeout=1)
+            done, _ = await asyncio.wait({worker, completed}, timeout=1, return_when=asyncio.FIRST_COMPLETED)
+            if worker in done:
+                await worker
+            assert completed in done, "transcript callback did not complete"
         finally:
             worker.cancel()
-            await asyncio.gather(worker, return_exceptions=True)
+            completed.cancel()
+            await asyncio.gather(worker, completed, return_exceptions=True)
 
         assert headers == [{"Authorization": "Token test-key"}]
+        assert sent_audio == [pcm]
         assert transcripts == ["test transcript"]
 
     asyncio.run(scenario())


### PR DESCRIPTION
## What changed and why

The Python SDK allowed websockets 10–13 while its Deepgram client uses `additional_headers`, supported by the default asyncio client from 14.0. A valid installation with 13.1 failed before connecting and retried indefinitely. This raises the minimum to 14.0 in both manifests, documents it, and adds a minimum-version SDK test lane to the existing check manifest.

Fixes #12953. No runtime implementation or reconnect-policy changes. The API boundary follows the [websockets migration guide](https://websockets.readthedocs.io/en/stable/howto/upgrade.html).

## Product invariants affected

none

## How it was verified

- Python 3.11.15: all 8 SDK tests pass with websockets 14.0 and 17.0.1.
- Negative control: the new regression fails with 13.1 because `additional_headers` reaches the TCP function.
- Real loopback WebSocket smoke on 14.0 verified Authorization, 160 synthetic PCM bytes and the returned transcript. No real credentials, audio, Bluetooth hardware or provider API was used.
- Built wheel metadata requires `websockets>=14.0`, excluding 13.1.
- All 13 selected local manifest checks passed on these six paths, including the 47-test manifest contract suite. The initially skipped 90-day failure-class guard was then run with full Git history and passed.
- Pinned Black 26.5.1, shell syntax and `git diff --check` passed.
- The published six-file tree was fetched back and its SHA-256 hashes matched the locally verified files.

## Tests

`sdks/python/tests/test_deepgram_handshake.py` exercises the actual SDK and WebSocket library while replacing only the TCP boundary. It verifies the Authorization handshake and transcript callback. `bash sdks/python/test.sh` installs the dependency floor declared in requirements.txt, so lowering that floor also exercises the incompatible version.

## Failure class (fixes)

Failure-Class: none

## New guards

The `python-device-sdk-tests` manifest entry catches the reproduced dependency/API mismatch in #12953. This is a package-specific compatibility contract, so it belongs in the SDK runner; dispatch and change detection reuse the existing shared manifest.

This contribution was prepared and validated with an AI coding assistant. Physical hardware, live Deepgram and remote CI were not claimed as tested.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

