### PR TITLE
fix(cli): accept ISO datetime offsets and fractional seconds

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -303,3 +303,12 @@ bash release.sh --build-only
 ## License
 
 MIT — see [`LICENSE`](LICENSE).
+
+### Datetime options
+
+Conversation and action-item datetime options accept ISO timestamps with `Z`
+(UTC), numeric offsets, and optional fractional seconds, for example
+`--due-at 2026-09-08T12:30:00Z` or
+`--start-date 2026-09-08T12:30:00.123456+05:30`. Offsets are preserved in API
+requests. Date-only values and timestamps without an offset remain supported;
+the CLI does not assign a timezone to those inputs.

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -283,6 +283,14 @@ The CLI retries `429` automatically with exponential backoff and honors the
 server's `Retry-After` hint where present. After all retries are exhausted you
 get exit code `4` plus a message telling you how long to wait.
 
+## Datetime options
+Conversation and action-item datetime options accept ISO timestamps with `Z`
+(UTC), numeric offsets, and optional fractional seconds, for example
+`--due-at 2026-09-08T12:30:00Z` or
+`--start-date 2026-09-08T12:30:00.123456+05:30`. Offsets are preserved in API
+requests. Date-only values and timestamps without an offset remain supported;
+the CLI does not assign a timezone to those inputs.
+
 ## Development
 
 ```bash
@@ -303,12 +311,3 @@ bash release.sh --build-only
 ## License
 
 MIT — see [`LICENSE`](LICENSE).
-
-### Datetime options
-
-Conversation and action-item datetime options accept ISO timestamps with `Z`
-(UTC), numeric offsets, and optional fractional seconds, for example
-`--due-at 2026-09-08T12:30:00Z` or
-`--start-date 2026-09-08T12:30:00.123456+05:30`. Offsets are preserved in API
-requests. Date-only values and timestamps without an offset remain supported;
-the CLI does not assign a timezone to those inputs.

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import typer
 
+from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import NotFoundError, UsageError
 from omi_cli.output import shorten
 
@@ -32,8 +33,8 @@ def list_action_items(
     typer_ctx: typer.Context,
     completed: Optional[bool] = typer.Option(None, "--completed/--open", help="Filter by completion."),
     conversation_id: Optional[str] = typer.Option(None, "--conversation-id"),
-    start_date: Optional[datetime] = typer.Option(None, "--start-date"),
-    end_date: Optional[datetime] = typer.Option(None, "--end-date"),
+    start_date: Optional[datetime] = typer.Option(None, "--start-date", formats=ISO_DATETIME_FORMATS),
+    end_date: Optional[datetime] = typer.Option(None, "--end-date", formats=ISO_DATETIME_FORMATS),
     limit: int = typer.Option(100, "--limit", min=1, max=500),
     offset: int = typer.Option(0, "--offset", min=0),
 ) -> None:
@@ -98,7 +99,7 @@ def create_action_item(
     typer_ctx: typer.Context,
     description: str = typer.Argument(..., help="Action item description (1-500 chars)."),
     completed: bool = typer.Option(False, "--completed/--open"),
-    due_at: Optional[datetime] = typer.Option(None, "--due-at", help="ISO datetime."),
+    due_at: Optional[datetime] = typer.Option(None, "--due-at", formats=ISO_DATETIME_FORMATS, help="ISO datetime."),
 ) -> None:
     ctx = _ctx(typer_ctx)
     body: dict[str, object] = {"description": description, "completed": completed}
@@ -116,7 +117,7 @@ def update_action_item(
     action_item_id: str = typer.Argument(..., help="Action item ID."),
     description: Optional[str] = typer.Option(None, "--description"),
     completed: Optional[bool] = typer.Option(None, "--completed/--open"),
-    due_at: Optional[datetime] = typer.Option(None, "--due-at"),
+    due_at: Optional[datetime] = typer.Option(None, "--due-at", formats=ISO_DATETIME_FORMATS),
 ) -> None:
     ctx = _ctx(typer_ctx)
     body: dict[str, object] = {}

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Optional
 
 import typer
 
+from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import UsageError
 from omi_cli.models import ConversationTextSource
 from omi_cli.output import shorten
@@ -36,8 +37,12 @@ def list_conversations(
     typer_ctx: typer.Context,
     limit: int = typer.Option(25, "--limit", min=1, max=200),
     offset: int = typer.Option(0, "--offset", min=0),
-    start_date: Optional[datetime] = typer.Option(None, "--start-date", help="ISO datetime lower bound."),
-    end_date: Optional[datetime] = typer.Option(None, "--end-date", help="ISO datetime upper bound."),
+    start_date: Optional[datetime] = typer.Option(
+        None, "--start-date", formats=ISO_DATETIME_FORMATS, help="ISO datetime lower bound."
+    ),
+    end_date: Optional[datetime] = typer.Option(
+        None, "--end-date", formats=ISO_DATETIME_FORMATS, help="ISO datetime upper bound."
+    ),
     categories: Optional[str] = typer.Option(None, "--categories", help="Comma-separated category filter."),
     include_transcript: bool = typer.Option(False, "--include-transcript", help="Include transcript_segments."),
 ) -> None:
@@ -97,8 +102,12 @@ def create_conversation(
         help="Source type. One of audio_transcript, message, other_text.",
     ),
     text_source_spec: Optional[str] = typer.Option(None, "--text-source-spec", help="e.g. 'email', 'slack'."),
-    started_at: Optional[datetime] = typer.Option(None, "--started-at", help="ISO datetime."),
-    finished_at: Optional[datetime] = typer.Option(None, "--finished-at", help="ISO datetime."),
+    started_at: Optional[datetime] = typer.Option(
+        None, "--started-at", formats=ISO_DATETIME_FORMATS, help="ISO datetime."
+    ),
+    finished_at: Optional[datetime] = typer.Option(
+        None, "--finished-at", formats=ISO_DATETIME_FORMATS, help="ISO datetime."
+    ),
     language: str = typer.Option("en", "--language", help="ISO 639-1 code."),
 ) -> None:
     ctx = _ctx(typer_ctx)
@@ -134,8 +143,8 @@ def from_segments(
     typer_ctx: typer.Context,
     segments_file: Path = typer.Argument(..., help="Path to a JSON file containing 'transcript_segments'."),
     source: Optional[str] = typer.Option(None, "--source", help="Conversation source (e.g. omi, friend, phone)."),
-    started_at: Optional[datetime] = typer.Option(None, "--started-at"),
-    finished_at: Optional[datetime] = typer.Option(None, "--finished-at"),
+    started_at: Optional[datetime] = typer.Option(None, "--started-at", formats=ISO_DATETIME_FORMATS),
+    finished_at: Optional[datetime] = typer.Option(None, "--finished-at", formats=ISO_DATETIME_FORMATS),
     language: str = typer.Option("en", "--language"),
 ) -> None:
     ctx = _ctx(typer_ctx)

--- a/sdks/python-cli/omi_cli/datetime_options.py
+++ b/sdks/python-cli/omi_cli/datetime_options.py
@@ -1,0 +1,15 @@
+"""Shared datetime input formats for the CLI's API-facing options."""
+
+# Keep Typer's original date/naive formats and accept API timestamps with
+# fractions and UTC offsets. strptime's %z also accepts the UTC designator Z.
+ISO_DATETIME_FORMATS = [
+    "%Y-%m-%d",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%d %H:%M:%S%z",
+    "%Y-%m-%d %H:%M:%S.%f%z",
+    "%Y-%m-%d %H:%M:%S.%f",
+]

--- a/sdks/python-cli/tests/test_datetime_options.py
+++ b/sdks/python-cli/tests/test_datetime_options.py
@@ -70,5 +70,5 @@ def test_datetime_option_reaches_api(
 def test_invalid_datetime_never_calls_api(authed_profile, respx_mock, cli_runner):
     result = cli_runner.invoke(app, ["action-item", "create", "test", "--due-at", "2026-02-30T12:00:00Z"])
     assert result.exit_code != 0
-    assert "Invalid value" in result.output
+    assert "Invalid value" in result.stderr
     assert len(respx_mock.calls) == 0

--- a/sdks/python-cli/tests/test_datetime_options.py
+++ b/sdks/python-cli/tests/test_datetime_options.py
@@ -1,0 +1,74 @@
+"""Datetime options preserve ISO offsets and fractions in outgoing API requests."""
+
+import json
+
+import pytest
+
+from omi_cli.main import app
+
+CASES = [
+    (["action-item", "create", "test"], "--due-at", "POST", "/v1/dev/user/action-items", "due_at"),
+    (["action-item", "update", "a1"], "--due-at", "PATCH", "/v1/dev/user/action-items/a1", "due_at"),
+    (["action-item", "list"], "--start-date", "GET", "/v1/dev/user/action-items", "start_date"),
+    (["action-item", "list"], "--end-date", "GET", "/v1/dev/user/action-items", "end_date"),
+    (["conversation", "list"], "--start-date", "GET", "/v1/dev/user/conversations", "start_date"),
+    (["conversation", "list"], "--end-date", "GET", "/v1/dev/user/conversations", "end_date"),
+    (["conversation", "create", "--text", "test"], "--started-at", "POST", "/v1/dev/user/conversations", "started_at"),
+    (
+        ["conversation", "create", "--text", "test"],
+        "--finished-at",
+        "POST",
+        "/v1/dev/user/conversations",
+        "finished_at",
+    ),
+    (
+        ["conversation", "from-segments"],
+        "--started-at",
+        "POST",
+        "/v1/dev/user/conversations/from-segments",
+        "started_at",
+    ),
+    (
+        ["conversation", "from-segments"],
+        "--finished-at",
+        "POST",
+        "/v1/dev/user/conversations/from-segments",
+        "finished_at",
+    ),
+]
+
+
+@pytest.mark.parametrize("command,option,method,path,field", CASES)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("2026-09-08T12:30:00Z", "2026-09-08T12:30:00+00:00"),
+        ("2026-09-08T12:30:00.123456+05:30", "2026-09-08T12:30:00.123456+05:30"),
+        ("2026-09-08T12:30:00-04:00", "2026-09-08T12:30:00-04:00"),
+        ("2026-09-08", "2026-09-08T00:00:00"),
+        ("2026-09-08T12:30:00", "2026-09-08T12:30:00"),
+        ("2026-09-08 12:30:00", "2026-09-08T12:30:00"),
+    ],
+)
+def test_datetime_option_reaches_api(
+    authed_profile, respx_mock, cli_runner, tmp_path, command, option, method, path, field, value, expected
+):
+    args = list(command)
+    if "from-segments" in args:
+        segments = tmp_path / "segments.json"
+        segments.write_text('[{"text":"test","start":0,"end":1}]', encoding="utf-8")
+        args.append(str(segments))
+    route = respx_mock.request(method, path).respond(json=[] if method == "GET" else {"id": "test"})
+    result = cli_runner.invoke(app, ["--json", *args, option, value])
+    assert result.exit_code == 0, result.output
+    assert route.call_count == 1
+    request = route.calls.last.request
+    actual = request.url.params[field] if method == "GET" else json.loads(request.content)[field]
+    assert actual == expected
+
+
+def test_invalid_datetime_never_calls_api(authed_profile, respx_mock, cli_runner):
+    result = cli_runner.invoke(app, ["action-item", "create", "test", "--due-at", "2026-02-30T12:00:00Z"])
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output
+    assert len(respx_mock.calls) == 0


### PR DESCRIPTION
Accept explicit timezones and fractional seconds in the Python CLI's conversation and action-item datetime options. Previously, `--due-at 2026-09-08T12:30:00Z` exited 2 before any API request, despite the ISO datetime help text. The options now share Typer input formats that preserve UTC offsets and fractions in the serialized request; existing date-only and naive formats remain supported.

Fixes #12966.

The shared format list owns parsing for all ten affected options. The regression tests exercise the real command and HTTP client with synthetic responses; they do not merely inspect source strings. The expected forms follow [Typer's custom datetime format support](https://typer.tiangolo.com/tutorial/parameter-types/datetime/) and Python datetime's offset-preserving `isoformat()` behavior.

Validation on macOS arm64 / Python 3.12.14:

- `python -m pytest tests/test_datetime_options.py`: 30 failures and 31 passes on unchanged production code; 61 passes with the fix.
- `python -m pytest`: 189 passed, 1 skipped (Windows DACL enforcement only). Two upstream Click deprecation warnings.
- Black and isort checks pass for changed Python files.
- `python -m build --wheel`: passed.
- Local and CI preflight lanes: 12 selected checks passed against the committed five-file diff. The history-dependent failure-class guard ratchet skipped because this checkout is shallow; full-history CI must enforce it.
- Review follow-up: full suite passes on Click 8.1.8 / Typer 0.15.4 and Click 8.5.0 / Typer 0.25.1 (189 passed, 1 Windows-only skip each). Reproduced the prior invalid-date assertion failure on the older pair before changing it to result.stderr. Datetime documentation now has its own usage section.
- No live Omi service or device was used; API requests were intercepted with synthetic fixtures.

## Product invariants affected

none

Failure-Class: none

The credential-permission class suggested by the path matcher concerns credential persistence, not CLI datetime parsing. The existing naive-UTC LLM-surface class concerns formatting model context, not accepting user input. This change fixes input-format selection at the command boundary without changing stored data or assigning a timezone to naive inputs.

AI assistance: OpenAI Codex prepared the investigation, implementation, tests and this description with the account owner's authorization.

Bounty status: a US$10 proposal is pending in #12966. This PR does not claim funding, acceptance or payment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

