### PR TITLE
fix: escape config status values in CLI output

### DIFF
--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import typer
+from rich.markup import escape
 
 from omi_cli import config as cfg
 from omi_cli.errors import UsageError
@@ -88,7 +89,10 @@ def set_value(
     display_value = (
         cfg.Profile(name=profile.name, local_token=value).masked_local_token() if key == "local_token" else value
     )
-    ctx.renderer.success(f"Set [bold]{key}[/bold] = {display_value} on profile [bold]{profile.name}[/bold].")
+    ctx.renderer.success(
+        f"Set [bold]{escape(key)}[/bold] = {escape(display_value)} "
+        f"on profile [bold]{escape(profile.name)}[/bold]."
+    )
 
 
 @profile_app.command("list", help="List all configured profiles.")
@@ -129,7 +133,7 @@ def profile_use(
         config.profiles[name] = cfg.Profile(name=name)
     config.active_profile = name
     cfg.save(config)
-    ctx.renderer.success(f"Active profile: [bold]{name}[/bold].")
+    ctx.renderer.success(f"Active profile: [bold]{escape(name)}[/bold].")
 
 
 @profile_app.command("delete", help="Delete a profile and its credentials.")
@@ -146,4 +150,4 @@ def profile_delete(
         typer.confirm(f"Delete profile '{name}'?", abort=True)
     config.delete_profile(name)
     cfg.save(config)
-    ctx.renderer.success(f"Deleted profile [bold]{name}[/bold].")
+    ctx.renderer.success(f"Deleted profile [bold]{escape(name)}[/bold].")

--- a/sdks/python-cli/tests/test_config_literal_status.py
+++ b/sdks/python-cli/tests/test_config_literal_status.py
@@ -1,0 +1,38 @@
+"""Regression tests for literal Rich status output in ``omi config``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omi_cli import config as cfg
+from omi_cli.main import app
+
+
+def test_config_profile_status_renders_user_markup_literally(config_path: Path, cli_runner) -> None:
+    name = "[/bold]"
+
+    use_result = cli_runner.invoke(app, ["config", "profile", "use", name])
+    assert use_result.exit_code == 0, use_result.output
+    assert name in use_result.stderr
+    assert cfg.load().active_profile == name
+
+    value = "https://example.test/[/bold]"
+    set_result = cli_runner.invoke(app, ["config", "set", "api_base", value])
+    assert set_result.exit_code == 0, set_result.output
+    assert value in set_result.stderr
+    assert cfg.load().get_profile(name).api_base == value
+
+    delete_result = cli_runner.invoke(app, ["config", "profile", "delete", name, "--yes"])
+    assert delete_result.exit_code == 0, delete_result.output
+    assert name in delete_result.stderr
+    assert name not in cfg.load().profiles
+
+
+def test_config_status_preserves_matched_rich_tags_as_literal_text(config_path: Path, cli_runner) -> None:
+    name = "[bold]literal[/bold]"
+
+    result = cli_runner.invoke(app, ["config", "profile", "use", name])
+
+    assert result.exit_code == 0, result.output
+    assert name in result.stderr
+    assert cfg.load().active_profile == name


### PR DESCRIPTION
Config mutations can currently succeed on disk and then fail while rendering their success message if a user-controlled profile name or config value contains Rich markup such as `[/bold]`. Escape only the dynamic fragments before interpolating them into the CLI-owned Rich formatting, preserving the intended bold presentation while rendering user data literally.

Fixes #12975.

This contribution is AI-assisted. A small bounty was proposed separately on the issue; no award or payment is assumed, and payout details will remain private.

Regression coverage includes:
- unmatched Rich closing tags across `config profile use`, `config set`, and `config profile delete`;
- matched Rich-looking profile text remaining visible literally rather than being interpreted as presentation markup.

Focused validation performed in this environment: the original generated status string `Active profile: [bold][/bold][/bold].` reproduces `rich.errors.MarkupError`; the patched escaped form renders without that exception. The branch also adds CLI regression tests using the repository's existing `cli_runner` and isolated config fixture. Full repository/CLI test execution could not be run here because the execution environment could not resolve GitHub for a checkout; hosted CI is therefore authoritative for the complete suite.

## Product invariants affected

none

Failure-Class: none

Root cause: config/profile values cross a presentation-markup boundary as unescaped user-controlled strings after persistence has already completed. The config command owns that boundary, so the fix escapes only those values at the status-message call sites rather than disabling Rich markup globally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

