### PR TITLE
fix(app): keep dev builds from crashing when opened without flutter run

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -308,6 +308,12 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "SCA-273: the real watch presentation contract must stop its ripple after five seconds, preserve elapsed time, and localize accessibility labels for every native locale"
+  - id: ios-flutter-launch-engine-guard
+    command: ["ruby", "app/ios/test/flutter_launch_engine_guard_test.rb"]
+    triggers: ["app/ios/Runner/FlutterLaunchEngineGuard.swift", "app/ios/Runner/AppDelegate.swift", "app/ios/test/flutter_launch_engine_guard_test.rb", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    platforms: ["macos"]
+    reason: "a debug build opened without Flutter tooling has no engine; AppDelegate must skip plugin registration instead of handing plugins a nil registrar (launch crash in SwiftAwesomeNotificationsPlugin.register)"
   - id: ios-ble-energy-policy
     command: ["ruby", "app/ios/test/omi_ble_energy_policy_test.rb"]
     triggers: ["app/ios/Runner/Ble/OmiBleEnergyPolicy.swift", "app/ios/Runner/Ble/OmiBleManager.swift", "app/ios/Runner/Ble/BleHostApiImpl.swift", "app/ios/Runner.xcodeproj/project.pbxproj", "app/ios/test/omi_ble_energy_policy_test.rb", ".github/checks-manifest.yaml"]

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -28,6 +28,8 @@ For physical-device builds, use the wrapper: it owns `dev + local_dev` and
 `prod + mobile_beta` pairing plus auth env setup. Direct builds must first run
 `scripts/validate_mobile_build_config.sh --flavor <dev|prod> --profile <profile>`
 with the matching `OMI_APP_PROFILE`; release/profile helpers do this too.
+`OMI_MOBILE_BUILD_MODE=profile` installs an AOT build that opens untethered
+(debug builds need `flutter run` attached on a physical iPhone; see README).
 
 ### Firebase Config
 Never run `flutterfire configure` — it overwrites prod credentials. Config files:

--- a/app/README.md
+++ b/app/README.md
@@ -91,6 +91,16 @@ build.
 
 To build and deploy the app to an iPhone so it can run independently from your laptop:
 
+The quick path is the setup wrapper with an AOT build mode:
+```bash
+OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios   # or release
+```
+A plain `bash setup.sh ios` installs a debug (JIT) build, which iOS only lets run
+while `flutter run` is attached; opened from the Home Screen it shows a notice
+explaining that instead of starting.
+
+Manual equivalent:
+
 1. Build the iOS app with release mode and specific flavor:
    ```bash
    # After the normal setup has seeded the iOS/Firebase files:

--- a/app/ios/Flutter/devProfile.xcconfig
+++ b/app/ios/Flutter/devProfile.xcconfig
@@ -9,4 +9,3 @@ BUNDLE_DISPLAY_NAME=Omi Dev
 APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12.development
 AUTH_CALLBACK_SCHEME=omi-dev
 INFOPLIST_FILE=Runner/Info-Dev.plist
-GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde

--- a/app/ios/Flutter/devProfile.xcconfig
+++ b/app/ios/Flutter/devProfile.xcconfig
@@ -6,5 +6,7 @@
 ASSET_PREFIX=dev
 BUNDLE_NAME=Omi Dev
 BUNDLE_DISPLAY_NAME=Omi Dev
+APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12.development
 AUTH_CALLBACK_SCHEME=omi-dev
 INFOPLIST_FILE=Runner/Info-Dev.plist
+GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde

--- a/app/ios/Flutter/devRelease.xcconfig
+++ b/app/ios/Flutter/devRelease.xcconfig
@@ -9,4 +9,3 @@ BUNDLE_DISPLAY_NAME=Omi Dev
 APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12.development
 AUTH_CALLBACK_SCHEME=omi-dev
 INFOPLIST_FILE=Runner/Info-Dev.plist
-GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde

--- a/app/ios/Flutter/devRelease.xcconfig
+++ b/app/ios/Flutter/devRelease.xcconfig
@@ -6,5 +6,7 @@
 ASSET_PREFIX=dev
 BUNDLE_NAME=Omi Dev
 BUNDLE_DISPLAY_NAME=Omi Dev
+APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12.development
 AUTH_CALLBACK_SCHEME=omi-dev
 INFOPLIST_FILE=Runner/Info-Dev.plist
+GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		15BE32846414AB444D807D9B /* PigeonCommunicator.g.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C7B2F69BC6600BFDA9D /* PigeonCommunicator.g.swift */; };
 		16935068EFFE77C62C493C3C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A9F5F37DDF9FA87AC8A5CD /* GoogleService-Info.plist */; };
 		18B5E977FCEDF03D5DDE4A21 /* AppleHealthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD12345678901234567890CE /* AppleHealthService.swift */; };
+		7A3F1C2E9B4D5E6F0A1B2C3E /* FlutterLaunchEngineGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3F1C2E9B4D5E6F0A1B2C3D /* FlutterLaunchEngineGuard.swift */; };
 		19570D5AA4C5B2E3154671BE /* RayBanMetaHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAADF00DF00DF00DF00DFC02 /* RayBanMetaHostApiImpl.swift */; };
 		1D93FD645488AAB7DBE4EF49 /* LimitlessProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAADF00DF00DF00DF00DF0D7 /* LimitlessProtocol.swift */; };
 		2233D9F0F73BEE78D735B79C /* devRelease.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 79B00761CB247C7EC7C8983B /* devRelease.xcconfig */; };
@@ -87,6 +88,7 @@
 		A99145F1E008BFA300A30BA0 /* BleHostApiImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B17C632F69B9E100BFDA9D /* BleHostApiImpl.swift */; };
 		AB12345678901234567890AB /* AppleRemindersService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD12345678901234567890CD /* AppleRemindersService.swift */; };
 		AB12345678901234567890AC /* AppleHealthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD12345678901234567890CE /* AppleHealthService.swift */; };
+		7A3F1C2E9B4D5E6F0A1B2C3F /* FlutterLaunchEngineGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3F1C2E9B4D5E6F0A1B2C3D /* FlutterLaunchEngineGuard.swift */; };
 		AFF50718E1B191240567E4A7 /* OmiRegionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42BABFCE2F2A81B100E78A3C /* OmiRegionCheck.swift */; };
 		B017E73914CFF7C22190E0C3 /* prodProfile.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B52E83A1CC630E163A04DC50 /* prodProfile.xcconfig */; };
 		B07ABDD2736E2C87A59FB5E1 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
@@ -279,6 +281,7 @@
 		C84EE89ABD9CB9B1CFD8B8CB /* Pods-Runner.profile-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"; sourceTree = "<group>"; };
 		CD12345678901234567890CD /* AppleRemindersService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleRemindersService.swift; sourceTree = "<group>"; };
 		CD12345678901234567890CE /* AppleHealthService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleHealthService.swift; sourceTree = "<group>"; };
+		7A3F1C2E9B4D5E6F0A1B2C3D /* FlutterLaunchEngineGuard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlutterLaunchEngineGuard.swift; sourceTree = "<group>"; };
 		CF0FE6142D61FDC10072C10D /* Custom.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Custom.xcconfig; path = Flutter/Custom.xcconfig; sourceTree = "<group>"; };
 		CF2F518C2EC08EA60025B331 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Base.xcconfig; path = Flutter/Base.xcconfig; sourceTree = "<group>"; };
 		E2100BFB54B13863400AB3AB /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -487,6 +490,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				CD12345678901234567890CD /* AppleRemindersService.swift */,
 				CD12345678901234567890CE /* AppleHealthService.swift */,
+				7A3F1C2E9B4D5E6F0A1B2C3D /* FlutterLaunchEngineGuard.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				6436409C27A31CD800820AF7 /* InfoPlist.strings */,
 			);
@@ -944,6 +948,7 @@
 				BAADF00DF00DF00DF00DF0DA /* LimitlessFlashDrainEngine.swift in Sources */,
 				AB12345678901234567890AB /* AppleRemindersService.swift in Sources */,
 				AB12345678901234567890AC /* AppleHealthService.swift in Sources */,
+				7A3F1C2E9B4D5E6F0A1B2C3F /* FlutterLaunchEngineGuard.swift in Sources */,
 				42B17C642F69B9E100BFDA9D /* BleHostApiImpl.swift in Sources */,
 				BAADF00DF00DF00DF00DFC03 /* RayBanMetaAudioCapture.swift in Sources */,
 				BAADF00DF00DF00DF00DFC04 /* RayBanMetaHostApiImpl.swift in Sources */,
@@ -989,6 +994,7 @@
 				648454527D23C31E3AF5A635 /* LimitlessFlashDrainEngine.swift in Sources */,
 				5A2653E6C23BCD2FF632A493 /* AppleRemindersService.swift in Sources */,
 				18B5E977FCEDF03D5DDE4A21 /* AppleHealthService.swift in Sources */,
+				7A3F1C2E9B4D5E6F0A1B2C3E /* FlutterLaunchEngineGuard.swift in Sources */,
 				A99145F1E008BFA300A30BA0 /* BleHostApiImpl.swift in Sources */,
 				5FC8F848E2BD3FDF3AF27F37 /* RayBanMetaAudioCapture.swift in Sources */,
 				19570D5AA4C5B2E3154671BE /* RayBanMetaHostApiImpl.swift in Sources */,

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -103,6 +103,21 @@ final class QuickActionsIconPatcher: NSObject {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // A debug build opened without Flutter tooling (Home Screen tap, or an iOS
+    // background relaunch after `flutter run` disconnected) has no engine: iOS
+    // refuses the JIT Dart VM, FlutterEngine init returns nil, and every
+    // registrar below would be nil. Registering plugins anyway crashed in
+    // SwiftAwesomeNotificationsPlugin.register; explain instead.
+    let flutterController = window?.rootViewController as? FlutterViewController
+    guard
+      FlutterLaunchEngineGuard.canRegisterPlugins(
+        hasFlutterRootViewController: flutterController != nil,
+        hasEngine: flutterController?.engine != nil
+      ), let controller = flutterController
+    else {
+      showFlutterEngineUnavailableNotice()
+      return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
     GeneratedPluginRegistrant.register(with: self)
     QuickActionsIconPatcher.shared.startObserving()
       
@@ -112,30 +127,28 @@ final class QuickActionsIconPatcher: NSObject {
           session?.delegate = self
           session?.activate();
 
-          let controller = window?.rootViewController as? FlutterViewController
-            flutterWatchAPI = WatchRecorderFlutterAPI(binaryMessenger: controller!.binaryMessenger)
+            flutterWatchAPI = WatchRecorderFlutterAPI(binaryMessenger: controller.binaryMessenger)
             let api: WatchRecorderHostAPI = RecorderHostApiImpl(session: session!, flutterWatchAPI: flutterWatchAPI)
 
-            WatchRecorderHostAPISetup.setUp(binaryMessenger: controller!.binaryMessenger, api: api)
+            WatchRecorderHostAPISetup.setUp(binaryMessenger: controller.binaryMessenger, api: api)
       }
 
       // Native BLE module — register Pigeon APIs
       NSLog("[OmiBle] Registering BLE Pigeon APIs")
-      let bleController = window?.rootViewController as? FlutterViewController
-      if let messenger = bleController?.binaryMessenger {
+      do {
+          let messenger = controller.binaryMessenger
           let bleFlutterApi = BleFlutterApi(binaryMessenger: messenger)
           OmiBleManager.shared.setFlutterApi(bleFlutterApi)
           let bleHostApi = BleHostApiImpl(bleManager: OmiBleManager.shared)
           BleHostApiSetup.setUp(binaryMessenger: messenger, api: bleHostApi)
           NSLog("[OmiBle] BLE Pigeon APIs registered successfully")
-      } else {
-          NSLog("[OmiBle] ERROR: Could not get FlutterBinaryMessenger")
       }
 
       // Ray-Ban Meta (Meta Wearables DAT camera + Bluetooth HFP mic) — Pigeon APIs.
       // Registered unconditionally; the impl reports availability mode based on
       // whether the DAT SDK is linked into this build.
-      if let messenger = (window?.rootViewController as? FlutterViewController)?.binaryMessenger {
+      do {
+          let messenger = controller.binaryMessenger
           let rayBanFlutterApi = RayBanMetaFlutterAPI(binaryMessenger: messenger)
           let rayBanApi = RayBanMetaHostApiImpl(flutterAPI: rayBanFlutterApi)
           rayBanMetaHostApi = rayBanApi
@@ -145,11 +158,12 @@ final class QuickActionsIconPatcher: NSObject {
       // Native phone-mic capture (conversation recording) — Pigeon APIs.
       // Self-healing AVAudioEngine capture; interruption/route recovery is
       // handled natively, Dart only mirrors the state.
-      if let messenger = (window?.rootViewController as? FlutterViewController)?.binaryMessenger {
+      do {
+          let messenger = controller.binaryMessenger
           let phoneMicFlutterApi = PhoneMicFlutterApi(binaryMessenger: messenger)
-          let controller = PhoneMicController(flutterApi: phoneMicFlutterApi)
-          phoneMicController = controller
-          PhoneMicHostApiSetup.setUp(binaryMessenger: messenger, api: PhoneMicHostApiImpl(controller: controller))
+          let micController = PhoneMicController(flutterApi: phoneMicFlutterApi)
+          phoneMicController = micController
+          PhoneMicHostApiSetup.setUp(binaryMessenger: messenger, api: PhoneMicHostApiImpl(controller: micController))
       }
 
       // Retrieve the link from parameters
@@ -159,33 +173,32 @@ final class QuickActionsIconPatcher: NSObject {
       return true // Returning true will stop the propagation to other packages
     }
     //Creates a method channel to handle notifications on kill
-    let controller = window?.rootViewController as? FlutterViewController
-    methodChannel = FlutterMethodChannel(name: "com.friend.ios/notifyOnKill", binaryMessenger: controller!.binaryMessenger)
+    methodChannel = FlutterMethodChannel(name: "com.friend.ios/notifyOnKill", binaryMessenger: controller.binaryMessenger)
     methodChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleMethodCall(call, result: result)
     }
     
     // Create Apple Reminders method channel
-    appleRemindersChannel = FlutterMethodChannel(name: "com.omi.apple_reminders", binaryMessenger: controller!.binaryMessenger)
+    appleRemindersChannel = FlutterMethodChannel(name: "com.omi.apple_reminders", binaryMessenger: controller.binaryMessenger)
     appleRemindersChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleAppleRemindersCall(call, result: result)
     }
 
     // Create Apple Health method channel
-    appleHealthChannel = FlutterMethodChannel(name: "com.omi.apple_health", binaryMessenger: controller!.binaryMessenger)
+    appleHealthChannel = FlutterMethodChannel(name: "com.omi.apple_health", binaryMessenger: controller.binaryMessenger)
     appleHealthChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleAppleHealthCall(call, result: result)
     }
 
     // Create Speech Recognition method channel
-    let speechChannel = FlutterMethodChannel(name: "com.omi.ios/speech", binaryMessenger: controller!.binaryMessenger)
+    let speechChannel = FlutterMethodChannel(name: "com.omi.ios/speech", binaryMessenger: controller.binaryMessenger)
     let speechHandler = SpeechRecognitionHandler()
     speechChannel.setMethodCallHandler { (call, result) in
         speechHandler.handle(call, result: result)
     }
 
     // TestFlight environment detection
-    let envChannel = FlutterMethodChannel(name: "com.omi/environment", binaryMessenger: controller!.binaryMessenger)
+    let envChannel = FlutterMethodChannel(name: "com.omi/environment", binaryMessenger: controller.binaryMessenger)
     envChannel.setMethodCallHandler { (call, result) in
         if call.method == "isTestFlight" {
             let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
@@ -196,7 +209,7 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     // Audio session configuration for Bluetooth microphone support
-    let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller!.binaryMessenger)
+    let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller.binaryMessenger)
     audioSessionChannel.setMethodCallHandler { (call, result) in
         if call.method == "configureForBluetooth" {
             let audioSession = AVAudioSession.sharedInstance()
@@ -218,7 +231,7 @@ final class QuickActionsIconPatcher: NSObject {
 
     // Battery widget channel — writes Omi device battery to the shared App Group
     // so the WidgetKit extension can read it.
-    let batteryWidgetChannel = FlutterMethodChannel(name: "com.omi.battery_widget", binaryMessenger: controller!.binaryMessenger)
+    let batteryWidgetChannel = FlutterMethodChannel(name: "com.omi.battery_widget", binaryMessenger: controller.binaryMessenger)
     batteryWidgetChannel.setMethodCallHandler { (call, result) in
       let defaults = UserDefaults(suiteName: "group.com.friend-app-with-wearable.ios12")
       guard let args = call.arguments as? [String: Any] else {
@@ -269,6 +282,41 @@ final class QuickActionsIconPatcher: NSObject {
       )
     }
     return launched
+  }
+
+  /// Swaps the engine-less storyboard controller for a plain notice before the
+  /// window is shown, so nothing in this launch touches the missing engine.
+  /// See FlutterLaunchEngineGuard for why the engine can be absent.
+  private func showFlutterEngineUnavailableNotice() {
+    #if DEBUG
+    let debugBuild = true
+    #else
+    let debugBuild = false
+    #endif
+    let displayName =
+      (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "Omi"
+    let message = FlutterLaunchEngineGuard.unavailableNotice(
+      debugBuild: debugBuild,
+      bundleDisplayName: displayName
+    )
+    NSLog("[OmiLaunch] Flutter engine unavailable at launch; skipping plugin registration.\n%@", message)
+
+    let notice = UIViewController()
+    notice.view.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.numberOfLines = 0
+    label.textAlignment = .center
+    label.font = .preferredFont(forTextStyle: .body)
+    label.textColor = .label
+    label.text = message
+    label.translatesAutoresizingMaskIntoConstraints = false
+    notice.view.addSubview(label)
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: notice.view.layoutMarginsGuide.leadingAnchor, constant: 16),
+      label.trailingAnchor.constraint(equalTo: notice.view.layoutMarginsGuide.trailingAnchor, constant: -16),
+      label.centerYAnchor.constraint(equalTo: notice.view.centerYAnchor),
+    ])
+    window?.rootViewController = notice
   }
 
   override func applicationDidEnterBackground(_ application: UIApplication) {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -316,7 +316,10 @@ final class QuickActionsIconPatcher: NSObject {
       label.trailingAnchor.constraint(equalTo: notice.view.layoutMarginsGuide.trailingAnchor, constant: -16),
       label.centerYAnchor.constraint(equalTo: notice.view.centerYAnchor),
     ])
+    // Also covers an iOS background relaunch (BLE/VoIP): nothing is drawn
+    // until the user foregrounds the app, and this is what they see then.
     window?.rootViewController = notice
+    window?.makeKeyAndVisible()
   }
 
   override func applicationDidEnterBackground(_ application: UIApplication) {

--- a/app/ios/Runner/FlutterLaunchEngineGuard.swift
+++ b/app/ios/Runner/FlutterLaunchEngineGuard.swift
@@ -23,8 +23,8 @@ enum FlutterLaunchEngineGuard {
             return """
             \(bundleDisplayName) is a debug build, and iOS only lets Flutter tooling start a debug Dart VM on a device.
 
-            Launch it again with flutter run, or install a build that opens on its own:
-            OMI_MOBILE_BUILD_MODE=profile bash app/setup.sh ios
+            Launch it again with flutter run, or install a build that opens on its own (from app/):
+            OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios
             """
         }
         return "\(bundleDisplayName) could not start its Flutter engine. Reinstall the app."

--- a/app/ios/Runner/FlutterLaunchEngineGuard.swift
+++ b/app/ios/Runner/FlutterLaunchEngineGuard.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Decides whether `AppDelegate` may register Flutter plugins at launch and
+/// what to show when it cannot.
+///
+/// A debug build launched without Flutter tooling attached (a Home Screen tap,
+/// or an iOS background relaunch for BLE/VoIP after `flutter run` has gone)
+/// cannot start a JIT Dart VM on a physical device. `FlutterEngine` init then
+/// returns nil, the storyboard `FlutterViewController` has no engine, every
+/// registrar the app delegate vends is nil, and the first Swift plugin
+/// dereferences it (SIGSEGV in `SwiftAwesomeNotificationsPlugin.register`).
+/// Skipping registration and explaining the situation turns that crash into an
+/// actionable screen. Foundation-only so `ios/test` can compile it standalone.
+enum FlutterLaunchEngineGuard {
+    /// True only when a Flutter root view controller exists and owns an engine.
+    static func canRegisterPlugins(hasFlutterRootViewController: Bool, hasEngine: Bool) -> Bool {
+        hasFlutterRootViewController && hasEngine
+    }
+
+    /// Developer-facing text for the replacement root view controller.
+    static func unavailableNotice(debugBuild: Bool, bundleDisplayName: String) -> String {
+        if debugBuild {
+            return """
+            \(bundleDisplayName) is a debug build, and iOS only lets Flutter tooling start a debug Dart VM on a device.
+
+            Launch it again with flutter run, or install a build that opens on its own:
+            OMI_MOBILE_BUILD_MODE=profile bash app/setup.sh ios
+            """
+        }
+        return "\(bundleDisplayName) could not start its Flutter engine. Reinstall the app."
+    }
+}

--- a/app/ios/Runner/RunnerProfile-dev.entitlements
+++ b/app/ios/Runner/RunnerProfile-dev.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>Devdevelopment</string>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/app/ios/test/flutter_launch_engine_guard_test.rb
+++ b/app/ios/test/flutter_launch_engine_guard_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+
+# Regression: a dev-flavor debug build opened from the Home Screen (or relaunched
+# by iOS in the background) after `flutter run` disconnected crashed inside
+# SwiftAwesomeNotificationsPlugin.register, because AppDelegate registered
+# plugins against a FlutterViewController whose engine never came up.
+class FlutterLaunchEngineGuardTest < Minitest::Test
+  IOS_ROOT = File.expand_path('..', __dir__)
+  GUARD_SOURCE = File.join(IOS_ROOT, 'Runner', 'FlutterLaunchEngineGuard.swift')
+
+  def test_plugin_registration_requires_a_live_engine
+    Dir.mktmpdir('omi-launch-engine-guard') do |directory|
+      harness = File.join(directory, 'main.swift')
+      binary = File.join(directory, 'omi-launch-engine-guard-test')
+      File.write(harness, <<~SWIFT)
+        import Foundation
+
+        @main
+        struct FlutterLaunchEngineGuardTestHarness {
+            static func main() {
+                // The storyboard controller exists but FlutterEngine init returned
+                // nil (debug JIT refused without tooling): never hand plugins a
+                // nil registrar.
+                precondition(!FlutterLaunchEngineGuard.canRegisterPlugins(
+                    hasFlutterRootViewController: true,
+                    hasEngine: false
+                ))
+                // No Flutter root controller at all (window not built yet).
+                precondition(!FlutterLaunchEngineGuard.canRegisterPlugins(
+                    hasFlutterRootViewController: false,
+                    hasEngine: false
+                ))
+                // Normal tooled or AOT launch.
+                precondition(FlutterLaunchEngineGuard.canRegisterPlugins(
+                    hasFlutterRootViewController: true,
+                    hasEngine: true
+                ))
+
+                let debugNotice = FlutterLaunchEngineGuard.unavailableNotice(
+                    debugBuild: true,
+                    bundleDisplayName: "Omi Dev"
+                )
+                precondition(debugNotice.contains("Omi Dev"))
+                precondition(debugNotice.contains("flutter run"))
+                precondition(debugNotice.contains("OMI_MOBILE_BUILD_MODE=profile"))
+
+                let releaseNotice = FlutterLaunchEngineGuard.unavailableNotice(
+                    debugBuild: false,
+                    bundleDisplayName: "Omi"
+                )
+                precondition(releaseNotice.contains("Omi"))
+                precondition(!releaseNotice.contains("OMI_MOBILE_BUILD_MODE"))
+            }
+        }
+      SWIFT
+
+      stdout, stderr, compile_status = Open3.capture3(
+        'swiftc',
+        '-parse-as-library',
+        GUARD_SOURCE,
+        harness,
+        '-o',
+        binary,
+      )
+      assert compile_status.success?, "swiftc failed:\n#{stdout}\n#{stderr}"
+
+      stdout, stderr, run_status = Open3.capture3(binary)
+      assert run_status.success?, "guard assertions failed:\n#{stdout}\n#{stderr}"
+    end
+  end
+end

--- a/app/scripts/mobile_build_wrapper_test.sh
+++ b/app/scripts/mobile_build_wrapper_test.sh
@@ -89,6 +89,13 @@ log_file="$fixture_dir/flutter.log"
     echo 'FAIL: profile build still warned about the untethered debug crash' >&2
     exit 1
   fi
+  # The remedy builds the dev flavor, so a beta (prod-flavor) build must not
+  # be pointed at it.
+  run_build_ios prod 2>"$warning_file"
+  if grep -F 'OMI_MOBILE_BUILD_MODE=profile' "$warning_file" >/dev/null; then
+    echo 'FAIL: prod-flavor build was given the dev-only untethered remedy' >&2
+    exit 1
+  fi
 )
 
 echo 'mobile build wrapper injects one required profile, rejects conflicts, and honors OMI_MOBILE_BUILD_MODE'

--- a/app/scripts/mobile_build_wrapper_test.sh
+++ b/app/scripts/mobile_build_wrapper_test.sh
@@ -47,6 +47,48 @@ log_file="$fixture_dir/flutter.log"
     echo 'FAIL: wrapper accepted a conflicting profile define' >&2
     exit 1
   fi
+
+  # OMI_MOBILE_BUILD_MODE: debug (default) adds no mode flag; profile/release
+  # add exactly one. Regression: a dev debug build on a physical iPhone crashed
+  # at launch as soon as flutter run disconnected (iOS refuses a JIT Dart VM
+  # without tooling), and nothing in the wrapper offered the AOT alternative.
+  : >"$log_file"
+  run_build_ios dev
+  grep -F 'flutter run --flavor dev -d TEST-DEVICE --dart-define=OMI_APP_PROFILE=local_dev' "$log_file" >/dev/null
+  if grep -E -- '--profile|--release' "$log_file" >/dev/null; then
+    echo 'FAIL: default build mode added a profile/release flag' >&2
+    exit 1
+  fi
+
+  : >"$log_file"
+  OMI_MOBILE_BUILD_MODE=profile run_build_ios dev
+  grep -F 'flutter run --flavor dev -d TEST-DEVICE --dart-define=OMI_APP_PROFILE=local_dev --profile' "$log_file" >/dev/null
+
+  : >"$log_file"
+  OMI_MOBILE_BUILD_MODE=release run_build_android dev
+  grep -E '^flutter run --flavor dev .*--release$' "$log_file" >/dev/null
+
+  : >"$log_file"
+  if OMI_MOBILE_BUILD_MODE=bogus run_build_ios dev 2>/dev/null; then
+    echo 'FAIL: wrapper accepted an unknown OMI_MOBILE_BUILD_MODE' >&2
+    exit 1
+  fi
+  if grep -F 'flutter run' "$log_file" >/dev/null; then
+    echo 'FAIL: wrapper ran flutter with an unknown OMI_MOBILE_BUILD_MODE' >&2
+    exit 1
+  fi
+
+  # A debug build headed for a physical iPhone gets the untethered-crash
+  # warning naming the fix; an AOT build does not.
+  _ios_device_is_physical() { return 0; }
+  warning_file="$fixture_dir/warning.log"
+  OMI_DEV_HOST=192.168.1.2 run_build_ios dev 2>"$warning_file"
+  grep -F 'OMI_MOBILE_BUILD_MODE=profile' "$warning_file" >/dev/null
+  OMI_DEV_HOST=192.168.1.2 OMI_MOBILE_BUILD_MODE=profile run_build_ios dev 2>"$warning_file"
+  if grep -F 'OMI_MOBILE_BUILD_MODE=profile' "$warning_file" >/dev/null; then
+    echo 'FAIL: profile build still warned about the untethered debug crash' >&2
+    exit 1
+  fi
 )
 
-echo 'mobile build wrapper injects one required profile and rejects conflicts'
+echo 'mobile build wrapper injects one required profile, rejects conflicts, and honors OMI_MOBILE_BUILD_MODE'

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -77,14 +77,14 @@ function mobile_build_mode_flag() {
   esac
 }
 
-# Printed when a debug build is about to land on a physical iPhone, so the
-# "works under flutter run, crashes from the Home Screen" symptom is explained
+# Printed when a dev debug build is about to land on a physical iPhone, so the
+# "works under flutter run, dead from the Home Screen" symptom is explained
 # before the developer walks away from the Mac with it.
 function warn_ios_debug_build_untethered() {
   echo "⚠️  Installing a DEBUG build on a physical iPhone. iOS only lets Flutter tooling" >&2
-  echo "   start a debug (JIT) Dart VM, so this build runs while flutter run is attached" >&2
-  echo "   and crashes on launch as soon as you open it from the Home Screen without it." >&2
-  echo "   For a build that opens on its own (no hot reload):" >&2
+  echo "   start a debug (JIT) Dart VM, so this build runs while flutter run is attached;" >&2
+  echo "   opened from the Home Screen without it, it shows an engine-unavailable notice" >&2
+  echo "   instead of running. For a build that opens on its own (no hot reload):" >&2
   echo "     OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios" >&2
 }
 
@@ -505,7 +505,7 @@ function run_build_ios() {
     echo "   both setup.sh and make dev-up, or the app will hang waiting for the" >&2
     echo "   backend. See the physical-device tip in docs/doc/developer/AppSetup.mdx." >&2
   fi
-  if [[ -z "$mode_flag" && "$physical_device" == 1 ]]; then
+  if [[ "$flavor" == "dev" && -z "$mode_flag" && "$physical_device" == 1 ]]; then
     warn_ios_debug_build_untethered
   fi
   flutter pub get \

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -48,6 +48,7 @@ echo "- bash setup.sh ios"
 echo "- bash setup.sh android"
 echo "- bash setup.sh ios beta   # explicit production-data dogfood build"
 echo "- bash setup.sh android beta   # explicit production-data dogfood build"
+echo "- OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios   # AOT build that opens from the Home Screen without flutter run"
 echo ""
 
 LOCAL_DEV_HOST="${OMI_DEV_HOST:-127.0.0.1}"
@@ -55,6 +56,37 @@ LOCAL_API_BASE_URL="${OMI_LOCAL_API_BASE_URL:-http://${LOCAL_DEV_HOST}:8000/}"
 ANDROID_DEV_HOST="${OMI_ANDROID_DEV_HOST:-${OMI_DEV_HOST:-10.0.2.2}}"
 ANDROID_LOCAL_API_BASE_URL="${OMI_LOCAL_API_BASE_URL:-http://${ANDROID_DEV_HOST}:8000/}"
 BETA_API_BASE_URL="${OMI_BETA_API_BASE_URL:-https://api.omiapi.com/}"
+
+# Maps OMI_MOBILE_BUILD_MODE (debug|profile|release, default debug) to the
+# `flutter run` flag. Debug builds are JIT, and iOS 14+ only lets Flutter
+# tooling start a JIT Dart VM on a physical device: FlutterEngine init returns
+# nil, the storyboard FlutterViewController has no engine, and the first Swift
+# plugin crashes on a nil registrar the moment the app is opened from the Home
+# Screen with `flutter run` gone. profile/release builds are AOT and open on
+# their own, at the cost of hot reload.
+function mobile_build_mode_flag() {
+  local mode="${OMI_MOBILE_BUILD_MODE:-debug}"
+  case "$mode" in
+    debug) ;;
+    profile) echo "--profile" ;;
+    release) echo "--release" ;;
+    *)
+      echo "ERROR: OMI_MOBILE_BUILD_MODE must be debug, profile, or release (got '${mode}')." >&2
+      return 1
+      ;;
+  esac
+}
+
+# Printed when a debug build is about to land on a physical iPhone, so the
+# "works under flutter run, crashes from the Home Screen" symptom is explained
+# before the developer walks away from the Mac with it.
+function warn_ios_debug_build_untethered() {
+  echo "⚠️  Installing a DEBUG build on a physical iPhone. iOS only lets Flutter tooling" >&2
+  echo "   start a debug (JIT) Dart VM, so this build runs while flutter run is attached" >&2
+  echo "   and crashes on launch as soon as you open it from the Home Screen without it." >&2
+  echo "   For a build that opens on its own (no hot reload):" >&2
+  echo "     OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios" >&2
+}
 
 ######################################
 # Generate device suffix from hostname
@@ -275,6 +307,8 @@ function run_build_android() {
       ;;
   esac
   prepare_mobile_build_env "$flavor" "$api_base_url"
+  local mode_flag
+  mode_flag=$(mobile_build_mode_flag) || return 1
   local flutter_args=(
     --flavor "$flavor"
     "--dart-define=OMI_APP_PROFILE=$profile"
@@ -282,6 +316,9 @@ function run_build_android() {
   )
   if [[ -n "$emulator_host" ]]; then
     flutter_args+=("--dart-define=OMI_FIREBASE_AUTH_EMULATOR_HOST=$emulator_host")
+  fi
+  if [[ -n "$mode_flag" ]]; then
+    flutter_args+=("$mode_flag")
   fi
   flutter pub get \
     && dart run build_runner build \
@@ -450,14 +487,26 @@ function run_build_ios() {
     flutter_args+=("$arg")
   done
   check_ios_prerequisites || return 1
+  local mode_flag
+  mode_flag=$(mobile_build_mode_flag) || return 1
+  if [[ -n "$mode_flag" ]]; then
+    flutter_args+=("$mode_flag")
+  fi
   local device_id
   device_id=$(select_ios_device) || return 1
-  if [[ "$flavor" == "dev" && -z "${OMI_DEV_HOST:-}" ]] && _ios_device_is_physical "$device_id"; then
+  local physical_device=0
+  if _ios_device_is_physical "$device_id"; then
+    physical_device=1
+  fi
+  if [[ "$flavor" == "dev" && -z "${OMI_DEV_HOST:-}" && "$physical_device" == 1 ]]; then
     echo "⚠️  Building for a physical device with OMI_DEV_HOST unset — the dev backend" >&2
     echo "   will default to 127.0.0.1, which on the device is itself, not this Mac." >&2
     echo "   Set OMI_DEV_HOST to this Mac's LAN or Tailscale address before running" >&2
     echo "   both setup.sh and make dev-up, or the app will hang waiting for the" >&2
     echo "   backend. See the physical-device tip in docs/doc/developer/AppSetup.mdx." >&2
+  fi
+  if [[ -z "$mode_flag" && "$physical_device" == 1 ]]; then
+    warn_ios_debug_build_untethered
   fi
   flutter pub get \
     && pushd ios && pod install --repo-update && popd \

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -354,30 +354,37 @@ ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit
     no hosted backend can verify. Production data requires the explicit `beta`
     profile.
   </Accordion>
-  <Accordion title="iOS: Unable to flip between RX and RW memory protection" icon="apple">
-    **Error Message:**
-    ```
-    error: Unable to flip between RX and RW memory protection on pages
-    ```
+  <Accordion title="iOS: works under flutter run, crashes when opened from the Home Screen" icon="apple">
+    **Symptoms:**
+    - The dev build runs fine while `flutter run` is attached, then crashes instantly
+      when you open it from the Home Screen after disconnecting (or iOS relaunches it
+      in the background for Bluetooth/VoIP). The phone's crash report ends in
+      `SwiftAwesomeNotificationsPlugin.register(with:)` with `KERN_INVALID_ADDRESS at 0x0`.
+    - `flutter run` itself prints:
+      ```
+      error: Unable to flip between RX and RW memory protection on pages
+      ```
 
     **Cause:**
-    This error occurs because iOS security restrictions prevent the Dart VM from changing memory protection during JIT compilation in Debug mode on physical devices.
+    Debug builds run the Dart VM in JIT mode, and iOS only lets Flutter tooling
+    start a JIT VM on a physical device. Without it, `FlutterEngine` init returns
+    nil, the app's `FlutterViewController` has no engine, and plugin registration
+    has nothing to register against. The app now shows a notice explaining this
+    instead of crashing, but it still cannot run.
 
     **Solutions:**
 
-    1. **Use iOS Simulator (Recommended for Development):**
-       - In Xcode, select an iOS Simulator (e.g., "iPhone 16 Pro") instead of your physical device
-       - The simulator doesn't have this restriction, so Debug mode works normally
-       - Or run: `flutter run --flavor dev` (it will use a simulator if available)
+    1. **Install an AOT build for untethered use (physical devices):**
+       ```bash
+       OMI_MOBILE_BUILD_MODE=profile bash setup.sh ios
+       ```
+       Profile (or `release`) builds open from the Home Screen on their own. You
+       lose hot reload; press `d` in `flutter run` to detach and keep the app running.
+       `setup.sh ios` warns whenever a debug build is about to land on a physical iPhone.
 
-    2. **Use Release/Profile Mode for Physical Devices:**
-       - If you need to test on a physical device, build in Release or Profile mode:
-         ```bash
-         flutter run --release --flavor dev
-         ```
-       - Or in Xcode, select "Release" or "Profile" scheme instead of "Debug"
-
-    **Note:** This is a known Flutter/iOS limitation. Debug mode with JIT compilation requires memory protection changes that iOS blocks on physical devices for security reasons.
+    2. **Use the iOS Simulator for debug-mode development:**
+       - The simulator has no JIT restriction, so `flutter run --flavor dev` works
+         from the Home Screen too.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

A dev-flavor build installed with `bash setup.sh ios` on a physical iPhone works while `flutter run` is attached and crashes the instant it is opened from the Home Screen afterwards (or when iOS relaunches it in the background for Bluetooth/VoIP). The phone's crash reports all end in `SwiftAwesomeNotificationsPlugin.register(with:)` with `KERN_INVALID_ADDRESS at 0x0`.

Root cause: debug builds run the Dart VM in JIT mode, and iOS only lets Flutter tooling start a JIT VM on a device. Without it `FlutterEngine` init returns nil (`EnableTracingIfNecessary` fails), the storyboard `FlutterViewController` has no engine, `FlutterAppDelegate.registrar(forPlugin:)` returns nil, and the first Swift plugin in `GeneratedPluginRegistrant` dereferences it.

Changes:
- `app/setup.sh`: `OMI_MOBILE_BUILD_MODE=debug|profile|release` (default `debug`) selects the `flutter run` mode for both platforms, and a debug build headed for a physical iPhone prints a warning naming the untethered crash and the `profile` alternative.
- `app/ios/Runner/AppDelegate.swift`: skip plugin registration and every `binaryMessenger` use when the root `FlutterViewController` has no engine, and show a plain notice explaining why instead of crashing. The decision and message live in the new Foundation-only `FlutterLaunchEngineGuard.swift`.
- Second commit: `devProfile.xcconfig`/`devRelease.xcconfig` now pin `APP_BUNDLE_IDENTIFIER` to the development id like `devDebug.xcconfig` (the hostname-suffixed fallback was unregistrable and a different app from the debug install), and `RunnerProfile-dev.entitlements` had `aps-environment` = `Devdevelopment`, which no profile satisfies.
- Docs: `docs/doc/developer/AppSetup.mdx` troubleshooting entry rewritten around the actual symptom, `app/README.md` quick path, `app/AGENTS.md` build-mode note.

## Verification

- `bash app/scripts/mobile_build_wrapper_test.sh` (new cases: default adds no mode flag, `profile`/`release` add exactly one, unknown value fails before `flutter run`, physical-device debug warning present/absent).
- `ruby app/ios/test/flutter_launch_engine_guard_test.rb` (new, registered in `.github/checks-manifest.yaml`).
- `OMI_MOBILE_BUILD_MODE=profile` dev build signed, installed on an iPhone 16 Pro via `devicectl`, and launched by iOS untethered without a crash report.
- Crash reports pulled from the phone with `xcrun devicectl device copy from --domain-type systemCrashLogs`; the same debug build launched standalone on the iOS Simulator (foreground and silent-push background launch) does not crash, isolating the trigger to the device JIT restriction.

## Product invariants affected

none

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YU5BMEAfcFxNSWmLLDNfZ3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

