### PR TITLE
fix(cli): render API data literally instead of as Rich markup

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -76,8 +76,8 @@ class Renderer:
         elif isinstance(data, Mapping):
             self._emit_mapping(data, title=title)
         else:
-            # Scalars or anything else — just print.
-            self._stdout.print(data)
+            # Scalars or anything else — print as literal text, not markup.
+            self._stdout.print(escape(_stringify(data)))
 
     def _emit_json(self, data: Any) -> None:
         # Use sys.stdout directly to avoid Rich coloring/wrapping the JSON.
@@ -103,7 +103,8 @@ class Renderer:
         for col in cols:
             table.add_column(col)
         for row in rows:
-            table.add_row(*[_stringify(row.get(c)) for c in cols])
+            # API data must render literally: escape Rich markup characters.
+            table.add_row(*[escape(_stringify(row.get(c))) for c in cols])
         self._stdout.print(table)
 
     def _emit_mapping(self, mapping: Mapping[str, Any], *, title: Optional[str]) -> None:
@@ -111,7 +112,8 @@ class Renderer:
         table.add_column("field", style="bold")
         table.add_column("value")
         for k, v in mapping.items():
-            table.add_row(k, _stringify(v))
+            # API data must render literally: escape Rich markup characters.
+            table.add_row(escape(str(k)), escape(_stringify(v)))
         self._stdout.print(table)
 
     # ------------------------------------------------------------------

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -123,3 +123,17 @@ def test_pretty_table_cell_with_invalid_markup_does_not_crash(capsys) -> None:
     renderer.emit([{"id": "m1", "content": UNSAFE_CONTENT}], columns=["id", "content"], title="memories")
     captured = capsys.readouterr()
     assert UNSAFE_CONTENT in captured.out
+
+
+def test_pretty_scalar_emit_preserves_literal_markup_tags(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit(MARKUP_CONTENT)
+    captured = capsys.readouterr()
+    assert MARKUP_CONTENT in captured.out
+
+
+def test_pretty_scalar_emit_with_invalid_markup_does_not_crash(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit(UNSAFE_CONTENT)
+    captured = capsys.readouterr()
+    assert UNSAFE_CONTENT in captured.out

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -89,3 +89,37 @@ def test_no_color_env_disables_color(monkeypatch, capsys) -> None:
     captured = capsys.readouterr()
     # No ANSI codes when NO_COLOR is set.
     assert "\x1b[" not in captured.err
+
+
+# --- Regression tests for issue #12959: API data must render literally ---
+
+MARKUP_CONTENT = "Remember [bold]literal[/bold]"
+UNSAFE_CONTENT = "Remember [/bold]"
+
+
+def test_pretty_memory_content_preserves_literal_markup_tags(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit({"id": "m1", "content": MARKUP_CONTENT})
+    captured = capsys.readouterr()
+    assert MARKUP_CONTENT in captured.out
+
+
+def test_pretty_memory_content_with_invalid_markup_does_not_crash(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit({"id": "m1", "content": UNSAFE_CONTENT})
+    captured = capsys.readouterr()
+    assert UNSAFE_CONTENT in captured.out
+
+
+def test_pretty_table_cell_preserves_literal_markup_tags(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit([{"id": "m1", "content": MARKUP_CONTENT}], columns=["id", "content"], title="memories")
+    captured = capsys.readouterr()
+    assert MARKUP_CONTENT in captured.out
+
+
+def test_pretty_table_cell_with_invalid_markup_does_not_crash(capsys) -> None:
+    renderer = Renderer(json_mode=False, no_color=True)
+    renderer.emit([{"id": "m1", "content": UNSAFE_CONTENT}], columns=["id", "content"], title="memories")
+    captured = capsys.readouterr()
+    assert UNSAFE_CONTENT in captured.out


### PR DESCRIPTION
Fixes #12959.

## Scope
`sdks/python-cli/omi_cli/output.py`: escape API-derived strings at the three pretty-mode render boundaries in `Renderer` (mapping rows, table cells, scalar emit) using `rich.markup.escape`. API text is now displayed literally instead of being parsed as Rich console markup.

CLI-authored decoration (success ✓/✗ lines, error templates, column headers, `(no results)`) is intentionally unchanged.

## Problem
Memory content like `Remember [bold]literal[/bold]` silently lost its bracketed tags on display in `omi --no-color memory get/list`, and content like `Remember [/bold]` raised `MarkupError` (exit 1). `--json` modes were unaffected. This matches the issue's minimal repro exactly.

## Tests
- 4 new regression tests in `tests/test_output.py` (both repro strings × mapping/table paths).
- RED-first verified: all 4 fail on unfixed code — the `[/bold]` case with `rich.errors.MarkupError`, matching the issue symptom.
- GREEN after fix: `python -m pytest tests/` → **132 passed, 1 skipped (Windows-only), 0 failed**.
- `mypy omi_cli/output.py`: Success, no issues.

## Risk
Low. Escaping is additive; the only behavioral change is that literal `[...]` sequences in API data no longer alter or break rendering. JSON mode untouched.

## Exclusions
No changes to JSON output, command logic, API client, or any pretty-path styling markup authored by the CLI itself. No bounty is claimed; this PR is offered unclaimed so the maintainer can pick a fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

