### PR TITLE
fix(cli): preserve unknown root configuration settings

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -97,6 +97,8 @@ omi memory list
 
 State lives at `~/.omi/config.toml` (overridable via `$OMI_CONFIG`). The file
 holds one or more named profiles, each with its own auth method and API base.
+Saving configuration preserves unknown settings at both the root and profile
+levels, so editing a known setting does not discard extensions from newer clients.
 Switch between them with `--profile`:
 
 ```bash

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -140,6 +140,7 @@ class Config:
     path: Path
     active_profile: str = DEFAULT_PROFILE_NAME
     profiles: dict[str, Profile] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
     def get_profile(self, name: Optional[str] = None) -> Profile:
         target = name or self.active_profile
@@ -172,7 +173,8 @@ def load(path: Optional[Path] = None) -> Config:
     profiles_data = data.get("profiles", {})
     profiles = {name: Profile.from_toml_dict(name, raw) for name, raw in profiles_data.items()}
 
-    return Config(path=p, active_profile=active, profiles=profiles)
+    extra = {key: value for key, value in data.items() if key not in {"active_profile", "profiles"}}
+    return Config(path=p, active_profile=active, profiles=profiles, extra=extra)
 
 
 def save(config: Config) -> None:
@@ -191,6 +193,7 @@ def save(config: Config) -> None:
         pass
 
     payload: dict[str, Any] = {
+        **config.extra,
         "active_profile": config.active_profile,
         "profiles": {name: p.to_toml_dict() for name, p in config.profiles.items()},
     }

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -44,6 +44,25 @@ def test_load_missing_file_returns_empty_config(config_path: Path) -> None:
     assert config.profiles == {}
 
 
+def test_config_set_preserves_unknown_root_settings(config_path: Path, cli_runner) -> None:
+    config_path.write_text(
+        'active_profile = "default"\n'
+        'future_flag = true\n'
+        '[future_display]\n'
+        'language = "ar"\n'
+        '[profiles.default]\n'
+        'api_base = "https://api.omi.me"\n',
+        encoding="utf-8",
+    )
+    result = cli_runner.invoke(app, ["config", "set", "api_base", "https://example.test"])
+    assert result.exit_code == 0, result.output
+    with config_path.open("rb") as handle:
+        saved = cfg.tomllib.load(handle)
+    assert saved["profiles"]["default"]["api_base"] == "https://example.test"
+    assert saved["future_flag"] is True
+    assert saved["future_display"] == {"language": "ar"}
+
+
 def test_save_and_round_trip_preserves_unknown_keys(config_path: Path) -> None:
     config = cfg.load()
     profile = config.get_profile("work")


### PR DESCRIPTION
Fixes #12978.

Changing a known setting with `omi config set` currently removes unknown top-level scalars and tables from `config.toml`, despite the configuration module's documented forward-compatible round-trip behavior. Preserve those fields through `Config.extra`, matching the existing profile-level mechanism. Known fields take precedence during serialization.

The regression invokes the real CLI command with an isolated synthetic configuration, then reparses the file to verify both the requested edit and preservation of unrelated scalar/table settings. It fails before the fix with `KeyError: 'future_flag'` and passes afterward. The illustrative extension names do not imply a released client already uses them. README clarifies the behavior.

Validation:
- Full CLI suite: 130 passed, 2 upstream deprecation warnings on Windows/Python 3.12 (pytest sdks/python-cli/tests -o addopts="" -q --disable-warnings).
- Black, isort, mypy on config.py, and git diff --check pass.
- Repository preflight on the committed three-file diff: 12 selected checks reported pass (Python entry point used by make preflight, local lane). The failure-class historical recurrence check explicitly skipped its 90-day analysis because this clone is shallow; that history-dependent check still needs a full-history CI checkout.

This contribution is AI-assisted on behalf of @ikoomm. The optional US$5 bounty proposal in #12978 remains unapproved; this PR does not assert an award or assignment.

## Product invariants affected

none

Failure-Class: none




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

