### PR TITLE
fix(cli): preserve saved credentials when API-key login is rejected

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -85,6 +85,12 @@ omi auth refresh                # force a Firebase refresh (no-op for API keys)
 omi auth logout                 # wipe the credential
 ```
 
+An API-key login candidate is checked before replacing the saved credentials.
+If verification rejects it with HTTP 401 or 403, the existing profile and active
+profile selection remain unchanged. Other HTTP errors retain the existing
+store-and-warn behavior. A transport failure leaves saved credentials unchanged;
+browser OAuth is a separate flow.
+
 You can also set `OMI_API_KEY` in the environment to bypass on-disk config
 entirely — handy in containers and CI:
 

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -131,19 +131,29 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
 
 
 def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
-    """Validate, persist, and verify a dev API key."""
-    profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key, api_base=ctx.api_base_override)
+    """Verify a candidate dev API key before replacing stored credentials."""
+    cleaned_key = api_key_auth.validate_api_key_format(api_key)
+    profile = cfg.Profile(
+        name=ctx.profile_name,
+        auth_method="api_key",
+        api_key=cleaned_key,
+        api_base=ctx.api_base_override or ctx.load_config().get_profile(ctx.profile_name).api_base,
+    )
+    verification_warning = None
 
     # Sanity check on a tolerant endpoint — see the original launch PR's
-    # rationale. AuthError → roll back; other CliError → warn and keep.
+    # rationale. AuthError leaves disk unchanged; other CliError warns and keeps.
     try:
         with OmiClient(profile, verbose=ctx.verbose) as client:
             client.get("/v1/dev/user/memories", params={"limit": 1})
-    except AuthError as exc:
-        clear_credentials(ctx.profile_name)
-        raise exc
+    except AuthError:
+        raise
     except CliError as exc:
-        ctx.renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")
+        verification_warning = f"Could not verify the key right now ({exc.message}). It is stored — try again shortly."
+
+    profile = api_key_auth.login_with_api_key(ctx.profile_name, cleaned_key, api_base=ctx.api_base_override)
+    if verification_warning:
+        ctx.renderer.warn(verification_warning)
 
     ctx.renderer.success(f"Logged in as profile [bold]{profile.name}[/bold] ({profile.masked_credential()}).")
     if ctx.renderer.json_mode:

--- a/sdks/python-cli/tests/test_auth_api_key.py
+++ b/sdks/python-cli/tests/test_auth_api_key.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from omi_cli import config as cfg
 from omi_cli.auth import api_key as api_key_auth
-from omi_cli.auth.store import clear_credentials, store_api_key
+from omi_cli.auth.store import clear_credentials, store_api_key, store_oauth_tokens
 from omi_cli.errors import UsageError
+from omi_cli.main import app
 
 
 def test_validate_rejects_empty_key() -> None:
@@ -61,3 +64,93 @@ def test_store_and_clear_round_trip(config_path) -> None:
 
 def test_clear_credentials_returns_false_for_unconfigured_profile(config_path) -> None:
     assert clear_credentials("nonexistent") is False
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@pytest.mark.parametrize("previous_auth", ["api_key", "oauth"])
+def test_rejected_login_preserves_existing_profile(
+    config_path, authed_profile, respx_mock, cli_runner, status_code, previous_auth
+) -> None:
+    if previous_auth == "oauth":
+        store_oauth_tokens(
+            "default",
+            id_token="fake-old-id-token",
+            refresh_token="fake-old-refresh-token",
+            expires_at=1,
+            api_base=authed_profile.api_base,
+        )
+    before = config_path.read_bytes()
+    rejected_key = "omi_dev_" + "r" * 32
+    route = respx_mock.get("/v1/dev/user/memories").respond(status_code, json={"detail": "Rejected candidate key"})
+
+    result = cli_runner.invoke(app, ["--json", "auth", "login", "--api-key", rejected_key])
+
+    assert result.exit_code == 2
+    assert route.calls.last.request.headers["Authorization"] == f"Bearer {rejected_key}"
+    assert config_path.read_bytes() == before
+
+
+def test_rejected_login_to_new_profile_does_not_change_active_profile(
+    config_path, authed_profile, respx_mock, cli_runner
+) -> None:
+    before = config_path.read_bytes()
+    respx_mock.get("/v1/dev/user/memories").respond(401, json={"detail": "Invalid candidate"})
+    result = cli_runner.invoke(
+        app,
+        [
+            "--profile",
+            "new",
+            "--api-base",
+            authed_profile.api_base,
+            "auth",
+            "login",
+            "--api-key",
+            "omi_dev_" + "r" * 32,
+        ],
+    )
+    assert result.exit_code == 2
+    assert config_path.read_bytes() == before
+
+
+def test_api_key_login_persists_only_after_verification(config_path, authed_profile, respx_mock, cli_runner) -> None:
+    import httpx
+
+    before = config_path.read_bytes()
+    new_key = "omi_dev_" + "n" * 32
+
+    def verify_candidate(request):
+        assert config_path.read_bytes() == before
+        assert request.headers["Authorization"] == f"Bearer {new_key}"
+        return httpx.Response(200, json=[])
+
+    respx_mock.get("/v1/dev/user/memories").mock(side_effect=verify_candidate)
+    result = cli_runner.invoke(app, ["--json", "auth", "login", "--api-key", new_key])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["auth_method"] == "api_key"
+    assert cfg.load().get_profile("default").api_key == new_key
+
+
+def test_api_key_login_keeps_existing_http_server_error_policy(
+    authed_profile, respx_mock, cli_runner, monkeypatch
+) -> None:
+    monkeypatch.setattr("omi_cli.client.MAX_RETRY_ATTEMPTS", 1)
+    new_key = "omi_dev_" + "n" * 32
+    respx_mock.get("/v1/dev/user/memories").respond(503, json={"detail": "Unavailable"})
+    result = cli_runner.invoke(app, ["--json", "auth", "login", "--api-key", new_key])
+    assert result.exit_code == 0
+    assert cfg.load().get_profile("default").api_key == new_key
+    assert json.loads(result.stdout)["auth_method"] == "api_key"
+
+
+def test_transport_failure_during_login_leaves_saved_config_unchanged(
+    config_path, authed_profile, respx_mock, cli_runner, monkeypatch
+) -> None:
+    import httpx
+
+    monkeypatch.setattr("omi_cli.client.MAX_RETRY_ATTEMPTS", 1)
+    before = config_path.read_bytes()
+    route = respx_mock.get("/v1/dev/user/memories").mock(side_effect=httpx.ConnectError("Connection unavailable"))
+    result = cli_runner.invoke(app, ["auth", "login", "--api-key", "omi_dev_" + "n" * 32])
+    assert result.exit_code != 0
+    assert route.call_count == 1
+    assert config_path.read_bytes() == before


### PR DESCRIPTION
## Summary

Fixes https://github.com/BasedHardware/omi/issues/12982.

Verify an API-key login candidate in memory before replacing the saved profile. A rejected candidate (401/403) must not erase the credential that was present before this command or switch the active profile. Successful verification still stores the new key. Other mapped HTTP errors keep the existing store-and-warn policy.

A transport failure now leaves the old configuration untouched. Transport error normalization remains outside this PR (already reported in #12961); browser OAuth and server-side key minting/revocation are unchanged.

## Verification

- Six regression cases fail against original main `7163538913e15dd86534b41dc695e2a5639c0774`: API-key/OAuth-backed existing profiles rejected with 401/403, rejected new-profile login, and a check that successful verification precedes the first write.
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_auth_api_key.py -ra`: 16 passed with the patch, including successful replacement, HTTP 503 legacy behavior, and a mocked transport failure.
- Final Python CLI component suite: 136 passed, 1 skipped (Windows-only DACL test on macOS), 2 upstream Typer/Click deprecation warnings.
- All CLI requests use fake keys, isolated temporary configuration, and respx HTTP mocks. No live Omi account, browser OAuth session, or production service was tested.
- Black, isort, `compileall`, and `git diff --check` passed on the changed component/files.
- `scripts/pr-preflight --lane local --head <candidate-commit> --pr-body-file <this-body>` passed its 12 selected checks. The failure-class 90-day history ratchet explicitly skipped enforcement because this is a shallow clone; that history-dependent check remains for full-history CI. No production, device, or macOS app suite was run.

## Failure Class

Failure-Class: FC-destructive-replace-precedes-derivation

The durable credential file was being used as scratch state for an unverified replacement. The existing API-key persistence helper remains the sole write path, but is called only after the candidate check has returned or the existing mapped-HTTP-error policy permits storage. Regression tests execute the actual CLI command handler and verify the old configuration bytes remain identical on rejection/interruption. This is an instance fix, not a registry or authority-model change.

## Product Invariants

none (`scripts/pr-preflight --suggest` reports no affected invariant paths).

## Contribution Disclosure

AI-assisted investigation, implementation, and independent agent review for Alex260106 / Exitus. The $25 bounty proposed in #12982 is a request, not an approved or paid award. No account credentials or payout details are included in this contribution.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

