### PR TITLE
fix(cli): export long screenshot text without filesystem errors

### DIFF
--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from typing import Any, Mapping, Optional
@@ -191,4 +192,11 @@ def existing_path(value: str) -> Optional[Path]:
         path = Path(value).expanduser()
     except RuntimeError:
         return None
-    return path if path.is_file() else None
+    try:
+        return path if path.is_file() else None
+    except OSError as exc:
+        # Screenshot responses may be text rather than paths. An oversized
+        # filename cannot name a file; let the caller use its text fallback.
+        if exc.errno == errno.ENAMETOOLONG:
+            return None
+        raise

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -336,6 +336,33 @@ def test_screenshot_writes_base64_output_and_keeps_json_stdout(config_path: Path
     assert payload["result"]["image_base64_redacted"] is True
 
 
+def test_screenshot_exports_long_text_response(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    """Text fallback must not fail merely because the text is too long for a filename."""
+    _configure_local_profile(config_path)
+    text = "Screenshot description " * 100
+    output = tmp_path / "shot.txt"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(text)))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(output)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert output.read_text() == text
+    assert json.loads(result.stdout)["bytes"] == len(text.encode())
+
+
+def test_screenshot_copies_existing_file_response(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    _configure_local_profile(config_path)
+    source = tmp_path / "source.jpg"
+    source.write_bytes(b"synthetic-image")
+    output = tmp_path / "copy.jpg"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(str(source))))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(output)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert output.read_bytes() == source.read_bytes()
+
+
 def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
     _configure_local_profile(config_path)
     output = tmp_path / "pending.jpg"


### PR DESCRIPTION
## What changed and why

Fixes #12985. A screenshot tool response containing long plain text currently fails with `ENAMETOOLONG` when the CLI probes it as a possible file path. Treat that specific error as a non-file response so the existing text export fallback writes the response; preserve other filesystem errors and existing-file copying.

## Product invariants affected

none

## How it was verified

On macOS with Python 3.11.6, exercised the registered `omi --json local screenshot 9 --output …` command using CliRunner and mocked Desktop HTTP responses. Before the fix, the 2,200-character text fixture failed with `OSError(63, 'File name too long')`; the existing-file control passed. Afterward, both passed and the text file contents and byte count matched exactly.

`python -m pytest tests/test_local.py -q`: 24 passed.
`python -m pytest -q`: 130 passed, 1 skipped (Windows-only DACL test on macOS).
`python -m black --check omi_cli/local_client.py tests/test_local.py`: passed.
`git diff --check`: passed.
`make preflight` with this PR body: all 12 selected checks passed (two changed files). The sparse checkout was hydrated with the referenced validation artifacts; no gate definitions were changed.

No live Omi Desktop response or real screenshot history was used; this verifies the CLI's existing text fallback contract with synthetic responses.

## Tests

Added `test_screenshot_exports_long_text_response` (fails before fix) and `test_screenshot_copies_existing_file_response` in `sdks/python-cli/tests/test_local.py`.

## Failure class (fixes)

Failure-Class: none

The suggested credential-permissions class does not apply: this fixes interpretation of a response as a candidate path, without changing credential persistence or permissions.

AI assistance: prepared and tested with Codex for @BuildThingsThatBuildthings. The small bounty proposal is tracked in #12985; no award or approval is assumed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

