### PR TITLE
perf(devex): cut repeated PR checks and catch local CI drift

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -196,7 +196,7 @@ checks:
     reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
   - id: pr-preflight-contract-tests
     command: ["python3", ".github/scripts/test_pr_preflight.py"]
-    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", "desktop/macos/scripts/check-e2e-flow-coverage.py", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/checks-manifest.yaml", ".github/workflows/**"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", "desktop/macos/scripts/check-e2e-flow-coverage.py", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/checks-manifest.yaml", ".github/workflows/**", ".github/actions/**"]
     lanes: ["local", "ci"]
     reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -197,7 +197,7 @@ checks:
     reason: "locked invariant citation enforcement must keep rejecting an uncited path match"
   - id: pr-preflight-contract-tests
     command: ["python3", ".github/scripts/test_pr_preflight.py"]
-    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", "desktop/macos/scripts/check-e2e-flow-coverage.py", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/checks-manifest.yaml"]
+    triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_pr_preflight.py", ".github/scripts/pr_metadata.py", "desktop/macos/scripts/check-e2e-flow-coverage.py", "scripts/pre-push-singleflight", "scripts/pr-preflight", ".github/checks-manifest.yaml", ".github/workflows/**"]
     lanes: ["local", "ci"]
     reason: "preflight resolves the check selection every PR depends on"
   - id: product-invariants

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -64,7 +64,6 @@ checks:
     command: ["python3", ".github/scripts/test_preflight_runner.py"]
     triggers: [".github/scripts/preflight_runner.py", ".github/scripts/pr_preflight.py", ".github/scripts/test_preflight_runner.py", ".github/scripts/run_checks.py", ".github/scripts/test_run_checks.py", "scripts/pre-push-singleflight", "scripts/pre-push", "scripts/pr-preflight", ".github/workflows/windows-preflight-portability.yml", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    platforms: ["windows"]
     reason: "the single-flight pre-push gate must manage child processes and launch Bash checks on native Windows and POSIX hosts"
   - id: context-for-claude-build-identity
     command: ["bash", "desktop/context-for-claude/scripts/test-build-identity.sh"]

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -14,7 +14,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pr_metadata import TransientPRMetadataError, PullRequestMetadata, load_from_api, load_from_event_file, load_from_gh
-from run_checks import detect_platform, load_manifest, resolve_checks
+from run_checks import (
+    MANIFEST_RELATIVE_PATH,
+    detect_platform,
+    load_manifest,
+    manifest_changed_check_ids,
+    resolve_checks,
+)
 
 
 @dataclass(frozen=True)
@@ -86,7 +92,7 @@ def configure_output_streams() -> None:
         reconfigure(**options)
 
 
-def changed_files(root: Path, base: str, head: str) -> list[str]:
+def changed_files(root: Path, base: str, head: str, *, include_worktree: bool = False) -> list[str]:
     output = run_git(
         root,
         "diff",
@@ -95,15 +101,40 @@ def changed_files(root: Path, base: str, head: str) -> list[str]:
         "--diff-filter=ACMRTD",
         f"{base}...{head}",
     )
-    return [line for line in output.splitlines() if line]
+    files = set(output.splitlines())
+    if include_worktree and head == "HEAD":
+        files.update(run_git(root, "diff", "--name-only", "--no-renames", "--diff-filter=ACMRTD", "HEAD").splitlines())
+        files.update(run_git(root, "ls-files", "--others", "--exclude-standard").splitlines())
+    return sorted(path for path in files if path)
 
 
-def select_checks(files: list[str], lane: str = "ci", platform: str | None = None) -> list[Check]:
-    root = Path(__file__).resolve().parents[2]
-    manifest = load_manifest(root / ".github/checks-manifest.yaml")
+def select_checks(
+    files: list[str],
+    lane: str = "ci",
+    platform: str | None = None,
+    *,
+    metadata_only: bool = False,
+    root: Path | None = None,
+    base: str | None = None,
+    head: str = "HEAD",
+) -> list[Check]:
+    root = root or Path(__file__).resolve().parents[2]
+    manifest = load_manifest(root / MANIFEST_RELATIVE_PATH)
+    changed_ids = (
+        manifest_changed_check_ids(root, base, head, include_worktree=lane == "local")
+        if base is not None and MANIFEST_RELATIVE_PATH in files
+        else None
+    )
     return [
         Check(check.id, check.reason)
-        for check in resolve_checks(manifest, files, lane, platform=platform or detect_platform())
+        for check in resolve_checks(
+            manifest,
+            files,
+            lane,
+            platform=platform or detect_platform(),
+            manifest_changed_ids=changed_ids,
+        )
+        if not metadata_only or check.requires_pr_body
     ]
 
 
@@ -206,6 +237,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--head", default="HEAD")
     parser.add_argument("--lane", choices=("local", "ci"), default="ci")
     parser.add_argument("--pr-body-file", type=Path)
+    parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help="Validate only metadata-dependent contracts, reporting all errors in one pass.",
+    )
     parser.add_argument("--repository", help="GitHub repository as owner/name; requires --pr-number")
     parser.add_argument("--pr-number", type=int, help="Load current PR metadata through the GitHub API")
     parser.add_argument(
@@ -234,11 +270,18 @@ def main() -> int:
     started = time.monotonic()
     try:
         merge_base = run_git(root, "merge-base", args.base, args.head)
-        files = changed_files(root, args.base, args.head)
+        files = changed_files(root, args.base, args.head, include_worktree=args.lane == "local")
     except subprocess.CalledProcessError as exc:
         print(f"FAIL: could not resolve preflight diff: {exc.stderr.strip()}", file=sys.stderr)
         return 1
-    checks = select_checks(files, args.lane)
+    checks = select_checks(
+        files,
+        args.lane,
+        metadata_only=args.metadata_only,
+        root=root,
+        base=merge_base,
+        head=args.head,
+    )
     summary = f"PR preflight: lane={args.lane} base={args.base} ({merge_base[:12]}) head={args.head} files={len(files)}"
     print(summary, file=sys.stderr if args.suggest else sys.stdout)
     for check in checks:
@@ -327,6 +370,8 @@ def main() -> int:
             "--pr-body-file",
             str(body_path),
         ]
+        if args.metadata_only:
+            command.append("--metadata-only")
         if skip_changelog:
             command.append("--skip-changelog")
         result = subprocess.run(command, cwd=root, check=False)

--- a/.github/scripts/run_checks.py
+++ b/.github/scripts/run_checks.py
@@ -417,6 +417,7 @@ def execute_checks(
     pr_body_file: Path,
     target_base: str | None = None,
     skip_changelog: bool = False,
+    keep_going: bool = False,
 ) -> int:
     failures: list[str] = []
     for check in checks:
@@ -437,7 +438,8 @@ def execute_checks(
         print(f"<== {status} {check.id} ({time.monotonic() - started:.2f}s)", flush=True)
         if returncode:
             failures.append(check.id)
-            break
+            if not keep_going:
+                break
     if failures:
         print(f"Manifest checks failed: {', '.join(failures)}", file=sys.stderr)
         return 1
@@ -459,6 +461,11 @@ def parse_args() -> argparse.Namespace:
         help="Exclude checks declared as requiring pull-request metadata.",
     )
     parser.add_argument("--skip-changelog", action="store_true")
+    parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help="Run only selected checks that consume PR metadata and report all their failures.",
+    )
     parser.add_argument(
         "--check-id",
         action="append",
@@ -489,6 +496,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    if args.metadata_only and (args.skip_pr_body_checks or args.check_id):
+        print("FAIL: --metadata-only cannot combine with --skip-pr-body-checks or --check-id", file=sys.stderr)
+        return 2
     root = (args.root or Path(run_git(Path.cwd(), "rev-parse", "--show-toplevel"))).resolve()
     manifest_path = (args.manifest or root / ".github/checks-manifest.yaml").resolve()
     try:
@@ -539,6 +549,8 @@ def main() -> int:
     except ValueError as exc:
         print(f"FAIL: could not select manifest checks: {exc}", file=sys.stderr)
         return 2
+    if args.metadata_only:
+        selections = [selection for selection in selections if selection.check.requires_pr_body]
     checks = [selection.check for selection in selections]
     if args.output == "json":
         print(
@@ -590,6 +602,7 @@ def main() -> int:
             head=args.head,
             pr_body_file=body_path,
             skip_changelog=args.skip_changelog,
+            keep_going=args.metadata_only,
         )
 
 

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -336,6 +336,100 @@ class SelectionTests(unittest.TestCase):
             "base...head",
         )
 
+    def test_local_diff_includes_staged_unstaged_untracked_and_both_rename_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ):
+            for key in list(os.environ):
+                if key.startswith("GIT_"):
+                    del os.environ[key]
+            root = Path(tmp)
+
+            def git(*args: str) -> None:
+                subprocess.run(
+                    [
+                        "git",
+                        "-c",
+                        "core.hooksPath=/dev/null",
+                        "-c",
+                        "commit.gpgsign=false",
+                        "-c",
+                        "user.name=Fixture",
+                        "-c",
+                        "user.email=fixture@example.com",
+                        *args,
+                    ],
+                    cwd=root,
+                    check=True,
+                    capture_output=True,
+                )
+
+            git("init", "-q")
+            for name in ("staged.txt", "unstaged.txt", "before.txt", "deleted.txt"):
+                (root / name).write_text("baseline\n", encoding="utf-8")
+            (root / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+            git("add", ".")
+            git("commit", "-qm", "baseline")
+            (root / "staged.txt").write_text("staged\n", encoding="utf-8")
+            git("add", "staged.txt")
+            (root / "unstaged.txt").write_text("unstaged\n", encoding="utf-8")
+            (root / "new.txt").write_text("new\n", encoding="utf-8")
+            (root / "ignored.txt").write_text("ignored\n", encoding="utf-8")
+            (root / "deleted.txt").unlink()
+            git("mv", "before.txt", "after.txt")
+            self.assertEqual(
+                changed_files(root, "HEAD", "HEAD", include_worktree=True),
+                ["after.txt", "before.txt", "deleted.txt", "new.txt", "staged.txt", "unstaged.txt"],
+            )
+            self.assertEqual(changed_files(root, "HEAD", "HEAD"), [])
+            self.assertEqual(changed_files(root, "HEAD", "HEAD~0", include_worktree=True), [])
+
+    def test_metadata_selection_preserves_every_body_dependent_contract(self) -> None:
+        # #12935 reran code tests for a description edit; the body needs four checks.
+        names = {
+            check.name
+            for check in select_checks(
+                ["backend/routers/example.py"],
+                platform="linux",
+                metadata_only=True,
+            )
+        }
+        self.assertEqual(
+            names,
+            {
+                "product-file-line-count-ratchet",
+                "product-invariants",
+                "failure-class-protocol",
+                "failure-class-guard-artifact-ratchet",
+            },
+        )
+
+    def test_manifest_edit_summary_uses_the_executors_entry_diff_filter(self) -> None:
+        with patch("pr_preflight.manifest_changed_check_ids", return_value={"pr-preflight-contract-tests"}):
+            names = {
+                check.name
+                for check in select_checks(
+                    [".github/checks-manifest.yaml"],
+                    platform="linux",
+                    base="base",
+                )
+            }
+        self.assertIn("pr-preflight-contract-tests", names)
+        self.assertNotIn("backend-deploy-source-admission", names)
+
+    def test_metadata_cli_forwards_scope_to_executor(self) -> None:
+        from pr_preflight import main
+
+        with patch("sys.argv", ["pr-preflight", "--metadata-only", "--root", str(REPO_ROOT)]), patch(
+            "pr_preflight.run_git", return_value="base"
+        ), patch("pr_preflight.changed_files", return_value=[]), patch(
+            "pr_preflight.resolve_pr_metadata", return_value=None
+        ), patch(
+            "pr_preflight.current_branch", return_value="feature"
+        ), patch(
+            "pr_preflight.subprocess.run", return_value=Mock(returncode=0)
+        ) as run:
+            self.assertEqual(main(), 0)
+        self.assertIn("--metadata-only", run.call_args.args[0])
+
     def test_stale_event_payload_base_widens_diff_scope_past_the_live_base(self) -> None:
         """Behavioral regression for FC-stale-event-payload-diff-base (#10758).
 
@@ -653,20 +747,20 @@ class SelectionTests(unittest.TestCase):
         # the behavioral regression backing FC-stale-event-payload-diff-base.
         self.assertNotIn("github.event.pull_request.base.sha", metadata_job)
         self.assertIn('--base "origin/${{ github.base_ref }}"', metadata_job)
-        self.assertIn("astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84", metadata_job)
-        self.assertLess(metadata_job.index("Set up uv"), metadata_job.index("Run current PR metadata preflight"))
+        self.assertIn("scripts/pr-preflight --metadata-only", metadata_job)
+        self.assertNotIn("--metadata-only", hygiene_job)
         self.assertIn("github.event_name != 'pull_request'", changes_job)
         self.assertIn("github.event_name != 'pull_request'", hygiene_job)
-
-        # The manifest can select the Firestore admission proof for either PR
-        # preflight path. Java must be present before the selected check runs.
-        for job, gate in (
-            (metadata_job, "Run current PR metadata preflight"),
-            (hygiene_job, "Run shared PR contract preflight"),
-        ):
-            self.assertIn("actions/setup-java@v5", job)
-            self.assertIn("java-version: '21'", job)
-            self.assertLess(job.index("Set up Java for manifest-selected Firestore checks"), job.index(gate))
+        # #12935: metadata checks took 0.70s; code checks consumed the remaining
+        # 140s. Only Hygiene needs the code suites' dependency toolchains.
+        for tool in ("astral-sh/setup-uv@", "actions/setup-java@", "oven-sh/setup-bun@"):
+            self.assertNotIn(tool, metadata_job)
+            self.assertIn(tool, hygiene_job)
+        self.assertIn("java-version: '21'", hygiene_job)
+        self.assertLess(
+            hygiene_job.index("Set up Java for manifest-selected Firestore checks"),
+            hygiene_job.index("Run shared PR contract preflight"),
+        )
 
     def test_issue_sync_action_is_pinned(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/main.yml").read_text(encoding="utf-8")

--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -619,7 +619,6 @@ class LaunchContractTests(unittest.TestCase):
         self.assertIn("路径🚀", completed.stdout)
         self.assertEqual(log, "路径🚀\n")
 
-    @unittest.skipUnless(os.name == "nt", "native Windows Git encoding contract")
     def test_pr_preflight_emits_utf8_from_unicode_branch_without_utf8_mode(self) -> None:
         git = shutil.which("git")
         self.assertIsNotNone(git)
@@ -627,16 +626,33 @@ class LaunchContractTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo-\u96ea"
             unicode_branch = "分支-🚀"
+            env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
             root.mkdir()
+            # Preflight selects from the invoking repository. Keep this fixture
+            # self-contained instead of depending on the source checkout's manifest.
+            manifest = root / ".github/checks-manifest.yaml"
+            manifest.parent.mkdir()
+            manifest.write_text(
+                'checks:\n  - id: unicode-fixture\n'
+                '    command: ["python3", "-c", "pass"]\n'
+                '    triggers: ["all"]\n    lanes: ["local", "ci"]\n'
+                '    reason: portable fixture selection\n',
+                encoding="utf-8",
+            )
             subprocess.run(
                 [git, "init", "--quiet"],
                 cwd=root,
+                env=env,
                 check=True,
                 capture_output=True,
             )
             subprocess.run(
                 [
                     git,
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-c",
+                    "commit.gpgsign=false",
                     "-c",
                     "user.name=Omi portability test",
                     "-c",
@@ -648,11 +664,11 @@ class LaunchContractTests(unittest.TestCase):
                     "initial",
                 ],
                 cwd=root,
+                env=env,
                 check=True,
                 capture_output=True,
             )
-            subprocess.run([git, "branch", unicode_branch], cwd=root, check=True, capture_output=True)
-            env = os.environ.copy()
+            subprocess.run([git, "branch", unicode_branch], cwd=root, env=env, check=True, capture_output=True)
             env["PYTHONUTF8"] = "0"
             env.pop("PYTHONIOENCODING", None)
             completed = subprocess.run(
@@ -673,7 +689,8 @@ class LaunchContractTests(unittest.TestCase):
                 check=False,
             )
 
-        self.assertEqual(completed.returncode, 0, completed.stdout)
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("SELECTED unicode-fixture", completed.stdout)
         self.assertIn("PR preflight:", completed.stdout)
         self.assertIn(f"head={unicode_branch}", completed.stdout)
 

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import os
 import re
 import shutil
@@ -293,6 +294,196 @@ class ManifestContractTests(unittest.TestCase):
 
 
 class RunnerBehaviorTests(unittest.TestCase):
+    def _prepare_cli_fixture(
+        self,
+        root: Path,
+        checks: list[dict[str, object]],
+        *,
+        changed_files: tuple[str, ...] = ("backend/example.py",),
+    ) -> tuple[Path, Path]:
+        """Create a tiny committed repo that exercises the real runner CLI."""
+        scripts = root / "checks"
+        scripts.mkdir(parents=True)
+        runs_file = root / "runs.txt"
+        manifest_lines = ["checks:"]
+        for spec in checks:
+            check_id = str(spec["id"])
+            script = scripts / f"{check_id}.py"
+            exit_code = int(spec.get("exit_code", 0))
+            script.write_text(
+                "from pathlib import Path\n"
+                f"Path({json.dumps(str(runs_file))}).open('a', encoding='utf-8').write({json.dumps(check_id + chr(10))})\n"
+                f"raise SystemExit({exit_code})\n",
+                encoding="utf-8",
+            )
+            triggers = spec.get("triggers", ("backend/**",))
+            manifest_lines.extend(
+                [
+                    f"  - id: {check_id}",
+                    f"    command: [\"python3\", \"checks/{check_id}.py\"]",
+                    f"    triggers: {json.dumps(list(triggers))}",
+                    "    lanes: [\"local\", \"ci\"]",
+                    f"    reason: {spec.get('reason', 'fixture check')}",
+                    f"    requires_pr_body: {'true' if spec.get('requires_pr_body', False) else 'false'}",
+                ]
+            )
+            if spec.get("platforms"):
+                manifest_lines.append(f"    platforms: {json.dumps(list(spec['platforms']))}")
+        manifest = root / ".github/checks-manifest.yaml"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
+        changed = root / "changed-files.txt"
+        changed.write_text("".join(f"{path}\n" for path in changed_files), encoding="utf-8")
+
+        env = os.environ.copy()
+        for key in tuple(env):
+            if key.startswith("GIT_"):
+                del env[key]
+        subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+        subprocess.run(["git", "-C", str(root), "add", "."], check=True, env=env)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "user.name=fixture",
+                "-c",
+                "user.email=fixture@example.invalid",
+                "commit",
+                "-qm",
+                "fixture",
+            ],
+            check=True,
+            env=env,
+        )
+        return manifest, changed
+
+    def _run_cli(self, root: Path, manifest: Path, changed: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+        runner = REPO_ROOT / ".github/scripts/run_checks.py"
+        env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+        return subprocess.run(
+            [
+                sys.executable,
+                str(runner),
+                "--root",
+                str(root),
+                "--manifest",
+                str(manifest),
+                "--changed-files",
+                str(changed),
+                "--base",
+                "HEAD",
+                "--head",
+                "HEAD",
+                "--lane",
+                "ci",
+                "--platform",
+                "linux",
+                *extra,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_metadata_only_selects_body_checks_for_matching_path_and_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest, changed = self._prepare_cli_fixture(
+                root,
+                [
+                    {"id": "body-linux", "requires_pr_body": True, "platforms": ("linux",)},
+                    {"id": "source-linux"},
+                    {"id": "body-macos", "requires_pr_body": True, "platforms": ("macos",)},
+                    {
+                        "id": "body-unrelated",
+                        "requires_pr_body": True,
+                        "triggers": ("app/**",),
+                    },
+                ],
+            )
+            result = self._run_cli(root, manifest, changed, "--metadata-only", "--list")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("SELECTED body-linux", result.stdout)
+        self.assertNotIn("SELECTED source-linux", result.stdout)
+        self.assertNotIn("SELECTED body-macos", result.stdout)
+        self.assertNotIn("SELECTED body-unrelated", result.stdout)
+
+    def test_metadata_only_runs_all_failures_and_returns_nonzero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest, changed = self._prepare_cli_fixture(
+                root,
+                [
+                    {"id": "body-first", "requires_pr_body": True, "exit_code": 3},
+                    {"id": "body-second", "requires_pr_body": True, "exit_code": 4},
+                ],
+            )
+            result = self._run_cli(root, manifest, changed, "--metadata-only")
+            runs = (root / "runs.txt").read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(runs, ["body-first", "body-second"])
+        self.assertIn("<== FAIL body-first", result.stdout)
+        self.assertIn("<== FAIL body-second", result.stdout)
+        self.assertIn("Manifest checks failed: body-first, body-second", result.stderr)
+
+    def test_metadata_only_success_returns_zero_without_running_source_checks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest, changed = self._prepare_cli_fixture(
+                root,
+                [
+                    {"id": "body-pass", "requires_pr_body": True},
+                    {"id": "source-fails", "exit_code": 9},
+                ],
+            )
+            result = self._run_cli(root, manifest, changed, "--metadata-only")
+            runs = (root / "runs.txt").read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(runs, ["body-pass"])
+        self.assertIn("Manifest checks passed: 1 check(s).", result.stdout)
+
+    def test_default_mode_runs_source_checks_and_remains_fail_fast(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest, changed = self._prepare_cli_fixture(
+                root,
+                [
+                    {"id": "body-pass", "requires_pr_body": True},
+                    {"id": "source-fails", "exit_code": 7},
+                    {"id": "source-after-failure", "exit_code": 8},
+                ],
+            )
+            result = self._run_cli(root, manifest, changed)
+            runs = (root / "runs.txt").read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(runs, ["body-pass", "source-fails"])
+        self.assertIn("Manifest checks failed: source-fails", result.stderr)
+        self.assertNotIn("==> source-after-failure", result.stdout)
+
+    def test_metadata_only_rejects_conflicting_selection_flags(self) -> None:
+        runner = REPO_ROOT / ".github/scripts/run_checks.py"
+        for flags in (("--skip-pr-body-checks",), ("--check-id", "source-check")):
+            with self.subTest(flags=flags):
+                result = subprocess.run(
+                    [sys.executable, str(runner), "--lane", "ci", "--metadata-only", *flags],
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("--metadata-only cannot combine", result.stderr)
+
     def test_run_git_decodes_unicode_checkout_path_as_utf8(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "路径 checkout"
@@ -521,6 +712,7 @@ esac
     def test_shared_windows_entrypoints_route_their_behavioral_contracts(self) -> None:
         manifest = load_manifest(MANIFEST_PATH)
         expected_by_path = {
+            ".github/workflows/gcp_storage_lifecycle.yml": {"pr-preflight-contract-tests"},
             "Makefile": {"dev-harness-unit-tests", "setup-pre-push-prerequisites"},
             "scripts/dev-harness/_resolve_python.sh": {
                 "dev-harness-unit-tests",

--- a/.github/workflows/gcp_storage_lifecycle.yml
+++ b/.github/workflows/gcp_storage_lifecycle.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload lifecycle evidence
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: storage-lifecycle-${{ env.RESOLVED_ENVIRONMENT }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/gcp_storage_lifecycle.yml
+++ b/.github/workflows/gcp_storage_lifecycle.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload lifecycle evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: storage-lifecycle-${{ env.RESOLVED_ENVIRONMENT }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -37,35 +37,8 @@ jobs:
         with:
           python-version-file: backend/.python-version
 
-      # The preflight can select uv-backed checks (e.g. backend-route-policy-baseline
-      # runs the OpenAPI runner) whenever a PR touches backend routes, so this job
-      # needs uv just like the sibling Hygiene job.
-      - name: Set up uv
-        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
-        with:
-          # Pin the resolved uv, not just the action commit. An unset version means
-          # "latest", which the action resolves by fetching the astral-sh/versions
-          # manifest over the network; that fetch has hard-failed a Repo Checks run.
-          # An exact version resolves locally and skips the manifest request. Keep it
-          # equal to backend/Dockerfile's UV_VERSION so CI matches the runtime image.
-          version: "0.11.13"
-          enable-cache: true
-          cache-dependency-glob: backend/openapi-requirements.txt
-
-      - name: Install runtime environment validator dependency
-        run: uv pip install --system pyyaml==6.0.1
-
-      - name: Set up Java for manifest-selected Firestore checks
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Set up Bun for manifest-selected web/app checks
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
+      # Metadata edits reuse the source verdict from Hygiene. These manifest
+      # checks consume only Python stdlib + Git; do not install code-test tools.
       - name: Run current PR metadata preflight
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -75,7 +48,7 @@ jobs:
           # days later can carry a value main has long since moved past. actions/checkout
           # already fetched origin/${{ github.base_ref }} live (fetch-depth: 0
           # above), so diff against that instead of the stale payload field.
-          scripts/pr-preflight \
+          scripts/pr-preflight --metadata-only \
             --base "origin/${{ github.base_ref }}" \
             --repository "${{ github.repository }}" \
             --pr-number "${{ github.event.pull_request.number }}"

--- a/docs/doc/developer/Contribution.mdx
+++ b/docs/doc/developer/Contribution.mdx
@@ -71,11 +71,15 @@ Good PRs are easy to review and come with evidence that the change works.
   static tripwires only; they do not prove lifecycle, concurrency, or integration
   behavior.
 - **Product invariants** — if you touch paths listed on a locked invariant, name the ID (for example `INV-CHAT-1`) in the PR body.
-- **Fast local deterministic checks** — run `make preflight`. New deterministic diff-scoped checks belong in `.github/checks-manifest.yaml`, never directly in workflow YAML.
+- **Fast local deterministic checks** — run `make preflight`. Selection includes staged, unstaged, and untracked files; commit-based checks still need a final run after committing. New deterministic diff-scoped checks belong in `.github/checks-manifest.yaml`, never directly in workflow YAML.
 - **PR metadata contract check** — draft the body, then run `scripts/pr-preflight --pr-body-file /path/to/draft-pr-body.md`.
   Use `scripts/pr-preflight --suggest` when you need the paste-ready invariant section. Once the branch has a PR,
   `scripts/pr-preflight` reads its current body automatically with `gh` (or set `OMI_PR_BODY_FILE`). Pre-push runs these
-  same cheap contracts.
+  same contracts. When editing only the PR body, use
+  `scripts/pr-preflight --metadata-only --pr-body-file /path/to/draft-pr-body.md`.
+  This runs every applicable metadata-dependent check and reports all failures together.
+  CI uses this mode for title, body, and label edits; code updates still run the full preflight.
+  Metadata success validates the PR description and does not replace the source-code verdict.
 
 ### Contributing with an AI agent
 


### PR DESCRIPTION
Editing a PR description currently reruns source-code checks and can reproduce an unrelated code failure. On [#12935](https://github.com/BasedHardware/omi/pull/12935), [one metadata run](https://github.com/BasedHardware/omi/actions/runs/34165203657) spent **141.40 seconds** executing preflight; its four metadata-dependent checks consumed **0.70 seconds combined**. This change removes the other checks from metadata events and reports all metadata errors together.

## Changes

- Add `scripts/pr-preflight --metadata-only`, using the manifest's existing `requires_pr_body` declarations after path/platform selection. Run every selected metadata check even if an earlier one fails; return failure with all failed check IDs. Reject contradictory selection flags.
- Use that mode for edited/labeled/unlabeled events in the existing Repo Checks workflow. Remove their uv/PyYAML/Java/Bun setup. Code events still run the full preflight in Hygiene, with the existing independent concurrency groups.
- Include staged, unstaged, untracked, renamed, and deleted paths in local preflight selection. Commit-based contracts still require the final committed check. Make the displayed selection use the executor's manifest-entry filtering instead of overreporting checks.
- Run portable preflight-runner contracts on every host; their Unicode CLI fixture owns its manifest and isolates Git state. Native Windows cases remain conditional and run in the Windows lane.
- Repair the existing artifact-action contract violation introduced in [#12631](https://github.com/BasedHardware/omi/pull/12631), and select the existing workflow contract suite on workflow edits. This keeps the same error from escaping local preflight again. Contributor instructions describe the new command.

## Audit evidence

Sample: latest 35 PRs authored by the requesting maintainer, across 121 commit SHAs; 698 sampled PR workflow runs (597 successful, 79 cancelled, 19 failed, 3 queued). These are historical samples, not a current branch-health verdict.

| Successful job | Sample size | Median execution |
| --- | ---: | ---: |
| Desktop Swift Static & Test Contracts | 23 | 41.2 min |
| Desktop Swift Release Compile | 28 | 20.3 min |
| Backend unit suite | 20 | 21.2 min |
| Android Compile Smoke | 18 | 13.0 min |
| Hygiene | 57 | 136 sec |
| PR Metadata Preflight | 41 | 147 sec |

The metadata job's median preflight step was 82 sec and checkout 44 sec. Four failed metadata jobs repeated #12935's source-only dead-code ratchet failure ([example](https://github.com/BasedHardware/omi/actions/runs/34000817044/job/101399238665)); source Hygiene still owns that failure after this change. Normal first-job queue delay was roughly 3–4 sec; [one backend run](https://github.com/BasedHardware/omi/actions/runs/34156925512) waited 92.8 min. Full Swift/backend execution remains a separate bottleneck; this PR does not claim to shorten those suites.

Other observed failures were [firmware formatting](https://github.com/BasedHardware/omi/actions/runs/34159603797/job/101858616516), [Swift async-lock compilation](https://github.com/BasedHardware/omi/actions/runs/34033262153/job/101486768146), a [Swift test timeout](https://github.com/BasedHardware/omi/actions/runs/33933398673/job/101216878082), and a [shared backend import break](https://github.com/BasedHardware/omi/actions/runs/34145891163/job/101817730951). Local firmware formatting currently silently passes if clang-format is missing; that setup gap remains outside this focused change.

## Validation

On macOS in an isolated BasedHardware/omi worktree based on `7163538913`:

- `make setup` completed; normal hooks installed.
- `OMI_PR_BODY_FILE=/tmp/omi-devex-pr-body.md make preflight`: 21 selected checks passed in 29.13 sec with the portability coverage included (`dcd8413207`).
- `python3 .github/scripts/test_run_checks.py`: 52 tests passed, including real subprocess fixtures for metadata selection, multiple failures, successful execution, default source checks, and conflicting flags.
- `python3 .github/scripts/test_pr_preflight.py`: 47 tests run, one Windows-only skip; all remaining tests passed. Includes real Git fixtures for local changed paths.
- `scripts/pr-preflight --lane local --metadata-only --pr-body-file /tmp/omi-devex-pr-body.md`: three applicable metadata checks passed in 1.41 sec. This is local CLI timing, not hosted CI latency or a like-for-like benchmark against #12935.
- `actionlint -shellcheck '' .github/workflows/repo-checks.yml .github/workflows/gcp_storage_lifecycle.yml` and `git diff --check` passed.
- `scripts/pr-preflight --pr-body-file /tmp/omi-devex-pr-body.md`: 20 checks passed on the committed tree in 27.61 sec. The normal pre-push gate also passed without skips.
- `python3 .github/scripts/test_preflight_runner.py`: 29 tests run, seven native Windows skips on macOS; remaining cases passed.
- Hosted metadata verification on `c5c25b5ba8` [passed in 55 seconds](https://github.com/BasedHardware/omi/actions/runs/34168712451), including a 3-second preflight step. Checkout/setup still dominate this lane.
- Independent review approved. Tests exercise the real runner CLI; workflow assertions are explicitly static wiring checks. No new workflow or policy gate was added.

## Product invariants affected

- INV-DATA-1: the storage workflow only updates its artifact-upload action runtime; storage policy and data-plane routing are unchanged.

Failure-Class: none
