### PR TITLE
fix(sdk): bound BLE discovery independently of advertisements

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: device-typescript-tests
+    command: ["bun", "test", "sdks/device/typescript"]
+    triggers: ["sdks/device/typescript/**"]
+    lanes: ["local", "ci"]
+    reason: "#12989: BLE scans waited forever for a discovery event after their deadline; exercise the SDK's production behavior with a controlled adapter"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/.github/failure-classes/FC-event-gated-operation-deadline.json
+++ b/.github/failure-classes/FC-event-gated-operation-deadline.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-event-gated-operation-deadline",
+  "violated_contract": "A bounded discovery operation must complete when its time budget expires even when its input stream produces no further events.",
+  "canonical_prevention": "Own the completion timer independently of input delivery, and release the discovery subscription and scan in one finally boundary. Drive the production scanner with a quiet adapter and a controlled timer in regression tests.",
+  "canonical_prevention_artifact": ["sdks/device/typescript/src/ble/scan.test.ts"],
+  "evidence_prs": [],
+  "scope_hints": ["sdks/device/typescript/**"],
+  "status": "open"
+}

--- a/sdks/device/typescript/README.md
+++ b/sdks/device/typescript/README.md
@@ -5,6 +5,9 @@ Shared Omi device BLE constants + packet framing.
 `scanForDevices(timeoutMs)` collects advertisements for the requested interval
 after scanning starts, then removes its listener and stops scanning. An empty
 scan returns `[]`; no advertisement is required to finish the scan.
+Binding-level scan pauses are resumed while the adapter remains powered on,
+without resetting that interval. A failed resume rejects the scan and cleans up
+its subscriptions. Cleanup waits for an in-flight resume before stopping.
 
 Run the hermetic SDK suite with `bun test sdks/device/typescript` from the
 repository root. Bluetooth adapter behavior is mocked; these tests do not

--- a/sdks/device/typescript/README.md
+++ b/sdks/device/typescript/README.md
@@ -2,6 +2,14 @@
 
 Shared Omi device BLE constants + packet framing.
 
+`scanForDevices(timeoutMs)` collects advertisements for the requested interval
+after scanning starts, then removes its listener and stops scanning. An empty
+scan returns `[]`; no advertisement is required to finish the scan.
+
+Run the hermetic SDK suite with `bun test sdks/device/typescript` from the
+repository root. Bluetooth adapter behavior is mocked; these tests do not
+establish physical-device compatibility.
+
 - Full BLE stack on React Native: use existing `sdks/react-native` (`OmiConnection`).
 - This package is the portable protocol layer for Node/Web/custom transports.
 

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -84,13 +84,39 @@ export async function scanForDevices(timeoutMs = 5000): Promise<ScannedDevice[]>
       rssi: Number(peripheral.rssi ?? 0) || 0,
     });
   };
+  let active = false;
+  let restart: Promise<void> = Promise.resolve();
+  let failScan: (error: unknown) => void = () => {};
+  const scanFailure = new Promise<never>((_, reject) => { failScan = reject; });
+  const onScanStop = () => {
+    if (!active || noble.state !== 'poweredOn') return;
+    // Bindings can pause discovery while connecting. Serialize resumes and
+    // recheck ownership so a queued resume cannot outlive this scan window.
+    restart = restart.then(async () => {
+      if (active && noble.state === 'poweredOn') await noble.startScanningAsync([], false);
+    });
+    void restart.catch(failScan);
+  };
   noble.on('discover', onDiscover);
+  noble.on('scanStop', onScanStop);
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     await noble.startScanningAsync([], false);
-    await new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, timeoutMs)));
+    active = true;
+    await Promise.race([
+      new Promise<void>((resolve) => { timer = setTimeout(resolve, Math.max(0, timeoutMs)); }),
+      scanFailure,
+    ]);
   } finally {
+    active = false;
+    clearTimeout(timer);
     noble.removeListener('discover', onDiscover);
-    await noble.stopScanningAsync();
+    noble.removeListener('scanStop', onScanStop);
+    try {
+      await restart;
+    } finally {
+      await noble.stopScanningAsync();
+    }
   }
 
   return [...byId.values()];

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -8,10 +8,9 @@ type NobleLike = {
   waitForPoweredOnAsync?: (timeout?: number) => Promise<void>;
   startScanningAsync: (serviceUUIDs?: string[], allowDuplicates?: boolean) => Promise<void>;
   stopScanningAsync: () => Promise<void>;
-  discoverAsync?: () => AsyncGenerator<any, void, unknown>;
   connectAsync?: (idOrAddress: string) => Promise<any>;
-  on?: (event: string, listener: (...args: any[]) => void) => void;
-  removeListener?: (event: string, listener: (...args: any[]) => void) => void;
+  on: (event: string, listener: (...args: any[]) => void) => void;
+  removeListener: (event: string, listener: (...args: any[]) => void) => void;
   state?: string;
   startScanning?: (serviceUUIDs?: string[], allowDuplicates?: boolean, cb?: (err?: Error) => void) => void;
   stopScanning?: (cb?: () => void) => void;
@@ -74,43 +73,23 @@ export async function scanForDevices(timeoutMs = 5000): Promise<ScannedDevice[]>
   await ensurePoweredOn(noble);
 
   const byId = new Map<string, ScannedDevice>();
-  const deadline = Date.now() + timeoutMs;
-
-  await noble.startScanningAsync([], false);
-
+  // Own one event subscription and one deadline. Waiting for the next item of
+  // discoverAsync() cannot enforce a deadline when the adapter is quiet.
+  const onDiscover = (peripheral: any) => {
+    const id = String(peripheral.id || peripheral.address || '');
+    if (!id) return;
+    byId.set(id, {
+      id,
+      name: String(peripheral.advertisement?.localName || peripheral.advertisement?.name || ''),
+      rssi: Number(peripheral.rssi ?? 0) || 0,
+    });
+  };
+  noble.on('discover', onDiscover);
   try {
-    if (typeof noble.discoverAsync === 'function') {
-      for await (const peripheral of noble.discoverAsync()) {
-        const id = String(peripheral.id || peripheral.address || '');
-        if (id) {
-          byId.set(id, {
-            id,
-            name: String(peripheral.advertisement?.localName || peripheral.advertisement?.name || ''),
-            rssi: Number(peripheral.rssi ?? 0) || 0,
-          });
-        }
-        if (Date.now() >= deadline) break;
-      }
-    } else {
-      await new Promise<void>((resolve) => {
-        const onDiscover = (peripheral: any) => {
-          const id = String(peripheral.id || peripheral.address || '');
-          if (!id) return;
-          byId.set(id, {
-            id,
-            name: String(peripheral.advertisement?.localName || ''),
-            rssi: Number(peripheral.rssi ?? 0) || 0,
-          });
-        };
-        noble.on?.('discover', onDiscover);
-        const left = Math.max(0, deadline - Date.now());
-        setTimeout(() => {
-          noble.removeListener?.('discover', onDiscover);
-          resolve();
-        }, left);
-      });
-    }
+    await noble.startScanningAsync([], false);
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, timeoutMs)));
   } finally {
+    noble.removeListener('discover', onDiscover);
     await noble.stopScanningAsync();
   }
 

--- a/sdks/device/typescript/src/ble/scan.test.ts
+++ b/sdks/device/typescript/src/ble/scan.test.ts
@@ -69,4 +69,46 @@ describe('scanForDevices deadline ownership', () => {
     expect(adapter.listenerCount('discover')).toBe(0);
     expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
   });
+
+  test('resumes binding pauses without extending the original deadline', async () => {
+    const result = scanForDevices(20);
+    await started;
+    await Promise.resolve();
+    const originalExpiry = expire;
+    let resumed!: () => void;
+    const didResume = new Promise<void>(resolve => { resumed = resolve; });
+    adapter.startScanningAsync.mockImplementation(async () => {
+      adapter.emit('discover', { id: 'after-pause', rssi: -40 });
+      resumed();
+    });
+    adapter.emit('scanStop');
+    await Promise.resolve();
+    expect(adapter.startScanningAsync).toHaveBeenCalledTimes(2);
+    await didResume;
+    expect(expire).toBe(originalExpiry);
+    expire!();
+    expect(await result).toEqual([{ id: 'after-pause', name: '', rssi: -40 }]);
+    expect(adapter.startScanningAsync).toHaveBeenCalledTimes(2);
+    expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
+    expect(adapter.listenerCount('scanStop')).toBe(0);
+    adapter.emit('scanStop');
+    await Promise.resolve();
+    expect(adapter.startScanningAsync).toHaveBeenCalledTimes(2);
+  });
+
+  test('propagates resume failure and releases both subscriptions', async () => {
+    const result = scanForDevices(20);
+    await started;
+    await Promise.resolve();
+    const failure = new Error('resume rejected');
+    adapter.startScanningAsync.mockRejectedValueOnce(failure);
+    const rejected = result.catch(error => error);
+    adapter.emit('scanStop');
+    await Promise.resolve();
+    expect(adapter.startScanningAsync).toHaveBeenCalledTimes(2);
+    expect(await rejected).toBe(failure);
+    expect(adapter.listenerCount('discover')).toBe(0);
+    expect(adapter.listenerCount('scanStop')).toBe(0);
+    expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
+  });
 });

--- a/sdks/device/typescript/src/ble/scan.test.ts
+++ b/sdks/device/typescript/src/ble/scan.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { scanForDevices } from './noble.ts';
+
+const adapter = Object.assign(new EventEmitter(), {
+  state: 'poweredOn',
+  startScanningAsync: mock(async () => {}),
+  stopScanningAsync: mock(async () => {}),
+  async *discoverAsync() { await new Promise(() => {}); },
+});
+mock.module('@stoprocent/noble', () => ({ default: adapter }));
+
+describe('scanForDevices deadline ownership', () => {
+  let expire: (() => void) | undefined;
+  let started: Promise<void>;
+  let timer: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    adapter.removeAllListeners();
+    adapter.startScanningAsync.mockReset();
+    started = new Promise<void>((resolve) => {
+      adapter.startScanningAsync.mockImplementation(async () => { resolve(); });
+    });
+    adapter.stopScanningAsync.mockClear();
+    expire = undefined;
+    timer = spyOn(globalThis, 'setTimeout').mockImplementation(((callback: () => void) => {
+      expire = callback;
+      return 1;
+    }) as typeof setTimeout);
+  });
+  afterEach(() => { timer.mockRestore(); adapter.removeAllListeners(); });
+
+  test('returns an empty list and stops when no advertisements arrive', async () => {
+    const result = scanForDevices(20);
+    await started;
+    await Promise.resolve();
+    expect(expire).toBeDefined();
+    expire!();
+    expect(await result).toEqual([]);
+    expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
+    expect(adapter.listenerCount('discover')).toBe(0);
+  });
+
+  test('captures immediate advertisements, deduplicates, then stops during silence', async () => {
+    const begin = adapter.startScanningAsync.getMockImplementation()!;
+    adapter.startScanningAsync.mockImplementation(async () => {
+      void begin();
+      adapter.emit('discover', { id: 'a', advertisement: { localName: 'Omi' }, rssi: -70 });
+    });
+    const result = scanForDevices(20);
+    await started;
+    await Promise.resolve();
+    expect(expire).toBeDefined();
+    adapter.emit('discover', { id: 'a', advertisement: { localName: 'Omi' }, rssi: -50 });
+    adapter.emit('discover', { address: 'b', advertisement: { name: 'Second' }, rssi: 0 });
+    expire!();
+    expect(await result).toEqual([
+      { id: 'a', name: 'Omi', rssi: -50 },
+      { id: 'b', name: 'Second', rssi: 0 },
+    ]);
+    expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
+    expect(adapter.listenerCount('discover')).toBe(0);
+  });
+
+  test('cleans up and propagates scan-start errors', async () => {
+    const failure = new Error('adapter rejected scan');
+    adapter.startScanningAsync.mockRejectedValueOnce(failure);
+    await expect(scanForDevices(20)).rejects.toBe(failure);
+    expect(adapter.listenerCount('discover')).toBe(0);
+    expect(adapter.stopScanningAsync).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #12989. A quiet Bluetooth adapter previously left scanForDevices pending past its timeout. The SDK now collects discovery events for a bounded interval and releases the listener and scan on completion or error.

Validation: Bun 1.3.14 SDK suite 15 passed; TypeScript 5.9.3 noEmit passed; three regression cases fail against original main and pass with this patch. Bluetooth is mocked; hardware compatibility is not claimed. All 14 applicable manifest checks and the bounded pre-push gate passed.

AI authorship: produced and tested by an AI coding agent with the account owner's authorization.

Product invariants affected: none.

Failure-Class: new
Root cause: the scan deadline was checked only after receiving a discovery item, so silence prevented deadline evaluation and cleanup.
Durable guard: the production scanner's event subscription is tested with a controllable completion timer and a quiet fake adapter, with normal device collection and startup failure also covered. Registered in the shared local/CI manifest; the new class is FC-event-gated-operation-deadline. This is a behavioral regression test for issue #12989 rather than a source-string guard.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

