### PR TITLE
fix(cli): preserve exit codes and JSON for transport failures

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -251,10 +251,17 @@ omi
 5  not found (404)
 ```
 
-Connection failures, timeouts, and transport protocol errors are retried
-automatically. If all attempts fail, the CLI exits with code `3` and emits a
-safe error message on stderr (JSON when `--json` is set), without raw transport
-exception details.
+For requests through the shared Omi API client, including post-login credential
+verification, connection failures, timeouts, and transport protocol errors are
+retried automatically. If all attempts fail, the CLI exits with code `3` and
+emits a safe error message on stderr (JSON when `--json` is set), without raw
+transport exception details. This guarantee does not cover separate OAuth HTTP
+requests (token exchange, refresh, or API-key minting) or local companion API
+requests.
+
+The shared client requires a valid absolute `http://` or `https://` API base URL.
+Invalid API base configuration is reported as a usage error (exit `1`) before
+the client attempts a request or refreshes credentials.
 
 ## For agents
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -268,12 +268,15 @@ to verify the stored credential. Browser login has already created a developer
 API key, and an earlier key for this machine may have been replaced.
 
 The shared client requires a valid absolute `http://` or `https://` API base URL,
-stored as a string, without a query or fragment, and with any explicit port in
-the range `1`–`65535` (port `0` is reserved). Path prefixes are supported.
+stored as a string, without embedded credentials, a query or fragment, and with
+any explicit port in the range `1`–`65535` (port `0` is reserved). Path prefixes
+and IPv6 hosts are supported. An explicitly empty `--api-base` is invalid;
+it does not fall back to the stored or environment URL.
 Invalid API base configuration is reported as a usage error (exit `1`) before
 the client attempts a request or refreshes credentials.
 Browser-login progress goes through the renderer: stderr for human output and
 suppressed in JSON mode, including when later credential verification fails.
+Fallback login URLs are printed literally, preserving IPv6 address brackets.
 
 ## For agents
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -259,6 +259,14 @@ transport exception details. This guarantee does not cover separate OAuth HTTP
 requests (token exchange, refresh, or API-key minting) or local companion API
 requests.
 
+If post-login verification encounters a transport or usage error after saving
+the new credential, the error explicitly reports that it is stored but
+unverified. JSON errors include
+`credential_stored: true` and `credential_verified: false`; the transport failure
+still exits with code `3`. Run `omi auth whoami` when connectivity is restored
+to verify the stored credential. Browser login has already created a developer
+API key, and an earlier key for this machine may have been replaced.
+
 The shared client requires a valid absolute `http://` or `https://` API base URL,
 with any explicit port in the range `1`–`65535` (port `0` is reserved).
 Invalid API base configuration is reported as a usage error (exit `1`) before

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -259,7 +259,8 @@ transport exception details. This guarantee does not cover separate OAuth HTTP
 requests (token exchange, refresh, or API-key minting) or local companion API
 requests.
 
-The shared client requires a valid absolute `http://` or `https://` API base URL.
+The shared client requires a valid absolute `http://` or `https://` API base URL,
+with any explicit port in the range `1`–`65535` (port `0` is reserved).
 Invalid API base configuration is reported as a usage error (exit `1`) before
 the client attempts a request or refreshes credentials.
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -268,9 +268,12 @@ to verify the stored credential. Browser login has already created a developer
 API key, and an earlier key for this machine may have been replaced.
 
 The shared client requires a valid absolute `http://` or `https://` API base URL,
-with any explicit port in the range `1`–`65535` (port `0` is reserved).
+stored as a string, without a query or fragment, and with any explicit port in
+the range `1`–`65535` (port `0` is reserved). Path prefixes are supported.
 Invalid API base configuration is reported as a usage error (exit `1`) before
 the client attempts a request or refreshes credentials.
+Browser-login progress goes through the renderer: stderr for human output and
+suppressed in JSON mode, including when later credential verification fails.
 
 ## For agents
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -251,6 +251,11 @@ omi
 5  not found (404)
 ```
 
+Connection failures, timeouts, and transport protocol errors are retried
+automatically. If all attempts fail, the CLI exits with code `3` and emits a
+safe error message on stderr (JSON when `--json` is set), without raw transport
+exception details.
+
 ## For agents
 
 The CLI is built so an LLM can use it without a wrapper:

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -268,10 +268,11 @@ to verify the stored credential. Browser login has already created a developer
 API key, and an earlier key for this machine may have been replaced.
 
 The shared client requires a valid absolute `http://` or `https://` API base URL,
-stored as a string, without embedded credentials, a query or fragment, and with
+stored as a string, without raw whitespace, embedded credentials, a query or fragment, and with
 any explicit port in the range `1`–`65535` (port `0` is reserved). Path prefixes
 and IPv6 hosts are supported. An explicitly empty `--api-base` is invalid;
-it does not fall back to the stored or environment URL.
+it does not fall back to the stored or environment URL. Spaces within path
+prefixes must be percent-encoded as `%20`.
 Invalid API base configuration is reported as a usage error (exit `1`) before
 the client attempts a request or refreshes credentials.
 Browser-login progress goes through the renderer: stderr for human output and

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -31,7 +31,7 @@ import threading
 import time
 import urllib.parse
 import webbrowser
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import httpx
 
@@ -90,6 +90,7 @@ def login_with_browser(
     profile_name: str,
     *,
     api_base: str,
+    on_progress: Callable[[str], None],
     provider: str = "google",
     open_browser: bool = True,
 ) -> Profile:
@@ -98,7 +99,8 @@ def login_with_browser(
     Returns the updated :class:`Profile`.
 
     ``open_browser=False`` is useful in headless tests; the caller is then
-    responsible for actually visiting the printed URL.
+    responsible for actually visiting the URL provided to ``on_progress``.
+    The command's renderer owns progress output and its JSON-mode policy.
     """
     if provider not in {"google", "apple"}:
         raise UsageError(
@@ -134,11 +136,11 @@ def login_with_browser(
         thread.start()
 
         try:
-            print(f"Opening browser for {provider} sign-in...")
-            print(f"If your browser does not open, visit:\n  {auth_url}")
+            on_progress(f"Opening browser for {provider} sign-in...")
+            on_progress(f"If your browser does not open, visit:\n  {auth_url}")
             if open_browser:
                 # webbrowser.open returns False on failure but is otherwise
-                # silent; we always print the URL above as a fallback.
+                # silent; the renderer supplies the URL in human output mode.
                 webbrowser.open(auth_url, new=2)
 
             if not received_event.wait(timeout=_BROWSER_TIMEOUT_SECONDS):

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -5,8 +5,8 @@ This is the single surface every command goes through. It owns:
 * Bearer-token injection from the active :class:`omi_cli.config.Profile`.
 * Retry/backoff for ``429`` and ``5xx`` responses, honoring ``Retry-After`` when
   the server provides one.
-* Translating non-2xx responses into the :mod:`omi_cli.errors` hierarchy so the
-  call sites just see a clean exception.
+* Translating non-2xx responses and exhausted transport failures into the
+  :mod:`omi_cli.errors` hierarchy so the call sites just see a clean exception.
 * Sniffing the rate-limit policy from the response body so the user gets a
   useful message instead of a bare ``429``.
 
@@ -158,6 +158,13 @@ class OmiClient:
         except _RetryableHttp as exc:
             # We exhausted retries — convert to the proper CliError now.
             raise self._error_from_response(exc.response)
+        except httpx.TransportError as exc:
+            # Transport failures can contain credentials or URLs; keep public
+            # output fixed while retaining the cause for callers debugging it.
+            raise ServerError(
+                message="Connection failed",
+                detail="Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+            ) from exc
         # Unreachable — Retrying always either returns or raises — but the type
         # checker doesn't know that.
         raise RuntimeError("unreachable")

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -63,6 +63,8 @@ def validate_api_base(value: str) -> httpx.URL:
         api_base is None
         or api_base.scheme not in ("http", "https")
         or not api_base.host
+        # HTTPX turns URL userinfo into Basic auth, overriding the Bearer header.
+        or api_base.userinfo
         # These delimiters change how endpoint paths are appended, even when
         # their component is empty. Percent-encoded path characters stay valid.
         or "?" in value

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -61,6 +61,8 @@ def validate_api_base(value: str) -> httpx.URL:
         api_base = None
     if (
         api_base is None
+        # HTTPX percent-encodes raw whitespace, including in otherwise invalid hosts.
+        or any(char.isspace() for char in value)
         or api_base.scheme not in ("http", "https")
         or not api_base.host
         # HTTPX turns URL userinfo into Basic auth, overriding the Bearer header.

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -56,13 +56,17 @@ def validate_api_base(value: str) -> httpx.URL:
     # HTTPX accepts port zero and ports above the TCP port range. Reject these here
     # instead of retrying the resulting ConnectError as a server failure.
     try:
-        api_base: Optional[httpx.URL] = httpx.URL(value.rstrip("/"))
+        api_base: Optional[httpx.URL] = httpx.URL(value.rstrip("/")) if isinstance(value, str) else None
     except httpx.InvalidURL:
         api_base = None
     if (
         api_base is None
         or api_base.scheme not in ("http", "https")
         or not api_base.host
+        # These delimiters change how endpoint paths are appended, even when
+        # their component is empty. Percent-encoded path characters stay valid.
+        or "?" in value
+        or "#" in value
         or (api_base.port is not None and not 1 <= api_base.port <= 65535)
     ):
         # Never include a possibly credential-bearing URL in public errors.

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -1,6 +1,6 @@
 """HTTP client for the Omi developer API.
 
-This is the single surface every command goes through. It owns:
+The shared request surface for Omi developer-API commands. It owns:
 
 * Bearer-token injection from the active :class:`omi_cli.config.Profile`.
 * Retry/backoff for ``429`` and ``5xx`` responses, honoring ``Retry-After`` when
@@ -32,7 +32,7 @@ from tenacity import (
 
 from omi_cli import __version__
 from omi_cli.config import Profile
-from omi_cli.errors import CliError, RateLimitError, ServerError, TransportError, from_status
+from omi_cli.errors import CliError, RateLimitError, ServerError, TransportError, UsageError, from_status
 
 USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
@@ -55,6 +55,18 @@ class OmiClient:
     """Thin wrapper around :class:`httpx.Client`. One per CLI invocation."""
 
     def __init__(self, profile: Profile, *, timeout: Optional[httpx.Timeout] = None, verbose: bool = False) -> None:
+        # Invalid local configuration must not trigger requests, token refresh,
+        # or transport retries. Do not include a possibly credential-bearing URL.
+        try:
+            api_base: Optional[httpx.URL] = httpx.URL(profile.api_base.rstrip("/"))
+        except httpx.InvalidURL:
+            api_base = None
+        if api_base is None or api_base.scheme not in ("http", "https") or not api_base.host:
+            raise UsageError(
+                message="Invalid API base URL",
+                detail="Use a valid absolute http:// or https:// URL for the Omi API.",
+            )
+
         # Pre-flight: if this is an OAuth profile and the cached Firebase ID
         # token is expired (or close to it), refresh before we build the bearer
         # header so the very first request goes out with a fresh token.
@@ -73,7 +85,7 @@ class OmiClient:
         self._profile = profile
         self._verbose = verbose
         self._http = httpx.Client(
-            base_url=profile.api_base.rstrip("/"),
+            base_url=api_base,
             headers=self._build_headers(profile),
             timeout=timeout or DEFAULT_TIMEOUT,
             follow_redirects=False,
@@ -160,11 +172,20 @@ class OmiClient:
             raise self._error_from_response(exc.response)
         except httpx.TransportError as exc:
             # Transport failures can contain credentials or URLs; keep public
-            # output fixed while retaining the cause for callers debugging it.
-            raise TransportError(
-                message="Connection failed",
-                detail="Could not reach the Omi API after multiple attempts. Check your connection and try again.",
-            ) from exc
+            # output fixed per category while retaining the cause for debugging.
+            if isinstance(exc, httpx.ConnectError):
+                message = "Connection failed"
+                detail = "Could not reach the Omi API after multiple attempts. Check your connection and try again."
+            elif isinstance(exc, httpx.TimeoutException):
+                message = "Request timed out"
+                detail = "The Omi API request timed out after multiple attempts."
+            elif isinstance(exc, httpx.ProtocolError):
+                message = "Protocol error"
+                detail = "The Omi API request encountered a protocol error after multiple attempts."
+            else:
+                message = "API communication failed"
+                detail = "Communication with the Omi API failed after multiple attempts."
+            raise TransportError(message=message, detail=detail) from exc
         # Unreachable — Retrying always either returns or raises — but the type
         # checker doesn't know that.
         raise RuntimeError("unreachable")

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -32,7 +32,7 @@ from tenacity import (
 
 from omi_cli import __version__
 from omi_cli.config import Profile
-from omi_cli.errors import CliError, RateLimitError, ServerError, from_status
+from omi_cli.errors import CliError, RateLimitError, ServerError, TransportError, from_status
 
 USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
@@ -161,7 +161,7 @@ class OmiClient:
         except httpx.TransportError as exc:
             # Transport failures can contain credentials or URLs; keep public
             # output fixed while retaining the cause for callers debugging it.
-            raise ServerError(
+            raise TransportError(
                 message="Connection failed",
                 detail="Could not reach the Omi API after multiple attempts. Check your connection and try again.",
             ) from exc

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -51,21 +51,35 @@ KNOWN_RATE_LIMIT_POLICIES = {
 }
 
 
+def validate_api_base(value: str) -> httpx.URL:
+    """Validate local API configuration before authentication or HTTP work."""
+    # HTTPX accepts numeric ports above the TCP port range. Reject these here
+    # instead of retrying the resulting ConnectError as a server failure.
+    try:
+        api_base: Optional[httpx.URL] = httpx.URL(value.rstrip("/"))
+    except httpx.InvalidURL:
+        api_base = None
+    if (
+        api_base is None
+        or api_base.scheme not in ("http", "https")
+        or not api_base.host
+        or (api_base.port is not None and not 0 <= api_base.port <= 65535)
+    ):
+        # Never include a possibly credential-bearing URL in public errors.
+        raise UsageError(
+            message="Invalid API base URL",
+            detail="Use a valid absolute http:// or https:// URL for the Omi API.",
+        )
+    return api_base
+
+
 class OmiClient:
     """Thin wrapper around :class:`httpx.Client`. One per CLI invocation."""
 
     def __init__(self, profile: Profile, *, timeout: Optional[httpx.Timeout] = None, verbose: bool = False) -> None:
         # Invalid local configuration must not trigger requests, token refresh,
         # or transport retries. Do not include a possibly credential-bearing URL.
-        try:
-            api_base: Optional[httpx.URL] = httpx.URL(profile.api_base.rstrip("/"))
-        except httpx.InvalidURL:
-            api_base = None
-        if api_base is None or api_base.scheme not in ("http", "https") or not api_base.host:
-            raise UsageError(
-                message="Invalid API base URL",
-                detail="Use a valid absolute http:// or https:// URL for the Omi API.",
-            )
+        api_base = validate_api_base(profile.api_base)
 
         # Pre-flight: if this is an OAuth profile and the cached Firebase ID
         # token is expired (or close to it), refresh before we build the bearer

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -53,7 +53,7 @@ KNOWN_RATE_LIMIT_POLICIES = {
 
 def validate_api_base(value: str) -> httpx.URL:
     """Validate local API configuration before authentication or HTTP work."""
-    # HTTPX accepts numeric ports above the TCP port range. Reject these here
+    # HTTPX accepts port zero and ports above the TCP port range. Reject these here
     # instead of retrying the resulting ConnectError as a server failure.
     try:
         api_base: Optional[httpx.URL] = httpx.URL(value.rstrip("/"))
@@ -63,7 +63,7 @@ def validate_api_base(value: str) -> httpx.URL:
         api_base is None
         or api_base.scheme not in ("http", "https")
         or not api_base.host
-        or (api_base.port is not None and not 0 <= api_base.port <= 65535)
+        or (api_base.port is not None and not 1 <= api_base.port <= 65535)
     ):
         # Never include a possibly credential-bearing URL in public errors.
         raise UsageError(

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -108,7 +108,9 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     """Run the OAuth browser flow + verify the resulting Firebase token works."""
     api_base = ctx.api_base_override or ctx.get_profile().api_base
     validate_api_base(api_base)
-    profile = oauth_auth.login_with_browser(ctx.profile_name, api_base=api_base, provider=provider)
+    profile = oauth_auth.login_with_browser(
+        ctx.profile_name, api_base=api_base, provider=provider, on_progress=ctx.renderer.info
+    )
 
     # Verify the freshly-minted Firebase ID token actually authenticates against
     # the Omi API. If it doesn't, roll back so the user isn't left holding a

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -11,7 +11,7 @@ from omi_cli import config as cfg
 from omi_cli.auth import api_key as api_key_auth
 from omi_cli.auth import oauth as oauth_auth
 from omi_cli.auth.store import clear_credentials
-from omi_cli.client import OmiClient
+from omi_cli.client import OmiClient, validate_api_base
 from omi_cli.errors import AuthError, CliError, TransportError, UsageError
 
 if TYPE_CHECKING:
@@ -95,6 +95,7 @@ def login(
 def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     """Run the OAuth browser flow + verify the resulting Firebase token works."""
     api_base = ctx.api_base_override or ctx.get_profile().api_base
+    validate_api_base(api_base)
     profile = oauth_auth.login_with_browser(ctx.profile_name, api_base=api_base, provider=provider)
 
     # Verify the freshly-minted Firebase ID token actually authenticates against
@@ -106,7 +107,7 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
-    except TransportError:
+    except (TransportError, UsageError):
         # Verification never completed; do not report a successful login.
         raise
     except CliError as exc:
@@ -134,10 +135,11 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
 
 def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     """Validate, persist, and verify a dev API key."""
+    validate_api_base(ctx.api_base_override or ctx.load_config().get_profile(ctx.profile_name).api_base)
     profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key, api_base=ctx.api_base_override)
 
     # Sanity check on a tolerant endpoint — see the original launch PR's
-    # rationale. AuthError → roll back; transport failures propagate;
+    # rationale. AuthError → roll back; transport and usage failures propagate;
     # other CliError → warn and keep.
     try:
         with OmiClient(profile, verbose=ctx.verbose) as client:
@@ -145,7 +147,7 @@ def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
-    except TransportError:
+    except (TransportError, UsageError):
         # Verification never completed; do not report a successful login.
         raise
     except CliError as exc:

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -92,6 +92,18 @@ def login(
     )
 
 
+def _mark_stored_but_unverified(exc: CliError, *, browser: bool) -> None:
+    """Describe the completed credential write without losing the typed failure."""
+    detail = (
+        "The new credential is stored but has not been verified. "
+        "Run `omi auth whoami` to verify it when the API is reachable."
+    )
+    if browser:
+        detail += " Browser login created a developer API key; an earlier machine key may have been replaced."
+    exc.detail = f"{exc.detail} {detail}" if exc.detail else detail
+    exc.extra.update({"credential_stored": True, "credential_verified": False})
+
+
 def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     """Run the OAuth browser flow + verify the resulting Firebase token works."""
     api_base = ctx.api_base_override or ctx.get_profile().api_base
@@ -107,8 +119,8 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
-    except (TransportError, UsageError):
-        # Verification never completed; do not report a successful login.
+    except (TransportError, UsageError) as exc:
+        _mark_stored_but_unverified(exc, browser=True)
         raise
     except CliError as exc:
         # Other API errors retain the existing warn-and-keep policy.
@@ -147,8 +159,8 @@ def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
-    except (TransportError, UsageError):
-        # Verification never completed; do not report a successful login.
+    except (TransportError, UsageError) as exc:
+        _mark_stored_but_unverified(exc, browser=False)
         raise
     except CliError as exc:
         ctx.renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -12,7 +12,7 @@ from omi_cli.auth import api_key as api_key_auth
 from omi_cli.auth import oauth as oauth_auth
 from omi_cli.auth.store import clear_credentials
 from omi_cli.client import OmiClient
-from omi_cli.errors import AuthError, CliError, UsageError
+from omi_cli.errors import AuthError, CliError, TransportError, UsageError
 
 if TYPE_CHECKING:
     from omi_cli.main import AppContext
@@ -106,9 +106,11 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
+    except TransportError:
+        # Verification never completed; do not report a successful login.
+        raise
     except CliError as exc:
-        # Insufficient scope / 403 also bubbles as AuthError above. Anything
-        # else is a transient network blip — keep the credential, just warn.
+        # Other API errors retain the existing warn-and-keep policy.
         ctx.renderer.warn(
             f"Could not verify the new token right now ({exc.message}). It is stored — try again shortly."
         )
@@ -135,13 +137,17 @@ def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key, api_base=ctx.api_base_override)
 
     # Sanity check on a tolerant endpoint — see the original launch PR's
-    # rationale. AuthError → roll back; other CliError → warn and keep.
+    # rationale. AuthError → roll back; transport failures propagate;
+    # other CliError → warn and keep.
     try:
         with OmiClient(profile, verbose=ctx.verbose) as client:
             client.get("/v1/dev/user/memories", params={"limit": 1})
     except AuthError as exc:
         clear_credentials(ctx.profile_name)
         raise exc
+    except TransportError:
+        # Verification never completed; do not report a successful login.
+        raise
     except CliError as exc:
         ctx.renderer.warn(f"Could not verify the key right now ({exc.message}). It is stored — try again shortly.")
 

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -106,10 +106,13 @@ def _mark_stored_but_unverified(exc: CliError, *, browser: bool) -> None:
 
 def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
     """Run the OAuth browser flow + verify the resulting Firebase token works."""
-    api_base = ctx.api_base_override or ctx.get_profile().api_base
+    api_base = ctx.api_base_override if ctx.api_base_override is not None else ctx.get_profile().api_base
     validate_api_base(api_base)
     profile = oauth_auth.login_with_browser(
-        ctx.profile_name, api_base=api_base, provider=provider, on_progress=ctx.renderer.info
+        ctx.profile_name,
+        api_base=api_base,
+        provider=provider,
+        on_progress=lambda message: ctx.renderer.info(message, markup=False),
     )
 
     # Verify the freshly-minted Firebase ID token actually authenticates against
@@ -149,7 +152,12 @@ def _do_browser_login(ctx: "AppContext", *, provider: str) -> None:
 
 def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     """Validate, persist, and verify a dev API key."""
-    validate_api_base(ctx.api_base_override or ctx.load_config().get_profile(ctx.profile_name).api_base)
+    api_base = (
+        ctx.api_base_override
+        if ctx.api_base_override is not None
+        else ctx.load_config().get_profile(ctx.profile_name).api_base
+    )
+    validate_api_base(api_base)
     profile = api_key_auth.login_with_api_key(ctx.profile_name, api_key, api_base=ctx.api_base_override)
 
     # Sanity check on a tolerant endpoint — see the original launch PR's

--- a/sdks/python-cli/omi_cli/errors.py
+++ b/sdks/python-cli/omi_cli/errors.py
@@ -91,6 +91,10 @@ class ServerError(CliError):
     exit_code = EXIT_SERVER
 
 
+class TransportError(ServerError):
+    """Exhausted HTTP transport attempts, distinct from an HTTP error response."""
+
+
 class NotFoundError(CliError):
     exit_code = EXIT_NOT_FOUND
 

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -75,7 +75,7 @@ class AppContext:
     def get_profile(self) -> cfg.Profile:
         config = self.load_config()
         profile = config.get_profile(self.profile_name)
-        if self.api_base_override:
+        if self.api_base_override is not None:
             profile.api_base = self.api_base_override
         # Allow OMI_API_KEY to take effect even if the on-disk profile has no key.
         # Validate the prefix here so an obviously-bad env value fails fast with the
@@ -86,7 +86,7 @@ class AppContext:
             profile.auth_method = "api_key"
             profile.api_key = validate_api_key_format(env_key)
         env_base = os.environ.get(cfg.ENV_API_BASE)
-        if env_base and not self.api_base_override:
+        if env_base and self.api_base_override is None:
             profile.api_base = env_base
         return profile
 

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -118,10 +118,10 @@ class Renderer:
     # Stderr (status/messages)
     # ------------------------------------------------------------------
 
-    def info(self, message: str) -> None:
+    def info(self, message: str, *, markup: bool = True) -> None:
         if self.json_mode:
             return  # silence in JSON mode — keep stderr clean for piping
-        self._stderr.print(message)
+        self._stderr.print(message, markup=markup)
 
     def success(self, message: str) -> None:
         if self.json_mode:

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -91,6 +91,7 @@ def test_explicit_login_key_recovers_from_invalid_environment_key(config_path, r
     "api_base",
     [
         "ftp://user:secret@example.invalid/?token=private-token",
+        "http://user:secret@127.0.0.1:0/?token=private-token",
         "http://user:secret@127.0.0.1:99999/?token=private-token",
     ],
 )

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -64,3 +64,68 @@ def test_login_http_503_keeps_existing_warning_policy(login_args, respx_mock, mo
     assert "Could not verify" in captured.err
     assert "It is stored" in captured.err
     assert "Logged in" in captured.err
+
+
+def test_explicit_login_key_recovers_from_invalid_environment_key(config_path, respx_mock, monkeypatch, capsys) -> None:
+    monkeypatch.setenv(cfg.ENV_API_KEY, "stale-malformed-key")
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "auth", "login", "--api-key", FAKE_API_KEY])
+    route = respx_mock.get(f"{cfg.DEFAULT_API_BASE}/v1/dev/user/memories").respond(200, json=[])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert route.call_count == 1
+    assert route.calls[0].request.headers["Authorization"] == f"Bearer {FAKE_API_KEY}"
+    assert json.loads(captured.out) == {
+        "profile": "default",
+        "auth_method": "api_key",
+        "api_base": cfg.DEFAULT_API_BASE,
+    }
+    assert captured.err == ""
+    assert cfg.load().get_profile("default").api_key == FAKE_API_KEY
+
+
+@pytest.mark.parametrize("source", ["flag", "profile"])
+@pytest.mark.parametrize("auth_method", ["api_key", "browser"])
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "ftp://user:secret@example.invalid/?token=private-token",
+        "http://user:secret@127.0.0.1:99999/?token=private-token",
+    ],
+)
+def test_invalid_login_base_preserves_existing_profile(
+    authed_profile, config_path, monkeypatch, capsys, source, auth_method, api_base
+) -> None:
+    argv = ["omi", "--json"]
+    if source == "flag":
+        argv.extend(["--api-base", api_base])
+    else:
+        config = cfg.load()
+        config.get_profile("default").api_base = api_base
+        cfg.save(config)
+    original_config = config_path.read_bytes()
+    argv.extend(["auth", "login"])
+    argv.extend(["--browser"] if auth_method == "browser" else ["--api-key", "omi_dev_" + ("y" * 32)])
+    monkeypatch.setattr(sys, "argv", argv)
+
+    def unexpected_call(*args, **kwargs):
+        pytest.fail("Invalid API configuration must fail before HTTP, browser login, or retry backoff")
+
+    monkeypatch.setattr(httpx, "Client", unexpected_call)
+    monkeypatch.setattr("omi_cli.auth.oauth.login_with_browser", unexpected_call)
+    monkeypatch.setattr(time, "sleep", unexpected_call)
+
+    with pytest.raises(SystemExit) as info:
+        main()
+
+    captured = capsys.readouterr()
+    assert info.value.code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": "Invalid API base URL",
+        "detail": "Use a valid absolute http:// or https:// URL for the Omi API.",
+    }
+    assert "secret" not in captured.err
+    assert "private-token" not in captured.err
+    assert config_path.read_bytes() == original_config

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -138,6 +138,8 @@ def test_explicit_login_key_recovers_from_invalid_environment_key(config_path, r
         "https://example.invalid/api?tenant=private-token",
         "https://example.invalid/api#private-token",
         "https://user:secret@example.invalid/api",
+        "https://api.omi.me ",
+        "https://api.omi.me/api v1",
         "",
     ],
 )

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 from omi_cli import config as cfg
+from omi_cli.auth.store import store_api_key
 from omi_cli.client import MAX_RETRY_ATTEMPTS
 from omi_cli.main import main
 from tests.conftest import FAKE_API_BASE, FAKE_API_KEY
@@ -23,18 +24,36 @@ def login_args(request, config_path, monkeypatch) -> list[str]:
     def fake_browser_login(profile_name, *, api_base, provider):
         # The browser/token exchange is external to this boundary; verification
         # still runs through the real OmiClient and HTTPX mock transport.
-        return cfg.Profile(name=profile_name, api_base=api_base, auth_method="api_key", api_key=FAKE_API_KEY)
+        return store_api_key(profile_name, FAKE_API_KEY, api_base=api_base)
 
     monkeypatch.setattr("omi_cli.auth.oauth.login_with_browser", fake_browser_login)
     return ["--browser"]
 
 
-def test_login_transport_failure_is_not_reported_as_success(login_args, respx_mock, monkeypatch, capsys) -> None:
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_login_transport_failure_is_not_reported_as_success(
+    login_args, respx_mock, monkeypatch, capsys, json_mode
+) -> None:
+    previous_key = "omi_dev_" + ("y" * 32)
+    store_api_key("default", previous_key, api_base=FAKE_API_BASE)
     route = respx_mock.get("/v1/dev/user/memories").mock(
         side_effect=httpx.ConnectError("request failed at https://user:secret@example.invalid/?token=private-token")
     )
     monkeypatch.setattr(time, "sleep", lambda _: None)
-    monkeypatch.setattr(sys, "argv", ["omi", "--json", "--api-base", FAKE_API_BASE, "auth", "login", *login_args])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "omi",
+            "--no-color",
+            *(["--json"] if json_mode else []),
+            "--api-base",
+            FAKE_API_BASE,
+            "auth",
+            "login",
+            *login_args,
+        ],
+    )
 
     with pytest.raises(SystemExit) as info:
         main()
@@ -43,12 +62,33 @@ def test_login_transport_failure_is_not_reported_as_success(login_args, respx_mo
     assert info.value.code == 3
     assert route.call_count == MAX_RETRY_ATTEMPTS
     assert captured.out == ""
-    assert json.loads(captured.err) == {
-        "error": "Connection failed",
-        "detail": "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
-    }
+    stored_detail = (
+        "The new credential is stored but has not been verified. "
+        "Run `omi auth whoami` to verify it when the API is reachable."
+    )
+    if "--browser" in login_args:
+        stored_detail += " Browser login created a developer API key; an earlier machine key may have been replaced."
+    if json_mode:
+        assert json.loads(captured.err) == {
+            "error": "Connection failed",
+            "detail": "Could not reach the Omi API after multiple attempts. Check your connection and try again. "
+            + stored_detail,
+            "credential_stored": True,
+            "credential_verified": False,
+        }
+    else:
+        assert "The new credential is stored but has not been verified." in captured.err
+        assert "omi auth whoami" in captured.err
+        assert "credential_stored" in captured.err
+        assert "credential_verified" in captured.err
+        if "--browser" in login_args:
+            assert "may have been replaced" in captured.err
+    assert cfg.load().get_profile("default").api_key == FAKE_API_KEY
+    assert "Logged in" not in captured.err
     assert "secret" not in captured.err
     assert "private-token" not in captured.err
+    assert FAKE_API_KEY not in captured.err
+    assert previous_key not in captured.err
 
 
 def test_login_http_503_keeps_existing_warning_policy(login_args, respx_mock, monkeypatch, capsys) -> None:

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -137,6 +137,8 @@ def test_explicit_login_key_recovers_from_invalid_environment_key(config_path, r
         "http://user:secret@127.0.0.1:99999/?token=private-token",
         "https://example.invalid/api?tenant=private-token",
         "https://example.invalid/api#private-token",
+        "https://user:secret@example.invalid/api",
+        "",
     ],
 )
 def test_invalid_login_base_preserves_existing_profile(
@@ -178,8 +180,9 @@ def test_invalid_login_base_preserves_existing_profile(
 
 @pytest.mark.parametrize("json_mode", [False, True])
 @pytest.mark.parametrize("failure", [False, True])
+@pytest.mark.parametrize("api_base", [FAKE_API_BASE, "http://[fe80::1]:8000"])
 def test_production_browser_login_respects_output_mode(
-    config_path, monkeypatch, respx_mock, capsys, json_mode, failure
+    config_path, monkeypatch, respx_mock, capsys, json_mode, failure, api_base
 ):
     """Keep the production OAuth flow; replace only browser, callback server, and token endpoints."""
     callback = {}
@@ -208,6 +211,7 @@ def test_production_browser_login_respects_output_mode(
             pass
 
     def browser_callback(url, **kwargs):
+        callback["url"] = url
         query = parse_qs(urlparse(url).query)
         callback["received"].update(state=query["state"][0], code="test-code")
         callback["event"].set()
@@ -220,7 +224,7 @@ def test_production_browser_login_respects_output_mode(
     monkeypatch.setattr(oauth, "_firebase_signin_with_custom_token", lambda *args: ("test-id", "test-refresh", 3600))
     monkeypatch.setattr(oauth, "_exchange_firebase_token_for_dev_key", lambda *args: FAKE_API_KEY)
     monkeypatch.setattr(time, "sleep", lambda _: None)
-    route = respx_mock.get("/v1/dev/user/memories")
+    route = respx_mock.get(f"{api_base}/v1/dev/user/memories")
     if failure:
         route.mock(side_effect=httpx.ConnectError("private-token"))
     else:
@@ -233,7 +237,7 @@ def test_production_browser_login_respects_output_mode(
             "--no-color",
             *(["--json"] if json_mode else []),
             "--api-base",
-            FAKE_API_BASE,
+            api_base,
             "auth",
             "login",
             "--browser",
@@ -259,4 +263,6 @@ def test_production_browser_login_respects_output_mode(
         assert captured.out == ""
         assert "Opening browser" in captured.err
         assert "/v1/auth/authorize?" in captured.err
+        # Rich may wrap the long URL, but must preserve every character, including IPv6 brackets.
+        assert callback["url"] in "".join(captured.err.split())
     assert "private-token" not in captured.out + captured.err

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -1,0 +1,66 @@
+"""Login verification uses the production client and preserves typed failures."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import httpx
+import pytest
+
+from omi_cli import config as cfg
+from omi_cli.client import MAX_RETRY_ATTEMPTS
+from omi_cli.main import main
+from tests.conftest import FAKE_API_BASE, FAKE_API_KEY
+
+
+@pytest.fixture(params=["api_key", "browser"])
+def login_args(request, config_path, monkeypatch) -> list[str]:
+    if request.param == "api_key":
+        return ["--api-key", FAKE_API_KEY]
+
+    def fake_browser_login(profile_name, *, api_base, provider):
+        # The browser/token exchange is external to this boundary; verification
+        # still runs through the real OmiClient and HTTPX mock transport.
+        return cfg.Profile(name=profile_name, api_base=api_base, auth_method="api_key", api_key=FAKE_API_KEY)
+
+    monkeypatch.setattr("omi_cli.auth.oauth.login_with_browser", fake_browser_login)
+    return ["--browser"]
+
+
+def test_login_transport_failure_is_not_reported_as_success(login_args, respx_mock, monkeypatch, capsys) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=httpx.ConnectError("request failed at https://user:secret@example.invalid/?token=private-token")
+    )
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "--api-base", FAKE_API_BASE, "auth", "login", *login_args])
+
+    with pytest.raises(SystemExit) as info:
+        main()
+
+    captured = capsys.readouterr()
+    assert info.value.code == 3
+    assert route.call_count == MAX_RETRY_ATTEMPTS
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": "Connection failed",
+        "detail": "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+    }
+    assert "secret" not in captured.err
+    assert "private-token" not in captured.err
+
+
+def test_login_http_503_keeps_existing_warning_policy(login_args, respx_mock, monkeypatch, capsys) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").respond(503, json={"detail": "unavailable"})
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monkeypatch.setattr(sys, "argv", ["omi", "--no-color", "--api-base", FAKE_API_BASE, "auth", "login", *login_args])
+
+    main()
+
+    captured = capsys.readouterr()
+    assert route.call_count == MAX_RETRY_ATTEMPTS
+    assert captured.out == ""
+    assert "Could not verify" in captured.err
+    assert "It is stored" in captured.err
+    assert "Logged in" in captured.err

--- a/sdks/python-cli/tests/test_auth_login.py
+++ b/sdks/python-cli/tests/test_auth_login.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import sys
 import time
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
 
 from omi_cli import config as cfg
+from omi_cli.auth import oauth
 from omi_cli.auth.store import store_api_key
 from omi_cli.client import MAX_RETRY_ATTEMPTS
 from omi_cli.main import main
@@ -21,7 +23,7 @@ def login_args(request, config_path, monkeypatch) -> list[str]:
     if request.param == "api_key":
         return ["--api-key", FAKE_API_KEY]
 
-    def fake_browser_login(profile_name, *, api_base, provider):
+    def fake_browser_login(profile_name, *, api_base, provider, on_progress):
         # The browser/token exchange is external to this boundary; verification
         # still runs through the real OmiClient and HTTPX mock transport.
         return store_api_key(profile_name, FAKE_API_KEY, api_base=api_base)
@@ -133,6 +135,8 @@ def test_explicit_login_key_recovers_from_invalid_environment_key(config_path, r
         "ftp://user:secret@example.invalid/?token=private-token",
         "http://user:secret@127.0.0.1:0/?token=private-token",
         "http://user:secret@127.0.0.1:99999/?token=private-token",
+        "https://example.invalid/api?tenant=private-token",
+        "https://example.invalid/api#private-token",
     ],
 )
 def test_invalid_login_base_preserves_existing_profile(
@@ -170,3 +174,89 @@ def test_invalid_login_base_preserves_existing_profile(
     assert "secret" not in captured.err
     assert "private-token" not in captured.err
     assert config_path.read_bytes() == original_config
+
+
+@pytest.mark.parametrize("json_mode", [False, True])
+@pytest.mark.parametrize("failure", [False, True])
+def test_production_browser_login_respects_output_mode(
+    config_path, monkeypatch, respx_mock, capsys, json_mode, failure
+):
+    """Keep the production OAuth flow; replace only browser, callback server, and token endpoints."""
+    callback = {}
+    original_handler = oauth._make_callback_handler
+
+    def capture_handler(received, event):
+        callback.update(received=received, event=event)
+        return original_handler(received, event)
+
+    class CallbackServer:
+        server_address = ("127.0.0.1", 43210)
+
+        def __init__(self, *args):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def serve_forever(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    def browser_callback(url, **kwargs):
+        query = parse_qs(urlparse(url).query)
+        callback["received"].update(state=query["state"][0], code="test-code")
+        callback["event"].set()
+        return True
+
+    monkeypatch.setattr(oauth, "_make_callback_handler", capture_handler)
+    monkeypatch.setattr(oauth, "_OneShotHTTPServer", CallbackServer)
+    monkeypatch.setattr(oauth.webbrowser, "open", browser_callback)
+    monkeypatch.setattr(oauth, "_exchange_code_for_custom_token", lambda *args: "test-custom-token")
+    monkeypatch.setattr(oauth, "_firebase_signin_with_custom_token", lambda *args: ("test-id", "test-refresh", 3600))
+    monkeypatch.setattr(oauth, "_exchange_firebase_token_for_dev_key", lambda *args: FAKE_API_KEY)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    route = respx_mock.get("/v1/dev/user/memories")
+    if failure:
+        route.mock(side_effect=httpx.ConnectError("private-token"))
+    else:
+        route.respond(200, json=[])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "omi",
+            "--no-color",
+            *(["--json"] if json_mode else []),
+            "--api-base",
+            FAKE_API_BASE,
+            "auth",
+            "login",
+            "--browser",
+        ],
+    )
+    if failure:
+        with pytest.raises(SystemExit) as info:
+            main()
+        assert info.value.code == 3
+    else:
+        main()
+    captured = capsys.readouterr()
+    assert route.call_count == (MAX_RETRY_ATTEMPTS if failure else 1)
+    if json_mode:
+        assert "Opening browser" not in captured.out + captured.err
+        if failure:
+            assert captured.out == ""
+            assert json.loads(captured.err)["credential_verified"] is False
+        else:
+            assert json.loads(captured.out)["provider"] == "google"
+            assert captured.err == ""
+    else:
+        assert captured.out == ""
+        assert "Opening browser" in captured.err
+        assert "/v1/auth/authorize?" in captured.err
+    assert "private-token" not in captured.out + captured.err

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -145,6 +145,7 @@ def test_login_with_browser_rejects_unknown_provider(config_path) -> None:
             "default",
             api_base="https://api.test.omi.local",
             provider="microsoft",  # unsupported
+            on_progress=lambda message: None,
             open_browser=False,
         )
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -38,6 +38,9 @@ def test_user_agent_contains_version_and_repo() -> None:
         "https://example.invalid/api#private-token",
         "https://example.invalid/api?",
         "https://example.invalid/api#",
+        "https://user:secret@example.invalid/api",
+        "https://user@example.invalid/api",
+        "https://:secret@example.invalid/api",
     ],
 )
 def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch, api_base) -> None:
@@ -65,7 +68,13 @@ def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch
 
 @pytest.mark.parametrize(
     "api_base",
-    ["http://localhost:1", "https://localhost:65535", "https://api.omi.me", "https://api.omi.me/api/v1/"],
+    [
+        "http://localhost:1",
+        "https://localhost:65535",
+        "https://api.omi.me",
+        "https://api.omi.me/api/v1/",
+        "http://[fe80::1]:8000",
+    ],
 )
 def test_valid_api_base_port_boundaries(api_base) -> None:
     assert validate_api_base(api_base).host

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -11,12 +11,45 @@ from omi_cli import __version__
 from omi_cli import config as cfg
 from omi_cli.auth.store import store_oauth_tokens
 from omi_cli.client import MAX_RETRY_ATTEMPTS, USER_AGENT, OmiClient
-from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
+from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError, UsageError
 
 
 def test_user_agent_contains_version_and_repo() -> None:
     assert __version__ in USER_AGENT
     assert "omi-cli" in USER_AGENT
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "ftp://user:secret@example.invalid/?token=private-token",
+        "ws://example.invalid",
+        "example.invalid",
+        "https://",
+        "https://example.invalid:private-token",
+    ],
+)
+def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch, api_base) -> None:
+    authed_profile.api_base = api_base
+    authed_profile.auth_method = "oauth"
+    authed_profile.id_token = "expired"
+    authed_profile.expires_at = time.time() - 60
+
+    def unexpected_call(*args, **kwargs):
+        pytest.fail("Invalid API configuration must fail before HTTP, OAuth refresh, or retry backoff")
+
+    monkeypatch.setattr(httpx, "Client", unexpected_call)
+    monkeypatch.setattr("omi_cli.auth.oauth.refresh_id_token", unexpected_call)
+    monkeypatch.setattr(time, "sleep", unexpected_call)
+
+    with pytest.raises(UsageError) as info:
+        OmiClient(authed_profile)
+
+    assert info.value.exit_code == 1
+    assert info.value.message == "Invalid API base URL"
+    assert info.value.detail == "Use a valid absolute http:// or https:// URL for the Omi API."
+    assert "secret" not in str(info.value)
+    assert "private-token" not in str(info.value)
 
 
 def test_oauth_pre_flight_refresh_when_token_expired(config_path, monkeypatch) -> None:
@@ -137,8 +170,38 @@ def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
     assert result == []
 
 
-@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError])
-def test_exhausted_transport_retries_surface_server_error(authed_profile, respx_mock, monkeypatch, error_type) -> None:
+@pytest.mark.parametrize(
+    "error_type, expected_message, expected_detail",
+    [
+        (
+            httpx.ConnectError,
+            "Connection failed",
+            "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+        ),
+        (httpx.ConnectTimeout, "Request timed out", "The Omi API request timed out after multiple attempts."),
+        (httpx.ReadTimeout, "Request timed out", "The Omi API request timed out after multiple attempts."),
+        (httpx.WriteTimeout, "Request timed out", "The Omi API request timed out after multiple attempts."),
+        (httpx.PoolTimeout, "Request timed out", "The Omi API request timed out after multiple attempts."),
+        (
+            httpx.RemoteProtocolError,
+            "Protocol error",
+            "The Omi API request encountered a protocol error after multiple attempts.",
+        ),
+        (
+            httpx.LocalProtocolError,
+            "Protocol error",
+            "The Omi API request encountered a protocol error after multiple attempts.",
+        ),
+        (
+            httpx.ReadError,
+            "API communication failed",
+            "Communication with the Omi API failed after multiple attempts.",
+        ),
+    ],
+)
+def test_exhausted_transport_retries_surface_server_error(
+    authed_profile, respx_mock, monkeypatch, error_type, expected_message, expected_detail
+) -> None:
     failure = error_type("request failed at https://user:secret@example.invalid/?token=private-token")
     route = respx_mock.get("/v1/dev/user/memories").mock(side_effect=failure)
     sleeps = []
@@ -153,10 +216,8 @@ def test_exhausted_transport_retries_surface_server_error(authed_profile, respx_
     assert all(delay > 0 for delay in sleeps)
     assert info.value.exit_code == 3
     assert info.value.__cause__ is failure
-    assert info.value.message == "Connection failed"
-    assert info.value.detail == (
-        "Could not reach the Omi API after multiple attempts. Check your connection and try again."
-    )
+    assert info.value.message == expected_message
+    assert info.value.detail == expected_detail
     assert "secret" not in str(info.value)
     assert "private-token" not in str(info.value)
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -30,6 +30,14 @@ def test_user_agent_contains_version_and_repo() -> None:
         "http://127.0.0.1:0",
         "http://127.0.0.1:65536",
         "https://user:secret@example.invalid:99999/?token=private-token",
+        123,
+        False,
+        ["https://api.omi.me"],
+        {"host": "https://api.omi.me"},
+        "https://example.invalid/api?tenant=private-token",
+        "https://example.invalid/api#private-token",
+        "https://example.invalid/api?",
+        "https://example.invalid/api#",
     ],
 )
 def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch, api_base) -> None:
@@ -55,7 +63,10 @@ def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch
     assert "private-token" not in str(info.value)
 
 
-@pytest.mark.parametrize("api_base", ["http://localhost:1", "https://localhost:65535", "https://api.omi.me"])
+@pytest.mark.parametrize(
+    "api_base",
+    ["http://localhost:1", "https://localhost:65535", "https://api.omi.me", "https://api.omi.me/api/v1/"],
+)
 def test_valid_api_base_port_boundaries(api_base) -> None:
     assert validate_api_base(api_base).host
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -10,7 +10,7 @@ import pytest
 from omi_cli import __version__
 from omi_cli import config as cfg
 from omi_cli.auth.store import store_oauth_tokens
-from omi_cli.client import USER_AGENT, OmiClient
+from omi_cli.client import MAX_RETRY_ATTEMPTS, USER_AGENT, OmiClient
 from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
 
 
@@ -135,6 +135,46 @@ def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
     with OmiClient(authed_profile) as client:
         result = client.get("/v1/dev/user/goals")
     assert result == []
+
+
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError])
+def test_exhausted_transport_retries_surface_server_error(authed_profile, respx_mock, monkeypatch, error_type) -> None:
+    failure = error_type("request failed at https://user:secret@example.invalid/?token=private-token")
+    route = respx_mock.get("/v1/dev/user/memories").mock(side_effect=failure)
+    sleeps = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError) as info:
+            client.get("/v1/dev/user/memories")
+
+    assert route.call_count == MAX_RETRY_ATTEMPTS
+    assert len(sleeps) == MAX_RETRY_ATTEMPTS - 1
+    assert all(delay > 0 for delay in sleeps)
+    assert info.value.exit_code == 3
+    assert info.value.__cause__ is failure
+    assert info.value.message == "Connection failed"
+    assert info.value.detail == (
+        "Could not reach the Omi API after multiple attempts. Check your connection and try again."
+    )
+    assert "secret" not in str(info.value)
+    assert "private-token" not in str(info.value)
+
+
+def test_transport_error_then_success_preserves_retry_recovery(authed_profile, respx_mock, monkeypatch) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[httpx.ConnectError("connection refused"), httpx.Response(200, json=[{"id": "m1"}])]
+    )
+    sleeps = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/memories")
+
+    assert result == [{"id": "m1"}]
+    assert route.call_count == 2
+    assert len(sleeps) == 1
+    assert sleeps[0] > 0
 
 
 def test_429_surfaces_rate_limit_with_policy(authed_profile, respx_mock) -> None:

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -36,7 +36,7 @@ def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch
     authed_profile.api_base = api_base
     authed_profile.auth_method = "oauth"
     authed_profile.id_token = "expired"
-    authed_profile.expires_at = time.time() - 60
+    authed_profile.id_token_expires_at = time.time() - 60
 
     def unexpected_call(*args, **kwargs):
         pytest.fail("Invalid API configuration must fail before HTTP, OAuth refresh, or retry backoff")

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -41,6 +41,9 @@ def test_user_agent_contains_version_and_repo() -> None:
         "https://user:secret@example.invalid/api",
         "https://user@example.invalid/api",
         "https://:secret@example.invalid/api",
+        "https://api.omi.me ",
+        "https://api.omi.me/api v1",
+        "https://api.omi.me/api\u00a0v1",
     ],
 )
 def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch, api_base) -> None:
@@ -73,6 +76,7 @@ def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch
         "https://localhost:65535",
         "https://api.omi.me",
         "https://api.omi.me/api/v1/",
+        "https://api.omi.me/api%20v1/",
         "http://[fe80::1]:8000",
     ],
 )

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -10,7 +10,7 @@ import pytest
 from omi_cli import __version__
 from omi_cli import config as cfg
 from omi_cli.auth.store import store_oauth_tokens
-from omi_cli.client import MAX_RETRY_ATTEMPTS, USER_AGENT, OmiClient
+from omi_cli.client import MAX_RETRY_ATTEMPTS, USER_AGENT, OmiClient, validate_api_base
 from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError, UsageError
 
 
@@ -27,6 +27,7 @@ def test_user_agent_contains_version_and_repo() -> None:
         "example.invalid",
         "https://",
         "https://example.invalid:private-token",
+        "http://127.0.0.1:0",
         "http://127.0.0.1:65536",
         "https://user:secret@example.invalid:99999/?token=private-token",
     ],
@@ -52,6 +53,11 @@ def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch
     assert info.value.detail == "Use a valid absolute http:// or https:// URL for the Omi API."
     assert "secret" not in str(info.value)
     assert "private-token" not in str(info.value)
+
+
+@pytest.mark.parametrize("api_base", ["http://localhost:1", "https://localhost:65535", "https://api.omi.me"])
+def test_valid_api_base_port_boundaries(api_base) -> None:
+    assert validate_api_base(api_base).host
 
 
 def test_oauth_pre_flight_refresh_when_token_expired(config_path, monkeypatch) -> None:

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -27,6 +27,8 @@ def test_user_agent_contains_version_and_repo() -> None:
         "example.invalid",
         "https://",
         "https://example.invalid:private-token",
+        "http://127.0.0.1:65536",
+        "https://user:secret@example.invalid:99999/?token=private-token",
     ],
 )
 def test_invalid_api_base_fails_before_http_or_oauth(authed_profile, monkeypatch, api_base) -> None:

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -72,6 +72,7 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
         "ftp://user:secret@example.invalid/?token=private-token",
         "http://user:secret@127.0.0.1:0/?token=private-token",
         "http://user:secret@127.0.0.1:99999/?token=private-token",
+        "https://user:secret@example.invalid/api",
     ],
 )
 def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsys, source, json_mode, api_base) -> None:
@@ -107,6 +108,26 @@ def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsy
     assert "Traceback" not in captured.err
     assert "secret" not in captured.err
     assert "private-token" not in captured.err
+
+
+@pytest.mark.parametrize("env_base", [None, "https://example.invalid"])
+def test_empty_api_base_flag_does_not_fall_back(authed_profile, config_path, monkeypatch, capsys, env_base):
+    if env_base is not None:
+        monkeypatch.setenv("OMI_API_BASE", env_base)
+    original_config = config_path.read_bytes()
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "--api-base", "", "memory", "list"])
+
+    def unexpected_call(*args, **kwargs):
+        pytest.fail("An explicit empty base must fail before HTTP construction")
+
+    monkeypatch.setattr(httpx, "Client", unexpected_call)
+    with pytest.raises(SystemExit) as info:
+        main()
+    captured = capsys.readouterr()
+    assert info.value.code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"] == "Invalid API base URL"
+    assert config_path.read_bytes() == original_config
 
 
 @pytest.mark.parametrize("api_base", [123, False, ["https://api.omi.me"], {"url": "https://api.omi.me"}])

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -63,12 +63,66 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     assert result.stdout.strip() == "[]"
 
 
+@pytest.mark.parametrize("source", ["flag", "env"])
 @pytest.mark.parametrize("json_mode", [False, True])
+def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsys, source, json_mode) -> None:
+    api_base = "ftp://user:secret@example.invalid/?token=private-token"
+    argv = ["omi", "--no-color", *(["--json"] if json_mode else [])]
+    if source == "flag":
+        argv.extend(["--api-base", api_base])
+    else:
+        monkeypatch.setenv("OMI_API_BASE", api_base)
+    argv.extend(["memory", "list"])
+    monkeypatch.setattr(sys, "argv", argv)
+
+    def unexpected_call(*args, **kwargs):
+        pytest.fail("Invalid API configuration must not issue HTTP requests or retry")
+
+    monkeypatch.setattr(httpx.Client, "request", unexpected_call)
+    monkeypatch.setattr(time, "sleep", unexpected_call)
+
+    with pytest.raises(SystemExit) as info:
+        main()
+
+    captured = capsys.readouterr()
+    assert info.value.code == 1
+    assert captured.out == ""
+    if json_mode:
+        assert json.loads(captured.err) == {
+            "error": "Invalid API base URL",
+            "detail": "Use a valid absolute http:// or https:// URL for the Omi API.",
+        }
+    else:
+        assert "Invalid API base URL" in captured.err
+        assert "Use a valid absolute http:// or https:// URL for the Omi API." in captured.err
+    assert "unexpected error" not in captured.err
+    assert "Traceback" not in captured.err
+    assert "secret" not in captured.err
+    assert "private-token" not in captured.err
+
+
+@pytest.mark.parametrize("json_mode", [False, True])
+@pytest.mark.parametrize(
+    "error_type, expected_message, expected_detail",
+    [
+        (
+            httpx.ConnectError,
+            "Connection failed",
+            "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+        ),
+        (httpx.ReadTimeout, "Request timed out", "The Omi API request timed out after multiple attempts."),
+        (
+            httpx.RemoteProtocolError,
+            "Protocol error",
+            "The Omi API request encountered a protocol error after multiple attempts.",
+        ),
+    ],
+)
 def test_main_transport_failure_preserves_error_contract(
-    authed_profile, respx_mock, monkeypatch, capsys, json_mode
+    authed_profile, respx_mock, monkeypatch, capsys, json_mode, error_type, expected_message, expected_detail
 ) -> None:
     route = respx_mock.get("/v1/dev/user/memories").mock(
-        side_effect=httpx.ConnectError("request failed at https://user:secret@example.invalid/?token=private-token")
+        side_effect=error_type("request failed at https://user:secret@example.invalid/?token=private-token")
     )
     monkeypatch.setattr(time, "sleep", lambda _: None)
     monkeypatch.setattr(sys, "argv", ["omi", "--no-color", *(["--json"] if json_mode else []), "memory", "list"])
@@ -82,12 +136,12 @@ def test_main_transport_failure_preserves_error_contract(
     assert captured.out == ""
     if json_mode:
         assert json.loads(captured.err) == {
-            "error": "Connection failed",
-            "detail": "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+            "error": expected_message,
+            "detail": expected_detail,
         }
     else:
-        assert "Connection failed" in captured.err
-        assert "Check your connection and try again." in captured.err
+        assert expected_message in captured.err
+        assert expected_detail in captured.err
     assert "unexpected error" not in captured.err
     assert "Traceback" not in captured.err
     assert "secret" not in captured.err

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -65,8 +65,14 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
 
 @pytest.mark.parametrize("source", ["flag", "env"])
 @pytest.mark.parametrize("json_mode", [False, True])
-def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsys, source, json_mode) -> None:
-    api_base = "ftp://user:secret@example.invalid/?token=private-token"
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "ftp://user:secret@example.invalid/?token=private-token",
+        "http://user:secret@127.0.0.1:99999/?token=private-token",
+    ],
+)
+def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsys, source, json_mode, api_base) -> None:
     argv = ["omi", "--no-color", *(["--json"] if json_mode else [])]
     if source == "flag":
         argv.extend(["--api-base", api_base])

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 from omi_cli import __version__
+from omi_cli import config as cfg
 from omi_cli.client import MAX_RETRY_ATTEMPTS
 from omi_cli.main import app, main
 
@@ -106,6 +107,20 @@ def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsy
     assert "Traceback" not in captured.err
     assert "secret" not in captured.err
     assert "private-token" not in captured.err
+
+
+@pytest.mark.parametrize("api_base", [123, False, ["https://api.omi.me"], {"url": "https://api.omi.me"}])
+def test_non_string_toml_api_base_is_structured_usage_error(authed_profile, monkeypatch, capsys, api_base):
+    config = cfg.load()
+    config.get_profile("default").api_base = api_base
+    cfg.save(config)
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "memory", "list"])
+    with pytest.raises(SystemExit) as info:
+        main()
+    captured = capsys.readouterr()
+    assert info.value.code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"] == "Invalid API base URL"
 
 
 @pytest.mark.parametrize("json_mode", [False, True])

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -73,6 +73,7 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
         "http://user:secret@127.0.0.1:0/?token=private-token",
         "http://user:secret@127.0.0.1:99999/?token=private-token",
         "https://user:secret@example.invalid/api",
+        "https://api.omi.me ",
     ],
 )
 def test_invalid_api_base_is_safe_usage_error(authed_profile, monkeypatch, capsys, source, json_mode, api_base) -> None:

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import json
+import sys
+import time
+
+import httpx
+import pytest
 
 from omi_cli import __version__
-from omi_cli.main import app
+from omi_cli.client import MAX_RETRY_ATTEMPTS
+from omi_cli.main import app, main
 
 
 def test_version_flag(cli_runner) -> None:
@@ -55,3 +61,34 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     result = cli_runner.invoke(app, ["--json", "memory", "list"])
     assert result.exit_code == 0
     assert result.stdout.strip() == "[]"
+
+
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_main_transport_failure_preserves_error_contract(
+    authed_profile, respx_mock, monkeypatch, capsys, json_mode
+) -> None:
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=httpx.ConnectError("request failed at https://user:secret@example.invalid/?token=private-token")
+    )
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monkeypatch.setattr(sys, "argv", ["omi", "--no-color", *(["--json"] if json_mode else []), "memory", "list"])
+
+    with pytest.raises(SystemExit) as info:
+        main()
+
+    captured = capsys.readouterr()
+    assert info.value.code == 3
+    assert route.call_count == MAX_RETRY_ATTEMPTS
+    assert captured.out == ""
+    if json_mode:
+        assert json.loads(captured.err) == {
+            "error": "Connection failed",
+            "detail": "Could not reach the Omi API after multiple attempts. Check your connection and try again.",
+        }
+    else:
+        assert "Connection failed" in captured.err
+        assert "Check your connection and try again." in captured.err
+    assert "unexpected error" not in captured.err
+    assert "Traceback" not in captured.err
+    assert "secret" not in captured.err
+    assert "private-token" not in captured.err

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -69,6 +69,7 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     "api_base",
     [
         "ftp://user:secret@example.invalid/?token=private-token",
+        "http://user:secret@127.0.0.1:0/?token=private-token",
         "http://user:secret@127.0.0.1:99999/?token=private-token",
     ],
 )


### PR DESCRIPTION
Fixes #12961.

Exhausted HTTP transport failures in the shared developer API client now preserve exit code 3 and fixed, structured error messages instead of collapsing into a generic exit-1 error. Connection failures, timeouts and protocol errors keep exception URLs and credentials out of public output. Both login methods propagate failed verification and disclose when the new credential is stored but unverified, including possible replacement of an earlier machine key during browser login.

API bases are validated before HTTP, OAuth refresh, browser authentication or credential storage. They must be strings containing absolute HTTP(S) URLs without raw whitespace, userinfo, queries or fragments, and explicit ports must be between 1 and 65535. Percent-encoded path prefixes and IPv6 hosts remain supported. Raw spaces in paths must be encoded as `%20`. Invalid TOML values and explicitly empty overrides produce safe exit-1 errors; login configuration remains byte-identical. Browser progress respects JSON mode and prints fallback URLs literally, preserving IPv6 brackets.

The existing four-attempt retry policy and HTTP 503 warning policy are unchanged. This transport guarantee covers the shared developer API client and login verification; separate OAuth token-exchange and local-companion HTTP operations remain outside it.

Validation on macOS / Python 3.12:

- `python -m pytest -o addopts='' sdks/python-cli/tests -q`: **248 passed, 1 Windows-only skip**, with two existing Typer/Click warnings.
- The latest whitespace regression run reproduced **15 failures before repair**, across shared-client validation, login credential preservation, and CLI flag/environment output. An encoded-path control also passes. Earlier coverage includes userinfo before OAuth/HTTP construction, empty override precedence over both environment and stored values, preserved credentials, and production browser-login output in human and JSON modes on success and verification failure. Browser launch/callback and token-service I/O are stubbed; the production OAuth orchestration and renderer execute.
- Six additional installed `omi` subprocess checks exercise trailing and embedded raw whitespace across memory listing and both login methods. Each exits 1 with safe JSON, empty stdout and byte-identical temporary configuration. Earlier installed checks covered malformed TOML, query/fragment bases, exhausted protocol errors and stored-but-unverified API-key login.
- Black, isort, diff hygiene, local manifest checks and saved PR-body checks pass. The history-based failure-class ratchet skips in this shallow checkout and needs full-history CI. Hosted workflows and maintainer acceptance remain separate gates.
- Earlier isolated integration with pending #12991 passed seven scenarios; both PRs touch login verification, so preserve the typed failure and early-validation paths when resolving overlap.

The expected JSON contract is documented in `sdks/python-cli/README.md` and `omi_cli/output.py`; public failure categories follow the [HTTPX exception definitions](https://www.python-httpx.org/exceptions/). Port bounds follow [RFC 6335 section 6](https://www.rfc-editor.org/rfc/rfc6335.html#section-6). The tests reproduce the [three collaborator review fixes](https://github.com/BasedHardware/omi/pull/12996#pullrequestreview-5138381771) and the [new whitespace finding](https://github.com/BasedHardware/omi/pull/12996#discussion_r3958903434) through production behavior. Raw versus encoded-space handling follows [RFC 3986 section 2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1). These cases extend the existing hermetic suite.

## Product invariants affected

none

Failure-Class: FC-typed-failure-collapsed-to-generic

Prepared with OpenAI Codex assistance. Other operating systems and Python versions were not tested locally. The requested $25 bounty has not been approved.
