### PR TITLE
fix(go-sdk): preserve Whisper audio when transcription fails

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -1,0 +1,29 @@
+name: Go Device SDK
+
+on:
+  pull_request:
+    paths:
+      - "sdks/device/go/**"
+      - ".github/workflows/sdk-go.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdks/device/go/**"
+      - ".github/workflows/sdk-go.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/device/go
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: sdks/device/go/go.mod
+          cache-dependency-path: sdks/device/go/go.sum
+      - run: go test -race ./...

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -26,4 +26,12 @@ jobs:
         with:
           go-version-file: sdks/device/go/go.mod
           cache-dependency-path: sdks/device/go/go.sum
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            printf '%s\n' "$unformatted"
+            exit 1
+          fi
+      - run: go vet ./...
       - run: go test -race ./...

--- a/sdks/device/go/README.md
+++ b/sdks/device/go/README.md
@@ -38,8 +38,13 @@ Mirrors Python `print_devices` / `listen_to_omi` in `sdks/python/omi/bluetooth.p
 
 `NewWhisper` accepts a runner and buffers PCM until a full batch or `Stop()`.
 If the runner returns an error, the buffered audio is retained. Retry with
-`Stop()` (or continue appending new PCM); do not append the failed audio again.
+`Stop()`; do not append the audio from that failed flush again. Until `Stop()`
+succeeds, `AppendPCM` rejects new chunks without buffering them or invoking the
+runner. Those rejections match `errors.Is(err, stt.ErrWhisperPendingAudio)`;
+the caller owns the rejected chunks and can submit them after recovery. Pause
+the source while retrying so a persistent failure does not accumulate audio.
 A successful flush clears the buffer and emits the non-empty transcript once.
 
-The Go Device SDK pull-request workflow runs `go test -race ./...` for this
+The Go Device SDK pull-request workflow checks `gofmt`, runs `go vet ./...`,
+and runs `go test -race ./...` for this
 module without BLE hardware or live transcription services.

--- a/sdks/device/go/README.md
+++ b/sdks/device/go/README.md
@@ -33,3 +33,13 @@ Mirrors Python `print_devices` / `listen_to_omi` in `sdks/python/omi/bluetooth.p
 - Needs Bluetooth permission/adapter; CI and headless hosts stay on default build.
 - macOS device IDs are CoreBluetooth identifiers (not always classic MACs).
 - `ReadCodec` relies on GATT Read; may fail if characteristic is notify-only on some firmware.
+
+### Local Whisper retries
+
+`NewWhisper` accepts a runner and buffers PCM until a full batch or `Stop()`.
+If the runner returns an error, the buffered audio is retained. Retry with
+`Stop()` (or continue appending new PCM); do not append the failed audio again.
+A successful flush clears the buffer and emits the non-empty transcript once.
+
+The Go Device SDK pull-request workflow runs `go test -race ./...` for this
+module without BLE hardware or live transcription services.

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -2,6 +2,7 @@ package stt
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -149,6 +150,10 @@ func extractText(msg map[string]any) string {
 	return ""
 }
 
+// ErrWhisperPendingAudio means AppendPCM did not accept its input because a
+// previous flush failed. Retry Stop successfully before submitting new PCM.
+var ErrWhisperPendingAudio = errors.New("whisper has pending audio; retry Stop before appending")
+
 // NewWhisper is feature-gated: requires injected runner.
 func NewWhisper(runner func(pcm []byte) (string, error), onTranscript Handler) (StreamingTranscriber, error) {
 	if runner == nil {
@@ -162,9 +167,13 @@ type whisperBatch struct {
 	onTranscript Handler
 	buf          []byte
 	batch        int
+	flushErr     error
 }
 
 func (w *whisperBatch) AppendPCM(pcm []byte) error {
+	if w.flushErr != nil {
+		return fmt.Errorf("%w: %v", ErrWhisperPendingAudio, w.flushErr)
+	}
 	w.buf = append(w.buf, pcm...)
 	if len(w.buf) < w.batch {
 		return nil
@@ -177,6 +186,7 @@ func (w *whisperBatch) Stop() error {
 		return nil
 	}
 	text, err := w.runner(w.buf)
+	w.flushErr = err
 	if err != nil {
 		return err
 	}

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -169,16 +169,7 @@ func (w *whisperBatch) AppendPCM(pcm []byte) error {
 	if len(w.buf) < w.batch {
 		return nil
 	}
-	chunk := w.buf
-	w.buf = nil
-	text, err := w.runner(chunk)
-	if err != nil {
-		return err
-	}
-	if text != "" && w.onTranscript != nil {
-		w.onTranscript(text)
-	}
-	return nil
+	return w.Stop()
 }
 
 func (w *whisperBatch) Stop() error {
@@ -186,10 +177,10 @@ func (w *whisperBatch) Stop() error {
 		return nil
 	}
 	text, err := w.runner(w.buf)
-	w.buf = nil
 	if err != nil {
 		return err
 	}
+	w.buf = nil
 	if text != "" && w.onTranscript != nil {
 		w.onTranscript(text)
 	}

--- a/sdks/device/go/omidevice/stt/whisper_retry_test.go
+++ b/sdks/device/go/omidevice/stt/whisper_retry_test.go
@@ -1,0 +1,56 @@
+package stt
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestWhisperRetriesFailedAudio(t *testing.T) {
+	for name, size := range map[string]int{"partial_batch_stop": 32, "full_batch_append": 16000 * 2 * 5} {
+		t.Run(name, func(t *testing.T) {
+			pcm := bytes.Repeat([]byte{1, 2}, size/2)
+			failure := errors.New("temporary runner failure")
+			calls := 0
+			var transcripts []string
+			transcriber, err := NewWhisper(func(chunk []byte) (string, error) {
+				calls++
+				if !bytes.Equal(chunk, pcm) {
+					t.Fatalf("retry lost audio: got %d bytes, want %d", len(chunk), len(pcm))
+				}
+				if calls <= 2 {
+					return "", failure
+				}
+				return "recovered", nil
+			}, func(text string) { transcripts = append(transcripts, text) })
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = transcriber.AppendPCM(pcm)
+			if size < 16000*2*5 {
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = transcriber.Stop()
+			}
+			if !errors.Is(err, failure) {
+				t.Fatalf("first flush: got %v, want runner error", err)
+			}
+			if err = transcriber.Stop(); !errors.Is(err, failure) {
+				t.Fatalf("second flush: got %v, want runner error", err)
+			}
+			if err = transcriber.Stop(); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 3 || len(transcripts) != 1 || transcripts[0] != "recovered" {
+				t.Fatalf("calls=%d transcripts=%v", calls, transcripts)
+			}
+			if err = transcriber.Stop(); err != nil {
+				t.Fatal(err)
+			}
+			if calls != 3 {
+				t.Fatalf("successful audio was transcribed twice: %d calls", calls)
+			}
+		})
+	}
+}

--- a/sdks/device/go/omidevice/stt/whisper_retry_test.go
+++ b/sdks/device/go/omidevice/stt/whisper_retry_test.go
@@ -54,3 +54,64 @@ func TestWhisperRetriesFailedAudio(t *testing.T) {
 		})
 	}
 }
+
+func TestWhisperRejectsNewAudioUntilFailedFlushRecovers(t *testing.T) {
+	for name, size := range map[string]int{"partial": 32, "full": 16000 * 2 * 5} {
+		t.Run(name, func(t *testing.T) {
+			original := bytes.Repeat([]byte{1}, size)
+			next := []byte{2, 3}
+			failure := errors.New("runner unavailable")
+			fail := true
+			var chunks [][]byte
+			transcriber, err := NewWhisper(func(pcm []byte) (string, error) {
+				chunks = append(chunks, append([]byte(nil), pcm...))
+				if fail {
+					return "", failure
+				}
+				return "", nil
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = transcriber.AppendPCM(original)
+			if size < 16000*2*5 {
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = transcriber.Stop()
+			}
+			if !errors.Is(err, failure) {
+				t.Fatalf("initial flush: %v", err)
+			}
+			for i := 0; i < 100; i++ {
+				if err := transcriber.AppendPCM(next); !errors.Is(err, ErrWhisperPendingAudio) {
+					t.Fatalf("append after failed flush: got %v, want ErrWhisperPendingAudio", err)
+				}
+			}
+			if len(chunks) != 1 {
+				t.Fatalf("rejected appends invoked runner: %d calls", len(chunks))
+			}
+			if err := transcriber.Stop(); !errors.Is(err, failure) {
+				t.Fatalf("retry: %v", err)
+			}
+			fail = false
+			if err := transcriber.Stop(); err != nil {
+				t.Fatal(err)
+			}
+			for _, pcm := range chunks {
+				if !bytes.Equal(pcm, original) {
+					t.Fatalf("retained audio changed: got %d bytes, want %d", len(pcm), size)
+				}
+			}
+			if err := transcriber.AppendPCM(next); err != nil {
+				t.Fatal(err)
+			}
+			if err := transcriber.Stop(); err != nil {
+				t.Fatal(err)
+			}
+			if len(chunks) != 4 || !bytes.Equal(chunks[3], next) {
+				t.Fatalf("new audio was not accepted exactly once: %v", chunks[len(chunks)-1])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #12995.

When an injected Whisper runner fails, the Go device SDK currently discards the pending PCM and a subsequent `Stop()` silently succeeds without retrying it. Retain the buffer until transcription succeeds and share the flush operation between a full-batch append and shutdown. Successful batches still clear before the transcript callback.

After a failed flush, new appends return `ErrWhisperPendingAudio` without accepting their input or invoking the runner. Callers retry `Stop()` until it succeeds, then may resubmit rejected chunks. This prevents a continuing stream from growing the retained buffer during an outage without discarding the original audio.

Regression tests exercise the exported `NewWhisper` interface with both full and partial batches: repeated failures retain identical PCM, 100 subsequent appends are rejected without additional runner calls, recovery reopens input, a later success emits once, and another stop does not retranscribe it. The README documents retry ownership. A Go SDK workflow checks formatting, runs explicit `go vet ./...`, and runs the component suite with the race detector on pull requests and main pushes.

Validation:
- Both new regression cases failed on unmodified main `7163538913e15dd86534b41dc695e2a5639c0774` because the second flush returned nil without invoking the runner.
- `cd sdks/device/go && go test -race ./...` passes (Go 1.23.8, macOS arm64).
- The new backpressure regression fails against the original PR implementation: partial batches accept more audio and full batches invoke the runner 101 times. Both cases pass with this update.
- `go vet ./...` passes and `gofmt -l .` reports no files.
- A standalone exported-API check rejects 1,000 new chunks during failure, preserves the original PCM byte-for-byte, and resumes accepting audio after recovery. The workflow passes actionlint 1.7.7.
- Ran the issue's standalone reproducer through the exported API: the patched second stop returns the runner error and invokes it again (2 calls instead of 1).
- `make preflight` and `scripts/pr-preflight --pr-body-file ../research/omi-whisper-pr.md` each pass all 17 selected checks on the committed diff.
- Synthetic PCM and an injected runner only; no hardware, model, or live transcription service is required.

Failure-Class: FC-destructive-replace-precedes-derivation

Why isn't this a shared primitive instead? It is: full-batch append now uses the same flush operation as `Stop`, so buffer retirement is owned in one place. The regression covers the shipped behavior from #10227, reproduced in #12995.

## Product invariants affected

None.

AI-assisted implementation and testing under mogja9. A $25 PayPal bounty has been proposed in #12995; funding and eligibility remain unconfirmed, and this PR does not assume payment approval.
