### PR TITLE
fix(cli): preserve literal error text and authentication exit codes

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -20,8 +20,8 @@ from datetime import datetime
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
 from rich.console import Console
-from rich.markup import escape
 from rich.table import Table
+from rich.text import Text
 
 
 def _no_color_env() -> bool:
@@ -145,12 +145,16 @@ class Renderer:
             sys.stderr.write(json.dumps(payload) + "\n")
             sys.stderr.flush()
         else:
-            line = f"[red]✗[/red] {message}"
+            # Error text can include server responses and user input. Apply
+            # our decoration to Text spans, without parsing that data as markup.
+            line = Text()
+            line.append("✗", style="red")
+            line.append(f" {message}")
             if detail:
-                line += f"\n  [dim]{detail}[/dim]"
+                line.append(f"\n  {detail}", style="dim")
             if extra:
                 for key, value in extra.items():
-                    line += f"\n  [dim]{escape(str(key))}: {escape(_stringify(value))}[/dim]"
+                    line.append(f"\n  {key}: {_stringify(value)}", style="dim")
             self._stderr.print(line)
 
     def debug(self, message: str) -> None:

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -106,6 +106,29 @@ def test_401_maps_to_auth_error(authed_profile, respx_mock) -> None:
             client.get("/v1/dev/user/memories")
 
 
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_cli_auth_error_with_markup_preserves_exit_code(
+    authed_profile, respx_mock, monkeypatch, capsys, json_mode
+) -> None:
+    import json
+
+    from omi_cli.main import main
+
+    detail = "Invalid key [/bold] :warning:"
+    respx_mock.get("/v1/dev/user/memories").respond(401, json={"detail": detail})
+    args = ["--json"] if json_mode else ["--no-color"]
+    monkeypatch.setattr("sys.argv", ["omi", *args, "memory", "list"])
+    with pytest.raises(SystemExit) as info:
+        main()
+    assert info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    if json_mode:
+        assert json.loads(captured.err)["detail"] == detail
+    else:
+        assert detail in captured.err
+
+
 def test_403_maps_to_auth_error(authed_profile, respx_mock) -> None:
     respx_mock.post("/v1/dev/user/memories").respond(
         403, json={"detail": "Insufficient permissions. Required scope: memories:write"}

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from omi_cli.output import Renderer, coalesce_rows, shorten
 
 
@@ -34,6 +36,15 @@ def test_json_mode_emits_errors_as_json_to_stderr(capsys) -> None:
     assert captured.out == ""
     parsed = json.loads(captured.err)
     assert parsed == {"error": "bad", "detail": "reason"}
+
+
+@pytest.mark.parametrize("literal", ["Missing [/bold]", "Keep [bold]tags[/bold] :warning:"])
+def test_pretty_error_preserves_literal_message_detail_and_metadata(capsys, literal) -> None:
+    renderer = Renderer(no_color=True)
+    renderer.error(literal, detail=literal, extra={literal: literal})
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.count(literal) == 4
 
 
 def test_json_mode_serializes_datetime() -> None:


### PR DESCRIPTION
Fixes #12999.

An HTTP 401 with the literal detail `Invalid key [/bold] :warning:` crashes the CLI's error renderer, producing a traceback and exit 1 instead of the documented authentication exit 2. Build error messages, details, and structured metadata with Rich `Text` spans so literal content is preserved while the error marker and dim detail styling remain available. JSON output is unchanged.

The regression tests exercise the renderer and the real `main()` entry point. Three cases fail on the original implementation and pass with the fix; a JSON-mode control remains green. This is related to #12959/#12960 and #12986, whose scope explicitly excludes error templates.

Validation:
- Python CLI suite: 132 passed, 1 skipped on macOS / Python 3.14.6.
- A separate CLI subprocess against a synthetic loopback HTTP server exited 1 with a traceback before the fix and 2 with the literal error detail afterward. No live service, hardware, real credentials, or user data was used.
- All four new regression/control cases passed again after a styling refinement.
- Black and `git diff --check` passed.
- `make preflight` and `scripts/pr-preflight --pr-body-file ../omi-pr-body.md` both passed all 12 selected checks against the committed three-file diff.
- `make setup` installed the hooks and refreshed main; its backend dependency download ran out of disk space. The task-specific download cache was cleared. No backend code changed or backend runtime tests are claimed.

The expected literal rendering uses Rich's documented Text API: https://rich.readthedocs.io/en/stable/text.html. This fixes the shared error-rendering boundary rather than adding call-site guards. It adds no new runtime checks or dependencies.

## Product invariants affected

none

Failure-Class: none

No existing registry class precisely covers treating CLI error data as console markup. The fix uses the renderer's existing single error-output boundary and exercises it through behavioral regression tests.

This contribution is AI-assisted on behalf of @owen109. A $5 bounty was proposed in #12999 under the contribution guide; no approval or payment is assumed. Payment details are private.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

