### PR TITLE
fix(cli): honor per-command API keys over saved credentials

### DIFF
--- a/.github/scripts/test_preflight_runner.py
+++ b/.github/scripts/test_preflight_runner.py
@@ -465,6 +465,7 @@ class LaunchContractTests(unittest.TestCase):
         git = shutil.which("git")
         self.assertIsNotNone(bash)
         self.assertIsNotNone(git)
+        env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"
@@ -475,6 +476,7 @@ class LaunchContractTests(unittest.TestCase):
             (scripts / "dev-harness").mkdir()
             subprocess.run(
                 [git, "init", "--quiet", str(root)],
+                env=env,
                 check=True,
                 capture_output=True,
             )
@@ -493,7 +495,6 @@ class LaunchContractTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            env = os.environ.copy()
             env["PYTHON"] = Path(sys.executable).as_posix()
             env["OMI_PREFLIGHT_STATE_DIR"] = (root / "state").as_posix()
             env["PATH"] = windows_path_without_python(bash, git)
@@ -582,6 +583,12 @@ class LaunchContractTests(unittest.TestCase):
     def test_runner_emits_utf8_from_unicode_checkout_without_utf8_mode(self) -> None:
         git = shutil.which("git")
         self.assertIsNotNone(git)
+        # These are foreign repositories: a hook's Git context must not select
+        # the real checkout instead of the disposable fixture (githooks docs).
+        env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+        env.pop("OMI_PREFLIGHT_STATE_DIR", None)
+        env["PYTHONUTF8"] = "0"
+        env.pop("PYTHONIOENCODING", None)
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo-\u96ea"
@@ -589,12 +596,10 @@ class LaunchContractTests(unittest.TestCase):
             subprocess.run(
                 [git, "init", "--quiet"],
                 cwd=root,
+                env=env,
                 check=True,
                 capture_output=True,
             )
-            env = os.environ.copy()
-            env["PYTHONUTF8"] = "0"
-            env.pop("PYTHONIOENCODING", None)
             completed = subprocess.run(
                 [
                     sys.executable,
@@ -623,6 +628,12 @@ class LaunchContractTests(unittest.TestCase):
     def test_pr_preflight_emits_utf8_from_unicode_branch_without_utf8_mode(self) -> None:
         git = shutil.which("git")
         self.assertIsNotNone(git)
+        # These are foreign repositories: a hook's Git context must not select
+        # the real checkout instead of the disposable fixture (githooks docs).
+        env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+        env.pop("OMI_PREFLIGHT_STATE_DIR", None)
+        env["PYTHONUTF8"] = "0"
+        env.pop("PYTHONIOENCODING", None)
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo-\u96ea"
@@ -631,6 +642,7 @@ class LaunchContractTests(unittest.TestCase):
             subprocess.run(
                 [git, "init", "--quiet"],
                 cwd=root,
+                env=env,
                 check=True,
                 capture_output=True,
             )
@@ -648,13 +660,11 @@ class LaunchContractTests(unittest.TestCase):
                     "initial",
                 ],
                 cwd=root,
+                env=env,
                 check=True,
                 capture_output=True,
             )
-            subprocess.run([git, "branch", unicode_branch], cwd=root, check=True, capture_output=True)
-            env = os.environ.copy()
-            env["PYTHONUTF8"] = "0"
-            env.pop("PYTHONIOENCODING", None)
+            subprocess.run([git, "branch", unicode_branch], cwd=root, env=env, check=True, capture_output=True)
             completed = subprocess.run(
                 [
                     sys.executable,

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -676,6 +676,10 @@ esac
             selected = resolve_checks(manifest, list(check.triggers), lane)
             self.assertIn(check, selected)
 
+        try:
+            bash = bash_executable()
+        except FileNotFoundError as exc:
+            self.skipTest(str(exc))
         runner = REPO_ROOT / check.command[1]
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -692,17 +696,17 @@ esac
             sync.write_text(
                 f'''#!/usr/bin/env bash
 set -euo pipefail
-mkdir -p "{python.parent}"
-cat > "{python}" <<'PYTHON'
+mkdir -p "{bash_path(python.parent, bash)}"
+cat > "{bash_path(python, bash)}" <<'PYTHON'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1" == "-c" ]]; then
   [[ "$2" == "import yaml" ]]
   exit
 fi
-printf '%s\\n' "$@" > "{root / 'guard-args.txt'}"
+printf '%s\\n' "$@" > "{bash_path(root / 'guard-args.txt', bash)}"
 PYTHON
-chmod +x "{python}"
+chmod +x "{bash_path(python, bash)}"
 ''',
                 encoding="utf-8",
             )
@@ -711,10 +715,6 @@ chmod +x "{python}"
             guard.parent.mkdir(parents=True, exist_ok=True)
             guard.write_text("# fixture\n", encoding="utf-8")
 
-            try:
-                bash = bash_executable()
-            except FileNotFoundError as exc:
-                self.skipTest(str(exc))
             env = os.environ.copy()
             env["PYTHON"] = "ambient-python-must-not-run"
             result = subprocess.run(
@@ -751,6 +751,10 @@ chmod +x "{python}"
             selected = resolve_checks(manifest, list(check.triggers), lane)
             self.assertIn(check, selected)
 
+        try:
+            bash = bash_executable()
+        except FileNotFoundError as exc:
+            self.skipTest(str(exc))
         runner = REPO_ROOT / check.command[1]
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -770,26 +774,22 @@ chmod +x "{python}"
             sync.write_text(
                 f'''#!/usr/bin/env bash
 set -euo pipefail
-mkdir -p "{python.parent}"
-cat > "{python}" <<'PYTHON'
+mkdir -p "{bash_path(python.parent, bash)}"
+cat > "{bash_path(python, bash)}" <<'PYTHON'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1" == "-c" ]]; then
   [[ "$2" == "import yaml" ]]
   exit
 fi
-printf '%s\\n' "$@" > "{root / 'compose-args.txt'}"
+printf '%s\\n' "$@" > "{bash_path(root / 'compose-args.txt', bash)}"
 PYTHON
-chmod +x "{python}"
+chmod +x "{bash_path(python, bash)}"
 ''',
                 encoding="utf-8",
             )
             sync.chmod(0o755)
 
-            try:
-                bash = bash_executable()
-            except FileNotFoundError as exc:
-                self.skipTest(str(exc))
             env = os.environ.copy()
             env["PYTHON"] = "ambient-python-must-not-run"
             result = subprocess.run(

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -86,10 +86,12 @@ omi auth logout                 # wipe the credential
 ```
 
 You can also set a non-empty `OMI_API_KEY` in the environment to override the
-saved authentication for that invocation - handy in containers and CI. The
+saved authentication for cloud API requests - handy in containers and CI. The
 key is validated even when the selected profile already has credentials;
-an invalid override fails before any API request. Saved credentials are not
-changed, and profile settings such as the API base URL still apply:
+an invalid override fails before any cloud API request. Local Desktop commands
+use their separate local token, and `auth status` reports the saved profile.
+Saved credentials are not changed, and profile settings such as the API base
+URL still apply:
 
 ```bash
 export OMI_API_KEY=omi_dev_...

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -85,8 +85,11 @@ omi auth refresh                # force a Firebase refresh (no-op for API keys)
 omi auth logout                 # wipe the credential
 ```
 
-You can also set `OMI_API_KEY` in the environment to bypass on-disk config
-entirely — handy in containers and CI:
+You can also set a non-empty `OMI_API_KEY` in the environment to override the
+saved authentication for that invocation - handy in containers and CI. The
+key is validated even when the selected profile already has credentials;
+an invalid override fails before any API request. Saved credentials are not
+changed, and profile settings such as the API base URL still apply:
 
 ```bash
 export OMI_API_KEY=omi_dev_...

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -77,12 +77,12 @@ class AppContext:
         profile = config.get_profile(self.profile_name)
         if self.api_base_override:
             profile.api_base = self.api_base_override
-        # Allow OMI_API_KEY to take effect even if the on-disk profile has no key.
+        # A per-command OMI_API_KEY overrides the saved account, as documented.
         # Validate the prefix here so an obviously-bad env value fails fast with the
         # same friendly UsageError the paste flow uses, instead of bouncing off the
         # API as a cryptic 401.
         env_key = os.environ.get(cfg.ENV_API_KEY)
-        if env_key and not profile.api_key:
+        if env_key:
             profile.auth_method = "api_key"
             profile.api_key = validate_api_key_format(env_key)
         env_base = os.environ.get(cfg.ENV_API_BASE)

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -77,21 +77,20 @@ class AppContext:
         profile = config.get_profile(self.profile_name)
         if self.api_base_override:
             profile.api_base = self.api_base_override
-        # A per-command OMI_API_KEY overrides the saved account, as documented.
-        # Validate the prefix here so an obviously-bad env value fails fast with the
-        # same friendly UsageError the paste flow uses, instead of bouncing off the
-        # API as a cryptic 401.
-        env_key = os.environ.get(cfg.ENV_API_KEY)
-        if env_key:
-            profile.auth_method = "api_key"
-            profile.api_key = validate_api_key_format(env_key)
         env_base = os.environ.get(cfg.ENV_API_BASE)
         if env_base and not self.api_base_override:
             profile.api_base = env_base
         return profile
 
     def make_client(self) -> OmiClient:
-        return OmiClient(self.get_profile(), verbose=self.verbose)
+        profile = self.get_profile()
+        # Apply the per-command key only to cloud API requests. Local Desktop
+        # commands and saved-profile management use their own credentials.
+        env_key = os.environ.get(cfg.ENV_API_KEY)
+        if env_key:
+            profile.api_key = validate_api_key_format(env_key)
+            profile.auth_method = "api_key"
+        return OmiClient(profile, verbose=self.verbose)
 
     def make_local_client(self) -> LocalOmiClient:
         profile = self.get_profile()

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from omi_cli import __version__
 from omi_cli.main import app
 
@@ -55,3 +57,38 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     result = cli_runner.invoke(app, ["--json", "memory", "list"])
     assert result.exit_code == 0
     assert result.stdout.strip() == "[]"
+
+
+@pytest.mark.parametrize("operation", ["list", "create"])
+def test_env_key_overrides_saved_key_without_persisting(
+    operation, authed_profile, config_path, cli_runner, monkeypatch, respx_mock
+) -> None:
+    """A per-command key must select the intended account for reads and writes."""
+    env_key = "omi_dev_" + "e" * 32
+    original_config = config_path.read_bytes()
+    monkeypatch.setenv("OMI_API_KEY", env_key)
+    if operation == "list":
+        route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
+        args = ["memory", "list"]
+    else:
+        route = respx_mock.post("/v1/dev/user/memories").respond(json={"id": "synthetic"})
+        args = ["memory", "create", "synthetic test memory"]
+
+    result = cli_runner.invoke(app, ["--json", *args])
+
+    assert result.exit_code == 0, result.output
+    assert route.calls.last.request.headers["Authorization"] == f"Bearer {env_key}"
+    assert config_path.read_bytes() == original_config
+
+
+def test_invalid_env_key_does_not_fall_back_to_saved_account(
+    authed_profile, cli_runner, monkeypatch, respx_mock
+) -> None:
+    monkeypatch.setenv("OMI_API_KEY", "invalid-key")
+    route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
+
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+
+    assert result.exit_code == 1
+    assert not route.called
+    assert "developer key" in result.stderr.lower()

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -59,7 +59,7 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     assert result.stdout.strip() == "[]"
 
 
-@pytest.mark.parametrize("operation", ["list", "create"])
+@pytest.mark.parametrize("operation", ["list", "create", "whoami"])
 def test_env_key_overrides_saved_key_without_persisting(
     operation, authed_profile, config_path, cli_runner, monkeypatch, respx_mock
 ) -> None:
@@ -67,9 +67,9 @@ def test_env_key_overrides_saved_key_without_persisting(
     env_key = "omi_dev_" + "e" * 32
     original_config = config_path.read_bytes()
     monkeypatch.setenv("OMI_API_KEY", env_key)
-    if operation == "list":
+    if operation in ("list", "whoami"):
         route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
-        args = ["memory", "list"]
+        args = ["auth", "whoami"] if operation == "whoami" else ["memory", "list"]
     else:
         route = respx_mock.post("/v1/dev/user/memories").respond(json={"id": "synthetic"})
         args = ["memory", "create", "synthetic test memory"]
@@ -92,3 +92,41 @@ def test_invalid_env_key_does_not_fall_back_to_saved_account(
     assert result.exit_code == 1
     assert not route.called
     assert "developer key" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("command", ["status", "tools"])
+def test_local_commands_ignore_invalid_cloud_key(
+    command, authed_profile, config_path, cli_runner, monkeypatch
+) -> None:
+    import respx
+
+    from omi_cli import config as cfg
+
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.local_api_url = "http://127.0.0.1:47778"
+    profile.local_token = "synthetic-local-token"
+    cfg.save(config)
+    original_config = config_path.read_bytes()
+    monkeypatch.setenv("OMI_API_KEY", "invalid-cloud-key")
+    with respx.mock(base_url=profile.local_api_url) as router:
+        if command == "status":
+            route = router.post("/v1/local/tool").respond(
+                json={"ok": True, "result": json.dumps({"ok": True})}
+            )
+        else:
+            route = router.get("/v1/local/tools").respond(json={"ok": True, "tools": []})
+        result = cli_runner.invoke(app, ["--json", "local", command])
+
+    assert result.exit_code == 0, result.output
+    assert route.calls.last.request.headers["Authorization"] == "Bearer synthetic-local-token"
+    assert config_path.read_bytes() == original_config
+
+
+def test_auth_status_reports_saved_profile_despite_invalid_env_key(
+    authed_profile, cli_runner, monkeypatch
+) -> None:
+    monkeypatch.setenv("OMI_API_KEY", "invalid-cloud-key")
+    result = cli_runner.invoke(app, ["--json", "auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["credential"] == authed_profile.masked_credential()


### PR DESCRIPTION
A per-command `OMI_API_KEY` was ignored when the selected profile already had a saved key, sending cloud reads and writes to the saved account. Cloud client creation now validates and applies the override in memory without changing saved credentials. Local Desktop commands and saved-profile status keep their separate authentication behavior.

Fixes #12980.

Rebased onto upstream `4551ac12a5a3` to address review 5260886400. Resolved README, CLI test, and portability-test conflicts while preserving upstream login safety documentation, module-entry-point regression coverage, and the self-contained Unicode fixture. The diff remains limited to the five files requested in review.

The two test-runner files retain Windows path conversion and isolation of disposable repositories from inherited Git context and preflight state. The foreign-repository contract is documented by Git: https://git-scm.com/docs/githooks. During conflict resolution, removed a duplicate environment assignment that would discard the fixture's explicit encoding and state isolation.

Validation on Windows/Python 3.12:
- `python -m pytest -q` from `sdks/python-cli`: 485 passed, two skipped. Real Typer commands run against synthetic intercepted HTTP; no live account or service was accessed.
- Portability suite: 29 tests passed.
- Manifest runner suite: 53 tests, one skip.
- `scripts/pr-preflight --lane local --base origin/main --pr-body-file ../omi-rebase-pr-body.md`: all 13 selected checks passed.
- Normal bounded pre-push gate passed without skip options.

Limits: the 90-day failure-class history check skips itself in this shallow checkout. Manifest runner has one skip standalone and three environment-dependent skips inside the push hook. Full CI remains required.

Failure-Class: FC-hook-git-env-reaches-child-git

The failure class applies to foreign-repository test isolation; the CLI change repairs explicit environment-over-saved credential precedence. No new guard or registry change is introduced.

Product invariants affected: none (confirmed with `scripts/pr-preflight --suggest`).

Prepared and tested with Codex. The proposed $10 bounty in #12980 remains unapproved; this PR makes no payment-eligibility claim.
