### PR TITLE
fix(cli): preserve literal screen-search characters

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -153,6 +153,11 @@ Agent screen-history workflow:
 5. Validate the file before handing it to vision tooling, for example
    `file /tmp/omi-shot.jpg`.
 
+When semantic search returns no results, JSON mode also tries a literal
+substring search across app names, window titles, and OCR text. In this
+fallback, `%` and `_` in the query or `--app` filter match those characters
+literally, rather than acting as SQL wildcards.
+
 If pixels are not available, JSON-mode errors preserve Desktop's structured
 fields such as `status_code`, `error`, `reason`, `hint`, and `screenshot_id`.
 For example, `screenshot_pending` means the frame is still in the active video

--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -377,13 +377,13 @@ def _add_exact_screen_fallback(
     next_payload = dict(payload)
     escaped_query = _sql_like_literal(query)
     query_clauses = [
-        f"appName LIKE '%{escaped_query}%'",
-        f"windowTitle LIKE '%{escaped_query}%'",
-        f"ocrText LIKE '%{escaped_query}%'",
+        f"appName LIKE '%{escaped_query}%' ESCAPE '!'",
+        f"windowTitle LIKE '%{escaped_query}%' ESCAPE '!'",
+        f"ocrText LIKE '%{escaped_query}%' ESCAPE '!'",
     ]
     if app_filter:
         escaped_app = _sql_like_literal(app_filter)
-        where_clause = f"(appName LIKE '%{escaped_app}%') AND ({' OR '.join(query_clauses)})"
+        where_clause = f"(appName LIKE '%{escaped_app}%' ESCAPE '!') AND ({' OR '.join(query_clauses)})"
     else:
         where_clause = " OR ".join(query_clauses)
 
@@ -410,7 +410,7 @@ def _add_exact_screen_fallback(
 
 
 def _sql_like_literal(value: str) -> str:
-    return value.replace("'", "''")
+    return value.replace("!", "!!").replace("%", "!%").replace("_", "!_").replace("'", "''")
 
 
 def _first_string(mapping: Mapping[str, Any], keys: tuple[str, ...]) -> Optional[str]:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import sqlite3
 from pathlib import Path
 
 import httpx
@@ -227,7 +228,44 @@ def test_search_screen_exact_fallback_constrains_app_filter(config_path: Path, c
 
     assert result.exit_code == 0, result.output
     fallback_query = json.loads(route.calls[1].request.content)["arguments"]["query"]
-    assert "WHERE (appName LIKE '%Discord%') AND" in fallback_query
+    assert "WHERE (appName LIKE '%Discord%' ESCAPE '!') AND" in fallback_query
+
+
+@pytest.mark.parametrize("literal,decoy", [("50%", "500"), ("a_b", "axb"), ("a!b", "ab"), ("it's", "its")])
+@pytest.mark.parametrize("field", ["appName", "windowTitle", "ocrText", "app_filter"])
+def test_search_screen_fallback_matches_literal_text(
+    config_path: Path, cli_runner, literal: str, decoy: str, field: str
+) -> None:
+    _configure_local_profile(config_path)
+    with sqlite3.connect(":memory:") as db:
+        db.row_factory = sqlite3.Row
+        db.execute(
+            "CREATE TABLE screenshots (id INTEGER, timestamp TEXT, appName TEXT, windowTitle TEXT, ocrText TEXT, isIndexed INTEGER)"
+        )
+        for row_id, value in enumerate((literal, decoy), start=1):
+            values = {"appName": "Browser", "windowTitle": "notes", "ocrText": "notes"}
+            values["appName" if field == "app_filter" else field] = value
+            db.execute(
+                "INSERT INTO screenshots VALUES (?, ?, ?, ?, ?, ?)",
+                (row_id, "2026-09-07T00:00:00Z", values["appName"], values["windowTitle"], values["ocrText"], 1),
+            )
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            if body["name"] == "search_screen_history":
+                return httpx.Response(200, json=_tool_response("No matching screen-history results"))
+            assert body["name"] == "execute_sql"
+            rows = [dict(row) for row in db.execute(body["arguments"]["query"])]
+            return httpx.Response(200, json=_tool_response({"rows": rows}))
+
+        args = ["--json", "local", "search-screen", "notes" if field == "app_filter" else literal]
+        if field == "app_filter":
+            args.extend(["--app", literal])
+        with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+            router.post("/v1/local/tool").mock(side_effect=respond)
+            result = cli_runner.invoke(app, args)
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["suggested_screenshot_ids"] == [1]
 
 
 def test_sql_routes_to_execute_sql_with_env_overrides(config_path: Path, cli_runner, monkeypatch) -> None:


### PR DESCRIPTION
Fixes #12969

## What changed and why

The exact screen-search fallback treated literal percent and underscore characters as SQLite LIKE wildcards, so searches such as `50%` could match `500` and `a_b` could match `axb`. Escape `%`, `_`, and `!` in query text and the app filter, and add an explicit `ESCAPE '!'` clause to every affected predicate. The README now documents literal substring matching.

## Product invariants affected

none

## How it was verified

- Complete Python CLI suite: 145 passed (two existing Typer/Click deprecation warnings).
- Focused local-command suite: 38 passed.
- PR preflight: 12 selected checks passed.
- Black and `git diff --check` passed.
- No live Desktop instance or real screen history was available; behavior was exercised through the CLI and generated SQL against in-memory SQLite.

## Tests

Sixteen regression cases cover percent, underscore, apostrophe, and the chosen escape character across app name, window title, OCR text, and app filtering. Eight of these cases fail before the fix.

This contribution was prepared with AI assistance for @DiegoSalsa.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

