### PR TITLE
fix(cli): route python -m omi_cli through the top-level error handler (#12998)

### DIFF
--- a/sdks/python-cli/omi_cli/__main__.py
+++ b/sdks/python-cli/omi_cli/__main__.py
@@ -1,11 +1,7 @@
 """Allow `python -m omi_cli` as an alternative entry point to the `omi` console script."""
 
-from omi_cli.main import app
-
-
-def _main() -> None:
-    app()
+from omi_cli.main import main
 
 
 if __name__ == "__main__":
-    _main()
+    main()

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -55,3 +55,24 @@ def test_omi_api_key_env_var_with_valid_format_is_accepted(config_path, cli_runn
     result = cli_runner.invoke(app, ["--json", "memory", "list"])
     assert result.exit_code == 0
     assert result.stdout.strip() == "[]"
+
+
+def test_module_entry_point_honors_json_error_contract(config_path, monkeypatch, tmp_path) -> None:
+    """Issue #12998: `python -m omi_cli` must route through omi_cli.main.main()
+    so the documented --json error contract survives module invocation."""
+    import os
+    import subprocess
+    import sys
+
+    env = dict(os.environ, OMI_API_KEY="not-a-real-key")
+    result = subprocess.run(
+        [sys.executable, "-m", "omi_cli", "--json", "memory", "list"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+        check=False,
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stderr)
+    assert "error" in payload

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -63,8 +63,13 @@ def test_module_entry_point_honors_json_error_contract(config_path, monkeypatch,
     import os
     import subprocess
     import sys
+    from pathlib import Path
 
+    package_root = str(Path(__file__).resolve().parents[1])
     env = dict(os.environ, OMI_API_KEY="not-a-real-key")
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [package_root, env.get("PYTHONPATH", "")])
+    )
     result = subprocess.run(
         [sys.executable, "-m", "omi_cli", "--json", "memory", "list"],
         capture_output=True,


### PR DESCRIPTION
Fixes #12998.

## What

`omi_cli/__main__.py` invoked the bare Typer app (`app()`), bypassing `omi_cli.main.main()`'s CliError → stable-exit-code ladder. With `--json`, an auth failure printed a Rich box on stderr, so `json.loads(stderr)` failed — the documented machine-readable error contract broke for module invocation only.

## Fix

Route `__main__` through `main()` (2-line change). `python -m omi_cli --json memory list` with an invalid `OMI_API_KEY` now writes the same JSON error object to stderr as the `omi` console script.

## Tests

Regression test `test_module_entry_point_honors_json_error_contract` runs the module via `subprocess` with an invalid `OMI_API_KEY` and asserts stderr parses as a JSON error object. Verified failing on main `71635389` (Rich box on stderr) before the fix, passing after.

- `python -m pytest tests/` → **129 passed, 1 skipped**
- `black --check omi_cli/__main__.py tests/test_main.py` → clean
- Manual repro: `OMI_API_KEY=not-a-real-key python -m omi_cli --json memory list` → stderr is valid JSON

Failure-Class: FC-json-error-contract | new | none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

