### PR TITLE
fix(go-sdk): synchronize Parakeet stream readiness

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,12 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: go-device-sdk-tests
+    command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
+    triggers: ["sdks/device/go/**"]
+    lanes: ["local", "ci"]
+    platforms: ["linux", "macos"]
+    reason: "Parakeet readiness is written by the WebSocket reader and read by PCM submission; execute the in-memory handshake with the race detector"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/sdks/device/go/README.md
+++ b/sdks/device/go/README.md
@@ -6,7 +6,13 @@ Protocol helpers + optional BLE scan/listen for the Omi wearable.
 
 ```bash
 go test ./...
+go test -race ./...
 ```
+
+The race-enabled suite exercises streaming-transcriber readiness with in-memory
+WebSocket connections; it needs no device, API credentials, or network service.
+Parakeet ignores PCM until its server sends `ready`, while Deepgram accepts PCM
+as soon as its connection is established.
 
 Exports UUIDs, `StripPacketHeader`, STT helpers. `Scan` / `Listen` / `ListenPayload` / `ReadCodec` return `ErrBLEDisabled`.
 

--- a/sdks/device/go/omidevice/stt/parakeet_test.go
+++ b/sdks/device/go/omidevice/stt/parakeet_test.go
@@ -1,0 +1,130 @@
+package stt
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// A pipe listener exercises the HTTP/WebSocket stack without network access.
+type pipeListener struct {
+	connections chan net.Conn
+	done        chan struct{}
+	once        sync.Once
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.connections:
+		return conn, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+func (l *pipeListener) Close() error   { l.once.Do(func() { close(l.done) }); return nil }
+func (l *pipeListener) Addr() net.Addr { return pipeAddr{} }
+
+type pipeAddr struct{}
+
+func (pipeAddr) Network() string { return "pipe" }
+func (pipeAddr) String() string  { return "parakeet.test" }
+
+func TestParakeetReadyWhileAppendingPCM(t *testing.T) {
+	testTranscriberReadiness(t, true)
+}
+
+func TestDeepgramStartsReady(t *testing.T) {
+	testTranscriberReadiness(t, false)
+}
+
+func testTranscriberReadiness(t *testing.T, parakeet bool) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	deadline := time.Now().Add(5 * time.Second)
+	clientConn.SetDeadline(deadline)
+	serverConn.SetDeadline(deadline)
+	t.Cleanup(func() { clientConn.Close(); serverConn.Close() })
+	listener := &pipeListener{connections: make(chan net.Conn, 1), done: make(chan struct{})}
+	listener.connections <- serverConn
+	releaseReady := make(chan struct{})
+	received := make(chan []byte, 1)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.Close()
+		<-releaseReady
+		if parakeet {
+			if err := conn.WriteJSON(map[string]string{"type": "ready"}); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+		for {
+			kind, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if kind == websocket.BinaryMessage {
+				select {
+				case received <- data:
+				default:
+				}
+			}
+		}
+	})}
+	go server.Serve(listener)
+	t.Cleanup(func() { server.Close() })
+	oldDialer := websocket.DefaultDialer
+	dialer := *oldDialer
+	dialer.Proxy = nil
+	dialer.NetDialContext = func(context.Context, string, string) (net.Conn, error) { return clientConn, nil }
+	// Deepgram uses wss; supply its already-connected transport in memory too.
+	dialer.NetDialTLSContext = dialer.NetDialContext
+	websocket.DefaultDialer = &dialer
+	t.Cleanup(func() { websocket.DefaultDialer = oldDialer })
+
+	var transcriber StreamingTranscriber
+	var err error
+	if parakeet {
+		transcriber, err = NewParakeet("http://parakeet.test", 16000, nil)
+	} else {
+		transcriber, err = NewDeepgram("test-key", 16000, nil)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transcriber.Stop()
+	pcm := []byte{1, 0, 2, 0}
+	// Audio arrives while the background reader is awaiting the ready message.
+	if parakeet {
+		if err := transcriber.AppendPCM(pcm); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(releaseReady)
+	for time.Now().Before(deadline) {
+		if err := transcriber.AppendPCM(pcm); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case got := <-received:
+			if !bytes.Equal(got, pcm) {
+				t.Fatalf("PCM = %v, want %v", got, pcm)
+			}
+			return
+		default:
+			runtime.Gosched()
+		}
+	}
+	t.Fatal("PCM never reached the ready transcriber")
+}

--- a/sdks/device/go/omidevice/stt/parakeet_test.go
+++ b/sdks/device/go/omidevice/stt/parakeet_test.go
@@ -48,24 +48,37 @@ func testTranscriberReadiness(t *testing.T, parakeet bool) {
 	t.Helper()
 	clientConn, serverConn := net.Pipe()
 	deadline := time.Now().Add(5 * time.Second)
-	clientConn.SetDeadline(deadline)
-	serverConn.SetDeadline(deadline)
-	t.Cleanup(func() { clientConn.Close(); serverConn.Close() })
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	// Gorilla resets transport deadlines during its handshake and writes.
+	// Closing the pipes bounds even a regression that blocks AppendPCM/Stop.
+	closed := make(chan struct{})
+	context.AfterFunc(ctx, func() {
+		clientConn.Close()
+		serverConn.Close()
+		close(closed)
+	})
 	listener := &pipeListener{connections: make(chan net.Conn, 1), done: make(chan struct{})}
 	listener.connections <- serverConn
 	releaseReady := make(chan struct{})
 	received := make(chan []byte, 1)
+	handlerDone := make(chan struct{})
+	serverErrors := make(chan error, 1)
 	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(handlerDone)
 		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
 		if err != nil {
-			t.Error(err)
+			serverErrors <- err
 			return
 		}
 		defer conn.Close()
-		<-releaseReady
+		select {
+		case <-releaseReady:
+		case <-ctx.Done():
+			return
+		}
 		if parakeet {
 			if err := conn.WriteJSON(map[string]string{"type": "ready"}); err != nil {
-				t.Error(err)
+				serverErrors <- err
 				return
 			}
 		}
@@ -82,8 +95,21 @@ func testTranscriberReadiness(t *testing.T, parakeet bool) {
 			}
 		}
 	})}
-	go server.Serve(listener)
-	t.Cleanup(func() { server.Close() })
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		server.Serve(listener)
+	}()
+	connected := false
+	t.Cleanup(func() {
+		cancel()
+		server.Close()
+		<-closed
+		<-serveDone
+		if connected {
+			<-handlerDone
+		}
+	})
 	oldDialer := websocket.DefaultDialer
 	dialer := *oldDialer
 	dialer.Proxy = nil
@@ -103,6 +129,7 @@ func testTranscriberReadiness(t *testing.T, parakeet bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	connected = true
 	defer transcriber.Stop()
 	pcm := []byte{1, 0, 2, 0}
 	// Audio arrives while the background reader is awaiting the ready message.
@@ -117,6 +144,8 @@ func testTranscriberReadiness(t *testing.T, parakeet bool) {
 			t.Fatal(err)
 		}
 		select {
+		case err := <-serverErrors:
+			t.Fatal(err)
 		case got := <-received:
 			if !bytes.Equal(got, pcm) {
 				t.Fatalf("PCM = %v, want %v", got, pcm)

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gorilla/websocket"
 )
@@ -34,14 +35,14 @@ func ParakeetWSURL(apiURL string, sampleRate int) string {
 
 type wsTranscriber struct {
 	conn  *websocket.Conn
-	ready bool
+	ready atomic.Bool
 }
 
 func (t *wsTranscriber) AppendPCM(pcm []byte) error {
 	if t.conn == nil {
 		return fmt.Errorf("not connected")
 	}
-	if !t.ready {
+	if !t.ready.Load() {
 		return nil
 	}
 	return t.conn.WriteMessage(websocket.BinaryMessage, pcm)
@@ -72,7 +73,8 @@ func NewDeepgram(apiKey string, sampleRate int, onTranscript Handler) (Streaming
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn, ready: true}
+	t := &wsTranscriber{conn: conn}
+	t.ready.Store(true)
 	go readDeepgram(conn, onTranscript)
 	return t, nil
 }
@@ -115,7 +117,7 @@ func NewParakeet(apiURL string, sampleRate int, onTranscript Handler) (Streaming
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn, ready: false}
+	t := &wsTranscriber{conn: conn}
 	// wait ready in background and stream
 	go func() {
 		for {
@@ -128,7 +130,7 @@ func NewParakeet(apiURL string, sampleRate int, onTranscript Handler) (Streaming
 				continue
 			}
 			if msg["type"] == "ready" {
-				t.ready = true
+				t.ready.Store(true)
 				continue
 			}
 			if text := extractText(msg); text != "" && onTranscript != nil {


### PR DESCRIPTION
## What changed and why

Fixes #13015. Parakeet's WebSocket reader writes the readiness flag concurrently with `AppendPCM`; use `atomic.Bool` to synchronize those accesses while preserving Parakeet's pre-ready gate and Deepgram's immediate readiness.

## Product invariants affected

none

## How it was verified

On macOS arm64 with Go 1.27.1:

- Before the fix, `go test -race ./omidevice/stt -run TestParakeetReadyWhileAppendingPCM -count=1` fails with the production `NewParakeet.func1` write racing the `AppendPCM` read.
- After the fix, `go test -race ./... -count=20` passes. `go vet ./...` passes.
- A temporary mutation marking Parakeet ready immediately is rejected within five seconds, without hanging the test suite; the mutation was removed.
- `make preflight`, `scripts/pr-preflight --pr-body-file ...`, and the pre-push gate pass. Preflight ran 119 selected checks.

The tests exercise the public constructors and PCM submission through real HTTP/WebSocket framing over `net.Pipe`. No network service, hardware, real credentials, or production account is used. This proves the SDK synchronization behavior, not end-to-end transcription against a live provider.

## Tests

`sdks/device/go/omidevice/stt/parakeet_test.go` covers the Parakeet readiness transition and immediate Deepgram readiness, checking the received PCM bytes. Cancellation closes blocked transports and cleans up the test server. The shared check manifest runs `go test -race ./...` on Linux and macOS.

## Failure class (fixes)

Failure-Class: none

No existing definition describes this unsynchronized Go readiness flag. The connection already has one state owner; the missing contract is synchronization between its reader goroutine and caller.

## New guards

The race-enabled Go suite catches the reproduced handshake race in #13015. The production fix uses the shared `sync/atomic.Bool` primitive; the regression exercises behavior rather than inspecting source strings.

The US$50 bounty proposed in #13015 awaits maintainer approval; submission does not assume a payment award.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

