### PR TITLE
fix(devex): require clang-format before firmware pushes

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -19,6 +19,11 @@ checks:
     triggers: ["scripts/pre-push", "scripts/pre-push-diff-base", "scripts/test-pre-push-diff-base.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "pre-push check selection must use the final PR diff rather than a stale remote feature tip"
+  - id: pre-push-firmware-formatter-prerequisite
+    command: ["bash", "scripts/test-pre-push-firmware-format-prerequisite.sh"]
+    triggers: ["scripts/pre-push", "scripts/test-pre-push-firmware-format-prerequisite.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "PR #12993 found that firmware formatting can fail only after a hosted run because pre-push silently skipped clang-format when it was absent; selected firmware sources now require the same formatter locally"
   - id: pre-commit-pinned-toolchains
     command: ["bash", "scripts/test-pre-commit-pinned-toolchains.sh"]
     triggers: ["scripts/pre-commit", "scripts/test-pre-commit-pinned-toolchains.sh", ".github/checks-manifest.yaml"]

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -236,12 +236,16 @@ check_firmware_formatters() {
     return
   fi
 
-  if command -v clang-format >/dev/null 2>&1; then
+  if [ "${PRE_PUSH_SKIP_FIRMWARE_FORMAT:-}" = "1" ]; then
+    echo "Skipping C/C++ format check because PRE_PUSH_SKIP_FIRMWARE_FORMAT=1."
+    ci_prediction_note_skipped "Firmware C/C++ formatting (PRE_PUSH_SKIP_FIRMWARE_FORMAT=1)"
+  elif command -v clang-format >/dev/null 2>&1; then
     echo "==> clang-format --dry-run (${#firmware_files[@]} file(s))"
     clang-format --dry-run --Werror "${firmware_files[@]}"
   else
     echo "FAIL: changed firmware C/C++ files require clang-format for local CI certification." >&2
     echo "      Install clang-format (for example, 'brew install clang-format') and retry the push." >&2
+    echo "      Deliberate hatch: PRE_PUSH_SKIP_FIRMWARE_FORMAT=1 git push" >&2
     return 1
   fi
 }

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -219,11 +219,37 @@ check_pr_preflight() {
   fi
 }
 
+check_firmware_formatters() {
+  local -a firmware_files=()
+  local file
+
+  for file in "${CHANGED_FILES[@]}"; do
+    [ -f "$file" ] || continue
+    case "$file" in
+      omi/*.c|omi/*.cc|omi/*.cpp|omi/*.cxx|omi/*.h|omi/*.hpp|omiGlass/*.c|omiGlass/*.cc|omiGlass/*.cpp|omiGlass/*.cxx|omiGlass/*.h|omiGlass/*.hpp)
+        firmware_files+=("$file")
+        ;;
+    esac
+  done
+
+  if [ "${#firmware_files[@]}" -eq 0 ]; then
+    return
+  fi
+
+  if command -v clang-format >/dev/null 2>&1; then
+    echo "==> clang-format --dry-run (${#firmware_files[@]} file(s))"
+    clang-format --dry-run --Werror "${firmware_files[@]}"
+  else
+    echo "FAIL: changed firmware C/C++ files require clang-format for local CI certification." >&2
+    echo "      Install clang-format (for example, 'brew install clang-format') and retry the push." >&2
+    return 1
+  fi
+}
+
 check_optional_formatters() {
   local -a dart_files=()
   local -a python_files=()
   local -a arb_files=()
-  local -a firmware_files=()
   local file
 
   for file in "${CHANGED_FILES[@]}"; do
@@ -239,9 +265,6 @@ check_optional_formatters() {
         ;;
       *.arb)
         arb_files+=("$file")
-        ;;
-      omi/*.c|omi/*.cc|omi/*.cpp|omi/*.cxx|omi/*.h|omi/*.hpp|omiGlass/*.c|omiGlass/*.cc|omiGlass/*.cpp|omiGlass/*.cxx|omiGlass/*.h|omiGlass/*.hpp)
-        firmware_files+=("$file")
         ;;
     esac
   done
@@ -300,14 +323,7 @@ if failed:
 PY
   fi
 
-  if [ "${#firmware_files[@]}" -gt 0 ]; then
-    if command -v clang-format >/dev/null 2>&1; then
-      echo "==> clang-format --dry-run (${#firmware_files[@]} file(s))"
-      clang-format --dry-run --Werror "${firmware_files[@]}"
-    else
-      echo "Skipping C/C++ format check; clang-format is not installed."
-    fi
-  fi
+  check_firmware_formatters
 }
 
 require_flutter_generated_prerequisites() {

--- a/scripts/test-pre-push-firmware-format-prerequisite.sh
+++ b/scripts/test-pre-push-firmware-format-prerequisite.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Behavioral regression for the formatter prerequisite deferred in #12993.
+# Source the actual hook branch into a controlled fixture so this verifies
+# process execution and exit status rather than matching hook diagnostics.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/omi-pre-push-firmware-format.XXXXXX")"
+trap 'rm -rf "$FIXTURE_TMP"' EXIT
+
+FUNCTION="$FIXTURE_TMP/check_firmware_formatters.sh"
+awk '/^check_firmware_formatters\(\) \{$/,/^\}$/' "$ROOT/scripts/pre-push" >"$FUNCTION"
+if ! grep -qx '}' "$FUNCTION"; then
+  echo "FAIL: could not extract check_firmware_formatters from scripts/pre-push" >&2
+  exit 1
+fi
+
+mkdir -p "$FIXTURE_TMP/repo/omi/firmware" "$FIXTURE_TMP/repo/omiGlass/firmware" "$FIXTURE_TMP/repo/docs" "$FIXTURE_TMP/bin" "$FIXTURE_TMP/no-formatter"
+printf 'int main(void) { return 0; }\n' >"$FIXTURE_TMP/repo/omi/firmware/fixture.c"
+printf '#pragma once\n' >"$FIXTURE_TMP/repo/omiGlass/firmware/fixture.hpp"
+printf 'fixture\n' >"$FIXTURE_TMP/repo/docs/fixture.md"
+
+cat >"$FIXTURE_TMP/bin/clang-format" <<'EOF'
+#!/bin/sh
+: "${FORMATTER_ARGS:?FORMATTER_ARGS is required}"
+printf '%s\n' "$@" >"$FORMATTER_ARGS"
+exit "${FORMATTER_EXIT:-0}"
+EOF
+chmod +x "$FIXTURE_TMP/bin/clang-format"
+
+run_formatter_check() (
+  cd "$FIXTURE_TMP/repo"
+  CHANGED_FILES=("$@")
+  # shellcheck source=/dev/null
+  source "${FORMATTER_FUNCTION:-$FUNCTION}"
+  check_firmware_formatters
+)
+
+# The assertion is expressed as behavior so the temporary legacy mutant below
+# can prove that the fixture would reject the old silent-pass branch.
+missing_formatter_must_fail() {
+  local function_file="$1"
+  if PATH="$FIXTURE_TMP/no-formatter" FORMATTER_FUNCTION="$function_file" run_formatter_check omi/firmware/fixture.c >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+# A selected firmware path must fail when no formatter can be resolved.
+missing_formatter_must_fail "$FUNCTION"
+
+# Restore the legacy no-op in a temporary extracted function. This must make
+# the missing-formatter assertion fail, proving the fixture is sensitive to
+# the historical silent pass instead of only the helper's presence.
+LEGACY_SKIP_FUNCTION="$FIXTURE_TMP/check_firmware_formatters-legacy-skip.sh"
+awk '
+  /^  else$/ { print; print "    :"; skipping = 1; next }
+  skipping && /^  fi$/ { print; skipping = 0; next }
+  !skipping { print }
+' "$FUNCTION" >"$LEGACY_SKIP_FUNCTION"
+if missing_formatter_must_fail "$LEGACY_SKIP_FUNCTION"; then
+  echo "FAIL: missing-formatter fixture did not detect the legacy silent pass" >&2
+  exit 1
+fi
+
+# A formatter on PATH must receive the hook's dry-run/Werror invocation and
+# every selected firmware source, including the legacy omiGlass tree.
+FORMATTER_ARGS="$FIXTURE_TMP/formatter-args"
+export FORMATTER_ARGS
+PATH="$FIXTURE_TMP/bin" run_formatter_check omi/firmware/fixture.c omiGlass/firmware/fixture.hpp >/dev/null
+expected_args="$FIXTURE_TMP/expected-formatter-args"
+printf '%s\n' --dry-run --Werror omi/firmware/fixture.c omiGlass/firmware/fixture.hpp >"$expected_args"
+if ! cmp -s "$expected_args" "$FORMATTER_ARGS"; then
+  echo "FAIL: pre-push did not invoke clang-format with the selected firmware files" >&2
+  exit 1
+fi
+
+# Formatter failures must propagate instead of being reported as a successful
+# pre-push formatting check.
+FORMATTER_EXIT=23
+export FORMATTER_EXIT
+if PATH="$FIXTURE_TMP/bin" run_formatter_check omi/firmware/fixture.c >/dev/null 2>&1; then
+  echo "FAIL: clang-format failure did not fail pre-push" >&2
+  exit 1
+fi
+unset FORMATTER_EXIT
+
+# A deleted firmware source and a non-firmware push must stay independent of
+# an unprovisioned formatter.
+PATH="$FIXTURE_TMP/no-formatter" run_formatter_check omi/firmware/deleted.c >/dev/null
+rm -f "$FORMATTER_ARGS"
+PATH="$FIXTURE_TMP/no-formatter" run_formatter_check docs/fixture.md >/dev/null
+if [ -e "$FORMATTER_ARGS" ]; then
+  echo "FAIL: non-firmware path invoked clang-format" >&2
+  exit 1
+fi
+
+echo "pre-push firmware formatter prerequisite tests passed"

--- a/scripts/test-pre-push-firmware-format-prerequisite.sh
+++ b/scripts/test-pre-push-firmware-format-prerequisite.sh
@@ -5,6 +5,17 @@ set -euo pipefail
 # Source the actual hook branch into a controlled fixture so this verifies
 # process execution and exit status rather than matching hook diagnostics.
 unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+fixture_mode="${1:-}"
+unset FORMATTER_ARGS FORMATTER_EXIT FORMATTER_FUNCTION PRE_PUSH_SKIP_FIRMWARE_FORMAT
+
+# The fixture is selected by pre-push and must not let a caller's formatter
+# test variables redirect the sourced function or change its expected result.
+if [ "$fixture_mode" != "--hostile-env-probe" ]; then
+  FORMATTER_ARGS=/dev/null \
+    FORMATTER_EXIT=97 \
+    FORMATTER_FUNCTION=/dev/null \
+    bash "${BASH_SOURCE[0]}" --hostile-env-probe >/dev/null
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/omi-pre-push-firmware-format.XXXXXX")"
@@ -33,6 +44,7 @@ chmod +x "$FIXTURE_TMP/bin/clang-format"
 run_formatter_check() (
   cd "$FIXTURE_TMP/repo"
   CHANGED_FILES=("$@")
+  ci_prediction_note_skipped() { : >"$SKIP_MARKER"; }
   # shellcheck source=/dev/null
   source "${FORMATTER_FUNCTION:-$FUNCTION}"
   check_firmware_formatters
@@ -85,6 +97,16 @@ if PATH="$FIXTURE_TMP/bin" run_formatter_check omi/firmware/fixture.c >/dev/null
   exit 1
 fi
 unset FORMATTER_EXIT
+
+# The deliberate formatter hatch must take the bypass visibly, so the hook's
+# bounded CI-prediction summary cannot look like a verified format check.
+SKIP_MARKER="$FIXTURE_TMP/firmware-format-skipped"
+export SKIP_MARKER
+PRE_PUSH_SKIP_FIRMWARE_FORMAT=1 PATH="$FIXTURE_TMP/no-formatter" run_formatter_check omi/firmware/fixture.c >/dev/null
+if [ ! -e "$SKIP_MARKER" ]; then
+  echo "FAIL: firmware-format hatch did not record a skipped formatter check" >&2
+  exit 1
+fi
 
 # A deleted firmware source and a non-firmware push must stay independent of
 # an unprovisioned formatter.


### PR DESCRIPTION
## Summary

Firmware C/C++ changes could pass the local pre-push gate without a formatting check when `clang-format` was absent, leaving the first failure to hosted CI. By default, the hook now fails with installation guidance only for selected `omi/` or `omiGlass/` C/C++ files. A deliberate `PRE_PUSH_SKIP_FIRMWARE_FORMAT=1` override is disclosed in the hook's CI-prediction summary.

- Register a manifest-backed branch fixture that executes the hook's formatter function with no formatter, a formatter on `PATH`, a formatter failure, the documented override, a deleted firmware path, and a non-firmware file. A temporary legacy silent-pass mutant must fail the missing-tool assertion, and hostile inherited formatter variables must not redirect the fixture. It is focused branch coverage, not a full Git pre-push invocation.
- Keep the existing `clang-format --dry-run --Werror` command and file selection unchanged when the formatter is available.

## Validation

- `make setup`
- `bash scripts/test-pre-push-firmware-format-prerequisite.sh`
- `scripts/pr-preflight --suggest --base origin/main --head HEAD`
- `scripts/failure-class explain FC-nonexecuting-verification-command --format json`
- `scripts/failure-class validate --base origin/main --head HEAD --pr-body-file /tmp/omi-meta-firmware-format-prerequisite-pr.md`
- `OMI_PR_BODY_FILE=/tmp/omi-meta-firmware-format-prerequisite-pr.md make preflight` — 120 checks passed in 29.92s after the follow-up commit.
- `python3 .github/scripts/test_run_checks.py` — 47 tests passed.
- Independent review approved commit `1ecacef8b3` after re-running `bash scripts/test-pre-push-firmware-format-prerequisite.sh`, `bash scripts/test-pre-push-diff-base.sh`, and `git diff --check`.
- Independent review approved follow-up commit `a5a58b341f` after re-running the fixture, including its hostile-environment probe, `python3 .github/scripts/check_pre_push_hatch_disclosure.py`, and `git diff --check`.

## Product invariants affected

none

Failure-Class: FC-nonexecuting-verification-command
