### PR TITLE
fix(tests): isolate action-items pagination cache

### DIFF
--- a/backend/tests/unit/test_action_items_router_pagination.py
+++ b/backend/tests/unit/test_action_items_router_pagination.py
@@ -7,6 +7,16 @@ import pytest
 import routers.action_items as action_items_router
 
 
+@pytest.fixture(autouse=True)
+def _disable_list_cache(monkeypatch):
+    """Keep the one-row-lookahead contract on its uncached database path.
+
+    The response-cache contract is covered by test_action_items_list_read_cost;
+    this module must exercise the database query for every parametrized page.
+    """
+    monkeypatch.setattr(action_items_router, 'list_cache_ttl_seconds', lambda: 0)
+
+
 def _item(item_id: str, *, locked: bool = False, description: str = 'Do a thing') -> dict:
     return {
         'id': item_id,


### PR DESCRIPTION
## Summary

The parametrized pagination test reused the same action-items cache entry, so
later cases could return a cached response before reaching their database mock.
Disable that response cache only for this uncached one-row-lookahead contract.
The cache behavior remains covered by `test_action_items_list_read_cost.py`.

## Verification

- `make setup`
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-pagination-test-files bash backend/test.sh` (29 passed: 4 pagination, 25 cache-contract cases)
- Temporary mutant: changing `get_action_items` from `limit=limit + 1` to `limit=limit` made all three lookahead parameter cases fail; restored before final verification.
- `scripts/pr-preflight --suggest`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

