### PR TITLE
fix(app): stop Profile settings rows overflowing with enlarged text

### DIFF
--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -10,6 +10,7 @@ import 'package:omi/pages/settings/change_name_widget.dart';
 import 'package:omi/pages/settings/language_settings_page.dart';
 import 'package:omi/pages/settings/custom_vocabulary_page.dart';
 import 'package:omi/pages/settings/people.dart';
+import 'package:omi/pages/settings/widgets/profile_settings_tile.dart';
 import 'package:omi/pages/speech_profile/page.dart';
 
 import 'package:omi/utils/alerts/app_snackbar.dart';
@@ -49,73 +50,15 @@ class _ProfilePageState extends State<ProfilePage> {
     bool showBetaTag = false,
     bool showChevron = true,
   }) {
-    return GestureDetector(
+    return ProfileSettingsTile(
+      title: title,
+      subtitle: subtitle,
+      chipValue: chipValue,
+      icon: icon,
       onTap: onTap,
-      child: Container(
-        decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(20)),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-          child: Row(
-            children: [
-              SizedBox(width: 24, height: 24, child: icon),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Text(
-                          title,
-                          style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w400),
-                        ),
-                        if (showBetaTag) ...[
-                          const SizedBox(width: 8),
-                          Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: Colors.orange.withValues(alpha: 0.2),
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                            child: const Text(
-                              'BETA',
-                              style: TextStyle(
-                                color: Colors.orange,
-                                fontSize: 10,
-                                fontWeight: FontWeight.w600,
-                                letterSpacing: 0.5,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                    if (showSubtitle && subtitle != null && chipValue == null) ...[
-                      const SizedBox(height: 2),
-                      Text(
-                        subtitle,
-                        style: const TextStyle(color: Color(0xFF8E8E93), fontSize: 12, fontWeight: FontWeight.w400),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-              if (chipValue != null) ...[
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  decoration: BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(100)),
-                  child: Text(
-                    chipValue,
-                    style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
-                  ),
-                ),
-                if (showChevron) const SizedBox(width: 8),
-              ],
-              if (showChevron) const Icon(Icons.chevron_right, color: Color(0xFF3C3C43), size: 20),
-            ],
-          ),
-        ),
-      ),
+      showSubtitle: showSubtitle,
+      showBetaTag: showBetaTag,
+      showChevron: showChevron,
     );
   }
 
@@ -201,35 +144,12 @@ class _ProfilePageState extends State<ProfilePage> {
     String? chipValue,
     VoidCallback? onTap,
   }) {
-    return InkWell(
+    return ProfileSettingsTile(
+      title: title,
+      chipValue: chipValue,
+      icon: FaIcon(icon, color: const Color(0xFF8E8E93), size: 20),
       onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-        child: Row(
-          children: [
-            SizedBox(width: 24, height: 24, child: FaIcon(icon, color: const Color(0xFF8E8E93), size: 20)),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Text(
-                title,
-                style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w400),
-              ),
-            ),
-            if (chipValue != null) ...[
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                decoration: BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(100)),
-                child: Text(
-                  chipValue,
-                  style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
-                ),
-              ),
-              const SizedBox(width: 8),
-            ],
-            const Icon(Icons.chevron_right, color: Color(0xFF3C3C43), size: 20),
-          ],
-        ),
-      ),
+      useInkWell: true,
     );
   }
 

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -140,14 +140,19 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
               SizedBox(width: 24, height: 24, child: icon),
               const SizedBox(width: 16),
               Expanded(
-                child: Row(
+                // Wrap so a long or enlarged title wraps by word and the tags
+                // flow beside or below it instead of overflowing the row
+                // (#12898).
+                child: Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  runSpacing: 4,
                   children: [
                     Text(
                       title,
                       style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w400),
                     ),
-                    if (showBetaTag) ...[
-                      const SizedBox(width: 8),
+                    if (showBetaTag)
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                         decoration: BoxDecoration(
@@ -164,9 +169,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                           ),
                         ),
                       ),
-                    ],
-                    if (showNewTag) ...[
-                      const SizedBox(width: 8),
+                    if (showNewTag)
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                         decoration: BoxDecoration(
@@ -183,8 +186,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                           ),
                         ),
                       ),
-                    ],
-                    if (trailingChip != null) ...[const SizedBox(width: 8), trailingChip],
+                    if (trailingChip != null) trailingChip,
                   ],
                 ),
               ),

--- a/app/lib/pages/settings/widgets/profile_settings_tile.dart
+++ b/app/lib/pages/settings/widgets/profile_settings_tile.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+
+/// One row of the Profile settings list: icon, title (optionally with a BETA
+/// tag and a subtitle), an optional value chip, and a chevron.
+///
+/// The title and its tag sit in a `Wrap` so the title wraps by word instead of
+/// pushing the tag off the row, and the chip is capped to [chipMaxWidthFraction] of the
+/// row so a long value cannot squeeze the title into mid-word breaks. Both
+/// overflowed with enlarged or bold system text (issue #12898: "Transcribe
+/// Later" + BETA + "Off" painted the debug overflow stripes).
+class ProfileSettingsTile extends StatelessWidget {
+  const ProfileSettingsTile({
+    super.key,
+    required this.title,
+    required this.icon,
+    required this.onTap,
+    this.subtitle,
+    this.chipValue,
+    this.showSubtitle = true,
+    this.showBetaTag = false,
+    this.showChevron = true,
+    this.useInkWell = false,
+  });
+
+  final String title;
+  final Widget icon;
+  final VoidCallback? onTap;
+  final String? subtitle;
+  final String? chipValue;
+  final bool showSubtitle;
+  final bool showBetaTag;
+  final bool showChevron;
+
+  /// Ripple feedback instead of a plain tap target (used by rows that open a
+  /// sheet rather than push a page).
+  final bool useInkWell;
+
+  /// Largest share of the width left for title and chip (after the icon, the
+  /// chevron, and their gaps) that the chip may take before its text is
+  /// ellipsized; the title always keeps the rest.
+  static const double chipMaxWidthFraction = 0.6;
+
+  static const double _iconWidth = 24;
+  static const double _iconGap = 16;
+  static const double _chipGap = 8;
+  static const double _chevronWidth = 20;
+  static const double _chevronGap = 8;
+
+  /// Width the chip may take in a row whose content area is [rowWidth] wide.
+  static double chipMaxWidth(double rowWidth, {required bool showChevron}) {
+    final fixed = _iconWidth + _iconGap + _chipGap + (showChevron ? _chevronGap + _chevronWidth : 0);
+    final shared = (rowWidth - fixed).clamp(0.0, double.infinity);
+    return shared * chipMaxWidthFraction;
+  }
+
+  static const Color _tileColor = Color(0xFF1C1C1E);
+  static const Color _chipColor = Color(0xFF2A2A2E);
+  static const Color _chevronColor = Color(0xFF3C3C43);
+
+  @override
+  Widget build(BuildContext context) {
+    final row = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Row(
+            children: [
+              SizedBox(width: _iconWidth, height: 24, child: icon),
+              const SizedBox(width: _iconGap),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Wrap, not Row: the title gets the full column width and
+                    // wraps by word, while the tag sits beside it when there is
+                    // room and drops below it otherwise. A Row with a Flexible
+                    // title breaks the title per character once the tag steals
+                    // width, and a rigid Row overflows to the right (#12898).
+                    Wrap(
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: [
+                        Text(
+                          title,
+                          style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w400),
+                        ),
+                        if (showBetaTag)
+                          Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: Colors.orange.withValues(alpha: 0.2),
+                              borderRadius: BorderRadius.circular(10),
+                            ),
+                            child: Text(
+                              context.l10n.beta,
+                              style: const TextStyle(
+                                color: Colors.orange,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                letterSpacing: 0.5,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                    if (showSubtitle && subtitle != null && chipValue == null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle!,
+                        style: const TextStyle(color: Color(0xFF8E8E93), fontSize: 12, fontWeight: FontWeight.w400),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              if (chipValue != null) ...[
+                const SizedBox(width: _chipGap),
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: chipMaxWidth(constraints.maxWidth, showChevron: showChevron),
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(color: _chipColor, borderRadius: BorderRadius.circular(100)),
+                    child: Text(
+                      chipValue!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
+                    ),
+                  ),
+                ),
+              ],
+              if (showChevron) ...[
+                const SizedBox(width: _chevronGap),
+                const Icon(Icons.chevron_right, color: _chevronColor, size: _chevronWidth),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+
+    if (useInkWell) {
+      return InkWell(onTap: onTap, child: row);
+    }
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(color: _tileColor, borderRadius: BorderRadius.circular(20)),
+        child: row,
+      ),
+    );
+  }
+}

--- a/app/test/widgets/profile_settings_tile_test.dart
+++ b/app/test/widgets/profile_settings_tile_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/settings/widgets/profile_settings_tile.dart';
+
+// Regression for #12898: the Profile page's "Transcribe Later" row (title +
+// BETA tag + "Off" chip) painted RIGHT OVERFLOWED stripes, and "Voice
+// response" broke mid-word next to its "Headphones only" chip, once system
+// text was enlarged. The tile must lay out without overflow at narrow widths
+// and large text scales, keep the chip from crowding out the title, and
+// still show every part.
+
+const double _narrowWidth = 320;
+
+Widget _app(Widget child, {double textScale = 1.0, double width = _narrowWidth}) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+      child: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: width, child: child),
+        ),
+      ),
+    ),
+  );
+}
+
+ProfileSettingsTile _transcribeLater() => ProfileSettingsTile(
+      title: 'Transcribe Later',
+      icon: const Icon(Icons.save),
+      showBetaTag: true,
+      chipValue: 'Off',
+      onTap: () {},
+    );
+
+void main() {
+  testWidgets('title, BETA tag and chip fit a narrow row at 1.6x text without overflow', (tester) async {
+    await tester.pumpWidget(_app(_transcribeLater(), textScale: 1.6));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Transcribe Later'), findsOneWidget);
+    expect(find.text('BETA'), findsOneWidget);
+    expect(find.text('Off'), findsOneWidget);
+  });
+
+  testWidgets('a wide chip is capped so the title keeps at least its share of the row', (tester) async {
+    const width = 360.0;
+    await tester.pumpWidget(
+      _app(
+        ProfileSettingsTile(
+          title: 'Voice response',
+          icon: const Icon(Icons.volume_up),
+          chipValue: 'Headphones only, and a much longer value than any row should hold',
+          onTap: () {},
+          useInkWell: true,
+        ),
+        textScale: 1.3,
+        width: width,
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    final chipTextFinder = find.textContaining('Headphones only');
+    expect(tester.widget<Text>(chipTextFinder).overflow, TextOverflow.ellipsis);
+
+    // The row's content area is the tile width minus its horizontal padding.
+    const contentWidth = width - 32;
+    final chipMax = ProfileSettingsTile.chipMaxWidth(contentWidth, showChevron: true);
+    final chipBox = tester.getSize(find.ancestor(of: chipTextFinder, matching: find.byType(ConstrainedBox)).first);
+    expect(chipBox.width, lessThanOrEqualTo(chipMax + 0.01));
+
+    // The title gets everything the chip cannot take: it sits left of the
+    // chip with at least the complementary share of the shared width.
+    final titleRect = tester.getRect(find.text('Voice response'));
+    final chipRect = tester.getRect(chipTextFinder);
+    expect(titleRect.right, lessThanOrEqualTo(chipRect.left));
+    final sharedWidth = chipMax / ProfileSettingsTile.chipMaxWidthFraction;
+    expect(titleRect.width, greaterThanOrEqualTo(sharedWidth * (1 - ProfileSettingsTile.chipMaxWidthFraction) - 0.01));
+  });
+
+  testWidgets('subtitle shows only without a chip, and the chevron can be hidden', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        ProfileSettingsTile(
+          title: 'User ID',
+          subtitle: 'Tap to copy',
+          icon: const Icon(Icons.badge),
+          onTap: () {},
+          showChevron: false,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Tap to copy'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
+}


### PR DESCRIPTION


The beta tag doesn't overflow anymore. Fixedd issue: https://github.com/BasedHardware/omi/issues/12898

<img width="603" height="1311" alt="IMG_2329" src="https://github.com/user-attachments/assets/335f58be-aad9-4c59-bf15-0efe46ddc3f6" />


## Summary

Fixes #12898. On the Profile settings page the "Transcribe Later" row painted `RIGHT OVERFLOWED BY 32 PIXELS` and the "Voice response" row broke mid-word ("Voice re / sponse") next to its "Headphones only" chip once system text was enlarged or bold.

Cause: the row builder placed the title and the BETA tag in a rigid `Row`, so the title could never give up width, and the value chip took whatever it wanted from the title's `Expanded` column.

Changes:
- New `ProfileSettingsTile` widget (`app/lib/pages/settings/widgets/profile_settings_tile.dart`), extracted from the two near-identical row builders in `profile.dart`. Title and tag sit in a `Wrap`, so the title wraps by word and the tag flows beside or below it. The value chip is capped to 60% of the width it shares with the title (after icon, chevron, and gaps) and ellipsizes past that, so the title always keeps at least 40%.
- `settings_drawer.dart`'s row gets the same `Wrap` for its title, BETA/NEW tags, and trailing chip.
- Widget test `app/test/widgets/profile_settings_tile_test.dart`: renders the tile 320 px wide at 1.6x text with title + BETA + chip and asserts no overflow exception; asserts a long chip is capped and the title keeps its share; covers the subtitle/chevron options.

## Verification

- `bash test.sh` (full app suite) green locally; `bash scripts/analyze_ratchet.sh` passes; `dart format` clean.
- Verified on the iPhone 17 simulator with Dynamic Type at extra-extra-extra-large (`xcrun simctl ui <udid> content_size extra-extra-extra-large`): no overflow stripes on the Profile page, "Transcribe Later" wraps with BETA on its own line, "Voice response" wraps by word, and long chip values ("Headphones only", the email) ellipsize instead of squeezing the title.

## Product invariants affected

none

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YU5BMEAfcFxNSWmLLDNfZ3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

