### PR TITLE
fix(backend): fill app history past reported rows

### DIFF
--- a/.github/failure-classes/FC-raw-page-limit-before-visibility-filter.json
+++ b/.github/failure-classes/FC-raw-page-limit-before-visibility-filter.json
@@ -5,7 +5,8 @@
   "canonical_prevention": "Scan the ordered raw stream with a bounded budget, skip hidden rows without consuming page capacity, and stop only when the visible limit is filled or the collection is exhausted \u2014 the same pattern get_messages_reconcile_page already uses. Floor that budget at the rows the page needs (offset + limit, which is what the raw query already streamed) and bound only the slack above it: capping the total instead leaves a deep offset unreachable, so the page comes back empty and the caller reads that as end-of-data \u2014 the same defect at a deeper boundary. Keep the slack flat rather than proportional to the page, or a small page gets an allowance too thin to cross a dense run of hidden rows. Prove it with a hermetic page whose middle row is hidden: the returned page must still contain limit visible ids, and the next visible offset must continue at the next visible row rather than a raw store slot.",
   "canonical_prevention_artifact": [
     "backend/tests/unit/test_get_messages_reported_pagination.py",
-    "backend/tests/unit/test_get_memories_scoring_visibility_pagination.py"
+    "backend/tests/unit/test_get_memories_scoring_visibility_pagination.py",
+    "backend/tests/unit/test_get_app_messages_visible_pagination.py"
   ],
   "evidence_prs": [
     12712,

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -195,23 +195,63 @@ def add_summary_message(text: str, uid: str) -> Message:
 def get_app_messages(
     uid: str, app_id: str, limit: int = 20, include_conversations: bool = False
 ) -> List[Dict[str, Any]]:
+    """Return an app's newest visible messages, up to ``limit``.
+
+    ``reported`` is intentionally filtered in Python because the legacy data
+    model permits the field to be absent.  The Firestore limit must therefore
+    not run before that visibility rule: a reported row inside the raw page
+    would otherwise consume a caller-visible slot and leave an older visible
+    message unfetched.  This follows the same bounded visible-row scan as
+    ``get_messages`` below.
+    """
+    visible_limit = max(0, int(limit))
+    if visible_limit == 0:
+        return []
+
     user_ref = db.collection('users').document(uid)
-    messages_ref = (
+    query: Any = (
         user_ref.collection('messages')
         .where(filter=FieldFilter('plugin_id', '==', app_id))
         .order_by('created_at', direction=firestore.Query.DESCENDING)
-        .limit(limit)
     )
+    # A clean page needs exactly ``visible_limit`` raw rows.  Bound only the
+    # extra rows needed to cross reported records, so this cannot become an
+    # unbounded history read while a deep run of reported rows still has a
+    # flat allowance to cross.
+    scan_budget = visible_limit + CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK
+    scanned = 0
+    reported_row_seen = False
+    cursor_snapshot: Any = None
     messages: List[Dict[str, Any]] = []
     conversations_id: set[str] = set()
 
-    # Fetch messages and collect conversation IDs
-    for doc in messages_ref.stream():
-        message: Dict[str, Any] = _typed_doc(doc)
-        if message.get('reported') is True:
-            continue
-        messages.append(message)
-        conversations_id.update(message.get('memories_id', []))
+    while scanned < scan_budget and len(messages) < visible_limit:
+        # A clean page reads exactly its requested visible rows, even when it
+        # needs more than one capped 100-row batch. Once a reported row has
+        # appeared, use capped batches to cross a dense hidden run without
+        # turning a missing visible row into one read per document.
+        batch_limit = min(100, scan_budget - scanned)
+        if not reported_row_seen:
+            batch_limit = min(batch_limit, max(1, visible_limit - len(messages)))
+        page_query = query.start_after(cursor_snapshot) if cursor_snapshot is not None else query
+        documents = list(page_query.limit(batch_limit).stream())
+        if not documents:
+            break
+
+        for document in documents:
+            scanned += 1
+            cursor_snapshot = document
+            message: Dict[str, Any] = _typed_doc(document)
+            if message.get('reported') is True:
+                reported_row_seen = True
+                continue
+            messages.append(message)
+            conversations_id.update(message.get('memories_id', []))
+            if len(messages) == visible_limit:
+                break
+
+        if len(documents) < batch_limit:
+            break
 
     if not include_conversations:
         return messages

--- a/backend/tests/unit/test_action_items_router_pagination.py
+++ b/backend/tests/unit/test_action_items_router_pagination.py
@@ -7,6 +7,16 @@ import pytest
 import routers.action_items as action_items_router
 
 
+@pytest.fixture(autouse=True)
+def _disable_list_cache(monkeypatch):
+    """Keep the one-row-lookahead contract on its uncached database path.
+
+    The response-cache contract is covered by test_action_items_list_read_cost;
+    this module must exercise the database query for every parametrized page.
+    """
+    monkeypatch.setattr(action_items_router, 'list_cache_ttl_seconds', lambda: 0)
+
+
 def _item(item_id: str, *, locked: bool = False, description: str = 'Do a thing') -> dict:
     return {
         'id': item_id,

--- a/backend/tests/unit/test_get_app_messages_visible_pagination.py
+++ b/backend/tests/unit/test_get_app_messages_visible_pagination.py
@@ -1,0 +1,205 @@
+"""Visible-row pagination for app message history.
+
+``get_app_messages`` filters reported rows in Python because legacy messages
+may omit ``reported``.  A Firestore limit before that filter makes a reported
+row steal a visible slot, so app-integration callers silently receive less
+history than they requested.  These fakes model Firestore's limit and keyset
+continuation behavior while exercising the production database function.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import database.chat as chat_db
+
+
+class _FakeDocument:
+    def __init__(self, document_id: str, data: dict[str, Any]):
+        self.id = document_id
+        self._data = dict(data)
+        self.exists = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+class _FakeQuery:
+    def __init__(self, collection: '_FakeMessageCollection', *, start: int = 0, limit: int | None = None):
+        self._collection = collection
+        self._start = start
+        self._limit = limit
+
+    def where(self, **_kwargs: Any) -> '_FakeQuery':
+        return self
+
+    def order_by(self, *_args: Any, **_kwargs: Any) -> '_FakeQuery':
+        return self
+
+    def limit(self, value: int) -> '_FakeQuery':
+        return _FakeQuery(self._collection, start=self._start, limit=value)
+
+    def start_after(self, document: _FakeDocument) -> '_FakeQuery':
+        start = next(index for index, row in enumerate(self._collection.rows) if row.id == document.id) + 1
+        return _FakeQuery(self._collection, start=start, limit=self._limit)
+
+    def stream(self) -> list[_FakeDocument]:
+        end = self._start + (self._limit if self._limit is not None else len(self._collection.rows))
+        page = self._collection.rows[self._start : end]
+        self._collection.streamed += len(page)
+        return page
+
+
+class _FakeMessageCollection:
+    def __init__(self, rows: list[_FakeDocument]):
+        self.rows = rows
+        self.streamed = 0
+
+    def where(self, **_kwargs: Any) -> _FakeQuery:
+        return _FakeQuery(self)
+
+
+class _FakeConversationsCollection:
+    def document(self, conversation_id: str) -> SimpleNamespace:
+        return SimpleNamespace(id=conversation_id)
+
+
+class _FakeDatabase:
+    def __init__(self, messages: _FakeMessageCollection, conversations: dict[str, _FakeDocument] | None = None):
+        self._messages = messages
+        self._conversations = conversations or {}
+        self.requested_conversation_ids: list[str] = []
+
+    def collection(self, name: str) -> '_FakeDatabase':
+        assert name == 'users'
+        return self
+
+    def document(self, _uid: str) -> SimpleNamespace:
+        return SimpleNamespace(collection=self._user_collection)
+
+    def _user_collection(self, name: str) -> Any:
+        if name == 'messages':
+            return self._messages
+        assert name == 'conversations'
+        return _FakeConversationsCollection()
+
+    def get_all(self, doc_refs: list[SimpleNamespace]) -> list[_FakeDocument]:
+        self.requested_conversation_ids = [ref.id for ref in doc_refs]
+        return [self._conversations[ref.id] for ref in doc_refs if ref.id in self._conversations]
+
+
+def _message(
+    document_id: str,
+    *,
+    reported: bool | None = False,
+    memories_id: list[str] | None = None,
+) -> _FakeDocument:
+    data: dict[str, Any] = {
+        'id': document_id,
+        'text': document_id,
+        'created_at': datetime(2026, 9, 7, tzinfo=timezone.utc),
+        'plugin_id': 'app-1',
+        'memories_id': memories_id or [],
+    }
+    if reported is not None:
+        data['reported'] = reported
+    return _FakeDocument(
+        document_id,
+        data,
+    )
+
+
+def test_reported_middle_row_does_not_shorten_app_history_and_only_visible_rows_hydrate_conversations():
+    """A hidden raw row must not consume history or trigger conversation hydration."""
+    collection = _FakeMessageCollection(
+        [
+            _message('visible-a', memories_id=['conversation-a']),
+            _message('reported', reported=True, memories_id=['conversation-hidden']),
+            _message('visible-b', memories_id=['conversation-b']),
+            _message('visible-c'),
+        ]
+    )
+    database = _FakeDatabase(
+        collection,
+        {
+            'conversation-a': _FakeDocument('conversation-a', {'id': 'conversation-a'}),
+            'conversation-b': _FakeDocument('conversation-b', {'id': 'conversation-b'}),
+            'conversation-hidden': _FakeDocument('conversation-hidden', {'id': 'conversation-hidden'}),
+        },
+    )
+
+    with patch.object(chat_db, 'db', database):
+        messages = chat_db.get_app_messages('uid-1', 'app-1', limit=2, include_conversations=True)
+
+    assert [message['id'] for message in messages] == ['visible-a', 'visible-b']
+    assert set(database.requested_conversation_ids) == {'conversation-a', 'conversation-b'}
+    assert [[conversation['id'] for conversation in message['memories']] for message in messages] == [
+        ['conversation-a'],
+        ['conversation-b'],
+    ]
+
+
+def test_clean_app_history_page_streams_only_the_requested_visible_rows():
+    """Slack is paid only after a reported row, not by ordinary prompt assembly."""
+    collection = _FakeMessageCollection([_message(f'visible-{index}') for index in range(500)])
+    database = _FakeDatabase(collection)
+
+    with patch.object(chat_db, 'db', database):
+        messages = chat_db.get_app_messages('uid-1', 'app-1', limit=5)
+
+    assert [message['id'] for message in messages] == [f'visible-{index}' for index in range(5)]
+    assert collection.streamed == 5
+
+
+def test_clean_app_history_larger_than_one_firestore_batch_has_no_extra_read():
+    """A 101-row clean page should not fetch a second full 100-row batch."""
+    collection = _FakeMessageCollection([_message(f'visible-{index}') for index in range(500)])
+    database = _FakeDatabase(collection)
+
+    with patch.object(chat_db, 'db', database):
+        messages = chat_db.get_app_messages('uid-1', 'app-1', limit=101)
+
+    assert [message['id'] for message in messages] == [f'visible-{index}' for index in range(101)]
+    assert collection.streamed == 101
+
+
+def test_reported_app_history_scan_stops_at_its_bounded_slack():
+    """Reported-heavy app history cannot turn one notification read into an unbounded scan."""
+    collection = _FakeMessageCollection([_message(f'reported-{index}', reported=True) for index in range(5000)])
+    database = _FakeDatabase(collection)
+
+    with patch.object(chat_db, 'db', database):
+        messages = chat_db.get_app_messages('uid-1', 'app-1', limit=10)
+
+    assert messages == []
+    assert collection.streamed == 10 + chat_db.CHAT_MESSAGES_VISIBLE_PAGE_SCAN_SLACK
+
+
+def test_legacy_app_history_without_reported_field_remains_visible():
+    """Only explicit ``reported is True`` hides a row; omitted legacy fields stay visible."""
+    collection = _FakeMessageCollection(
+        [
+            _message('visible-a'),
+            _message('legacy-visible', reported=None),
+            _message('reported', reported=True),
+            _message('visible-b'),
+        ]
+    )
+    database = _FakeDatabase(collection)
+
+    with patch.object(chat_db, 'db', database):
+        messages = chat_db.get_app_messages('uid-1', 'app-1', limit=3)
+
+    assert [message['id'] for message in messages] == ['visible-a', 'legacy-visible', 'visible-b']
+
+
+def test_non_positive_app_history_limit_returns_without_a_firestore_read():
+    collection = _FakeMessageCollection([_message('visible-a')])
+    database = _FakeDatabase(collection)
+
+    with patch.object(chat_db, 'db', database):
+        assert chat_db.get_app_messages('uid-1', 'app-1', limit=0) == []
+        assert chat_db.get_app_messages('uid-1', 'app-1', limit=-1) == []
+
+    assert collection.streamed == 0


### PR DESCRIPTION
## Summary

`get_app_messages` applied its Firestore limit before filtering `reported` rows in Python. A reported app message inside the raw window therefore made app-integration callers receive a short history and leave older visible context unread.

The reader now scans the same newest-first `plugin_id` query as before until it fills the requested number of visible rows, reaches the collection tail, or spends the shared flat slack budget. A clean history reads exactly the requested row count across our capped 100-row batches; after it encounters a reported row, capped batches traverse hidden runs without one request per missing row. Hidden rows do not contribute conversation ids, and non-positive limits return before querying Firestore.

The regression fake exercises the production decorated function and proves a hidden middle row still fills the page, only returned rows hydrate conversations, clean pages (including 101 rows) read exactly their visible limit, omitted legacy `reported` fields remain visible, and a reported-only history stops exactly at the bounded budget. It is recorded as a third artifact for the existing visible-row pagination failure class.

## Dependency

Depends on #13018.

This main-targeted PR temporarily includes the independently reviewed 10-line test-only repair from `codex/meta-pagination-test-isolation`, which makes the action-items router pagination suite explicitly opt out of response caching. Merge #13018 first; after it merges, this PR's diff will contain only the app-history fix above that prerequisite.

## Product invariants affected

None.

## Verification

- `pytest tests/unit/test_get_app_messages_visible_pagination.py tests/unit/test_get_messages_reported_pagination.py tests/unit/test_app_integrations_safe_messages.py tests/unit/test_firestore_query_contract.py` — 63 passed.
- `python -m pyright tests/unit/test_get_app_messages_visible_pagination.py` — 0 errors.
- `scripts/failure-class validate --pr-body-file /tmp/omi-pr-meta-app-visible-history.md` — passed.
- `OMI_PR_BODY_FILE=/tmp/omi-pr-meta-app-visible-history.md make preflight` — passed 28 manifest checks.
- `backend/scripts/run-unit-ci.sh --changed-files <this PR's three paths>` — passed. `backend/database/chat.py` expands the selector to 1,107 discovered files; the runner executed 1,106 unit-test files after its E2E exclusion. The complete log is `/tmp/omi-app-history-stacked-run-unit-ci.log`.

## Honest gaps

No live Firestore or app-integration run; the hermetic fake models Firestore limit and keyset continuation for this database-only read path.

Failure-Class: FC-raw-page-limit-before-visibility-filter


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

