### PR TITLE
fix(app): shorten the home chat bar placeholder to "Ask Omi"

### DIFF
--- a/app/e2e/IOS_DEVICE_TESTING.md
+++ b/app/e2e/IOS_DEVICE_TESTING.md
@@ -67,7 +67,7 @@ Primary command palette (all verified on iOS):
 | Text entry that actually works | MCP `mcp__marionette__enter_text` with a `ValueKey` (see §6) |
 | Screenshot (last resort / human evidence) | `agent-flutter screenshot /tmp/x.png` — path **must** be under `/tmp` |
 
-Navigation facts and the current screen map live in [`SKILL.md`](./SKILL.md) — notably: chat opens from the **"Ask Omi anything…" input bar on home**, not a nav tab; back is the **in-app top-left IconButton** (`agent-flutter back` is adb/Android-only).
+Navigation facts and the current screen map live in [`SKILL.md`](./SKILL.md) — notably: chat opens from the **"Ask Omi" input bar on home**, not a nav tab; back is the **in-app top-left IconButton** (`agent-flutter back` is adb/Android-only).
 
 ## 5. Verify like an agent (no screenshots)
 

--- a/app/e2e/SKILL.md
+++ b/app/e2e/SKILL.md
@@ -122,7 +122,7 @@ Onboarding (wrapper.dart) — step wizard
 └── 11: Complete (complete_screen.dart) → Home
 
 Home (home/page.dart) — main app after auth, 4-slot bottom nav
-├── ["Ask Omi anything…" input bar] → Chat (chat/page.dart) — full-width bar above bottom nav, not a tab
+├── ["Ask Omi" input bar] → Chat (chat/page.dart) — full-width bar above bottom nav, not a tab
 │   ├── Message history, "Ask anything" field, AI responses
 │   └── AI-message action row: Copy ("✨ Message copied to clipboard" snackbar), thumbs up, thumbs down, Share
 ├── [mic in the bar] → Chat with voice auto-start
@@ -249,7 +249,7 @@ Speech Profile (speech_profile/page.dart)
   slot 3 = Apps marketplace ("Search 1500+ Apps" / "Featured")
 
 **Chat entry point (not a bottom-nav tab):**
-- Open chat by tapping the "Ask Omi anything…" input bar on the home screen — a full-width gesture
+- Open chat by tapping the "Ask Omi" input bar on the home screen — a full-width gesture
   element directly above the bottom nav (~y=756, w≈382 on a 414pt-wide screen; verified iOS 2026-07-11)
 
 **Settings gear:**

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -923,10 +923,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         child: Row(
           children: [
             const SizedBox(width: 18),
-            const Expanded(
+            Expanded(
               child: Text(
-                'Ask Omi anything about your life...',
-                style: TextStyle(color: Color(0xFF8E8E93), fontSize: 15),
+                context.l10n.askOmi,
+                style: const TextStyle(color: Color(0xFF8E8E93), fontSize: 15),
                 overflow: TextOverflow.ellipsis,
               ),
             ),


### PR DESCRIPTION
From this:
<img width="1206" height="651" alt="IMG_2331" src="https://github.com/user-attachments/assets/ca127083-c96e-4b7b-82e1-c1077a9efe69" />

To this:
<img width="1206" height="735" alt="askomi" src="https://github.com/user-attachments/assets/c1d16f08-5789-4121-b910-7ce2196012cd" />

## Summary

The chat bar on the mobile home screen read "Ask Omi anything about your life..." but the bar shares its row with the mic button and the record button, so the copy was cut off after "Ask Omi anything ab…" on a phone. The bar now reads **"Ask Omi"**, the same short prompt the app already uses for its "Ask Omi" shortcut, so it fits with room to spare at every width.

Changes:
- `app/lib/pages/home/page.dart`: the home chat bar uses the existing localized `askOmi` string ("Ask Omi") instead of a hardcoded English sentence. All 49 locales already translate that key, so the bar is localized for the first time as a side effect.
- `app/e2e/SKILL.md`, `app/e2e/IOS_DEVICE_TESTING.md`: the screen map now names the bar by its new copy.

## Verification

- `bash app/scripts/analyze_ratchet.sh` passes; `dart format` clean on the touched file.
- Copy-only change with no layout or behavior change; the tap targets and the voice button are untouched.

## Product invariants affected

none

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BViCmmJpJ3FaExYyxD2TJx


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

