### PR TITLE
fix(backend): preserve explicit null in action-item PATCH

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -986,7 +986,7 @@ def update_action_item(
     if action_item.get('is_locked', False):
         raise HTTPException(status_code=402, detail="A paid plan is required to access this action item.")
 
-    # Build update data from non-None fields
+    # Build update data from explicitly provided fields so due_at=null can clear the date.
     update_data = {}
     if request.description is not None:
         update_data['description'] = request.description.strip()
@@ -997,7 +997,7 @@ def update_action_item(
             update_data['completed_at'] = datetime.now(timezone.utc)
         else:
             update_data['completed_at'] = None
-    if request.due_at is not None:
+    if 'due_at' in request.model_fields_set:
         update_data['due_at'] = request.due_at
 
     if not update_data:

--- a/backend/tests/unit/test_dev_api_action_items_poison.py
+++ b/backend/tests/unit/test_dev_api_action_items_poison.py
@@ -153,13 +153,17 @@ from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from routers.developer import router as developer_router  # noqa: E402
 import routers.developer as developer_module  # noqa: E402
-from dependencies import get_uid_with_action_items_read  # noqa: E402
+from dependencies import (  # noqa: E402
+    get_uid_with_action_items_read,
+    get_uid_with_action_items_write,
+)
 
 
 def _build():
     app = FastAPI()
     app.include_router(developer_router)
     app.dependency_overrides[get_uid_with_action_items_read] = lambda: 'uid1'
+    app.dependency_overrides[get_uid_with_action_items_write] = lambda: 'uid1'
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -201,16 +205,15 @@ def _update_fixture():
 def test_developer_patch_explicit_null_clears_due_date_and_reminder():
     existing, _ = _update_fixture()
     updated = {**existing, 'due_at': None}
-    request = developer_module.UpdateActionItemRequest(due_at=None)
 
     with (
         patch.object(action_items_db, 'get_action_item', side_effect=[existing, updated]),
         patch.object(action_items_db, 'update_action_item', return_value=True) as update,
         patch.object(developer_module, 'sync_action_item_reminder') as sync,
     ):
-        result = developer_module.update_action_item('a1', request, uid='uid1')
+        response = _build().patch('/v1/dev/user/action-items/a1', json={'due_at': None})
 
-    assert request.model_fields_set == {'due_at'}
+    assert response.status_code == 200
     assert update.call_args.args[2] == {'due_at': None}
     sync.assert_called_once_with(
         user_id='uid1',
@@ -219,25 +222,27 @@ def test_developer_patch_explicit_null_clears_due_date_and_reminder():
         completed=False,
         due_at=None,
     )
-    assert result['due_at'] is None
+    assert response.json()['due_at'] is None
 
 
 def test_developer_patch_omitted_due_date_preserves_existing_value():
     existing, due = _update_fixture()
     updated = {**existing, 'description': 'Updated task'}
-    request = developer_module.UpdateActionItemRequest(description='Updated task')
 
     with (
         patch.object(action_items_db, 'get_action_item', side_effect=[existing, updated]),
         patch.object(action_items_db, 'update_action_item', return_value=True) as update,
         patch.object(developer_module, 'sync_action_item_reminder') as sync,
     ):
-        result = developer_module.update_action_item('a1', request, uid='uid1')
+        response = _build().patch(
+            '/v1/dev/user/action-items/a1',
+            json={'description': 'Updated task'},
+        )
 
-    assert 'due_at' not in request.model_fields_set
+    assert response.status_code == 200
     assert update.call_args.args[2] == {'description': 'Updated task'}
     sync.assert_not_called()
-    assert result['due_at'] == due
+    assert response.json()['due_at'] == due.isoformat().replace('+00:00', 'Z')
 
 
 def test_developer_patch_replaces_due_date_when_supplied():

--- a/backend/tests/unit/test_dev_api_action_items_poison.py
+++ b/backend/tests/unit/test_dev_api_action_items_poison.py
@@ -6,9 +6,13 @@ malformed record made FastAPI raise ResponseValidationError -> HTTP 500 for the 
 
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -181,3 +185,87 @@ def test_pagination_is_clamped_before_firestore():
     high = m.call_args_list[0].kwargs
     assert high['limit'] == 1000 and high['offset'] == 0  # 99999 -> 1000, -1 -> 0
     assert m.call_args_list[1].kwargs['limit'] == 1  # 0 -> 1
+
+
+def _update_fixture():
+    due = datetime(2026, 9, 10, 12, tzinfo=timezone.utc)
+    existing = {
+        'id': 'a1',
+        'description': 'Original task',
+        'completed': False,
+        'due_at': due,
+    }
+    return existing, due
+
+
+def test_developer_patch_explicit_null_clears_due_date_and_reminder():
+    existing, _ = _update_fixture()
+    updated = {**existing, 'due_at': None}
+    request = developer_module.UpdateActionItemRequest(due_at=None)
+
+    with (
+        patch.object(action_items_db, 'get_action_item', side_effect=[existing, updated]),
+        patch.object(action_items_db, 'update_action_item', return_value=True) as update,
+        patch.object(developer_module, 'sync_action_item_reminder') as sync,
+    ):
+        result = developer_module.update_action_item('a1', request, uid='uid1')
+
+    assert request.model_fields_set == {'due_at'}
+    assert update.call_args.args[2] == {'due_at': None}
+    sync.assert_called_once_with(
+        user_id='uid1',
+        action_item_id='a1',
+        description='Original task',
+        completed=False,
+        due_at=None,
+    )
+    assert result['due_at'] is None
+
+
+def test_developer_patch_omitted_due_date_preserves_existing_value():
+    existing, due = _update_fixture()
+    updated = {**existing, 'description': 'Updated task'}
+    request = developer_module.UpdateActionItemRequest(description='Updated task')
+
+    with (
+        patch.object(action_items_db, 'get_action_item', side_effect=[existing, updated]),
+        patch.object(action_items_db, 'update_action_item', return_value=True) as update,
+        patch.object(developer_module, 'sync_action_item_reminder') as sync,
+    ):
+        result = developer_module.update_action_item('a1', request, uid='uid1')
+
+    assert 'due_at' not in request.model_fields_set
+    assert update.call_args.args[2] == {'description': 'Updated task'}
+    sync.assert_not_called()
+    assert result['due_at'] == due
+
+
+def test_developer_patch_replaces_due_date_when_supplied():
+    existing, _ = _update_fixture()
+    replacement = datetime(2026, 9, 12, 12, tzinfo=timezone.utc)
+    updated = {**existing, 'due_at': replacement}
+    request = developer_module.UpdateActionItemRequest(due_at=replacement)
+
+    with (
+        patch.object(action_items_db, 'get_action_item', side_effect=[existing, updated]),
+        patch.object(action_items_db, 'update_action_item', return_value=True) as update,
+        patch.object(developer_module, 'sync_action_item_reminder') as sync,
+    ):
+        result = developer_module.update_action_item('a1', request, uid='uid1')
+
+    assert update.call_args.args[2] == {'due_at': replacement}
+    sync.assert_called_once()
+    assert sync.call_args.kwargs['due_at'] == replacement
+    assert result['due_at'] == replacement
+
+
+def test_developer_patch_rejects_empty_payload():
+    existing, _ = _update_fixture()
+    request = developer_module.UpdateActionItemRequest()
+
+    with patch.object(action_items_db, 'get_action_item', return_value=existing):
+        with pytest.raises(HTTPException) as exc:
+            developer_module.update_action_item('a1', request, uid='uid1')
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == 'At least one field must be provided'


### PR DESCRIPTION
## Summary

- Fixes `PATCH /v1/dev/user/action-items/{id}` so an explicit `due_at: null` clears the due date.
- Keeps an omitted `due_at` unchanged and continues to apply a supplied replacement date.
- Reconciles the reminder after an explicit due-date change, including clearing it.

Fixes #13022

## Root cause

The route built its update payload by discarding `None` values. That made an explicit JSON `null` indistinguishable from an omitted field: a null-only request became an empty update, while a combined update silently retained the old due date.

The route now checks Pydantic's explicitly-provided field set before adding `due_at` to the update payload.

## Verification

- `backend/.venv/bin/python -m pytest -q tests/unit/test_dev_api_action_items_poison.py` — 6 passed
- `backend/.venv/bin/python -m pytest -q tests/unit/test_action_item_reminder_cancel_on_complete.py` — 7 passed
- `backend/.venv/bin/python -m pytest -q tests/unit/test_action_item_canonical_contract.py` — 18 passed
- `scripts/backend-python-format --check backend/routers/developer.py backend/tests/unit/test_dev_api_action_items_poison.py` — unchanged
- `backend/.venv/bin/python -m compileall -q backend/routers/developer.py backend/tests/unit/test_dev_api_action_items_poison.py` — passed
- `git diff --check` — passed

The regression test fails against the unmodified route for the explicit-null behavior and passes with this patch. Tests use synthetic records and mocked persistence/reminder boundaries; no customer data or deployed service was accessed. The full backend merge gate was not run.

## Scope

- No schema, migration, API authentication, or customer-data changes.
- No deployed-service verification was performed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

