### PR TITLE
fix(cli): preserve resource delete responses in JSON mode

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -259,6 +259,8 @@ The CLI is built so an LLM can use it without a wrapper:
   mode (errors go to stderr as `{"error": "...", "detail": "..."}`).
 * Stable exit codes (above) let an agent disambiguate retryable vs terminal
   errors.
+* Successful resource `delete --yes` commands preserve the API response in
+  JSON mode. A successful response without a body is emitted as JSON `null`.
 * Rate-limit errors include a `Retry-After` window in the message and surface
   the policy name (`dev:conversations`, etc.) so an agent can back off
   intelligently.

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -158,5 +158,7 @@ def delete_action_item(
     if not confirm:
         typer.confirm(f"Delete action item {action_item_id}?", abort=True)
     with ctx.make_client() as client:
-        client.delete(f"/v1/dev/user/action-items/{action_item_id}")
+        result = client.delete(f"/v1/dev/user/action-items/{action_item_id}")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(result)
     ctx.renderer.success(f"Deleted action item [bold]{action_item_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -198,5 +198,7 @@ def delete_conversation(
     if not confirm:
         typer.confirm(f"Delete conversation {conversation_id}?", abort=True)
     with ctx.make_client() as client:
-        client.delete(f"/v1/dev/user/conversations/{conversation_id}")
+        result = client.delete(f"/v1/dev/user/conversations/{conversation_id}")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(result)
     ctx.renderer.success(f"Deleted conversation [bold]{conversation_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -168,5 +168,7 @@ def delete_goal(
     if not confirm:
         typer.confirm(f"Delete goal {goal_id}?", abort=True)
     with ctx.make_client() as client:
-        client.delete(f"/v1/dev/user/goals/{goal_id}")
+        result = client.delete(f"/v1/dev/user/goals/{goal_id}")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(result)
     ctx.renderer.success(f"Deleted goal [bold]{goal_id}[/bold].")

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -147,5 +147,7 @@ def delete_memory(
     if not confirm:
         typer.confirm(f"Delete memory {memory_id}?", abort=True)
     with ctx.make_client() as client:
-        client.delete(f"/v1/dev/user/memories/{memory_id}")
+        result = client.delete(f"/v1/dev/user/memories/{memory_id}")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(result)
     ctx.renderer.success(f"Deleted memory [bold]{memory_id}[/bold].")

--- a/sdks/python-cli/tests/test_delete_output.py
+++ b/sdks/python-cli/tests/test_delete_output.py
@@ -1,0 +1,55 @@
+"""The four resource DELETE commands preserve the CLI's JSON output contract."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omi_cli.main import app
+
+
+@pytest.fixture(params=["memory", "conversation", "action-item", "goal"])
+def resource(request):
+    command = request.param
+    collection = {
+        "memory": "memories",
+        "conversation": "conversations",
+        "action-item": "action-items",
+        "goal": "goals",
+    }[command]
+    return command, f"/v1/dev/user/{collection}/test-id"
+
+
+@pytest.mark.parametrize("status_code,payload", [(200, {"success": True}), (204, None)])
+def test_delete_json_preserves_success_response(
+    resource, status_code, payload, authed_profile, respx_mock, cli_runner
+) -> None:
+    command, path = resource
+    route = respx_mock.delete(path).respond(status_code, json=payload)
+    result = cli_runner.invoke(app, ["--json", command, "delete", "test-id", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert route.call_count == 1
+    assert json.loads(result.stdout) == payload
+    assert result.stderr == ""
+
+
+def test_delete_pretty_keeps_success_message(resource, authed_profile, respx_mock, cli_runner) -> None:
+    command, path = resource
+    respx_mock.delete(path).respond(json={"success": True})
+    result = cli_runner.invoke(app, ["--no-color", command, "delete", "test-id", "--yes"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert "Deleted" in result.stderr
+    assert "test-id" in result.stderr
+
+
+def test_delete_declined_confirmation_makes_no_request(resource, authed_profile, respx_mock, cli_runner) -> None:
+    command, path = resource
+    route = respx_mock.delete(path).respond(json={"success": True})
+    result = cli_runner.invoke(app, ["--json", command, "delete", "test-id"], input="n\n")
+
+    assert result.exit_code != 0
+    assert not route.called


### PR DESCRIPTION
## What changed and why

Fixes #13028. Successful `omi --json {memory,conversation,action-item,goal} delete ID --yes` commands currently exit 0 with empty stdout, violating the JSON output contract. Preserve the existing client's return value through the JSON renderer, including `null` for an empty successful response, while retaining confirmations and pretty-mode success messages.

## Product invariants affected

none

## How it was verified

- Python 3.12.14 on macOS, from `sdks/python-cli`: `python -m pytest -q` — **144 passed, 1 Windows-specific test skipped**.
- Independent automated review reran the shared suite plus the existing memory, conversation, action-item and goal modules — **43 passed**.
- Exercised the installed `omi` executable with a temporary config and synthetic loopback server: all four commands with HTTP 200 `{"success": true}` and HTTP 204. Unchanged upstream produced **0/8 valid JSON outputs**; this patch produced **8/8**, each after exactly one request. No live Omi account, user data or hardware was used.
- `python -m black --check` on the five changed Python files and `git diff --check` passed.
- `make preflight` with the prepared Python environment and this draft body — all 12 selected check commands succeeded. The historical failure-class guard explicitly skips because this checkout is shallow; its 90-day audit still needs full-history CI. Required tracked manifest, registry and repository-wide source-scan inputs were materialized before this run.
- `scripts/pr-preflight --pr-body-file <draft>` and the standard pre-push hook passed against tested base `01320e54d06576f3ac944a473295ffc6913e7ddf`, with the same disclosed history skip. Upstream CI has not yet been verified.

## Tests

`tests/test_delete_output.py` adds 16 parametrized cases through the registered Typer commands and existing intercepted-HTTP fixtures: JSON 200/204 output, unchanged pretty output and declined confirmation without a request for each resource. README documents the successful response contract.

## Failure class (fixes)

Failure-Class: none

## Contribution context

AI-assisted implementation and independent automated review using Codex on behalf of @solracnyc. The US$10 bounty request in #13028 is a proposal awaiting maintainer agreement. This patch addresses successful delete acknowledgements; it does not claim to resolve #13012's full output architecture or #12955's separate empty HTTP error handling.

Independent follow-up: Claude Fable 5.1 reviewed the exact submitted commit after publication, reproduced the tests above and found no blocking issues within scope. One existing limitation remains: JSON `null` reflects the client's response classification. Until #12955 is fixed, an empty-body HTTP error can still be misclassified as success; this patch does not fix that client behavior. GitHub Actions await maintainer approval.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

