### PR TITLE
fix: preserve CV1 Opus codec identity in React Native SDK

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: react-native-sdk-cv1-codec
+    command: ["bun", "test", "./.github/tests/react_native_codec.test.ts"]
+    triggers: ["sdks/react-native/src/OmiConnection.ts", "sdks/react-native/src/types.ts", "sdks/react-native/src/codecs.ts", "sdks/device/PROTOCOL.md", ".github/tests/react_native_codec.test.ts"]
+    lanes: ["local", "ci"]
+    reason: "#13026: the React Native SDK reports CV1 codec 21 as PCM8; the public connection-path regression exercises discovery, characteristic decoding and codec selection without native hardware"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/.github/tests/react_native_codec.test.ts
+++ b/.github/tests/react_native_codec.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test';
+
+let encodedCodec = '';
+const device = {
+  discoverAllServicesAndCharacteristics: async () => {},
+  onDisconnected: () => {},
+  cancelConnection: async () => {},
+  services: async () => [{
+    uuid: '19b10000-e8f2-537e-4f6c-d104768a1214',
+    characteristics: async () => [{
+      uuid: '19b10002-e8f2-537e-4f6c-d104768a1214',
+      read: async () => ({ value: encodedCodec }),
+    }],
+  }],
+};
+
+// Only the native transport is replaced; discovery, base64 decoding and codec
+// selection all execute the production public SDK path. No device or network.
+mock.module('react-native', () => ({ Platform: { OS: 'ios' } }));
+mock.module('react-native-ble-plx', () => ({
+  BleManager: class {
+    async connectToDevice() { return device; }
+  },
+}));
+
+const { OmiConnection } = await import('../../sdks/react-native/src/OmiConnection');
+const { BleAudioCodec } = await import('../../sdks/react-native/src/types');
+const { mapCodecToName } = await import('../../sdks/react-native/src/codecs');
+let connection: InstanceType<typeof OmiConnection>;
+
+beforeEach(async () => {
+  encodedCodec = '';
+  connection = new OmiConnection();
+  expect(await connection.connect('synthetic-device')).toBe(true);
+});
+
+afterEach(async () => {
+  await connection.disconnect();
+});
+
+test('CV1 wire codec 21 stays Opus FS320 instead of falling back to PCM8', async () => {
+  // sdks/device/PROTOCOL.md: CV1 reports 21, 320 samples per 20 ms frame.
+  encodedCodec = Buffer.from([21]).toString('base64');
+  expect(await connection.getAudioCodec()).toBe('opus_fs320');
+  expect(BleAudioCodec.OPUS_FS320).toBe('opus_fs320');
+});
+
+test('CV1 has a codec name that preserves its frame-duration distinction', () => {
+  expect(mapCodecToName('opus_fs320' as typeof BleAudioCodec.OPUS_FS320)).toBe('Opus FS320 (20 ms)');
+});
+
+test.each([
+  [1, 'pcm8'],
+  [20, 'opus'],
+])('existing codec %i remains %s', async (wire, expected) => {
+  encodedCodec = Buffer.from([Number(wire)]).toString('base64');
+  expect(await connection.getAudioCodec()).toBe(expected);
+});
+
+test('missing codec characteristic data retains its previous fallback', async () => {
+  expect(await connection.getAudioCodec()).toBe('pcm8');
+});

--- a/docs/doc/developer/sdk/ReactNative.mdx
+++ b/docs/doc/developer/sdk/ReactNative.mdx
@@ -236,6 +236,28 @@ async function connectToDevice(deviceId) {
 
 ---
 
+## Omi CV1 Audio Codec
+
+`getAudioCodec()` returns `BleAudioCodec.OPUS_FS320` (`opus_fs320`) for Omi CV1
+devices reporting codec ID 21. These are 320-sample Opus frames (20 ms at 16 kHz),
+distinct from DevKit codec ID 20 (`BleAudioCodec.OPUS`, 160-sample / 10 ms frames).
+Both codecs carry Opus audio; do not interpret a CV1 stream as PCM8.
+
+`mapCodecToName(BleAudioCodec.OPUS_FS320)` returns `Opus FS320 (20 ms)`.
+
+### Codec Regression Tests
+
+From the repository root, with Bun 1.3.14 (the version used by Repo Checks):
+
+```bash
+bun test ./.github/tests/react_native_codec.test.ts
+```
+
+The test exercises the public connection and codec-reading methods with a mocked
+native BLE boundary. It needs no device, network service, or installed native
+modules and runs through the shared check manifest in local and CI lanes. It does
+not replace physical-device audio validation.
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/docs/doc/developer/sdk/ReactNative.mdx
+++ b/docs/doc/developer/sdk/ReactNative.mdx
@@ -228,6 +228,7 @@ async function connectToDevice(deviceId) {
       PCM16 = 'pcm16',
       PCM8 = 'pcm8',
       OPUS = 'opus',
+      OPUS_FS320 = 'opus_fs320',
       UNKNOWN = 'unknown'
     }
     ```

--- a/sdks/react-native/README.md
+++ b/sdks/react-native/README.md
@@ -113,6 +113,28 @@ async function connectToDevice(deviceId) {
 ```
 
 
+## Omi CV1 Audio Codec
+
+`getAudioCodec()` returns `BleAudioCodec.OPUS_FS320` (`opus_fs320`) for Omi CV1
+devices reporting codec ID 21. These are 320-sample Opus frames (20 ms at 16 kHz),
+distinct from DevKit codec ID 20 (`BleAudioCodec.OPUS`, 160-sample / 10 ms frames).
+Both codecs carry Opus audio; do not interpret a CV1 stream as PCM8.
+
+`mapCodecToName(BleAudioCodec.OPUS_FS320)` returns `Opus FS320 (20 ms)`.
+
+### Codec Regression Tests
+
+From the repository root, with Bun 1.3.14 (the version used by Repo Checks):
+
+```bash
+bun test ./.github/tests/react_native_codec.test.ts
+```
+
+The test exercises the public connection and codec-reading methods with a mocked
+native BLE boundary. It needs no device, network service, or installed native
+modules and runs through the shared check manifest in local and CI lanes. It does
+not replace physical-device audio validation.
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/sdks/react-native/src/OmiConnection.ts
+++ b/sdks/react-native/src/OmiConnection.ts
@@ -254,6 +254,9 @@ export class OmiConnection {
         case 20:
           codec = BleAudioCodec.OPUS;
           break;
+        case 21:
+          codec = BleAudioCodec.OPUS_FS320;
+          break;
         default:
           console.warn(`Unknown codec id: ${codecId}`);
           break;

--- a/sdks/react-native/src/codecs.ts
+++ b/sdks/react-native/src/codecs.ts
@@ -17,6 +17,8 @@ export function mapCodecToName(codec: BleAudioCodec): string {
       return 'PCM 8-bit';
     case BleAudioCodec.OPUS:
       return 'Opus';
+    case BleAudioCodec.OPUS_FS320:
+      return 'Opus FS320 (20 ms)';
     default:
       return 'Unknown';
   }

--- a/sdks/react-native/src/types.ts
+++ b/sdks/react-native/src/types.ts
@@ -6,6 +6,8 @@ export enum BleAudioCodec {
   PCM16 = 'pcm16',
   PCM8 = 'pcm8',
   OPUS = 'opus',
+  /** Omi CV1: 320-sample Opus frames (20 ms at 16 kHz). */
+  OPUS_FS320 = 'opus_fs320',
   UNKNOWN = 'unknown',
 }
 


### PR DESCRIPTION
Omi CV1 reports audio codec 21, but the React Native SDK currently returns PCM8 for that characteristic. Add the `OPUS_FS320` enum value (`opus_fs320`), map codec 21 to it, and expose the distinct 20 ms display name. This aligns the React Native public API with the existing shared device protocol and #11254/#11255.

Fixes #13026.

The regression connects through a synthetic BLE device and exercises the actual discovery, characteristic read, base64 decoding and codec mapping. Before the fix, the CV1 mapping and display-name tests fail while three controls pass; after it, all five pass. The shared manifest registers the test for local and CI execution, and the source MDX and regenerated SDK README describe the new enum and test command.

Why isn't this a shared primitive instead? The defect is a missing case in this SDK's authoritative wire-to-enum mapping. The patch corrects that owner directly, without adding another fallback or observer. The behavioral regression covers the concrete defect in #13026; the wire contract is `sdks/device/PROTOCOL.md`.

Validation:

- Bun 1.3.14: `bun test ./.github/tests/react_native_codec.test.ts` — 5 pass, 0 fail, 11 assertions.
- Baseline production source with the same test — 3 pass, 2 fail, isolating the codec 21 and display-name failures.
- Same suite in an isolated copy with no installed native modules — 5 pass.
- Manifest contract suite — 47 tests, 1 skipped, no failures.
- Full local shared-check run on the seven-file working diff — 13 checks pass, including the 90-day failure-class historical audit with full repository history.
- `npm run typecheck` — fails with the same three STT diagnostics before and after the patch; output is byte-identical. The errors concern WebSocket `binaryType` in deepgram/parakeet and the optional WebSocket factory in stt/index.
- No physical CV1 or native mobile app was tested. This verifies the software mapping, not live audio capture or decoding.

Product invariants affected: none.

Failure-Class: none

AI assistance: this investigation, implementation and software verification were performed with OpenAI Codex.

No award or payment agreement is assumed. The bounty inquiry in #13026 remains subject to maintainer approval.


- Committed-diff PR preflight and the bounded pre-push gate passed before publication. CI remains the full test authority.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

