### PR TITLE
fix(desktop): prevent black bands in Rewind window captures

### DIFF
--- a/.github/failure-classes/FC-transparent-capture-flattened-without-backing.json
+++ b/.github/failure-classes/FC-transparent-capture-flattened-without-backing.json
@@ -11,7 +11,7 @@
   "scope_hints": [
     "desktop/macos/Desktop/Sources/ScreenCaptureService.swift",
     "desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift",
-    "desktop/macos/Desktop/Sources/VideoChunkEncoder.swift"
+    "desktop/macos/Desktop/Sources/Rewind/Core/VideoChunkEncoder.swift"
   ],
   "status": "open"
 }

--- a/.github/failure-classes/FC-transparent-capture-flattened-without-backing.json
+++ b/.github/failure-classes/FC-transparent-capture-flattened-without-backing.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-transparent-capture-flattened-without-backing",
+  "violated_contract": "Pixels produced by a capture API with transparency must not cross into an opaque persistence format without an explicit backing policy. Otherwise window shadows and translucent margins are silently flattened into black stored content, so every downstream Rewind surface faithfully renders corruption that no display-side layout can remove.",
+  "canonical_prevention": "Configure single-window capture at the shared ScreenCaptureKit boundary to exclude shadow framing and request opaque backing before frames reach JPEG or HEVC sinks. Keep a behavioral contract test against SCStreamConfiguration so both one-shot and persistent capture engines inherit the same pixel-integrity policy.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/ScreenCaptureService.swift",
+    "desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ScreenCaptureService.swift",
+    "desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift",
+    "desktop/macos/Desktop/Sources/VideoChunkEncoder.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -1013,7 +1013,22 @@ final class ScreenCaptureService: Sendable {
     return (Int(configWidth), Int(configHeight))
   }
 
+  /// Keep single-window captures safe for opaque storage formats.
+  ///
+  /// ScreenCaptureKit includes window framing/shadows by default and represents
+  /// those pixels, plus any other translucent window content, with alpha. Rewind
+  /// persists JPEG and HEVC projections that cannot retain that alpha; allowing the
+  /// default clear backing through makes the transparent region become a black band.
+  /// Remove the framing and ask ScreenCaptureKit to back any remaining transparency
+  /// with its documented solid-white opaque fill before bytes reach either sink.
+  @available(macOS 14.0, *)
+  static func applySingleWindowPixelIntegrityPolicy(to configuration: SCStreamConfiguration) {
+    configuration.ignoreShadowsSingleWindow = true
+    configuration.shouldBeOpaque = true
+  }
+
   /// Aspect-preserving stream configuration, or nil if the window has no area.
+  @available(macOS 14.0, *)
   private func captureConfiguration(for window: SCWindow, maxSize: CGFloat = ScreenCaptureService.maxSize)
     -> SCStreamConfiguration?
   {
@@ -1027,6 +1042,7 @@ final class ScreenCaptureService: Sendable {
     config.showsCursor = false
     config.width = size.width
     config.height = size.height
+    Self.applySingleWindowPixelIntegrityPolicy(to: config)
     return config
   }
 

--- a/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
+++ b/desktop/macos/Desktop/Sources/WindowCaptureStreamEngine.swift
@@ -374,6 +374,7 @@ actor WindowCaptureStreamEngine {
     config.width = Int(size.width)
     config.height = Int(size.height)
     config.pixelFormat = kCVPixelFormatType_32BGRA
+    ScreenCaptureService.applySingleWindowPixelIntegrityPolicy(to: config)
     config.minimumFrameInterval = Self.minimumFrameInterval
     config.queueDepth = 3
     return config

--- a/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
@@ -1,3 +1,4 @@
+import ScreenCaptureKit
 import XCTest
 
 @testable import Omi_Computer
@@ -62,5 +63,15 @@ final class ScreenCaptureDimensionsTests: XCTestCase {
 
   func testReturnsNilForNegativeFrame() {
     XCTAssertNil(ScreenCaptureService.captureDimensions(width: -100, height: 900, maxSize: maxSize))
+  }
+
+  @available(macOS 14.0, *)
+  func testSingleWindowCaptureConfigurationProducesOpaqueContentWithoutShadowFraming() {
+    let configuration = SCStreamConfiguration()
+
+    ScreenCaptureService.applySingleWindowPixelIntegrityPolicy(to: configuration)
+
+    XCTAssertTrue(configuration.ignoreShadowsSingleWindow)
+    XCTAssertTrue(configuration.shouldBeOpaque)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260907-rewind-opaque-window-captures.json
+++ b/desktop/macos/changelog/unreleased/20260907-rewind-opaque-window-captures.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed black transparent bands being baked into Rewind window captures"
+}


### PR DESCRIPTION
## What changed and why

Fixes #11207.

Rewind's single-window capture paths allowed ScreenCaptureKit's transparent shadow/framing pixels to reach opaque JPEG and HEVC sinks, where those pixels were flattened into the wide black band stored on disk. This PR adds one shared pixel-integrity policy for both the one-shot screenshot path and the persistent window stream: exclude single-window shadows and ask ScreenCaptureKit to back any remaining transparency with opaque white before encoding.

This follows ScreenCaptureKit's documented contracts for [`ignoreShadowsSingleWindow`](https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/ignoreshadowssinglewindow) and [`shouldBeOpaque`](https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration/shouldbeopaque).

## Product invariants affected

none

## How it was verified

- `xcrun swift test --package-path Desktop --filter 'ScreenCaptureDimensionsTests|WindowCaptureStreamPolicyTests|WindowCaptureFrameSinkTests|ScreenCaptureWebPTests'` — 25 tests passed, 0 failures.
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/ScreenCaptureService.swift Desktop/Sources/WindowCaptureStreamEngine.swift Desktop/Tests/ScreenCaptureDimensionsTests.swift` — changed Swift files passed the pinned formatter.
- `./scripts/swiftlint-wrapper.sh lint` — 1,633 files linted, 0 violations.
- `python3 scripts/check_desktop_test_quality.py` — test-quality ratchet passed.
- `make preflight` — repository PR contracts passed.

A full named-bundle capture comparison is tracked as the final manual proof because macOS Screen Recording permission is TCC-gated per bundle identity.

## Tests

`ScreenCaptureDimensionsTests.testSingleWindowCaptureConfigurationProducesOpaqueContentWithoutShadowFraming` constructs the real production `SCStreamConfiguration`, applies the shared policy, and verifies that shadow framing is excluded and the output is opaque. The same helper is called by both one-shot and persistent capture engines.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

**Violated contract:** capture pixels that may contain alpha cannot cross into opaque persistence formats without an explicit backing policy; otherwise transparent framing becomes stored black content.

**Canonical guard:** both single-window capture engines now call one shared ScreenCaptureKit configuration primitive that excludes shadow framing and requests opaque backing, with a behavioral regression test against the real configuration object.

**Evidence:** issue #11207 measured the corruption inside the stored image rather than in presentation layout, and the production paths persist those capture frames into JPEG/HEVC formats that cannot preserve alpha. The new `FC-transparent-capture-flattened-without-backing` registry entry records this boundary for future capture sinks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

