### PR TITLE
fix(ci): point prod pusher alert-route at MONITOR_GRAFANA_TOKEN

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -242,27 +242,23 @@ jobs:
       - name: Verify live finalization alert route before publishing
         if: env.SERVICE == 'pusher'
         env:
-          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+          # Dest: repo MONITOR_GRAFANA_TOKEN → monitor.omiapi.com
+          # Prod: environment MONITOR_GRAFANA_TOKEN → monitor.omi.me
+          # Do not use GRAFANA_TOKEN; that belongs to the TV Cloud Run Grafana.
           MONITOR_GRAFANA_TOKEN: ${{ secrets.MONITOR_GRAFANA_TOKEN }}
         run: |
           set -euo pipefail
           umask 077
           token_file="$(mktemp "$RUNNER_TEMP/omi-grafana-token.XXXXXX")"
-          cleanup() { rm -f "$token_file"; unset GRAFANA_TOKEN MONITOR_GRAFANA_TOKEN grafana_token; }
+          cleanup() { rm -f "$token_file"; unset MONITOR_GRAFANA_TOKEN; }
           trap cleanup EXIT
+          test -n "$MONITOR_GRAFANA_TOKEN"
           case "${{ vars.ENV }}" in
-            dev|development)
-              grafana_url=https://monitor.omiapi.com
-              grafana_token="${MONITOR_GRAFANA_TOKEN:-}"
-              ;;
-            prod)
-              grafana_url=https://monitor.omi.me
-              grafana_token="${GRAFANA_TOKEN:-}"
-              ;;
+            dev|development) grafana_url=https://monitor.omiapi.com ;;
+            prod) grafana_url=https://monitor.omi.me ;;
             *) echo "Unsupported Grafana environment." >&2; exit 1 ;;
           esac
-          test -n "$grafana_token"
-          printf '%s' "$grafana_token" > "$token_file"
+          printf '%s' "$MONITOR_GRAFANA_TOKEN" > "$token_file"
           python3 backend/scripts/verify_pusher_live_alert_route.py \
             --grafana-url "$grafana_url" \
             --token-file "$token_file" \
@@ -658,15 +654,15 @@ jobs:
       - name: Reverify live finalization alert route after production rollout
         if: env.SERVICE == 'pusher' && github.event.inputs.environment == 'prod'
         env:
-          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+          MONITOR_GRAFANA_TOKEN: ${{ secrets.MONITOR_GRAFANA_TOKEN }}
         run: |
           set -euo pipefail
           umask 077
           token_file="$(mktemp "$RUNNER_TEMP/omi-grafana-final-token.XXXXXX")"
-          cleanup() { rm -f "$token_file"; unset GRAFANA_TOKEN; }
+          cleanup() { rm -f "$token_file"; unset MONITOR_GRAFANA_TOKEN; }
           trap cleanup EXIT
-          test -n "$GRAFANA_TOKEN"
-          printf '%s' "$GRAFANA_TOKEN" > "$token_file"
+          test -n "$MONITOR_GRAFANA_TOKEN"
+          printf '%s' "$MONITOR_GRAFANA_TOKEN" > "$token_file"
           python3 backend/scripts/verify_pusher_live_alert_route.py \
             --grafana-url https://monitor.omi.me \
             --token-file "$token_file" \

--- a/backend/charts/monitoring/README.md
+++ b/backend/charts/monitoring/README.md
@@ -584,9 +584,11 @@ with byte-for-byte equal objects when indexed by stable Grafana UID. The determi
 both exports, including duplicate UIDs, before a change can land.
 
 Pusher release workflows additionally call `verify_pusher_live_alert_route.py`
-before publishing or promoting an image. The protected `GRAFANA_TOKEN` secret
-must be able to read provisioned alert rules, datasource health and queries,
-and contact points. The gate fails closed unless the committed memory-admission
+before publishing or promoting an image. The protected `MONITOR_GRAFANA_TOKEN`
+secret (repo-scoped for dest `monitor.omiapi.com`, `prod` environment-scoped
+for `monitor.omi.me`) must be able to read provisioned alert rules, datasource
+health and queries, and contact points. Do not reuse `GRAFANA_TOKEN` here; that
+secret belongs to the TV Cloud Run Grafana. The gate fails closed unless the committed memory-admission
 and capture-outcome pager set is live and unpaused, Prometheus reports healthy,
 both Pusher and backend-listen scrape targets are currently healthy, and the
 exact Telegram receiver exists with resolve notifications enabled. After each

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -183,7 +183,9 @@ deployment health, not read as zero traffic.
 
 Both Pusher release workflows verify the live Grafana provisioning contract
 before any image publication or promotion. This requires the protected
-`GRAFANA_TOKEN` secret and proves the exact memory-admission and capture-outcome
+`MONITOR_GRAFANA_TOKEN` secret (dest repo secret for `monitor.omiapi.com`,
+prod environment secret for `monitor.omi.me`; never the TV `GRAFANA_TOKEN`)
+and proves the exact memory-admission and capture-outcome
 rule identities and expressions, unpaused state, healthy Prometheus datasource,
 current healthy Pusher/backend-listen scrape targets, and Telegram contact-point
 route. The post-rollout proof additionally requires all three finalization

--- a/backend/tests/unit/test_pusher_deployment_control_workflow.py
+++ b/backend/tests/unit/test_pusher_deployment_control_workflow.py
@@ -131,7 +131,7 @@ def test_dev_and_prod_require_the_live_finalization_alert_route_before_publishin
     assert "secrets.MONITOR_GRAFANA_TOKEN" in AUTO
     assert "secrets.GRAFANA_TOKEN" not in AUTO
     assert "secrets.MONITOR_GRAFANA_TOKEN" in MANUAL
-    assert "secrets.GRAFANA_TOKEN" in MANUAL
+    assert "secrets.GRAFANA_TOKEN" not in MANUAL
 
 
 def test_prod_rechecks_live_finalization_alerts_after_rollout_before_final_pass() -> None:


### PR DESCRIPTION
## Summary
- Prod pusher alert-route steps now read `MONITOR_GRAFANA_TOKEN` against `https://monitor.omi.me`.
- Dest already uses the same secret name (repo-scoped) for `monitor.omiapi.com`. The `prod` GitHub environment secret is a different value.
- Leave TV `GRAFANA_TOKEN` + `GRAFANA_URL` for omi-tv. Do not skip the alert-route gate.

## Test plan
- [x] Token authenticates on `monitor.omi.me` (health 200, seven rule UIDs 200, Prometheus health 200)
- [ ] Repo `MONITOR_GRAFANA_TOKEN` `updated_at` remains 2026-09-08T01:49:27Z
- [ ] Repo `GRAFANA_TOKEN` `updated_at` remains 2026-08-18T23:08:07Z

## Product invariants affected

- INV-DATA-1

## Failure class (fixes)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

