### PR TITLE
fix(react-native): deliver Whisper transcripts after stop

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: react-native-whisper-tests
+    command: ["bun", "test", "sdks/react-native/tests/whisper.test.mjs"]
+    triggers: ["sdks/react-native/src/stt/**", "sdks/react-native/tests/**"]
+    lanes: ["local", "ci"]
+    reason: "#13011: stopping Whisper must deliver accepted audio, including the buffered final tail and in-flight decodes"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/docs/doc/developer/sdk/ReactNative.mdx
+++ b/docs/doc/developer/sdk/ReactNative.mdx
@@ -276,7 +276,8 @@ async function connectToDevice(deviceId) {
 For the injected Whisper runner, `stop()` stops accepting new PCM audio and
 flushes any buffered tail. Transcripts from accepted audio are still delivered
 through `onTranscript`, including decodes that finish after `stop()` returns.
-Repeated `stop()` calls do not decode the tail again.
+Decodes run sequentially in the order audio was accepted, so a short tail cannot
+overtake an earlier batch. Repeated `stop()` calls do not decode the tail again.
 
 Run the hardware-independent stop behavior tests from the repository root:
 

--- a/docs/doc/developer/sdk/ReactNative.mdx
+++ b/docs/doc/developer/sdk/ReactNative.mdx
@@ -271,6 +271,19 @@ async function connectToDevice(deviceId) {
 
 ---
 
+## Local Whisper transcription
+
+For the injected Whisper runner, `stop()` stops accepting new PCM audio and
+flushes any buffered tail. Transcripts from accepted audio are still delivered
+through `onTranscript`, including decodes that finish after `stop()` returns.
+Repeated `stop()` calls do not decode the tail again.
+
+Run the hardware-independent stop behavior tests from the repository root:
+
+```bash
+bun test sdks/react-native/tests/whisper.test.mjs
+```
+
 ## License
 
 MIT License

--- a/sdks/react-native/src/stt/whisper.ts
+++ b/sdks/react-native/src/stt/whisper.ts
@@ -14,13 +14,19 @@ export function createWhisperTranscriber(options: {
   const batchBytes = (options.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
+  let pending = Promise.resolve();
 
-  async function flush() {
+  function flush() {
     if (buffer.byteLength === 0) return;
     const pcm = buffer;
     buffer = new Uint8Array(0);
-    const text = await options.runner(pcm);
-    if (text) options.onTranscript(text);
+    const decode = async () => {
+      const text = await options.runner(pcm);
+      if (text) options.onTranscript(text);
+    };
+    // A failed batch must not prevent later accepted audio from being decoded.
+    pending = pending.then(decode, decode);
+    return pending;
   }
 
   return {

--- a/sdks/react-native/src/stt/whisper.ts
+++ b/sdks/react-native/src/stt/whisper.ts
@@ -20,7 +20,7 @@ export function createWhisperTranscriber(options: {
     const pcm = buffer;
     buffer = new Uint8Array(0);
     const text = await options.runner(pcm);
-    if (text && !stopped) options.onTranscript(text);
+    if (text) options.onTranscript(text);
   }
 
   return {
@@ -36,6 +36,7 @@ export function createWhisperTranscriber(options: {
       }
     },
     stop() {
+      if (stopped) return;
       stopped = true;
       void flush();
     },

--- a/sdks/react-native/tests/whisper.test.mjs
+++ b/sdks/react-native/tests/whisper.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createWhisperTranscriber } from '../src/stt/whisper.ts';
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+test('stopping delivers the accepted final tail once and ignores later PCM', async () => {
+  const calls = [];
+  const transcripts = [];
+  const t = createWhisperTranscriber({
+    batchSeconds: 1,
+    runner: async (pcm) => {
+      calls.push([...pcm]);
+      return 'tail';
+    },
+    onTranscript: (text) => transcripts.push(text),
+  });
+  t.appendPcm(new Uint8Array([1, 2]));
+  t.stop();
+  t.appendPcm(new Uint8Array([3, 4]));
+  t.stop();
+  await settle();
+  assert.deepEqual(calls, [[1, 2]]);
+  assert.deepEqual(transcripts, ['tail']);
+});
+
+test('stopping preserves a full batch already being decoded', async () => {
+  const transcripts = [];
+  let finish;
+  const t = createWhisperTranscriber({
+    batchSeconds: 1,
+    runner: () => new Promise((resolve) => { finish = resolve; }),
+    onTranscript: (text) => transcripts.push(text),
+  });
+  t.appendPcm(new Uint8Array(32000));
+  t.stop();
+  finish('full batch');
+  await settle();
+  assert.deepEqual(transcripts, ['full batch']);
+});
+
+test('stopping without audio does not invoke the runner', async () => {
+  const t = createWhisperTranscriber({
+    runner: () => assert.fail('no audio to decode'),
+    onTranscript: () => assert.fail('no transcript expected'),
+  });
+  t.stop();
+  t.stop();
+  await settle();
+});

--- a/sdks/react-native/tests/whisper.test.mjs
+++ b/sdks/react-native/tests/whisper.test.mjs
@@ -34,6 +34,7 @@ test('stopping preserves a full batch already being decoded', async () => {
   });
   t.appendPcm(new Uint8Array(32000));
   t.stop();
+  await settle();
   finish('full batch');
   await settle();
   assert.deepEqual(transcripts, ['full batch']);
@@ -47,4 +48,51 @@ test('stopping without audio does not invoke the runner', async () => {
   t.stop();
   t.stop();
   await settle();
+});
+
+
+test('stopping decodes the final tail after all earlier batches', async () => {
+  const calls = [];
+  const transcripts = [];
+  let finishFirst;
+  const t = createWhisperTranscriber({
+    batchSeconds: 1,
+    runner: (pcm) => {
+      calls.push(pcm.byteLength);
+      if (calls.length === 1) {
+        return new Promise((resolve) => { finishFirst = resolve; });
+      }
+      return pcm.byteLength === 32000 ? 'second batch' : 'tail';
+    },
+    onTranscript: (text) => transcripts.push(text),
+  });
+  t.appendPcm(new Uint8Array(32000));
+  t.appendPcm(new Uint8Array(32000));
+  t.appendPcm(new Uint8Array([1, 2]));
+  t.stop();
+  await settle();
+  assert.deepEqual(calls, [32000]);
+  assert.deepEqual(transcripts, []);
+  finishFirst('first batch');
+  await settle();
+  assert.deepEqual(calls, [32000, 32000, 2]);
+  assert.deepEqual(transcripts, ['first batch', 'second batch', 'tail']);
+});
+
+
+test('a failed batch does not prevent the queued tail from being delivered', async () => {
+  const transcripts = [];
+  const t = createWhisperTranscriber({
+    batchSeconds: 1,
+    runner: (pcm) => {
+      if (pcm.byteLength === 32000) throw new Error('decode failed');
+      return 'tail';
+    },
+    onTranscript: (text) => transcripts.push(text),
+  });
+  t.appendPcm(new Uint8Array(32000));
+  t.appendPcm(new Uint8Array([1, 2]));
+  t.stop();
+  await settle();
+  assert.deepEqual(transcripts, ['tail']);
 });


### PR DESCRIPTION
Stopping the React Native Whisper transcriber discards the final buffered transcript and any decode still running. Queue decodes in audio order and deliver results for audio accepted before stop, while continuing to ignore later audio and repeated stop calls.

Related to #13011. This fixes the React Native adapter only; the shared cross-language lifecycle discussion remains open.

Validation:
- Five hardware-independent tests exercise the exported transcriber with synthetic PCM and injected runners. The tail and in-flight tests fail on unchanged upstream and pass with the fix. A delayed first batch reproduces the ordering issue before serialization and passes after it. The queue also continues after a failed earlier batch.
- The tests run through the shared local/CI check manifest using the existing Bun runtime.
- No physical device or live model was used.

Failure-Class: none

Product invariants affected: none.
