### PR TITLE
fix(rust-sdk): recognize PCM16 audio codec

### DIFF
--- a/sdks/rust/omi-device/README.md
+++ b/sdks/rust/omi-device/README.md
@@ -4,6 +4,10 @@
 
 The crate deliberately does not choose a BLE runtime. Implement `BleAdapter` and `BleConnection` with the platform/runtime your application already uses, then call `discover_omi` and `connect_omi`.
 
+`Device::audio_codec()` recognizes the shared protocol's PCM16 (0), PCM8 (1),
+Opus (20), and Opus FS320 (21) codec IDs. Other bytes remain `AudioCodec::Unknown(id)`;
+an empty characteristic read returns a truncated-protocol error.
+
 ```rust
 use omi_device::{connect_omi, discover_omi, BleAdapter};
 

--- a/sdks/rust/omi-device/src/lib.rs
+++ b/sdks/rust/omi-device/src/lib.rs
@@ -165,6 +165,7 @@ impl<C: BleConnection> Device<C> {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AudioCodec {
+    Pcm16,
     Pcm8,
     Opus,
     OpusFs320,
@@ -174,6 +175,7 @@ pub enum AudioCodec {
 impl AudioCodec {
     pub const fn from_id(id: u8) -> Self {
         match id {
+            0 => Self::Pcm16,
             1 => Self::Pcm8,
             20 => Self::Opus,
             21 => Self::OpusFs320,

--- a/sdks/rust/omi-device/tests/codec_recognition.rs
+++ b/sdks/rust/omi-device/tests/codec_recognition.rs
@@ -1,0 +1,62 @@
+use omi_device::{
+    AudioCodec, BleConnection, Device, OmiError, ProtocolError, AUDIO_CODEC_CHARACTERISTIC,
+    OMI_SERVICE,
+};
+
+struct CodecRead(Vec<u8>);
+
+impl BleConnection for CodecRead {
+    type Error = std::io::Error;
+
+    fn read(&mut self, service: &str, characteristic: &str) -> Result<Vec<u8>, Self::Error> {
+        assert_eq!(service, OMI_SERVICE);
+        assert_eq!(characteristic, AUDIO_CODEC_CHARACTERISTIC);
+        Ok(self.0.clone())
+    }
+
+    fn write(&mut self, _: &str, _: &str, _: &[u8]) -> Result<(), Self::Error> {
+        panic!("reading a codec must not write to the device")
+    }
+
+    fn subscribe(&mut self, _: &str, _: &str) -> Result<(), Self::Error> {
+        panic!("reading a codec must not subscribe to notifications")
+    }
+}
+
+fn read_codec(bytes: &[u8]) -> Result<AudioCodec, OmiError<std::io::Error>> {
+    Device::new(CodecRead(bytes.to_vec())).audio_codec()
+}
+
+#[test]
+fn protocol_defined_pcm16_is_recognized() {
+    // The shared device protocol assigns codec ID 0 to PCM 16-bit audio.
+    assert_eq!(read_codec(&[0]).unwrap(), AudioCodec::Pcm16);
+}
+
+#[test]
+fn other_documented_codec_ids_keep_their_meaning() {
+    for (id, expected) in [
+        (1, AudioCodec::Pcm8),
+        (20, AudioCodec::Opus),
+        (21, AudioCodec::OpusFs320),
+    ] {
+        assert_eq!(read_codec(&[id]).unwrap(), expected);
+    }
+}
+
+#[test]
+fn unknown_codec_ids_are_preserved() {
+    assert_eq!(read_codec(&[99]).unwrap(), AudioCodec::Unknown(99));
+}
+
+#[test]
+fn empty_codec_read_keeps_the_protocol_error() {
+    assert!(matches!(
+        read_codec(&[]),
+        Err(OmiError::Protocol(ProtocolError::Truncated {
+            message: "audio codec",
+            expected: 1,
+            actual: 0,
+        }))
+    ));
+}


### PR DESCRIPTION
The Rust SDK returned `AudioCodec::Unknown(0)` when the audio-codec characteristic contained the protocol-defined PCM16 value. Add `AudioCodec::Pcm16` and route ID 0 through the existing conversion used by `Device::audio_codec()`.

Fixes https://github.com/BasedHardware/omi/issues/13036.

The regression exercises the public device method with a synthetic BLE read and verifies the requested service/characteristic. The expected codec IDs come from `sdks/device/PROTOCOL.md`. Existing codecs, unknown values and truncated reads retain their behavior. The existing Rust SDK workflow runs the new integration tests.

Compatibility: a new public enum variant requires downstream exhaustive matches to account for `Pcm16`. This change does not claim physical-device verification or an observed recording failure.

Validation:

- Original source: 10 tests passed; the PCM16 recognition regression failed with `Unknown(0)`.
- Candidate: all 11 crate tests passed, including exact PCM16 classification.
- Crate formatting and Clippy passed.
- All 11 selected shared repository checks passed on the actual working-tree changes. The history check was rerun with full history and passed its 90-day declaration audit.

## Product invariants affected

none

## Failure class

Failure-Class: FC-mirrored-model-omits-new-member

The Rust codec enum omits a member already defined by the shared in-tree protocol. The existing `AudioCodec::from_id()` conversion owns classification for every Rust device caller; this patch repairs that mapping and adds behavioral coverage at its public caller, without introducing another classifier or a new guard service.

The optional USD 25 bounty proposal in issue 13036 has not been approved. This description makes no payment claim.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

