### PR TITLE
feat(desktop): on-device speaker diarization and a People view with remembered voices

### DIFF
--- a/desktop/macos/Desktop/Sources/Analytics/SearchAnalytics.swift
+++ b/desktop/macos/Desktop/Sources/Analytics/SearchAnalytics.swift
@@ -13,6 +13,7 @@ enum SearchSurface: String, CaseIterable, Sendable {
   case apps
   case tasks
   case brainMap = "brain_map"
+  case people
 }
 
 /// Content-free search analytics. Call sites pass the committed query only so

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -576,6 +576,18 @@ class AppState: ObservableObject {
   }
 
   var currentSessionId: Int64?
+  /// Transcript storage work that arrived while `currentSessionId` was still nil. The DB
+  /// session is created in a detached task at capture start and at every meeting-boundary
+  /// rotation, so segments and relabels can outrun it — on a real meeting boundary the id
+  /// has landed tens of seconds after capture resumed. Work held here, in arrival order,
+  /// is flushed into the session the moment its id exists instead of being silently lost.
+  /// Owned by the transcript handlers in `AppState+ListenEvents.swift`.
+  enum HeldTranscriptWorkUnit {
+    case segments([TranscriptionService.BackendSegment])
+    case relabels([Int: LocalSpeakerRegistry.Resolution])
+  }
+
+  var heldTranscriptWork: [HeldTranscriptWorkUnit] = []
   /// Serializes segment persistence so a local duplicate replacement cannot race
   /// the original mic segment's upsert in SQLite.
   var transcriptPersistenceTail: Task<Void, Never>?

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -50,6 +50,9 @@ struct SpeakerSegment: Identifiable {
   var isUser: Bool = false
   var personId: String?  // Backend-assigned person ID from speaker identification
   var translations: [SegmentTranslation] = []
+  /// Capture lane for on-device transcription (nil on the cloud path). Echo dedup keys on it
+  /// now that a speaker id no longer implies a lane.
+  var lane: LocalTranscriptionLane? = nil
 }
 
 /// Result of finalizing a conversation

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -245,6 +245,29 @@ extension AppState {
     }
   }
 
+  /// Renames a person on the backend and in the local list.
+  func renamePerson(id: String, name: String) async -> Bool {
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    let generation = ownerScopeGeneration
+    do {
+      try await APIClient.shared.renamePerson(id: id, name: trimmed)
+    } catch {
+      logError("People: Failed to rename person", error: error)
+      return false
+    }
+    guard generation == ownerScopeGeneration else { return false }
+    if let index = people.firstIndex(where: { $0.id == id }) {
+      let old = people[index]
+      people[index] = Person(
+        id: old.id, name: trimmed, createdAt: old.createdAt, updatedAt: Date(),
+        speechSamples: old.speechSamples, speechSampleTranscripts: old.speechSampleTranscripts,
+        speechSamplesVersion: old.speechSamplesVersion)
+    }
+    log("People: Renamed person \(id)")
+    return true
+  }
+
   /// Deletes a person on the backend and locally, including the voice Omi remembered for them.
   func deletePerson(id: String) async -> Bool {
     let generation = ownerScopeGeneration

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -245,6 +245,25 @@ extension AppState {
     }
   }
 
+  /// Deletes a person on the backend and locally, including the voice Omi remembered for them.
+  func deletePerson(id: String) async -> Bool {
+    let generation = ownerScopeGeneration
+    do {
+      try await APIClient.shared.deletePerson(id: id)
+    } catch {
+      logError("People: Failed to delete person", error: error)
+      return false
+    }
+    guard generation == ownerScopeGeneration else { return false }
+    people.removeAll { $0.id == id }
+    for (speakerId, personId) in liveSpeakerPersonMap where personId == id {
+      liveSpeakerPersonMap[speakerId] = nil
+    }
+    await LocalSpeakerDiarizer.shared.forgetVoice(personId: id)
+    log("People: Deleted person \(id)")
+    return true
+  }
+
   /// Assigns segments to a person or user via bulk API
   /// When a backend bulk-assign fails, only "the conversation does not exist
   /// there yet" may fall back to a local-first assignment — any other failure

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -45,7 +45,10 @@ enum ProactiveListenAdmission {
 
 @MainActor
 extension AppState {
-  func handleBackendSegments(_ segments: [TranscriptionService.BackendSegment]) {
+  func handleBackendSegments(
+    _ segments: [TranscriptionService.BackendSegment],
+    lane: LocalTranscriptionLane? = nil
+  ) {
     var segmentsToPersist = [TranscriptionService.BackendSegment]()
 
     for segment in segments {
@@ -78,7 +81,8 @@ extension AppState {
         end: segment.end,
         isUser: segment.is_user,
         personId: segment.person_id,
-        translations: translations
+        translations: translations,
+        lane: lane
       )
 
       // Upsert: if we already have a segment with this ID, update it; otherwise append
@@ -187,15 +191,52 @@ extension AppState {
     )
   }
 
+  /// On-device diarization moved already-emitted segments to other speakers — typically the
+  /// provisional "You" turned out to be the other person in the room. Rewrites the live
+  /// transcript in memory and the current session's rows, in the persistence queue so a
+  /// still-pending upsert of an old segment cannot land after the relabel and undo it.
+  func applyLocalSpeakerRelabels(_ relabels: [Int: LocalSpeakerRegistry.Resolution]) {
+    guard !relabels.isEmpty else { return }
+    var moved = 0
+    for index in speakerSegments.indices {
+      guard let target = relabels[speakerSegments[index].speaker] else { continue }
+      speakerSegments[index].speaker = target.speakerId
+      speakerSegments[index].isUser = target.isUser
+      if target.isUser { speakerSegments[index].personId = nil }
+      moved += 1
+    }
+    let summary = relabels.map { "\($0.key)→\($0.value.speakerId)\($0.value.isUser ? "(you)" : "")" }
+      .sorted().joined(separator: " ")
+    log("Transcript [RELABEL] \(summary): \(moved) in-memory segments moved")
+    if moved > 0 {
+      LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
+    }
+    guard let sessionId = currentSessionId else { return }
+    enqueueTranscriptStorageWork {
+      do {
+        let rows = try await TranscriptionStorage.shared.relabelSpeakers(sessionId: sessionId, relabels: relabels)
+        log("Transcript [RELABEL] \(rows) stored segments moved in session \(sessionId)")
+      } catch {
+        logError("Transcript [RELABEL] failed to persist speaker relabel", error: error)
+      }
+    }
+  }
+
   private func enqueueTranscriptPersistence(
     _ segments: [TranscriptionService.BackendSegment],
     sessionId: Int64
   ) {
+    enqueueTranscriptStorageWork { [weak self] in
+      await self?.persistBackendSegmentsToStorage(segments, sessionId: sessionId)
+    }
+  }
+
+  /// Serialize transcript storage writes: each unit runs after every earlier one finished.
+  private func enqueueTranscriptStorageWork(_ work: @escaping @MainActor () async -> Void) {
     let previous = transcriptPersistenceTail
-    transcriptPersistenceTail = Task { @MainActor [weak self] in
+    transcriptPersistenceTail = Task { @MainActor in
       await previous?.value
-      guard let self else { return }
-      await self.persistBackendSegmentsToStorage(segments, sessionId: sessionId)
+      await work()
     }
   }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -208,14 +208,15 @@ extension AppState {
       speakerSegments[index].personId = target.personId
       moved += 1
     }
-    // The live name map is keyed by speaker id; move the names with the ids.
-    let previousNames = liveSpeakerPersonMap
-    for (from, target) in relabels {
+    // The live name map is keyed by speaker id; move the names with the ids. Cleared in a
+    // pass of its own before anything is written: a swap (0↔1) visits both ends, and
+    // clearing one while writing the other would let dictionary order decide whether the
+    // second entry wipes what the first just wrote. Ids no relabel mentions keep their name.
+    for from in relabels.keys {
       liveSpeakerPersonMap[from] = nil
-      liveSpeakerPersonMap[target.speakerId] = target.personId
     }
-    for (speakerId, personId) in previousNames where relabels[speakerId] == nil {
-      liveSpeakerPersonMap[speakerId] = personId
+    for target in relabels.values {
+      liveSpeakerPersonMap[target.speakerId] = target.personId
     }
     let summary = relabels.map {
       "\($0.key)→\($0.value.speakerId)\($0.value.isUser ? "(you)" : "")\($0.value.personId.map { " person=\($0)" } ?? "")"

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -157,9 +157,15 @@ extension AppState {
     // Update published segments for UI (via isolated monitor)
     LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
 
-    // Persist segments to DB for crash safety (upsert by backend segment ID)
-    if let sessionId = currentSessionId, !segmentsToPersist.isEmpty {
-      enqueueTranscriptPersistence(segmentsToPersist, sessionId: sessionId)
+    // Persist segments to DB for crash safety (upsert by backend segment ID). While the
+    // session id has not landed yet, hold the segments for the session instead of dropping
+    // them — they are flushed the moment `currentSessionId` is installed.
+    if !segmentsToPersist.isEmpty {
+      if let sessionId = currentSessionId {
+        enqueueTranscriptPersistence(segmentsToPersist, sessionId: sessionId)
+      } else {
+        holdTranscriptWorkUntilSessionExists(.segments(segmentsToPersist))
+      }
     }
   }
 
@@ -226,15 +232,14 @@ extension AppState {
     if moved > 0 {
       LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
     }
-    guard let sessionId = currentSessionId else { return }
-    enqueueTranscriptStorageWork {
-      do {
-        let rows = try await TranscriptionStorage.shared.relabelSpeakers(sessionId: sessionId, relabels: relabels)
-        log("Transcript [RELABEL] \(rows) stored segments moved in session \(sessionId)")
-      } catch {
-        logError("Transcript [RELABEL] failed to persist speaker relabel", error: error)
-      }
+    guard let sessionId = currentSessionId else {
+      // The session id has not landed yet. The moved bubbles are on screen; hold the
+      // storage-level relabel so it reaches the stored rows in arrival order once the
+      // session exists, instead of being dropped with them.
+      holdTranscriptWorkUntilSessionExists(.relabels(relabels))
+      return
     }
+    enqueueRelabelPersistence(sessionId: sessionId, relabels: relabels)
   }
 
   /// "This is me" on a live bubble: the on-device diarizer makes that speaker the user and
@@ -264,6 +269,60 @@ extension AppState {
     enqueueTranscriptStorageWork { [weak self] in
       await self?.persistBackendSegmentsToStorage(segments, sessionId: sessionId)
     }
+  }
+
+  private func enqueueRelabelPersistence(
+    sessionId: Int64,
+    relabels: [Int: LocalSpeakerRegistry.Resolution]
+  ) {
+    enqueueTranscriptStorageWork {
+      do {
+        let rows = try await TranscriptionStorage.shared.relabelSpeakers(sessionId: sessionId, relabels: relabels)
+        log("Transcript [RELABEL] \(rows) stored segments moved in session \(sessionId)")
+      } catch {
+        logError("Transcript [RELABEL] failed to persist speaker relabel", error: error)
+      }
+    }
+  }
+
+  /// Hold transcript storage work that arrived before the DB session existed, so a segment
+  /// or relabel is never silently dropped for racing the async session creation. Only an
+  /// active recording holds work — one that already stopped will never have a session.
+  private func holdTranscriptWorkUntilSessionExists(_ unit: HeldTranscriptWorkUnit) {
+    guard isTranscribing else { return }
+    heldTranscriptWork.append(unit)
+    switch unit {
+    case .segments(let segments):
+      log("Transcript [HOLD] \(segments.count) segment(s) held until the DB session exists")
+    case .relabels:
+      log("Transcript [HOLD] speaker relabel(s) held until the DB session exists")
+    }
+  }
+
+  /// Flush held transcript work into the freshly created session, preserving arrival order
+  /// so a held relabel still lands after the held segments it renames. Called right after
+  /// `currentSessionId` is installed by the session-creation tasks.
+  func flushHeldTranscriptWork(sessionId: Int64) {
+    guard !heldTranscriptWork.isEmpty else { return }
+    let units = heldTranscriptWork
+    heldTranscriptWork = []
+    for unit in units {
+      switch unit {
+      case .segments(let segments):
+        enqueueTranscriptPersistence(segments, sessionId: sessionId)
+      case .relabels(let relabels):
+        enqueueRelabelPersistence(sessionId: sessionId, relabels: relabels)
+      }
+    }
+    log("Transcript [HOLD] flushed \(units.count) held unit(s) into session \(sessionId)")
+  }
+
+  /// Drop held transcript work when the recording that would have created its session ends
+  /// without one — it has nowhere to land and must not leak into an unrelated recording.
+  func discardHeldTranscriptWork() {
+    guard !heldTranscriptWork.isEmpty else { return }
+    heldTranscriptWork = []
+    log("Transcript [HOLD] discarded held transcript work — no session will exist for it")
   }
 
   /// Serialize transcript storage writes: each unit runs after every earlier one finished.

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -73,6 +73,9 @@ extension AppState {
       let translations = (segment.translations ?? []).map {
         SegmentTranslation(lang: $0.lang, text: $0.text)
       }
+      if lane != nil, !segment.is_user, let personId = segment.person_id, liveSpeakerPersonMap[speakerId] != personId {
+        liveSpeakerPersonMap[speakerId] = personId
+      }
       let newSeg = SpeakerSegment(
         segmentId: segment.id,
         speaker: speakerId,
@@ -202,11 +205,22 @@ extension AppState {
       guard let target = relabels[speakerSegments[index].speaker] else { continue }
       speakerSegments[index].speaker = target.speakerId
       speakerSegments[index].isUser = target.isUser
-      if target.isUser { speakerSegments[index].personId = nil }
+      speakerSegments[index].personId = target.personId
       moved += 1
     }
-    let summary = relabels.map { "\($0.key)→\($0.value.speakerId)\($0.value.isUser ? "(you)" : "")" }
-      .sorted().joined(separator: " ")
+    // The live name map is keyed by speaker id; move the names with the ids.
+    let previousNames = liveSpeakerPersonMap
+    for (from, target) in relabels {
+      liveSpeakerPersonMap[from] = nil
+      liveSpeakerPersonMap[target.speakerId] = target.personId
+    }
+    for (speakerId, personId) in previousNames where relabels[speakerId] == nil {
+      liveSpeakerPersonMap[speakerId] = personId
+    }
+    let summary = relabels.map {
+      "\($0.key)→\($0.value.speakerId)\($0.value.isUser ? "(you)" : "")\($0.value.personId.map { " person=\($0)" } ?? "")"
+    }
+    .sorted().joined(separator: " ")
     log("Transcript [RELABEL] \(summary): \(moved) in-memory segments moved")
     if moved > 0 {
       LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
@@ -219,6 +233,26 @@ extension AppState {
       } catch {
         logError("Transcript [RELABEL] failed to persist speaker relabel", error: error)
       }
+    }
+  }
+
+  /// "This is me" on a live bubble: the on-device diarizer makes that speaker the user and
+  /// remembers the voice, and every earlier bubble moves accordingly.
+  func markLiveSpeakerAsUser(_ speakerId: Int) {
+    Task { @MainActor [weak self] in
+      let relabels = await LocalSpeakerDiarizer.shared.markSpeakerAsUser(speakerId)
+      self?.applyLocalSpeakerRelabels(relabels)
+    }
+  }
+
+  /// A live speaker was named. Shows the name now and, on the on-device path, teaches the
+  /// diarizer that person's voice so it is stamped automatically next time.
+  func assignLiveSpeaker(_ speakerId: Int, toPerson personId: String?) {
+    liveSpeakerPersonMap[speakerId] = personId
+    guard sttSession.useLocalSTT else { return }
+    Task { @MainActor [weak self] in
+      let relabels = await LocalSpeakerDiarizer.shared.assignPerson(personId, toSpeaker: speakerId)
+      self?.applyLocalSpeakerRelabels(relabels)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -1053,6 +1053,8 @@ extension AppState {
     let onRelabel: LocalTranscriptionService.SpeakerRelabelHandler = { [weak self] relabels in
       self?.applyLocalSpeakerRelabels(relabels)
     }
+    // A push-to-talk enrollment can identify a live speaker too; route those here as well.
+    Task { await LocalSpeakerDiarizer.shared.setRelabelSink(onRelabel) }
     let mic = LocalTranscriptionService(language: language, isUser: true)
     mic.start(
       onSegments: { [weak self] segments in self?.handleBackendSegments(segments, lane: .microphone) },

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -268,6 +268,7 @@ extension AppState {
           let sessionStillCurrent = await MainActor.run { () -> Bool in
             guard self.recordingGeneration == sessionGeneration else { return false }
             self.currentSessionId = sessionId
+            self.flushHeldTranscriptWork(sessionId: sessionId)
             // Start live notes session
             LiveNotesMonitor.shared.startSession(sessionId: sessionId)
             return true
@@ -1389,6 +1390,7 @@ extension AppState {
         let sessionStillCurrent = await MainActor.run { () -> Bool in
           guard self.isTranscribing, self.recordingGeneration == sessionGeneration else { return false }
           self.currentSessionId = sessionId
+          self.flushHeldTranscriptWork(sessionId: sessionId)
           LiveNotesMonitor.shared.startSession(sessionId: sessionId)
           return true
         }
@@ -1541,6 +1543,9 @@ extension AppState {
     LiveNotesMonitor.shared.clear()
     recordingStartTime = nil
     currentSessionId = nil
+    // Work still held for a session that never existed has nowhere to land; the recording
+    // that would have created it is over and it must not leak into the next one.
+    discardHeldTranscriptWork()
     currentClientConversationId = nil
     meetingBoundaryInProgress = false
     pendingMeetingState = nil

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -104,21 +104,16 @@ extension AppState {
 
       if sttSession.useLocalSTT {
         log("Transcription: ON-DEVICE Parakeet mode (OMI_LOCAL_STT) — no cloud STT")
-        // Segments are delivered on the main actor by the service, so no Task hop here.
-        let onLocalSegments: LocalTranscriptionService.SegmentsHandler = { [weak self] segments in
-          self?.handleBackendSegments(segments)
-        }
         // If the on-device model can't load, fall back to cloud STT instead of recording
         // into a void (the failure is otherwise silent — a blank transcript).
         let onModelLoadFailed: @MainActor () -> Void = { [weak self] in
           self?.handleLocalSTTModelLoadFailure()
         }
-        // Mic = the user; system audio = another speaker. Transcribed separately for diarization.
-        let mic = LocalTranscriptionService(language: effectiveLanguage, isUser: true)
-        mic.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
+        // Mic and system audio are transcribed separately; the shared on-device diarizer
+        // tells the two lanes' voices apart and which mic voice is the user.
+        let (mic, system) = makeLocalTranscriptionServices(
+          language: effectiveLanguage, onModelLoadFailed: onModelLoadFailed)
         localMicService = mic
-        let system = LocalTranscriptionService(language: effectiveLanguage, isUser: false)
-        system.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
         localSystemService = system
       } else {
         // Always streaming via Python backend /v4/listen
@@ -1047,6 +1042,32 @@ extension AppState {
     return nil
   }
 
+  /// One Parakeet instance per capture lane, both feeding `handleBackendSegments` with their
+  /// lane so echo dedup can tell a mic row from a system-audio row, and both able to move
+  /// earlier segments when the shared diarizer revises who the user is.
+  private func makeLocalTranscriptionServices(
+    language: String,
+    onModelLoadFailed: @escaping @MainActor () -> Void
+  ) -> (mic: LocalTranscriptionService, system: LocalTranscriptionService) {
+    // Segments are delivered on the main actor by the service, so no Task hop here.
+    let onRelabel: LocalTranscriptionService.SpeakerRelabelHandler = { [weak self] relabels in
+      self?.applyLocalSpeakerRelabels(relabels)
+    }
+    let mic = LocalTranscriptionService(language: language, isUser: true)
+    mic.start(
+      onSegments: { [weak self] segments in self?.handleBackendSegments(segments, lane: .microphone) },
+      onModelLoadFailed: onModelLoadFailed,
+      onSpeakerRelabel: onRelabel
+    )
+    let system = LocalTranscriptionService(language: language, isUser: false)
+    system.start(
+      onSegments: { [weak self] segments in self?.handleBackendSegments(segments, lane: .systemAudio) },
+      onModelLoadFailed: onModelLoadFailed,
+      onSpeakerRelabel: onRelabel
+    )
+    return (mic, system)
+  }
+
   /// On-device Parakeet failed to load — fall back to cloud STT instead of silently recording a
   /// blank transcript. Cleanly stops the dead on-device session and restarts the SAME recording in
   /// cloud mode (no fragile mid-stream audio rerouting). Sticky for the app run so we don't retry a
@@ -1288,9 +1309,6 @@ extension AppState {
         // On-device mode: re-arm fresh local Parakeet instances (mic + system) for the next
         // conversation — do NOT reconnect the cloud WebSocket. Stopping the old ones flushes
         // their final tails; the source-routed capture callbacks feed the new instances.
-        let onLocalSegments: LocalTranscriptionService.SegmentsHandler = { [weak self] segments in
-          self?.handleBackendSegments(segments)
-        }
         // Mirror startTranscription: wire onModelLoadFailed so a Parakeet model
         // load failure on the re-armed instances falls back to cloud instead of
         // recording into a void (a silent blank transcript). Without this, every
@@ -1298,11 +1316,9 @@ extension AppState {
         let onModelLoadFailed: @MainActor () -> Void = { [weak self] in
           self?.handleLocalSTTModelLoadFailure()
         }
-        let mic = LocalTranscriptionService(language: effectiveLanguage, isUser: true)
-        mic.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
+        let (mic, system) = makeLocalTranscriptionServices(
+          language: effectiveLanguage, onModelLoadFailed: onModelLoadFailed)
         localMicService = mic
-        let system = LocalTranscriptionService(language: effectiveLanguage, isUser: false)
-        system.start(onSegments: onLocalSegments, onModelLoadFailed: onModelLoadFailed)
         localSystemService = system
         // CoreAudio callbacks capture their local transcription sinks when the
         // tap starts. Rebuild them so audio reaches these fresh services rather

--- a/desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
@@ -53,11 +53,19 @@ enum LocalTranscriptionDuplicatePolicy {
     // Keep one canonical segment. If the mic copy arrived first, promote that
     // existing row to the system-audio source rather than deleting and reinserting
     // it. If the system copy arrived first, discard only the later mic copy.
-    return incoming.isUser ? .suppressIncoming : .replaceExisting(segmentId: segmentId)
+    return lane(of: incoming) == .microphone ? .suppressIncoming : .replaceExisting(segmentId: segmentId)
+  }
+
+  /// The lane a segment was captured on. Segments carry it explicitly since on-device
+  /// diarization; before that `isUser` *was* the lane (mic = user), which stays the
+  /// fallback for rows that predate the field.
+  static func lane(of segment: SpeakerSegment) -> LocalTranscriptionLane {
+    segment.lane ?? (segment.isUser ? .microphone : .systemAudio)
   }
 
   static func isDuplicate(_ lhs: SpeakerSegment, _ rhs: SpeakerSegment) -> Bool {
-    guard lhs.isUser != rhs.isUser else { return false }
+    let lhsLane = lane(of: lhs)
+    guard lhsLane != lane(of: rhs) else { return false }
     let lhsWords = normalizedWords(lhs.text)
     let rhsWords = normalizedWords(rhs.text)
     guard min(lhsWords.count, rhsWords.count) >= minimumWordCount else { return false }
@@ -71,8 +79,8 @@ enum LocalTranscriptionDuplicatePolicy {
     // than the playback — human speech, a longer capture window, or both — and
     // must survive.
     guard min(lhsWords.count, rhsWords.count) >= minimumContainmentWordCount else { return false }
-    let micWords = lhs.isUser ? lhsWords : rhsWords
-    let systemWords = lhs.isUser ? rhsWords : lhsWords
+    let micWords = lhsLane == .microphone ? lhsWords : rhsWords
+    let systemWords = lhsLane == .microphone ? rhsWords : lhsWords
     guard containsContiguous(systemWords, subsequence: micWords) else { return false }
 
     return timestampRangesAreClose(lhs, rhs)

--- a/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
+++ b/desktop/macos/Desktop/Sources/Chat/RuntimeOwnerIdentity.swift
@@ -428,6 +428,8 @@ enum RuntimeOwnerIdentity {
     await FileIndexerService.shared.invalidateCache()
     await OCREmbeddingService.shared.reset()
     await RewindDatabase.shared.retargetEffectiveOwner(to: nextOwner)
+    await LocalSpeakerDiarizer.shared.retargetEffectiveOwner(
+      to: .forCurrentUser(userId: nextOwner))
     await TranscriptionStorage.shared.invalidateCache()
     await MemoryStorage.shared.invalidateCache()
     await ActionItemStorage.shared.invalidateCache()

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -205,36 +205,18 @@ actor ConversationFinalizationService {
       return false
     }
 
-    var merged: [APIClient.UploadSegment] = []
-    for seg in bundle.segments {
-      let upload = APIClient.UploadSegment(
-        text: seg.text,
-        speaker: seg.speakerLabel ?? String(format: "SPEAKER_%02d", seg.speaker),
-        speaker_id: seg.speaker,
-        is_user: seg.isUser,
-        person_id: seg.personId,
-        start: seg.startTime,
-        end: seg.endTime
-      )
-      if let last = merged.last,
-        last.speaker_id == upload.speaker_id,
-        last.speaker == upload.speaker,
-        last.is_user == upload.is_user,
-        last.person_id == upload.person_id
-      {
-        merged[merged.count - 1] = APIClient.UploadSegment(
-          text: last.text + " " + upload.text,
-          speaker: last.speaker,
-          speaker_id: last.speaker_id,
-          is_user: last.is_user,
-          person_id: last.person_id,
-          start: last.start,
-          end: upload.end
+    let merged = Self.mergeConsecutiveSpeakerRuns(
+      bundle.segments.map { seg in
+        APIClient.UploadSegment(
+          text: seg.text,
+          speaker: seg.speakerLabel ?? String(format: "SPEAKER_%02d", seg.speaker),
+          speaker_id: seg.speaker,
+          is_user: seg.isUser,
+          person_id: seg.personId,
+          start: seg.startTime,
+          end: seg.endTime
         )
-      } else {
-        merged.append(upload)
-      }
-    }
+      })
 
     let uploadSegments = Self.compactSegmentsForBackendLimit(merged)
     if uploadSegments.count != merged.count {
@@ -338,6 +320,39 @@ actor ConversationFinalizationService {
         error: error
       )
     }
+  }
+
+  /// Join consecutive rows of one speaker into a single upload segment.
+  ///
+  /// A run only extends forward in time. The mic and system-audio lanes keep independent
+  /// clocks, and since on-device diarization a remote voice and its mic echo share a speaker
+  /// id, so a system row can follow a mic row of the same speaker with an *earlier* start;
+  /// joining those produced `end < start` and the backend rejected the whole conversation
+  /// ("Segment 3: end time must be after start time", 422). Such a row starts a new run.
+  static func mergeConsecutiveSpeakerRuns(_ segments: [APIClient.UploadSegment]) -> [APIClient.UploadSegment] {
+    var merged: [APIClient.UploadSegment] = []
+    for upload in segments {
+      if let last = merged.last,
+        last.speaker_id == upload.speaker_id,
+        last.speaker == upload.speaker,
+        last.is_user == upload.is_user,
+        last.person_id == upload.person_id,
+        upload.start >= last.start
+      {
+        merged[merged.count - 1] = APIClient.UploadSegment(
+          text: last.text + " " + upload.text,
+          speaker: last.speaker,
+          speaker_id: last.speaker_id,
+          is_user: last.is_user,
+          person_id: last.person_id,
+          start: last.start,
+          end: max(last.end, upload.end)
+        )
+      } else {
+        merged.append(upload)
+      }
+    }
+    return merged
   }
 
   static func compactSegmentsForBackendLimit(

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -39,6 +39,9 @@ enum DefaultsKey: String {
   case automationOwnerABackup = "automation_swap_owner_a_backup"
   case chatBridgeMode = "chatBridgeMode"
   case preferredMicrophoneDeviceUID = "preferredMicrophoneDeviceUID"
+  /// L2-normalized WeSpeaker embedding of the user's voice, learned by on-device transcription
+  /// so "You" is recognised from the first sentence of the next session (`LocalSpeakerDiarizer`).
+  case localSpeakerUserVoiceprint = "localSpeakerUserVoiceprint"
   case multiChatEnabled = "multiChatEnabled"
   /// Opt-in: proactive notifications are also spoken out loud on delivery.
   case speakNotificationsAloud = "speakNotificationsAloud"

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -39,9 +39,6 @@ enum DefaultsKey: String {
   case automationOwnerABackup = "automation_swap_owner_a_backup"
   case chatBridgeMode = "chatBridgeMode"
   case preferredMicrophoneDeviceUID = "preferredMicrophoneDeviceUID"
-  /// L2-normalized WeSpeaker embedding of the user's voice, learned by on-device transcription
-  /// so "You" is recognised from the first sentence of the next session (`LocalSpeakerDiarizer`).
-  case localSpeakerUserVoiceprint = "localSpeakerUserVoiceprint"
   case multiChatEnabled = "multiChatEnabled"
   /// Opt-in: proactive notifications are also spoken out loud on delivery.
   case speakNotificationsAloud = "speakNotificationsAloud"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1574,6 +1574,15 @@ class PushToTalkManager: ObservableObject {
     // the "thinking" indicator through the transcription/first-token gap; it hands
     // off to the conversation surface (or voice glow) the moment output arrives.
     recordSilentMicRecoveryOutcome(silentMicRecoveryPolicy.recordSuccessfulTurn())
+    if isOmniSTT || isBatch {
+      // Whoever holds the shortcut and talks to Omi is the user: the one sample of the
+      // user's voice that needs no guessing. Teaches the on-device diarizer (no-op when its
+      // models are not loaded, e.g. cloud STT) so the live transcript's "You" is right.
+      batchAudioLock.lock()
+      let userVoiceSample = batchAudioBuffer
+      batchAudioLock.unlock()
+      Task { await LocalSpeakerDiarizer.shared.enrollUserVoice(pcm16k: userVoiceSample) }
+    }
     voiceTurnCoordinator.publish(.transcriptionStarted(turnID: turnID))
 
     // Realtime omni: commit the turn and wait for the final transcript.

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -157,7 +157,9 @@ actor LocalSpeakerDiarizer {
     if confident, let key = registry.cluster(forSpeakerId: outcome.resolution.speakerId)?.key {
       var windows = recentWindows[key, default: []]
       windows.append(window)
-      if windows.count > Self.recentWindowsPerCluster { windows.removeFirst(windows.count - Self.recentWindowsPerCluster) }
+      if windows.count > Self.recentWindowsPerCluster {
+        windows.removeFirst(windows.count - Self.recentWindowsPerCluster)
+      }
       recentWindows[key] = windows
     }
 
@@ -229,6 +231,60 @@ actor LocalSpeakerDiarizer {
       let relabels = result.relabels
       await MainActor.run { relabelSink(relabels) }
     }
+  }
+
+  /// Speaker embedding of a clip (16 kHz mono), for callers that rebuild voices from stored
+  /// audio. Nil until the models are loaded.
+  func embedding(for samples: [Float]) -> [Float]? {
+    guard case .ready = state, let manager else { return nil }
+    return dominantEmbedding(in: samples, manager: manager)
+  }
+
+  /// Replace remembered voices with ones rebuilt from conversation audio. Favorites and use
+  /// scores survive; the embedding becomes the mean of the rebuilt cuts and the longest cuts
+  /// become the voice's clips. Returns how many clips were saved.
+  func applyRebuild(_ rebuilt: [RebuiltVoice]) -> Int {
+    let now = now()
+    var clipsSaved = 0
+    for voice in rebuilt {
+      guard let centroid = Self.meanEmbedding(voice.embeddings) else { continue }
+      let update = VoiceprintUpdate(
+        personId: voice.personId, embedding: centroid, speechSeconds: voice.speechSeconds, isEnrolled: true)
+      // Replace rather than blend: the rebuild heard the whole history, not one session.
+      voiceprints.removeAll { $0.personId == voice.personId }
+      voiceprints = LocalVoiceprintStore.applying(update, to: voiceprints, now: now)
+      if let index = voiceprints.firstIndex(where: { $0.personId == voice.personId }) {
+        let previous = voiceprints[index]
+        voiceprints[index].useScore = max(
+          policy.decayedScore(previous.useScore, lastUsedAt: previous.lastUsedAt, now: now),
+          Double(voice.conversationCount))
+        voiceprints[index].lastUsedAt = [previous.lastUsedAt, voice.lastHeardAt].compactMap { $0 }.max()
+        store.removeAllSamples(personId: voice.personId)
+        voiceprints[index].sampleFiles = []
+        for (offset, clip) in voice.clips.enumerated() {
+          // Distinct names: clips share `now`, and the file name is the timestamp.
+          let stamp = now.addingTimeInterval(-Double(offset))
+          if let file = store.addSample(personId: voice.personId, samples: clip, now: stamp) {
+            voiceprints[index].sampleFiles.append(file)
+            clipsSaved += 1
+          }
+        }
+      }
+      registry.rememberKnownVoice(
+        LocalSpeakerRegistry.KnownVoice(personId: voice.personId, embedding: centroid, isEnrolled: true))
+    }
+    evictIfOverCapacity()
+    persist()
+    return clipsSaved
+  }
+
+  private static func meanEmbedding(_ embeddings: [[Float]]) -> [Float]? {
+    guard let first = embeddings.first else { return nil }
+    var sum = [Float](repeating: 0, count: first.count)
+    for embedding in embeddings where embedding.count == first.count {
+      for i in sum.indices { sum[i] += embedding[i] }
+    }
+    return LocalSpeakerRegistry.normalized(sum)
   }
 
   /// Forget a remembered voice and its audio (the user's when `personId` is nil).
@@ -330,7 +386,8 @@ actor LocalSpeakerDiarizer {
   }
 
   private static func knownVoice(_ stored: StoredVoiceprint) -> LocalSpeakerRegistry.KnownVoice {
-    LocalSpeakerRegistry.KnownVoice(personId: stored.personId, embedding: stored.embedding, isEnrolled: stored.isEnrolled)
+    LocalSpeakerRegistry.KnownVoice(
+      personId: stored.personId, embedding: stored.embedding, isEnrolled: stored.isEnrolled)
   }
 
   // MARK: - Embeddings

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -7,8 +7,9 @@ import Foundation
 /// on the Neural Engine) and one `LocalSpeakerRegistry` shared by the mic and system-audio
 /// `LocalTranscriptionService` instances, so speaker ids are consistent across both lanes and
 /// across conversation rotations within an app run. Remembered voices — the user's and every
-/// named person's — live in `LocalVoiceprintStore`, so "You" and known people are recognised
-/// from the first sentence of the next session.
+/// named person's, each with a few short audio samples — live in `LocalVoiceprintStore`,
+/// bounded by `VoiceEnrollmentPolicy` (aged frequency, favorites pinned), so "You" and known
+/// people are recognised from the first sentence of the next session.
 ///
 /// Fails open: if the models can't load, `resolve` returns nil and the transcriber keeps the
 /// old source-based labels (mic = "You", system = Speaker 1).
@@ -22,6 +23,9 @@ actor LocalSpeakerDiarizer {
     let speechSeconds: Double
     let updatedAt: Date
     let isEnrolled: Bool
+    let isFavorite: Bool
+    let lastHeardAt: Date?
+    let sampleURLs: [URL]
   }
 
   private enum State {
@@ -31,10 +35,12 @@ actor LocalSpeakerDiarizer {
     case unavailable
   }
 
+  typealias RelabelSink = @MainActor ([Int: LocalSpeakerRegistry.Resolution]) -> Void
+
   /// Shortest push-to-talk sample worth learning the user's voice from.
   static let minEnrollmentSeconds = 2.0
-
-  typealias RelabelSink = @MainActor ([Int: LocalSpeakerRegistry.Resolution]) -> Void
+  /// Recent confident windows kept per live speaker, so naming them can save audio at once.
+  private static let recentWindowsPerCluster = 3
 
   private var state: State = .idle
   /// Where relabels go when they originate here rather than from a transcriber window (a
@@ -43,16 +49,27 @@ actor LocalSpeakerDiarizer {
   private var relabelSink: RelabelSink?
   private var manager: DiarizerManager?
   private var registry: LocalSpeakerRegistry
-  private var store: LocalVoiceprintStore
+  private let store: LocalVoiceprintStore
+  private let policy: VoiceEnrollmentPolicy
   private var voiceprints: [StoredVoiceprint]
   private let loadModels: @Sendable () async throws -> DiarizerModels
+  private let now: @Sendable () -> Date
+  /// Confident windows per registry cluster key, newest last.
+  private var recentWindows: [Int: [[Float]]] = [:]
+  /// Voices already counted as "heard" this app run (`VoiceEnrollmentPolicy` scores sessions).
+  private var usedThisRun: Set<String> = []
+  private var lastSampleAt: [String: Date] = [:]
 
   init(
     store: LocalVoiceprintStore = .forCurrentUser(),
-    loadModels: @escaping @Sendable () async throws -> DiarizerModels = { try await DiarizerModels.downloadIfNeeded() }
+    policy: VoiceEnrollmentPolicy = VoiceEnrollmentPolicy(),
+    loadModels: @escaping @Sendable () async throws -> DiarizerModels = { try await DiarizerModels.downloadIfNeeded() },
+    now: @escaping @Sendable () -> Date = { Date() }
   ) {
     self.store = store
+    self.policy = policy
     self.loadModels = loadModels
+    self.now = now
     let voiceprints = store.load()
     self.voiceprints = voiceprints
     self.registry = LocalSpeakerRegistry(knownVoices: voiceprints.map(Self.knownVoice))
@@ -129,11 +146,38 @@ actor LocalSpeakerDiarizer {
   ) -> LocalSpeakerRegistry.Outcome? {
     guard case .ready = state, let manager else { return nil }
     guard let embedding = dominantEmbedding(in: window, manager: manager) else { return nil }
-    let outcome = registry.observe(
-      LocalSpeakerRegistry.Observation(
-        embedding: embedding, durationSeconds: durationSeconds, loudness: rms, lane: lane))
-    if let updates = outcome?.voiceprintsToPersist, !updates.isEmpty {
-      remember(updates)
+    guard
+      let outcome = registry.observe(
+        LocalSpeakerRegistry.Observation(
+          embedding: embedding, durationSeconds: durationSeconds, loudness: rms, lane: lane))
+    else { return nil }
+
+    // A window that joined its cluster confidently (or opened it) is clean audio of one voice.
+    let confident = outcome.nearestDistance == .infinity || outcome.nearestDistance <= registry.config.updateThreshold
+    if confident, let key = registry.cluster(forSpeakerId: outcome.resolution.speakerId)?.key {
+      var windows = recentWindows[key, default: []]
+      windows.append(window)
+      if windows.count > Self.recentWindowsPerCluster { windows.removeFirst(windows.count - Self.recentWindowsPerCluster) }
+      recentWindows[key] = windows
+    }
+
+    // A remembered voice was heard: count the session and, now and then, keep a clip.
+    let owner: String??
+    if let personId = outcome.resolution.personId {
+      owner = .some(personId)
+    } else if outcome.resolution.isUser, registry.userIsConfirmed {
+      owner = .some(nil)
+    } else {
+      owner = nil
+    }
+    if let owner, voiceprints.contains(where: { $0.personId == owner }) {
+      var changed = touchUse(personId: owner)
+      if confident, saveSampleIfDue(personId: owner, samples: window) { changed = true }
+      if changed { persist() }
+    }
+
+    if !outcome.voiceprintsToPersist.isEmpty {
+      remember(outcome.voiceprintsToPersist)
     }
     return outcome
   }
@@ -142,16 +186,26 @@ actor LocalSpeakerDiarizer {
 
   /// "This is me" on a live bubble. Returns the relabels for segments already on screen.
   func markSpeakerAsUser(_ speakerId: Int) -> [Int: LocalSpeakerRegistry.Resolution] {
+    let clusterKey = registry.cluster(forSpeakerId: speakerId)?.key
     guard let result = registry.markAsUser(speakerId: speakerId) else { return [:] }
     remember([result.persist])
+    if let clusterKey { saveRecentWindows(of: clusterKey, as: nil) }
+    _ = touchUse(personId: nil)
+    persist()
     log("LocalSpeakerDiarizer: speaker \(speakerId) marked as the user")
     return result.relabels
   }
 
-  /// A live speaker was named (or un-named). Teaches that person's voice.
+  /// A live speaker was named (or un-named). Teaches that person's voice and keeps a clip.
   func assignPerson(_ personId: String?, toSpeaker speakerId: Int) -> [Int: LocalSpeakerRegistry.Resolution] {
+    let clusterKey = registry.cluster(forSpeakerId: speakerId)?.key
     guard let result = registry.assignPerson(personId, toSpeakerId: speakerId) else { return [:] }
     if let update = result.persist { remember([update]) }
+    if let personId, let clusterKey {
+      saveRecentWindows(of: clusterKey, as: personId)
+      _ = touchUse(personId: personId)
+      persist()
+    }
     return result.relabels
   }
 
@@ -167,6 +221,9 @@ actor LocalSpeakerDiarizer {
       let result = registry.enrollUser(embedding: embedding, speechSeconds: seconds)
     else { return }
     remember([result.persist])
+    _ = saveSampleIfDue(personId: nil, samples: samples, force: true)
+    _ = touchUse(personId: nil)
+    persist()
     log("LocalSpeakerDiarizer: learned the user's voice from a \(String(format: "%.1f", seconds))s push-to-talk turn")
     if !result.relabels.isEmpty, let relabelSink {
       let relabels = result.relabels
@@ -174,26 +231,102 @@ actor LocalSpeakerDiarizer {
     }
   }
 
-  /// Forget a remembered voice (the user's when `personId` is nil).
+  /// Forget a remembered voice and its audio (the user's when `personId` is nil).
   func forgetVoice(personId: String?) {
     registry.forgetVoice(personId: personId)
     voiceprints.removeAll { $0.personId == personId }
-    store.save(voiceprints)
+    store.removeAllSamples(personId: personId)
+    persist()
+  }
+
+  /// Pin (or unpin) a person so their voice is never evicted and they list first.
+  func setFavorite(personId: String, _ isFavorite: Bool) {
+    guard let index = voiceprints.firstIndex(where: { $0.personId == personId }) else { return }
+    voiceprints[index].isFavorite = isFavorite
+    persist()
   }
 
   func voiceSummaries() -> [VoiceSummary] {
-    voiceprints.map {
-      VoiceSummary(personId: $0.personId, speechSeconds: $0.speechSeconds, updatedAt: $0.updatedAt, isEnrolled: $0.isEnrolled)
+    voiceprints.map { voiceprint in
+      VoiceSummary(
+        personId: voiceprint.personId,
+        speechSeconds: voiceprint.speechSeconds,
+        updatedAt: voiceprint.updatedAt,
+        isEnrolled: voiceprint.isEnrolled,
+        isFavorite: voiceprint.isFavorite,
+        lastHeardAt: voiceprint.lastUsedAt,
+        sampleURLs: voiceprint.sampleFiles.map { store.sampleURL(for: $0) }
+      )
     }
   }
 
+  // MARK: - Remembering
+
   private func remember(_ updates: [VoiceprintUpdate]) {
+    let now = now()
     for update in updates {
-      voiceprints = LocalVoiceprintStore.applying(update, to: voiceprints)
+      voiceprints = LocalVoiceprintStore.applying(update, to: voiceprints, now: now)
     }
-    store.save(voiceprints)
+    evictIfOverCapacity()
+    persist()
     let who = updates.map { $0.personId ?? "user" }.joined(separator: ", ")
     log("LocalSpeakerDiarizer: remembered voice for \(who)")
+  }
+
+  /// Aged-frequency bookkeeping: one bump per voice per app run. Returns whether anything
+  /// changed.
+  private func touchUse(personId: String?) -> Bool {
+    let key = LocalVoiceprintStore.sampleOwner(personId)
+    guard !usedThisRun.contains(key), let index = voiceprints.firstIndex(where: { $0.personId == personId })
+    else { return false }
+    usedThisRun.insert(key)
+    voiceprints[index] = policy.recordingUse(of: voiceprints[index], now: now())
+    return true
+  }
+
+  private func evictIfOverCapacity() {
+    let evicted = policy.evictions(from: voiceprints, now: now())
+    guard !evicted.isEmpty else { return }
+    for personId in evicted {
+      registry.forgetVoice(personId: personId)
+      store.removeAllSamples(personId: personId)
+      voiceprints.removeAll { $0.personId == personId }
+    }
+    log("LocalSpeakerDiarizer: forgot \(evicted.count) rarely heard voice(s) to stay within \(policy.capacity)")
+  }
+
+  private func persist() {
+    store.save(voiceprints)
+  }
+
+  private func saveRecentWindows(of clusterKey: Int, as personId: String?) {
+    for window in recentWindows[clusterKey] ?? [] {
+      _ = saveSampleIfDue(personId: personId, samples: window, force: true)
+    }
+  }
+
+  /// Keep a clip of this voice unless one was kept recently. Trims to the freshest
+  /// `maxSampleSeconds`; drops the oldest clip beyond `maxSamplesPerVoice`.
+  @discardableResult
+  private func saveSampleIfDue(personId: String?, samples: [Float], force: Bool = false) -> Bool {
+    guard let index = voiceprints.firstIndex(where: { $0.personId == personId }) else { return false }
+    let key = LocalVoiceprintStore.sampleOwner(personId)
+    let now = now()
+    if !force, let last = lastSampleAt[key], now.timeIntervalSince(last) < policy.sampleIntervalSeconds {
+      return false
+    }
+    let maxSamples = Int(policy.maxSampleSeconds * Double(LocalVoiceprintStore.sampleRate))
+    let clip = samples.count > maxSamples ? Array(samples.suffix(maxSamples)) : samples
+    guard let file = store.addSample(personId: personId, samples: clip, now: now) else { return false }
+    lastSampleAt[key] = now
+    var files = voiceprints[index].sampleFiles
+    files.insert(file, at: 0)
+    if files.count > policy.maxSamplesPerVoice {
+      store.removeSamples(Array(files[policy.maxSamplesPerVoice...]))
+      files = Array(files.prefix(policy.maxSamplesPerVoice))
+    }
+    voiceprints[index].sampleFiles = files
+    return true
   }
 
   private static func knownVoice(_ stored: StoredVoiceprint) -> LocalSpeakerRegistry.KnownVoice {

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -250,23 +250,30 @@ actor LocalSpeakerDiarizer {
       guard let centroid = Self.meanEmbedding(voice.embeddings) else { continue }
       let update = VoiceprintUpdate(
         personId: voice.personId, embedding: centroid, speechSeconds: voice.speechSeconds, isEnrolled: true)
-      // Replace rather than blend: the rebuild heard the whole history, not one session.
+      // Replace rather than blend: the rebuild heard the whole history, not one session. What
+      // the person chose — a pin, and how often Omi has heard them — is theirs and carries over.
+      let previous = voiceprints.first { $0.personId == voice.personId }
       voiceprints.removeAll { $0.personId == voice.personId }
       voiceprints = LocalVoiceprintStore.applying(update, to: voiceprints, now: now)
       if let index = voiceprints.firstIndex(where: { $0.personId == voice.personId }) {
-        let previous = voiceprints[index]
+        voiceprints[index].isFavorite = previous?.isFavorite ?? false
         voiceprints[index].useScore = max(
-          policy.decayedScore(previous.useScore, lastUsedAt: previous.lastUsedAt, now: now),
+          policy.decayedScore(previous?.useScore ?? 0, lastUsedAt: previous?.lastUsedAt, now: now),
           Double(voice.conversationCount))
-        voiceprints[index].lastUsedAt = [previous.lastUsedAt, voice.lastHeardAt].compactMap { $0 }.max()
-        store.removeAllSamples(personId: voice.personId)
-        voiceprints[index].sampleFiles = []
-        for (offset, clip) in voice.clips.enumerated() {
-          // Distinct names: clips share `now`, and the file name is the timestamp.
-          let stamp = now.addingTimeInterval(-Double(offset))
-          if let file = store.addSample(personId: voice.personId, samples: clip, now: stamp) {
-            voiceprints[index].sampleFiles.append(file)
-            clipsSaved += 1
+        voiceprints[index].lastUsedAt = [previous?.lastUsedAt, voice.lastHeardAt].compactMap { $0 }.max()
+        // Only trade clips for clips: a rebuild that heard nothing must not leave the voice mute.
+        if voice.clips.isEmpty {
+          voiceprints[index].sampleFiles = previous?.sampleFiles ?? []
+        } else {
+          store.removeAllSamples(personId: voice.personId)
+          voiceprints[index].sampleFiles = []
+          for (offset, clip) in voice.clips.enumerated() {
+            // Distinct names: clips share `now`, and the file name is the timestamp.
+            let stamp = now.addingTimeInterval(-Double(offset))
+            if let file = store.addSample(personId: voice.personId, samples: clip, now: stamp) {
+              voiceprints[index].sampleFiles.append(file)
+              clipsSaved += 1
+            }
           }
         }
       }

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -6,14 +6,23 @@ import Foundation
 /// Owns FluidAudio's diarization models (pyannote segmentation + WeSpeaker embeddings, CoreML
 /// on the Neural Engine) and one `LocalSpeakerRegistry` shared by the mic and system-audio
 /// `LocalTranscriptionService` instances, so speaker ids are consistent across both lanes and
-/// across conversation rotations within an app run. The user's voiceprint persists in
-/// `UserDefaults` so "You" is recognised from the first sentence of the next session.
+/// across conversation rotations within an app run. Remembered voices — the user's and every
+/// named person's — live in `LocalVoiceprintStore`, so "You" and known people are recognised
+/// from the first sentence of the next session.
 ///
 /// Fails open: if the models can't load, `resolve` returns nil and the transcriber keeps the
 /// old source-based labels (mic = "You", system = Speaker 1).
 actor LocalSpeakerDiarizer {
 
   static let shared = LocalSpeakerDiarizer()
+
+  /// What the People page shows about a remembered voice.
+  struct VoiceSummary: Equatable, Sendable {
+    let personId: String?
+    let speechSeconds: Double
+    let updatedAt: Date
+    let isEnrolled: Bool
+  }
 
   private enum State {
     case idle
@@ -22,24 +31,40 @@ actor LocalSpeakerDiarizer {
     case unavailable
   }
 
+  /// Shortest push-to-talk sample worth learning the user's voice from.
+  static let minEnrollmentSeconds = 2.0
+
+  typealias RelabelSink = @MainActor ([Int: LocalSpeakerRegistry.Resolution]) -> Void
+
   private var state: State = .idle
+  /// Where relabels go when they originate here rather than from a transcriber window (a
+  /// push-to-talk enrollment that identifies a live speaker). Set by the app when the local
+  /// transcription services start.
+  private var relabelSink: RelabelSink?
   private var manager: DiarizerManager?
   private var registry: LocalSpeakerRegistry
-  private let defaults: UserDefaults
+  private var store: LocalVoiceprintStore
+  private var voiceprints: [StoredVoiceprint]
   private let loadModels: @Sendable () async throws -> DiarizerModels
 
   init(
-    defaults: UserDefaults = .standard,
+    store: LocalVoiceprintStore = .forCurrentUser(),
     loadModels: @escaping @Sendable () async throws -> DiarizerModels = { try await DiarizerModels.downloadIfNeeded() }
   ) {
-    self.defaults = defaults
+    self.store = store
     self.loadModels = loadModels
-    self.registry = LocalSpeakerRegistry(userVoiceprint: Self.loadVoiceprint(from: defaults))
+    let voiceprints = store.load()
+    self.voiceprints = voiceprints
+    self.registry = LocalSpeakerRegistry(knownVoices: voiceprints.map(Self.knownVoice))
   }
 
   var isAvailable: Bool {
     if case .ready = state { return true }
     return false
+  }
+
+  func setRelabelSink(_ sink: RelabelSink?) {
+    relabelSink = sink
   }
 
   /// Load the models once per app run. Safe to call from both lanes; the second caller
@@ -70,8 +95,9 @@ actor LocalSpeakerDiarizer {
       manager.initialize(models: models)
       self.manager = manager
       state = .ready
+      let known = voiceprints.filter { $0.personId != nil }.count
       log(
-        "LocalSpeakerDiarizer: models ready in \(String(format: "%.1f", Date().timeIntervalSince(started)))s (voiceprint: \(registry.userVoiceprint == nil ? "none" : "stored"))"
+        "LocalSpeakerDiarizer: models ready in \(String(format: "%.1f", Date().timeIntervalSince(started)))s (user voice: \(userVoiceDescription), \(known) known people)"
       )
     } catch {
       state = .unavailable
@@ -86,6 +112,13 @@ actor LocalSpeakerDiarizer {
     }
   }
 
+  private var userVoiceDescription: String {
+    guard let user = voiceprints.first(where: { $0.personId == nil }) else { return "none" }
+    return user.isEnrolled ? "enrolled" : "learned"
+  }
+
+  // MARK: - Windows
+
   /// Identify the dominant voice in one transcribed window. Nil when the diarizer is not
   /// available or the window yields no usable embedding — the caller keeps its lane label.
   func resolve(
@@ -99,12 +132,75 @@ actor LocalSpeakerDiarizer {
     let outcome = registry.observe(
       LocalSpeakerRegistry.Observation(
         embedding: embedding, durationSeconds: durationSeconds, loudness: rms, lane: lane))
-    if let voiceprint = outcome?.voiceprintToPersist {
-      Self.storeVoiceprint(voiceprint, in: defaults)
-      log("LocalSpeakerDiarizer: persisted user voiceprint")
+    if let updates = outcome?.voiceprintsToPersist, !updates.isEmpty {
+      remember(updates)
     }
     return outcome
   }
+
+  // MARK: - Explicit identity
+
+  /// "This is me" on a live bubble. Returns the relabels for segments already on screen.
+  func markSpeakerAsUser(_ speakerId: Int) -> [Int: LocalSpeakerRegistry.Resolution] {
+    guard let result = registry.markAsUser(speakerId: speakerId) else { return [:] }
+    remember([result.persist])
+    log("LocalSpeakerDiarizer: speaker \(speakerId) marked as the user")
+    return result.relabels
+  }
+
+  /// A live speaker was named (or un-named). Teaches that person's voice.
+  func assignPerson(_ personId: String?, toSpeaker speakerId: Int) -> [Int: LocalSpeakerRegistry.Resolution] {
+    guard let result = registry.assignPerson(personId, toSpeakerId: speakerId) else { return [:] }
+    if let update = result.persist { remember([update]) }
+    return result.relabels
+  }
+
+  /// Learn the user's voice from a push-to-talk turn: whoever holds the shortcut and talks to
+  /// Omi is the user beyond doubt. 16 kHz mono Int16 PCM. When a live mic speaker turns out
+  /// to be the user, the relabels go to the sink the app registered.
+  func enrollUserVoice(pcm16k: Data) async {
+    guard case .ready = state, let manager else { return }
+    let seconds = Double(pcm16k.count / 2) / 16000
+    guard seconds >= Self.minEnrollmentSeconds else { return }
+    let samples = Self.int16ToFloat32(pcm16k)
+    guard let embedding = dominantEmbedding(in: samples, manager: manager),
+      let result = registry.enrollUser(embedding: embedding, speechSeconds: seconds)
+    else { return }
+    remember([result.persist])
+    log("LocalSpeakerDiarizer: learned the user's voice from a \(String(format: "%.1f", seconds))s push-to-talk turn")
+    if !result.relabels.isEmpty, let relabelSink {
+      let relabels = result.relabels
+      await MainActor.run { relabelSink(relabels) }
+    }
+  }
+
+  /// Forget a remembered voice (the user's when `personId` is nil).
+  func forgetVoice(personId: String?) {
+    registry.forgetVoice(personId: personId)
+    voiceprints.removeAll { $0.personId == personId }
+    store.save(voiceprints)
+  }
+
+  func voiceSummaries() -> [VoiceSummary] {
+    voiceprints.map {
+      VoiceSummary(personId: $0.personId, speechSeconds: $0.speechSeconds, updatedAt: $0.updatedAt, isEnrolled: $0.isEnrolled)
+    }
+  }
+
+  private func remember(_ updates: [VoiceprintUpdate]) {
+    for update in updates {
+      voiceprints = LocalVoiceprintStore.applying(update, to: voiceprints)
+    }
+    store.save(voiceprints)
+    let who = updates.map { $0.personId ?? "user" }.joined(separator: ", ")
+    log("LocalSpeakerDiarizer: remembered voice for \(who)")
+  }
+
+  private static func knownVoice(_ stored: StoredVoiceprint) -> LocalSpeakerRegistry.KnownVoice {
+    LocalSpeakerRegistry.KnownVoice(personId: stored.personId, embedding: stored.embedding, isEnrolled: stored.isEnrolled)
+  }
+
+  // MARK: - Embeddings
 
   /// Embedding of whoever spoke most in the window. Segmentation masks out silence and the
   /// other voice in a two-speaker window, which an all-ones mask would blend in; if
@@ -137,17 +233,12 @@ actor LocalSpeakerDiarizer {
     }
   }
 
-  // MARK: - Voiceprint persistence
-
-  private static func loadVoiceprint(from defaults: UserDefaults) -> [Float]? {
-    guard let data = defaults.data(forKey: DefaultsKey.localSpeakerUserVoiceprint.rawValue),
-      data.count % MemoryLayout<Float>.size == 0, !data.isEmpty
-    else { return nil }
-    return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
-  }
-
-  private static func storeVoiceprint(_ voiceprint: [Float], in defaults: UserDefaults) {
-    let data = voiceprint.withUnsafeBufferPointer { Data(buffer: $0) }
-    defaults.set(data, forKey: DefaultsKey.localSpeakerUserVoiceprint.rawValue)
+  private static func int16ToFloat32(_ data: Data) -> [Float] {
+    let count = data.count / 2
+    guard count > 0 else { return [] }
+    return data.withUnsafeBytes { raw -> [Float] in
+      let samples = raw.bindMemory(to: Int16.self)
+      return (0..<count).map { Float(Int16(littleEndian: samples[$0])) / 32768.0 }
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -49,7 +49,7 @@ actor LocalSpeakerDiarizer {
   private var relabelSink: RelabelSink?
   private var manager: DiarizerManager?
   private var registry: LocalSpeakerRegistry
-  private let store: LocalVoiceprintStore
+  private var store: LocalVoiceprintStore
   private let policy: VoiceEnrollmentPolicy
   private var voiceprints: [StoredVoiceprint]
   private let loadModels: @Sendable () async throws -> DiarizerModels
@@ -73,6 +73,24 @@ actor LocalSpeakerDiarizer {
     let voiceprints = store.load()
     self.voiceprints = voiceprints
     self.registry = LocalSpeakerRegistry(knownVoices: voiceprints.map(Self.knownVoice))
+  }
+
+  /// Follow the effective owner to their own voices. Remembered voices are per-account:
+  /// they live under the signed-in user's profile, and everything held here — the prints,
+  /// the session's clusters, the windows kept for a naming — belongs to the owner it was
+  /// heard under. Called from `RuntimeOwnerIdentity` while the transition reservation is
+  /// held, so the next owner's first window is clustered against their own voices and the
+  /// previous owner's are never written into their file or listed on their People page.
+  ///
+  /// The loaded models are the same for every account and stay as they are.
+  func retargetEffectiveOwner(to store: LocalVoiceprintStore) {
+    self.store = store
+    voiceprints = store.load()
+    registry = LocalSpeakerRegistry(knownVoices: voiceprints.map(Self.knownVoice))
+    relabelSink = nil
+    recentWindows = [:]
+    usedThisRun = []
+    lastSampleAt = [:]
   }
 
   var isAvailable: Bool {

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
@@ -1,0 +1,153 @@
+import FluidAudio
+import Foundation
+
+/// On-device speaker identification for the local (Parakeet) transcription path.
+///
+/// Owns FluidAudio's diarization models (pyannote segmentation + WeSpeaker embeddings, CoreML
+/// on the Neural Engine) and one `LocalSpeakerRegistry` shared by the mic and system-audio
+/// `LocalTranscriptionService` instances, so speaker ids are consistent across both lanes and
+/// across conversation rotations within an app run. The user's voiceprint persists in
+/// `UserDefaults` so "You" is recognised from the first sentence of the next session.
+///
+/// Fails open: if the models can't load, `resolve` returns nil and the transcriber keeps the
+/// old source-based labels (mic = "You", system = Speaker 1).
+actor LocalSpeakerDiarizer {
+
+  static let shared = LocalSpeakerDiarizer()
+
+  private enum State {
+    case idle
+    case loading(Task<Void, Never>)
+    case ready
+    case unavailable
+  }
+
+  private var state: State = .idle
+  private var manager: DiarizerManager?
+  private var registry: LocalSpeakerRegistry
+  private let defaults: UserDefaults
+  private let loadModels: @Sendable () async throws -> DiarizerModels
+
+  init(
+    defaults: UserDefaults = .standard,
+    loadModels: @escaping @Sendable () async throws -> DiarizerModels = { try await DiarizerModels.downloadIfNeeded() }
+  ) {
+    self.defaults = defaults
+    self.loadModels = loadModels
+    self.registry = LocalSpeakerRegistry(userVoiceprint: Self.loadVoiceprint(from: defaults))
+  }
+
+  var isAvailable: Bool {
+    if case .ready = state { return true }
+    return false
+  }
+
+  /// Load the models once per app run. Safe to call from both lanes; the second caller
+  /// awaits the first load. Returns once the diarizer is ready or has given up.
+  func prepare() async {
+    switch state {
+    case .ready, .unavailable:
+      return
+    case .loading(let task):
+      await task.value
+      return
+    case .idle:
+      break
+    }
+    let task = Task { await self.load() }
+    state = .loading(task)
+    await task.value
+  }
+
+  private func load() async {
+    let started = Date()
+    do {
+      let models = try await loadModels()
+      // Short windows are common (pause-closed utterances); default 1.0 s would drop them.
+      var config = DiarizerConfig()
+      config.minSpeechDuration = 0.5
+      let manager = DiarizerManager(config: config)
+      manager.initialize(models: models)
+      self.manager = manager
+      state = .ready
+      log(
+        "LocalSpeakerDiarizer: models ready in \(String(format: "%.1f", Date().timeIntervalSince(started)))s (voiceprint: \(registry.userVoiceprint == nil ? "none" : "stored"))"
+      )
+    } catch {
+      state = .unavailable
+      logError("LocalSpeakerDiarizer: model load failed; falling back to source-based speaker labels", error: error)
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "stt_selection",
+        from: "on_device_diarization",
+        to: "source_lanes",
+        reason: "model_load_failed",
+        outcome: .degraded
+      )
+    }
+  }
+
+  /// Identify the dominant voice in one transcribed window. Nil when the diarizer is not
+  /// available or the window yields no usable embedding — the caller keeps its lane label.
+  func resolve(
+    window: [Float],
+    durationSeconds: Double,
+    rms: Float,
+    lane: LocalTranscriptionLane
+  ) -> LocalSpeakerRegistry.Outcome? {
+    guard case .ready = state, let manager else { return nil }
+    guard let embedding = dominantEmbedding(in: window, manager: manager) else { return nil }
+    let outcome = registry.observe(
+      LocalSpeakerRegistry.Observation(
+        embedding: embedding, durationSeconds: durationSeconds, loudness: rms, lane: lane))
+    if let voiceprint = outcome?.voiceprintToPersist {
+      Self.storeVoiceprint(voiceprint, in: defaults)
+      log("LocalSpeakerDiarizer: persisted user voiceprint")
+    }
+    return outcome
+  }
+
+  /// Embedding of whoever spoke most in the window. Segmentation masks out silence and the
+  /// other voice in a two-speaker window, which an all-ones mask would blend in; if
+  /// segmentation finds nothing (very short window), fall back to embedding the whole clip.
+  private func dominantEmbedding(in window: [Float], manager: DiarizerManager) -> [Float]? {
+    do {
+      // Clustering is ours (LocalSpeakerRegistry); FluidAudio's per-manager speaker table would
+      // otherwise grow for the whole app run.
+      manager.speakerManager.reset()
+      let result = try manager.performCompleteDiarization(window)
+      var durationBySpeaker: [String: Float] = [:]
+      var longestBySpeaker: [String: TimedSpeakerSegment] = [:]
+      for segment in result.segments where manager.validateEmbedding(segment.embedding) {
+        durationBySpeaker[segment.speakerId, default: 0] += segment.durationSeconds
+        if let current = longestBySpeaker[segment.speakerId], current.durationSeconds >= segment.durationSeconds {
+          continue
+        }
+        longestBySpeaker[segment.speakerId] = segment
+      }
+      if let dominant = durationBySpeaker.max(by: { $0.value < $1.value })?.key,
+        let segment = longestBySpeaker[dominant]
+      {
+        return segment.embedding
+      }
+      let whole = try manager.extractSpeakerEmbedding(from: window)
+      return manager.validateEmbedding(whole) ? whole : nil
+    } catch {
+      logError("LocalSpeakerDiarizer: embedding failed", error: error)
+      return nil
+    }
+  }
+
+  // MARK: - Voiceprint persistence
+
+  private static func loadVoiceprint(from defaults: UserDefaults) -> [Float]? {
+    guard let data = defaults.data(forKey: DefaultsKey.localSpeakerUserVoiceprint.rawValue),
+      data.count % MemoryLayout<Float>.size == 0, !data.isEmpty
+    else { return nil }
+    return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+  }
+
+  private static func storeVoiceprint(_ voiceprint: [Float], in defaults: UserDefaults) {
+    let data = voiceprint.withUnsafeBufferPointer { Data(buffer: $0) }
+    defaults.set(data, forKey: DefaultsKey.localSpeakerUserVoiceprint.rawValue)
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
@@ -11,20 +11,20 @@ enum LocalTranscriptionLane: String, Sendable, Equatable {
 ///
 /// Before this, the mic lane stamped every window "You" and the system lane "Speaker 1", so a
 /// second person in the room was transcribed as the user. The registry clusters per-window
-/// speaker embeddings (cosine distance, running-mean centroids) and decides which cluster is
-/// the user:
+/// speaker embeddings (cosine distance, running-mean centroids), names clusters that match a
+/// remembered person, and decides which cluster is the user:
 ///
-///  1. A persisted voiceprint (`userVoiceprint`) wins: the first mic-lane cluster within
-///     `userMatchThreshold` of it becomes "You" and stays "You".
-///  2. With no voiceprint — or when nothing has matched it after `voiceprintGraceSeconds` of
-///     mic speech (new microphone, different room) — the dominant mic-lane voice, scored by
-///     loudness-weighted speech time, is the provisional user. The Mac's owner sits closest
-///     to its microphone and is present in every session, so this converges quickly. When a
-///     different mic voice overtakes the provisional user by `bootstrapSwapMargin`, the two
-///     swap public ids and `Outcome.relabels` tells the caller which already-emitted
-///     segments to rewrite.
-///  3. Once the user cluster has `voiceprintPersistSeconds` of speech the registry hands
-///     back a voiceprint to persist, so later sessions start with rule 1.
+///  1. A remembered voice of the user (`KnownVoice` with `personId == nil`) wins: the first
+///     mic-lane cluster within `knownVoiceMatchThreshold` of it becomes "You". An *enrolled*
+///     print ("This is me", a push-to-talk turn) locks that for the session; a print the
+///     bootstrap merely learned stays open to correction.
+///  2. With no remembered voice — or when nothing has matched it after `voiceprintGraceSeconds`
+///     of mic speech (new microphone, different room) — the dominant mic-lane voice, scored by
+///     loudness-weighted speech time, is the provisional user. When a different mic voice
+///     overtakes it by `bootstrapSwapMargin`, the two swap public ids and `Outcome.relabels`
+///     tells the caller which already-emitted segments to rewrite.
+///  3. `markAsUser` / `enrollUser` make the identity explicit; `assignPerson` teaches a named
+///     person's voice so later sessions stamp their `personId` on arrival.
 ///
 /// Public speaker ids: the user is always 0 (`VoiceBargeInPolicy` and
 /// `EnvironmentalSpeakerContext` rely on that); everyone else counts up from 1 in order of
@@ -35,6 +35,13 @@ struct LocalSpeakerRegistry: Sendable {
   struct Resolution: Equatable, Hashable, Sendable {
     let speakerId: Int
     let isUser: Bool
+    let personId: String?
+
+    init(speakerId: Int, isUser: Bool, personId: String? = nil) {
+      self.speakerId = speakerId
+      self.isUser = isUser
+      self.personId = isUser ? nil : personId
+    }
 
     var speakerLabel: String { String(format: "SPEAKER_%02d", speakerId) }
   }
@@ -47,13 +54,20 @@ struct LocalSpeakerRegistry: Sendable {
     let lane: LocalTranscriptionLane
   }
 
+  /// A voice remembered from earlier sessions. `personId == nil` is the user.
+  struct KnownVoice: Sendable {
+    let personId: String?
+    let embedding: [Float]
+    let isEnrolled: Bool
+  }
+
   struct Outcome: Equatable, Sendable {
     let resolution: Resolution
     /// Previous public speaker id → new resolution, for segments already emitted. Empty
-    /// unless the user cluster changed.
+    /// unless a cluster's identity changed.
     let relabels: [Int: Resolution]
-    /// Non-nil when the caller should persist this as the user's voiceprint.
-    let voiceprintToPersist: [Float]?
+    /// Voices the caller should remember now.
+    let voiceprintsToPersist: [VoiceprintUpdate]
     /// Cosine distance to the closest cluster that existed before this window (infinity for
     /// the first one). Logged so the thresholds can be calibrated against real audio.
     let nearestDistance: Float
@@ -61,22 +75,23 @@ struct LocalSpeakerRegistry: Sendable {
 
   struct Config: Sendable {
     /// Max cosine distance for a window to join an existing cluster. WeSpeaker ResNet34
-    /// distances: same voice ≈ 0.2–0.45, different voices ≈ 0.7+. Matches the backend's
-    /// `SPEAKER_CLUSTERING_THRESHOLD`.
+    /// distances measured live: same voice 0.06–0.26 (mixed windows ≈ 0.5), different voices
+    /// 0.68–0.94. Matches the backend's `SPEAKER_CLUSTERING_THRESHOLD`.
     var matchThreshold: Float = 0.60
     /// Only confident matches move a centroid, so a borderline window can't drag a cluster
     /// toward another voice.
     var updateThreshold: Float = 0.45
-    /// Distance to the persisted voiceprint that identifies the user. Tighter than
-    /// `matchThreshold`: a false "You" is worse than a late one.
-    var userMatchThreshold: Float = 0.50
-    /// Mic speech tolerated without a voiceprint match before falling back to bootstrap.
+    /// Distance to a remembered voice that identifies that person. Tighter than
+    /// `matchThreshold`: a false "You" (or a false name) is worse than a late one.
+    var knownVoiceMatchThreshold: Float = 0.50
+    /// Mic speech tolerated without a match to the remembered user before falling back to
+    /// bootstrap.
     var voiceprintGraceSeconds: Double = 30
     /// A rival mic voice must out-score the provisional user by this factor to take over.
     var bootstrapSwapMargin: Double = 1.5
-    /// User speech needed before the voiceprint is (re)persisted.
+    /// Speech a cluster needs before its voice is (re)remembered.
     var voiceprintPersistSeconds: Double = 20
-    /// Voiceprint is re-persisted every time user speech grows by this much.
+    /// A voice is re-remembered every time its speech grows by this much.
     var voiceprintRepersistSeconds: Double = 60
     /// Hard cap on tracked voices; beyond it a window joins its nearest cluster.
     var maxClusters: Int = 16
@@ -94,11 +109,13 @@ struct LocalSpeakerRegistry: Sendable {
     var speakerId: Int
     var centroid: [Float]
     var centroidWeightSeconds: Double
+    var personId: String?
     var speechSeconds: Double = 0
     var micSeconds: Double = 0
     var systemSeconds: Double = 0
     /// Σ duration × RMS over mic-lane windows: louder-and-longer wins the bootstrap.
     var micEnergySeconds: Double = 0
+    var secondsAtLastPersist: Double = 0
 
     /// A voice that is mostly heard through the speakers is a remote party, never the user —
     /// even when its echo also reaches the mic.
@@ -108,24 +125,28 @@ struct LocalSpeakerRegistry: Sendable {
   let config: Config
   private(set) var clusters: [Cluster] = []
   private(set) var userClusterKey: Int?
-  /// Voiceprint carried over from earlier sessions — the only one that identifies the user
-  /// outright (rule 1). One learned this session is provisional until it survives a restart.
-  private let storedVoiceprint: [Float]?
-  /// Latest voiceprint handed back for persistence (starts as `storedVoiceprint`).
-  private(set) var userVoiceprint: [Float]?
-  /// True once the user cluster was chosen by matching the persisted voiceprint (rule 1).
-  /// Locks out bootstrap swaps for the rest of the session.
+  /// Voices remembered from earlier sessions, plus anything enrolled this session.
+  private(set) var knownVoices: [KnownVoice]
+  /// True once the user cluster is beyond doubt: it matched an enrolled print, or the user
+  /// confirmed it this session. Locks out bootstrap swaps for the rest of the session.
   private(set) var userIsConfirmed = false
   private var micSecondsSinceStart: Double = 0
   private var nextClusterKey = 0
   private var nextOtherSpeakerId = 1
-  private var userSecondsAtLastPersist: Double = 0
 
-  init(userVoiceprint: [Float]? = nil, config: Config = Config()) {
+  init(knownVoices: [KnownVoice] = [], config: Config = Config()) {
     self.config = config
-    let normalized = userVoiceprint.flatMap(Self.normalized)
-    self.storedVoiceprint = normalized
-    self.userVoiceprint = normalized
+    self.knownVoices = knownVoices.compactMap { voice in
+      guard let normalized = Self.normalized(voice.embedding) else { return nil }
+      return KnownVoice(personId: voice.personId, embedding: normalized, isEnrolled: voice.isEnrolled)
+    }
+  }
+
+  /// Convenience for the common single-voiceprint case.
+  init(userVoiceprint: [Float]?, userIsEnrolled: Bool = false, config: Config = Config()) {
+    self.init(
+      knownVoices: userVoiceprint.map { [KnownVoice(personId: nil, embedding: $0, isEnrolled: userIsEnrolled)] } ?? [],
+      config: config)
   }
 
   var userSpeakerId: Int { 0 }
@@ -134,6 +155,18 @@ struct LocalSpeakerRegistry: Sendable {
     guard let userClusterKey else { return nil }
     return clusters.first { $0.key == userClusterKey }
   }
+
+  var knownUserVoice: KnownVoice? { knownVoices.first { $0.personId == nil } }
+
+  func cluster(forSpeakerId speakerId: Int) -> Cluster? {
+    clusters.first { $0.speakerId == speakerId }
+  }
+
+  private func resolution(for cluster: Cluster) -> Resolution {
+    Resolution(speakerId: cluster.speakerId, isUser: cluster.key == userClusterKey, personId: cluster.personId)
+  }
+
+  // MARK: - Observing windows
 
   /// Fold one transcribed window into the registry and say who spoke.
   mutating func observe(_ observation: Observation) -> Outcome? {
@@ -148,23 +181,100 @@ struct LocalSpeakerRegistry: Sendable {
     accumulate(at: index, observation: observation, duration: duration)
 
     var relabels: [Int: Resolution] = [:]
+    if let named = matchKnownPerson(at: index) { relabels.merge(named) { _, new in new } }
     if observation.lane == .microphone {
-      relabels = reconsiderUser(afterObserving: index)
-      if created {
-        // No segment carries a brand-new cluster's provisional id yet; only the resolution
-        // returned below needs it.
-        relabels.removeValue(forKey: idBeforeReconsidering)
-      }
+      relabels.merge(reconsiderUser(afterObserving: index)) { _, new in new }
+    }
+    if created {
+      // No segment carries a brand-new cluster's provisional id yet; only the resolution
+      // returned below needs it.
+      relabels.removeValue(forKey: idBeforeReconsidering)
     }
 
-    let voiceprint = voiceprintToPersistIfDue()
     let cluster = clusters[index]
     return Outcome(
-      resolution: Resolution(speakerId: cluster.speakerId, isUser: cluster.key == userClusterKey),
+      resolution: resolution(for: cluster),
       relabels: relabels,
-      voiceprintToPersist: voiceprint,
+      voiceprintsToPersist: voiceprintsDue(),
       nearestDistance: nearestDistance
     )
+  }
+
+  // MARK: - Explicit identity
+
+  /// "This is me": the cluster behind `speakerId` is the user, beyond doubt.
+  /// Returns the relabels for its (and the previous user's) earlier segments and the print
+  /// to remember; nil when no such speaker exists.
+  mutating func markAsUser(speakerId: Int) -> (relabels: [Int: Resolution], persist: VoiceprintUpdate)? {
+    guard let index = clusters.firstIndex(where: { $0.speakerId == speakerId }) else { return nil }
+    clusters[index].personId = nil
+    var relabels = promoteToUser(index)
+    userIsConfirmed = true
+    // Always report the cluster itself: when it was already the user, promote changed nothing,
+    // but the caller may still hold segments that predate a name it carried.
+    relabels[speakerId] = resolution(for: clusters[index])
+    let update = VoiceprintUpdate(
+      personId: nil, embedding: clusters[index].centroid,
+      speechSeconds: clusters[index].speechSeconds, isEnrolled: true)
+    rememberUserVoice(clusters[index].centroid, isEnrolled: true)
+    clusters[index].secondsAtLastPersist = clusters[index].speechSeconds
+    return (relabels, update)
+  }
+
+  /// Name (or un-name) the cluster behind `speakerId`. Naming teaches the person's voice.
+  mutating func assignPerson(_ personId: String?, toSpeakerId speakerId: Int)
+    -> (relabels: [Int: Resolution], persist: VoiceprintUpdate?)?
+  {
+    guard let index = clusters.firstIndex(where: { $0.speakerId == speakerId }),
+      clusters[index].key != userClusterKey
+    else { return nil }
+    clusters[index].personId = personId
+    let relabels = [speakerId: resolution(for: clusters[index])]
+    guard let personId else { return (relabels, nil) }
+    knownVoices.removeAll { $0.personId == personId }
+    knownVoices.append(KnownVoice(personId: personId, embedding: clusters[index].centroid, isEnrolled: true))
+    clusters[index].secondsAtLastPersist = clusters[index].speechSeconds
+    let update = VoiceprintUpdate(
+      personId: personId, embedding: clusters[index].centroid,
+      speechSeconds: clusters[index].speechSeconds, isEnrolled: true)
+    return (relabels, update)
+  }
+
+  /// A sample that is the user's voice beyond doubt (a push-to-talk turn). Remembers it and,
+  /// if a mic cluster already matches, makes that cluster the user.
+  mutating func enrollUser(embedding: [Float], speechSeconds: Double)
+    -> (relabels: [Int: Resolution], persist: VoiceprintUpdate)?
+  {
+    guard let normalized = Self.normalized(embedding) else { return nil }
+    rememberUserVoice(normalized, isEnrolled: true)
+    var relabels: [Int: Resolution] = [:]
+    if !userIsConfirmed,
+      let index = nearestMicCluster(to: normalized, within: config.knownVoiceMatchThreshold)
+    {
+      relabels = promoteToUser(index)
+      userIsConfirmed = true
+    }
+    return (
+      relabels,
+      VoiceprintUpdate(personId: nil, embedding: normalized, speechSeconds: speechSeconds, isEnrolled: true)
+    )
+  }
+
+  /// Forget a remembered voice (the user's when `personId` is nil) for the rest of the session.
+  mutating func forgetVoice(personId: String?) {
+    knownVoices.removeAll { $0.personId == personId }
+    if personId == nil {
+      userIsConfirmed = false
+    } else {
+      for index in clusters.indices where clusters[index].personId == personId {
+        clusters[index].personId = nil
+      }
+    }
+  }
+
+  private mutating func rememberUserVoice(_ embedding: [Float], isEnrolled: Bool) {
+    knownVoices.removeAll { $0.personId == nil }
+    knownVoices.append(KnownVoice(personId: nil, embedding: embedding, isEnrolled: isEnrolled))
   }
 
   // MARK: - Clustering
@@ -229,21 +339,50 @@ struct LocalSpeakerRegistry: Sendable {
     }
   }
 
-  // MARK: - Who is the user
+  private func nearestMicCluster(to embedding: [Float], within threshold: Float) -> Int? {
+    var best: (index: Int, distance: Float)?
+    for (index, cluster) in clusters.enumerated() where cluster.isMicVoice {
+      let distance = Self.cosineDistance(embedding, cluster.centroid)
+      if distance <= threshold, distance < (best?.distance ?? .infinity) {
+        best = (index, distance)
+      }
+    }
+    return best?.index
+  }
+
+  // MARK: - Who is this
+
+  /// Stamp a remembered person on an unnamed cluster whose voice matches. Returns the relabel
+  /// for that cluster's earlier segments when the match arrived after they were emitted.
+  private mutating func matchKnownPerson(at index: Int) -> [Int: Resolution]? {
+    guard clusters[index].personId == nil, clusters[index].key != userClusterKey else { return nil }
+    let taken = Set(clusters.compactMap(\.personId))
+    var best: (personId: String, distance: Float)?
+    for voice in knownVoices {
+      guard let personId = voice.personId, !taken.contains(personId) else { continue }
+      let distance = Self.cosineDistance(clusters[index].centroid, voice.embedding)
+      if distance <= config.knownVoiceMatchThreshold, distance < (best?.distance ?? .infinity) {
+        best = (personId, distance)
+      }
+    }
+    guard let best else { return nil }
+    clusters[index].personId = best.personId
+    return [clusters[index].speakerId: resolution(for: clusters[index])]
+  }
 
   private mutating func reconsiderUser(afterObserving index: Int) -> [Int: Resolution] {
     if userIsConfirmed { return [:] }
 
-    // Rule 1: the persisted voiceprint identifies the user outright.
-    if let storedVoiceprint, clusters[index].isMicVoice,
-      Self.cosineDistance(clusters[index].centroid, storedVoiceprint) <= config.userMatchThreshold
+    // Rule 1: the remembered voice of the user identifies them outright.
+    if let known = knownUserVoice, clusters[index].isMicVoice, clusters[index].key != userClusterKey,
+      Self.cosineDistance(clusters[index].centroid, known.embedding) <= config.knownVoiceMatchThreshold
     {
-      userIsConfirmed = true
+      userIsConfirmed = known.isEnrolled
       return promoteToUser(index)
     }
 
-    // Rule 2: no voiceprint, or it has gone stale — the dominant mic voice is the user.
-    if storedVoiceprint != nil && micSecondsSinceStart < config.voiceprintGraceSeconds {
+    // Rule 2: no remembered voice, or it has gone stale — the dominant mic voice is the user.
+    if knownUserVoice != nil && userClusterKey == nil && micSecondsSinceStart < config.voiceprintGraceSeconds {
       return [:]
     }
     guard let dominant = dominantMicClusterIndex() else { return [:] }
@@ -260,7 +399,7 @@ struct LocalSpeakerRegistry: Sendable {
 
   private func dominantMicClusterIndex() -> Int? {
     var best: (index: Int, score: Double)?
-    for (index, cluster) in clusters.enumerated() where cluster.isMicVoice {
+    for (index, cluster) in clusters.enumerated() where cluster.isMicVoice && cluster.personId == nil {
       if cluster.micEnergySeconds > (best?.score ?? -1) {
         best = (index, cluster.micEnergySeconds)
       }
@@ -276,44 +415,52 @@ struct LocalSpeakerRegistry: Sendable {
     var relabels: [Int: Resolution] = [:]
     if let currentKey = userClusterKey, let currentIndex = clusters.firstIndex(where: { $0.key == currentKey }) {
       clusters[currentIndex].speakerId = vacatedId
-      relabels[userSpeakerId] = Resolution(speakerId: vacatedId, isUser: false)
-    }
-    if userClusterKey == nil, vacatedId == nextOtherSpeakerId - 1 {
+      clusters[currentIndex].secondsAtLastPersist = 0
+      relabels[userSpeakerId] = Resolution(
+        speakerId: vacatedId, isUser: false, personId: clusters[currentIndex].personId)
+    } else if vacatedId == nextOtherSpeakerId - 1 {
       // Nobody inherits the vacated id: give it back so the next other voice is "Speaker 1",
       // not "Speaker 2".
       nextOtherSpeakerId -= 1
     }
     clusters[index].speakerId = userSpeakerId
+    clusters[index].personId = nil
+    clusters[index].secondsAtLastPersist = 0
     userClusterKey = clusters[index].key
-    userSecondsAtLastPersist = 0
     if vacatedId != userSpeakerId {
       relabels[vacatedId] = Resolution(speakerId: userSpeakerId, isUser: true)
     }
     return relabels
   }
 
-  // MARK: - Voiceprint persistence
+  // MARK: - Remembering voices
 
-  private mutating func voiceprintToPersistIfDue() -> [Float]? {
-    guard let user = userCluster, user.speechSeconds >= config.voiceprintPersistSeconds else { return nil }
-    let due =
-      userSecondsAtLastPersist == 0
-      || user.speechSeconds - userSecondsAtLastPersist >= config.voiceprintRepersistSeconds
-    guard due else { return nil }
-    userSecondsAtLastPersist = user.speechSeconds
-
-    // Blend with the stored voiceprint so one odd session (a cold, a bad mic) cannot replace
-    // the user's identity outright — but let it drift toward what this session heard. A
-    // bootstrap pick (unconfirmed) overwrites instead: the stored print was stale or absent.
-    var next = user.centroid
-    if let previous = userVoiceprint, userIsConfirmed {
-      for i in next.indices {
-        next[i] = previous[i] * 0.5 + user.centroid[i] * 0.5
+  /// Voices that have accumulated enough speech since they were last remembered: the user's
+  /// (as a learned print unless already confirmed) and every named person's.
+  private mutating func voiceprintsDue() -> [VoiceprintUpdate] {
+    var updates: [VoiceprintUpdate] = []
+    for index in clusters.indices {
+      let cluster = clusters[index]
+      let isUser = cluster.key == userClusterKey
+      guard isUser || cluster.personId != nil else { continue }
+      guard cluster.speechSeconds >= config.voiceprintPersistSeconds else { continue }
+      let due =
+        cluster.secondsAtLastPersist == 0
+        || cluster.speechSeconds - cluster.secondsAtLastPersist >= config.voiceprintRepersistSeconds
+      guard due else { continue }
+      clusters[index].secondsAtLastPersist = cluster.speechSeconds
+      updates.append(
+        VoiceprintUpdate(
+          personId: isUser ? nil : cluster.personId,
+          embedding: cluster.centroid,
+          speechSeconds: cluster.speechSeconds,
+          isEnrolled: isUser ? userIsConfirmed : true
+        ))
+      if isUser {
+        rememberUserVoice(cluster.centroid, isEnrolled: userIsConfirmed)
       }
     }
-    guard let normalized = Self.normalized(next) else { return nil }
-    userVoiceprint = normalized
-    return normalized
+    return updates
   }
 
   // MARK: - Math

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
@@ -272,6 +272,13 @@ struct LocalSpeakerRegistry: Sendable {
     }
   }
 
+  /// Replace (or add) a remembered voice, e.g. after a rebuild from conversation audio.
+  mutating func rememberKnownVoice(_ voice: KnownVoice) {
+    guard let normalized = Self.normalized(voice.embedding) else { return }
+    knownVoices.removeAll { $0.personId == voice.personId }
+    knownVoices.append(KnownVoice(personId: voice.personId, embedding: normalized, isEnrolled: voice.isEnrolled))
+  }
+
   private mutating func rememberUserVoice(_ embedding: [Float], isEnrolled: Bool) {
     knownVoices.removeAll { $0.personId == nil }
     knownVoices.append(KnownVoice(personId: nil, embedding: embedding, isEnrolled: isEnrolled))

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
@@ -1,0 +1,347 @@
+import Foundation
+
+/// Which capture lane an on-device transcription window came from.
+enum LocalTranscriptionLane: String, Sendable, Equatable {
+  case microphone
+  case systemAudio
+}
+
+/// Session-stable speaker identities for on-device transcription, shared by the microphone
+/// and system-audio lanes.
+///
+/// Before this, the mic lane stamped every window "You" and the system lane "Speaker 1", so a
+/// second person in the room was transcribed as the user. The registry clusters per-window
+/// speaker embeddings (cosine distance, running-mean centroids) and decides which cluster is
+/// the user:
+///
+///  1. A persisted voiceprint (`userVoiceprint`) wins: the first mic-lane cluster within
+///     `userMatchThreshold` of it becomes "You" and stays "You".
+///  2. With no voiceprint — or when nothing has matched it after `voiceprintGraceSeconds` of
+///     mic speech (new microphone, different room) — the dominant mic-lane voice, scored by
+///     loudness-weighted speech time, is the provisional user. The Mac's owner sits closest
+///     to its microphone and is present in every session, so this converges quickly. When a
+///     different mic voice overtakes the provisional user by `bootstrapSwapMargin`, the two
+///     swap public ids and `Outcome.relabels` tells the caller which already-emitted
+///     segments to rewrite.
+///  3. Once the user cluster has `voiceprintPersistSeconds` of speech the registry hands
+///     back a voiceprint to persist, so later sessions start with rule 1.
+///
+/// Public speaker ids: the user is always 0 (`VoiceBargeInPolicy` and
+/// `EnvironmentalSpeakerContext` rely on that); everyone else counts up from 1 in order of
+/// first appearance across both lanes, so a remote voice heard through the speakers and its
+/// echo on the mic share one id. Pure value type — no CoreML — so the policy is unit-testable.
+struct LocalSpeakerRegistry: Sendable {
+
+  struct Resolution: Equatable, Hashable, Sendable {
+    let speakerId: Int
+    let isUser: Bool
+
+    var speakerLabel: String { String(format: "SPEAKER_%02d", speakerId) }
+  }
+
+  struct Observation: Sendable {
+    let embedding: [Float]
+    let durationSeconds: Double
+    /// Window RMS, used only to weight speech time when picking the provisional user.
+    let loudness: Float
+    let lane: LocalTranscriptionLane
+  }
+
+  struct Outcome: Equatable, Sendable {
+    let resolution: Resolution
+    /// Previous public speaker id → new resolution, for segments already emitted. Empty
+    /// unless the user cluster changed.
+    let relabels: [Int: Resolution]
+    /// Non-nil when the caller should persist this as the user's voiceprint.
+    let voiceprintToPersist: [Float]?
+    /// Cosine distance to the closest cluster that existed before this window (infinity for
+    /// the first one). Logged so the thresholds can be calibrated against real audio.
+    let nearestDistance: Float
+  }
+
+  struct Config: Sendable {
+    /// Max cosine distance for a window to join an existing cluster. WeSpeaker ResNet34
+    /// distances: same voice ≈ 0.2–0.45, different voices ≈ 0.7+. Matches the backend's
+    /// `SPEAKER_CLUSTERING_THRESHOLD`.
+    var matchThreshold: Float = 0.60
+    /// Only confident matches move a centroid, so a borderline window can't drag a cluster
+    /// toward another voice.
+    var updateThreshold: Float = 0.45
+    /// Distance to the persisted voiceprint that identifies the user. Tighter than
+    /// `matchThreshold`: a false "You" is worse than a late one.
+    var userMatchThreshold: Float = 0.50
+    /// Mic speech tolerated without a voiceprint match before falling back to bootstrap.
+    var voiceprintGraceSeconds: Double = 30
+    /// A rival mic voice must out-score the provisional user by this factor to take over.
+    var bootstrapSwapMargin: Double = 1.5
+    /// User speech needed before the voiceprint is (re)persisted.
+    var voiceprintPersistSeconds: Double = 20
+    /// Voiceprint is re-persisted every time user speech grows by this much.
+    var voiceprintRepersistSeconds: Double = 60
+    /// Hard cap on tracked voices; beyond it a window joins its nearest cluster.
+    var maxClusters: Int = 16
+    /// A window shorter than this never opens a new cluster — its embedding is too noisy
+    /// (live: a 1.7 s echo fragment became a phantom "Speaker 4"). It joins the nearest voice.
+    var minNewClusterSeconds: Double = 2.0
+    /// Weight (in seconds) at which a centroid stops moving faster for new windows.
+    var centroidWeightCapSeconds: Double = 90
+
+    init() {}
+  }
+
+  struct Cluster: Sendable {
+    let key: Int
+    var speakerId: Int
+    var centroid: [Float]
+    var centroidWeightSeconds: Double
+    var speechSeconds: Double = 0
+    var micSeconds: Double = 0
+    var systemSeconds: Double = 0
+    /// Σ duration × RMS over mic-lane windows: louder-and-longer wins the bootstrap.
+    var micEnergySeconds: Double = 0
+
+    /// A voice that is mostly heard through the speakers is a remote party, never the user —
+    /// even when its echo also reaches the mic.
+    var isMicVoice: Bool { micSeconds > 0 && micSeconds >= systemSeconds }
+  }
+
+  let config: Config
+  private(set) var clusters: [Cluster] = []
+  private(set) var userClusterKey: Int?
+  /// Voiceprint carried over from earlier sessions — the only one that identifies the user
+  /// outright (rule 1). One learned this session is provisional until it survives a restart.
+  private let storedVoiceprint: [Float]?
+  /// Latest voiceprint handed back for persistence (starts as `storedVoiceprint`).
+  private(set) var userVoiceprint: [Float]?
+  /// True once the user cluster was chosen by matching the persisted voiceprint (rule 1).
+  /// Locks out bootstrap swaps for the rest of the session.
+  private(set) var userIsConfirmed = false
+  private var micSecondsSinceStart: Double = 0
+  private var nextClusterKey = 0
+  private var nextOtherSpeakerId = 1
+  private var userSecondsAtLastPersist: Double = 0
+
+  init(userVoiceprint: [Float]? = nil, config: Config = Config()) {
+    self.config = config
+    let normalized = userVoiceprint.flatMap(Self.normalized)
+    self.storedVoiceprint = normalized
+    self.userVoiceprint = normalized
+  }
+
+  var userSpeakerId: Int { 0 }
+
+  var userCluster: Cluster? {
+    guard let userClusterKey else { return nil }
+    return clusters.first { $0.key == userClusterKey }
+  }
+
+  /// Fold one transcribed window into the registry and say who spoke.
+  mutating func observe(_ observation: Observation) -> Outcome? {
+    guard let embedding = Self.normalized(observation.embedding), observation.durationSeconds > 0 else {
+      return nil
+    }
+    let duration = observation.durationSeconds
+    if observation.lane == .microphone { micSecondsSinceStart += duration }
+
+    let (index, created, nearestDistance) = assignCluster(embedding: embedding, duration: duration)
+    let idBeforeReconsidering = clusters[index].speakerId
+    accumulate(at: index, observation: observation, duration: duration)
+
+    var relabels: [Int: Resolution] = [:]
+    if observation.lane == .microphone {
+      relabels = reconsiderUser(afterObserving: index)
+      if created {
+        // No segment carries a brand-new cluster's provisional id yet; only the resolution
+        // returned below needs it.
+        relabels.removeValue(forKey: idBeforeReconsidering)
+      }
+    }
+
+    let voiceprint = voiceprintToPersistIfDue()
+    let cluster = clusters[index]
+    return Outcome(
+      resolution: Resolution(speakerId: cluster.speakerId, isUser: cluster.key == userClusterKey),
+      relabels: relabels,
+      voiceprintToPersist: voiceprint,
+      nearestDistance: nearestDistance
+    )
+  }
+
+  // MARK: - Clustering
+
+  private mutating func assignCluster(
+    embedding: [Float], duration: Double
+  ) -> (index: Int, created: Bool, nearestDistance: Float) {
+    var best: (index: Int, distance: Float)?
+    for (index, cluster) in clusters.enumerated() {
+      let distance = Self.cosineDistance(embedding, cluster.centroid)
+      if distance < (best?.distance ?? .infinity) {
+        best = (index, distance)
+      }
+    }
+
+    if let best,
+      best.distance <= config.matchThreshold || clusters.count >= config.maxClusters
+        || duration < config.minNewClusterSeconds
+    {
+      if best.distance <= config.updateThreshold {
+        moveCentroid(at: best.index, toward: embedding, weight: duration)
+      }
+      return (best.index, false, best.distance)
+    }
+
+    let cluster = Cluster(
+      key: nextClusterKey,
+      speakerId: nextOtherSpeakerId,
+      centroid: embedding,
+      centroidWeightSeconds: duration
+    )
+    nextClusterKey += 1
+    nextOtherSpeakerId += 1
+    clusters.append(cluster)
+    return (clusters.count - 1, true, best?.distance ?? .infinity)
+  }
+
+  private mutating func moveCentroid(at index: Int, toward embedding: [Float], weight: Double) {
+    let existingWeight = min(clusters[index].centroidWeightSeconds, config.centroidWeightCapSeconds)
+    let total = existingWeight + weight
+    guard total > 0 else { return }
+    let keep = Float(existingWeight / total)
+    let add = Float(weight / total)
+    var blended = clusters[index].centroid
+    for i in blended.indices {
+      blended[i] = blended[i] * keep + embedding[i] * add
+    }
+    if let normalized = Self.normalized(blended) {
+      clusters[index].centroid = normalized
+    }
+    clusters[index].centroidWeightSeconds += weight
+  }
+
+  private mutating func accumulate(at index: Int, observation: Observation, duration: Double) {
+    clusters[index].speechSeconds += duration
+    switch observation.lane {
+    case .microphone:
+      clusters[index].micSeconds += duration
+      clusters[index].micEnergySeconds += duration * Double(max(observation.loudness, 0))
+    case .systemAudio:
+      clusters[index].systemSeconds += duration
+    }
+  }
+
+  // MARK: - Who is the user
+
+  private mutating func reconsiderUser(afterObserving index: Int) -> [Int: Resolution] {
+    if userIsConfirmed { return [:] }
+
+    // Rule 1: the persisted voiceprint identifies the user outright.
+    if let storedVoiceprint, clusters[index].isMicVoice,
+      Self.cosineDistance(clusters[index].centroid, storedVoiceprint) <= config.userMatchThreshold
+    {
+      userIsConfirmed = true
+      return promoteToUser(index)
+    }
+
+    // Rule 2: no voiceprint, or it has gone stale — the dominant mic voice is the user.
+    if storedVoiceprint != nil && micSecondsSinceStart < config.voiceprintGraceSeconds {
+      return [:]
+    }
+    guard let dominant = dominantMicClusterIndex() else { return [:] }
+    guard let currentKey = userClusterKey, let currentIndex = clusters.firstIndex(where: { $0.key == currentKey })
+    else {
+      return promoteToUser(dominant)
+    }
+    if dominant == currentIndex { return [:] }
+    let challenger = clusters[dominant].micEnergySeconds
+    let incumbent = clusters[currentIndex].micEnergySeconds
+    guard challenger > incumbent * config.bootstrapSwapMargin else { return [:] }
+    return promoteToUser(dominant)
+  }
+
+  private func dominantMicClusterIndex() -> Int? {
+    var best: (index: Int, score: Double)?
+    for (index, cluster) in clusters.enumerated() where cluster.isMicVoice {
+      if cluster.micEnergySeconds > (best?.score ?? -1) {
+        best = (index, cluster.micEnergySeconds)
+      }
+    }
+    return best?.index
+  }
+
+  /// Make `index` the user (public id 0). A previous user cluster takes over the id the new
+  /// one vacates, so the change is a pure swap and every earlier segment has a new home.
+  private mutating func promoteToUser(_ index: Int) -> [Int: Resolution] {
+    guard clusters[index].key != userClusterKey else { return [:] }
+    let vacatedId = clusters[index].speakerId
+    var relabels: [Int: Resolution] = [:]
+    if let currentKey = userClusterKey, let currentIndex = clusters.firstIndex(where: { $0.key == currentKey }) {
+      clusters[currentIndex].speakerId = vacatedId
+      relabels[userSpeakerId] = Resolution(speakerId: vacatedId, isUser: false)
+    }
+    if userClusterKey == nil, vacatedId == nextOtherSpeakerId - 1 {
+      // Nobody inherits the vacated id: give it back so the next other voice is "Speaker 1",
+      // not "Speaker 2".
+      nextOtherSpeakerId -= 1
+    }
+    clusters[index].speakerId = userSpeakerId
+    userClusterKey = clusters[index].key
+    userSecondsAtLastPersist = 0
+    if vacatedId != userSpeakerId {
+      relabels[vacatedId] = Resolution(speakerId: userSpeakerId, isUser: true)
+    }
+    return relabels
+  }
+
+  // MARK: - Voiceprint persistence
+
+  private mutating func voiceprintToPersistIfDue() -> [Float]? {
+    guard let user = userCluster, user.speechSeconds >= config.voiceprintPersistSeconds else { return nil }
+    let due =
+      userSecondsAtLastPersist == 0
+      || user.speechSeconds - userSecondsAtLastPersist >= config.voiceprintRepersistSeconds
+    guard due else { return nil }
+    userSecondsAtLastPersist = user.speechSeconds
+
+    // Blend with the stored voiceprint so one odd session (a cold, a bad mic) cannot replace
+    // the user's identity outright — but let it drift toward what this session heard. A
+    // bootstrap pick (unconfirmed) overwrites instead: the stored print was stale or absent.
+    var next = user.centroid
+    if let previous = userVoiceprint, userIsConfirmed {
+      for i in next.indices {
+        next[i] = previous[i] * 0.5 + user.centroid[i] * 0.5
+      }
+    }
+    guard let normalized = Self.normalized(next) else { return nil }
+    userVoiceprint = normalized
+    return normalized
+  }
+
+  // MARK: - Math
+
+  static func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
+    guard a.count == b.count, !a.isEmpty else { return .infinity }
+    var dot: Float = 0
+    var normA: Float = 0
+    var normB: Float = 0
+    for i in a.indices {
+      dot += a[i] * b[i]
+      normA += a[i] * a[i]
+      normB += b[i] * b[i]
+    }
+    guard normA > 0, normB > 0 else { return .infinity }
+    return 1 - dot / (normA.squareRoot() * normB.squareRoot())
+  }
+
+  /// L2-normalized copy, or nil for an empty / all-zero / non-finite vector.
+  static func normalized(_ vector: [Float]) -> [Float]? {
+    guard !vector.isEmpty else { return nil }
+    var sumSquares: Float = 0
+    for value in vector {
+      guard value.isFinite else { return nil }
+      sumSquares += value * value
+    }
+    guard sumSquares > 0 else { return nil }
+    let scale = 1 / sumSquares.squareRoot()
+    return vector.map { $0 * scale }
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
@@ -115,7 +115,17 @@ final class LocalVoiceprintStore: @unchecked Sendable {
 
   // MARK: - Audio samples
 
-  static func sampleOwner(_ personId: String?) -> String { personId ?? "user" }
+  /// Directory name for a voice's clips. The id becomes a path component, so anything that
+  /// could climb out of the samples directory is replaced rather than trusted; ids the backend
+  /// mints are UUIDs and pass through unchanged.
+  static func sampleOwner(_ personId: String?) -> String {
+    guard let personId else { return "user" }
+    let safe = String(
+      personId.map { character in
+        character.isLetter || character.isNumber || character == "-" || character == "_" ? character : "_"
+      })
+    return safe.isEmpty || safe == "user" ? "person_\(abs(personId.hashValue))" : safe
+  }
 
   func sampleURL(for file: String) -> URL {
     samplesDirectory.appendingPathComponent(file)

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
@@ -80,9 +80,12 @@ final class LocalVoiceprintStore: @unchecked Sendable {
 
   /// The store for the signed-in user's profile root.
   static func forCurrentUser(userId: String? = RewindDatabase.currentUserId) -> LocalVoiceprintStore {
+    // Same resolution as `RewindDatabase.retargetEffectiveOwner`: a missing *or empty* id is
+    // the anonymous profile, never a nameless directory beside it.
+    let owner = userId.flatMap { $0.isEmpty ? nil : $0 } ?? "anonymous"
     let root = DesktopLocalProfile.applicationSupportURL()
       .appendingPathComponent("users", isDirectory: true)
-      .appendingPathComponent(userId ?? "anonymous", isDirectory: true)
+      .appendingPathComponent(owner, isDirectory: true)
     return LocalVoiceprintStore(fileURL: root.appendingPathComponent(fileName))
   }
 

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import OmiSupport
+
+/// One remembered voice: the user's own (`personId == nil`) or a named person's.
+struct StoredVoiceprint: Codable, Equatable, Sendable {
+  var personId: String?
+  /// L2-normalized WeSpeaker embedding (256 floats).
+  var embedding: [Float]
+  /// How much speech the print has been averaged over, across sessions.
+  var speechSeconds: Double
+  var updatedAt: Date
+  /// True when a person confirmed the identity — "This is me", naming a speaker, or a
+  /// push-to-talk turn — as opposed to a print the bootstrap merely guessed.
+  var isEnrolled: Bool
+}
+
+/// What the diarizer asks to remember after a window, a naming, or an enrollment.
+struct VoiceprintUpdate: Equatable, Sendable {
+  let personId: String?
+  let embedding: [Float]
+  let speechSeconds: Double
+  let isEnrolled: Bool
+}
+
+/// Per-user JSON file of remembered voices, next to the user's other local data. Small (a few
+/// KB per person) and rewritten whole on every change; reads fail soft to "no voices known".
+final class LocalVoiceprintStore: @unchecked Sendable {
+  static let fileName = "voiceprints.json"
+
+  private let fileURL: URL
+  private let lock = NSLock()
+
+  init(fileURL: URL) {
+    self.fileURL = fileURL
+  }
+
+  /// The store for the signed-in user's profile root.
+  static func forCurrentUser(userId: String? = RewindDatabase.currentUserId) -> LocalVoiceprintStore {
+    let root = DesktopLocalProfile.applicationSupportURL()
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(userId ?? "anonymous", isDirectory: true)
+    return LocalVoiceprintStore(fileURL: root.appendingPathComponent(fileName))
+  }
+
+  func load() -> [StoredVoiceprint] {
+    lock.withLock {
+      guard let data = try? Data(contentsOf: fileURL) else { return [] }
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .iso8601
+      return (try? decoder.decode([StoredVoiceprint].self, from: data)) ?? []
+    }
+  }
+
+  func save(_ voiceprints: [StoredVoiceprint]) {
+    lock.withLock {
+      do {
+        try FileManager.default.createDirectory(
+          at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(voiceprints).write(to: fileURL, options: .atomic)
+      } catch {
+        logError("LocalVoiceprintStore: save failed", error: error)
+      }
+    }
+  }
+
+  /// Fold `update` into `voiceprints` and return the new list. A guessed (learned) update blends
+  /// 50/50 with an existing print so one odd session cannot replace an identity outright; an
+  /// enrolled update replaces a guessed print, and blends with an enrolled one.
+  static func applying(_ update: VoiceprintUpdate, to voiceprints: [StoredVoiceprint], now: Date = Date())
+    -> [StoredVoiceprint]
+  {
+    guard let embedding = LocalSpeakerRegistry.normalized(update.embedding) else { return voiceprints }
+    var next = voiceprints
+    if let index = next.firstIndex(where: { $0.personId == update.personId }) {
+      let existing = next[index]
+      let replace = update.isEnrolled && !existing.isEnrolled
+      var blended = embedding
+      if !replace {
+        for i in blended.indices {
+          blended[i] = existing.embedding[i] * 0.5 + embedding[i] * 0.5
+        }
+      }
+      next[index] = StoredVoiceprint(
+        personId: update.personId,
+        embedding: LocalSpeakerRegistry.normalized(blended) ?? embedding,
+        speechSeconds: replace ? update.speechSeconds : existing.speechSeconds + update.speechSeconds,
+        updatedAt: now,
+        isEnrolled: existing.isEnrolled || update.isEnrolled
+      )
+    } else {
+      next.append(
+        StoredVoiceprint(
+          personId: update.personId,
+          embedding: embedding,
+          speechSeconds: update.speechSeconds,
+          updatedAt: now,
+          isEnrolled: update.isEnrolled
+        ))
+    }
+    return next
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import OmiSupport
 
@@ -12,6 +13,46 @@ struct StoredVoiceprint: Codable, Equatable, Sendable {
   /// True when a person confirmed the identity — "This is me", naming a speaker, or a
   /// push-to-talk turn — as opposed to a print the bootstrap merely guessed.
   var isEnrolled: Bool
+  /// Pinned: never evicted, listed first.
+  var isFavorite: Bool = false
+  /// Aged use count (`VoiceEnrollmentPolicy`): one per session heard, halving over time.
+  var useScore: Double = 0
+  var lastUsedAt: Date?
+  /// WAV clips of this voice, newest first, relative to the store's sample directory.
+  var sampleFiles: [String] = []
+
+  init(
+    personId: String?, embedding: [Float], speechSeconds: Double, updatedAt: Date, isEnrolled: Bool,
+    isFavorite: Bool = false, useScore: Double = 0, lastUsedAt: Date? = nil, sampleFiles: [String] = []
+  ) {
+    self.personId = personId
+    self.embedding = embedding
+    self.speechSeconds = speechSeconds
+    self.updatedAt = updatedAt
+    self.isEnrolled = isEnrolled
+    self.isFavorite = isFavorite
+    self.useScore = useScore
+    self.lastUsedAt = lastUsedAt
+    self.sampleFiles = sampleFiles
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case personId, embedding, speechSeconds, updatedAt, isEnrolled, isFavorite, useScore, lastUsedAt, sampleFiles
+  }
+
+  /// Files written before favorites/usage/samples existed decode with their defaults.
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    personId = try c.decodeIfPresent(String.self, forKey: .personId)
+    embedding = try c.decode([Float].self, forKey: .embedding)
+    speechSeconds = try c.decode(Double.self, forKey: .speechSeconds)
+    updatedAt = try c.decode(Date.self, forKey: .updatedAt)
+    isEnrolled = try c.decode(Bool.self, forKey: .isEnrolled)
+    isFavorite = try c.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
+    useScore = try c.decodeIfPresent(Double.self, forKey: .useScore) ?? 0
+    lastUsedAt = try c.decodeIfPresent(Date.self, forKey: .lastUsedAt)
+    sampleFiles = try c.decodeIfPresent([String].self, forKey: .sampleFiles) ?? []
+  }
 }
 
 /// What the diarizer asks to remember after a window, a naming, or an enrollment.
@@ -22,12 +63,15 @@ struct VoiceprintUpdate: Equatable, Sendable {
   let isEnrolled: Bool
 }
 
-/// Per-user JSON file of remembered voices, next to the user's other local data. Small (a few
-/// KB per person) and rewritten whole on every change; reads fail soft to "no voices known".
+/// Per-user JSON file of remembered voices plus a directory of short WAV samples, next to the
+/// user's other local data. The JSON is small (a few KB per person) and rewritten whole on
+/// every change; reads fail soft to "no voices known".
 final class LocalVoiceprintStore: @unchecked Sendable {
   static let fileName = "voiceprints.json"
+  static let samplesDirectoryName = "voice-samples"
+  static let sampleRate = 16_000
 
-  private let fileURL: URL
+  let fileURL: URL
   private let lock = NSLock()
 
   init(fileURL: URL) {
@@ -40,6 +84,10 @@ final class LocalVoiceprintStore: @unchecked Sendable {
       .appendingPathComponent("users", isDirectory: true)
       .appendingPathComponent(userId ?? "anonymous", isDirectory: true)
     return LocalVoiceprintStore(fileURL: root.appendingPathComponent(fileName))
+  }
+
+  var samplesDirectory: URL {
+    fileURL.deletingLastPathComponent().appendingPathComponent(Self.samplesDirectoryName, isDirectory: true)
   }
 
   func load() -> [StoredVoiceprint] {
@@ -65,9 +113,79 @@ final class LocalVoiceprintStore: @unchecked Sendable {
     }
   }
 
+  // MARK: - Audio samples
+
+  static func sampleOwner(_ personId: String?) -> String { personId ?? "user" }
+
+  func sampleURL(for file: String) -> URL {
+    samplesDirectory.appendingPathComponent(file)
+  }
+
+  /// Write `samples` (16 kHz mono, -1…1) as a WAV clip for this voice. Returns the file name
+  /// relative to the sample directory, or nil when nothing could be written.
+  func addSample(personId: String?, samples: [Float], now: Date = Date()) -> String? {
+    guard !samples.isEmpty else { return nil }
+    let owner = Self.sampleOwner(personId)
+    let file = "\(owner)/\(Int(now.timeIntervalSince1970 * 1000)).wav"
+    let url = sampleURL(for: file)
+    return lock.withLock {
+      do {
+        try FileManager.default.createDirectory(
+          at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Self.writeWAV(samples, to: url)
+        return file
+      } catch {
+        logError("LocalVoiceprintStore: sample write failed", error: error)
+        return nil
+      }
+    }
+  }
+
+  func removeSamples(_ files: [String]) {
+    lock.withLock {
+      for file in files {
+        try? FileManager.default.removeItem(at: sampleURL(for: file))
+      }
+    }
+  }
+
+  func removeAllSamples(personId: String?) {
+    lock.withLock {
+      try? FileManager.default.removeItem(
+        at: samplesDirectory.appendingPathComponent(Self.sampleOwner(personId), isDirectory: true))
+    }
+  }
+
+  private static func writeWAV(_ samples: [Float], to url: URL) throws {
+    guard
+      let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32, sampleRate: Double(sampleRate), channels: 1, interleaved: false),
+      let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)),
+      let channel = buffer.floatChannelData
+    else { throw CocoaError(.fileWriteUnknown) }
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { source in
+      guard let base = source.baseAddress else { return }
+      channel[0].update(from: base, count: samples.count)
+    }
+    let settings: [String: Any] = [
+      AVFormatIDKey: kAudioFormatLinearPCM,
+      AVSampleRateKey: Double(sampleRate),
+      AVNumberOfChannelsKey: 1,
+      AVLinearPCMBitDepthKey: 16,
+      AVLinearPCMIsFloatKey: false,
+      AVLinearPCMIsBigEndianKey: false,
+    ]
+    let file = try AVAudioFile(forWriting: url, settings: settings)
+    try file.write(from: buffer)
+  }
+
+  // MARK: - Merging
+
   /// Fold `update` into `voiceprints` and return the new list. A guessed (learned) update blends
   /// 50/50 with an existing print so one odd session cannot replace an identity outright; an
-  /// enrolled update replaces a guessed print, and blends with an enrolled one.
+  /// enrolled update replaces a guessed print, and blends with an enrolled one. Favorites,
+  /// usage and samples ride along untouched.
   static func applying(_ update: VoiceprintUpdate, to voiceprints: [StoredVoiceprint], now: Date = Date())
     -> [StoredVoiceprint]
   {
@@ -82,13 +200,12 @@ final class LocalVoiceprintStore: @unchecked Sendable {
           blended[i] = existing.embedding[i] * 0.5 + embedding[i] * 0.5
         }
       }
-      next[index] = StoredVoiceprint(
-        personId: update.personId,
-        embedding: LocalSpeakerRegistry.normalized(blended) ?? embedding,
-        speechSeconds: replace ? update.speechSeconds : existing.speechSeconds + update.speechSeconds,
-        updatedAt: now,
-        isEnrolled: existing.isEnrolled || update.isEnrolled
-      )
+      var merged = existing
+      merged.embedding = LocalSpeakerRegistry.normalized(blended) ?? embedding
+      merged.speechSeconds = replace ? update.speechSeconds : existing.speechSeconds + update.speechSeconds
+      merged.updatedAt = now
+      merged.isEnrolled = existing.isEnrolled || update.isEnrolled
+      next[index] = merged
     } else {
       next.append(
         StoredVoiceprint(

--- a/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
@@ -1,10 +1,13 @@
 import AVFoundation
 import Foundation
 
-/// One stretch of a conversation's audio that belongs to a known voice.
+/// One stretch of a conversation's audio worth listening to again.
 struct PeopleRebuildCut: Equatable, Sendable {
-  /// nil is the user.
+  /// The person the transcript names for it, if any.
   let personId: String?
+  /// What the backend's diarization said. Treated as a hint: "You" is decided by who is
+  /// heard in the most conversations, not by this flag.
+  let labeledAsUser: Bool
   let artifactStart: TimeInterval
   let artifactEnd: TimeInterval
 
@@ -19,15 +22,16 @@ enum PeopleRebuildPlanner {
   /// Longest cut kept: enough voice for a stable embedding and a listenable clip.
   static let maxCutSeconds: TimeInterval = 12.0
 
-  /// The transcript segments of a conversation that name a person (or the user), mapped onto
-  /// the aggregate artifact's media time. Segments across a gap in captured audio are skipped
-  /// rather than guessed at.
+  /// Cuts embedded per conversation at most, longest first, so a long history stays a bounded job.
+  static let maxCutsPerConversation = 40
+
+  /// Every transcript segment long enough to carry a voice, mapped onto the artifact's media
+  /// time. Segments across a gap in captured audio are skipped rather than guessed at.
   static func cuts(
     segments: [TranscriptSegment],
     artifact: CapturePlaybackArtifact
   ) -> [PeopleRebuildCut] {
-    segments.compactMap { segment in
-      guard segment.isUser || segment.personId != nil else { return nil }
+    let all: [PeopleRebuildCut] = segments.compactMap { segment in
       let wallEnd = min(segment.end, segment.start + maxCutSeconds)
       guard wallEnd - segment.start >= minCutSeconds,
         let start = artifact.artifactOffset(forWallOffset: segment.start),
@@ -35,8 +39,10 @@ enum PeopleRebuildPlanner {
       else { return nil }
       guard end - start >= minCutSeconds else { return nil }
       return PeopleRebuildCut(
-        personId: segment.isUser ? nil : segment.personId, artifactStart: start, artifactEnd: end)
+        personId: segment.isUser ? nil : segment.personId, labeledAsUser: segment.isUser,
+        artifactStart: start, artifactEnd: end)
     }
+    return Array(all.sorted { $0.length > $1.length }.prefix(maxCutsPerConversation))
   }
 
   /// How often, and how recently, each named person appears across conversations.
@@ -85,6 +91,78 @@ enum PeopleRebuildPlanner {
   }
 }
 
+/// Greedy cosine clustering of every cut heard across conversations, so the user can be found
+/// as the voice present in the most conversations. Pure, so the choice is testable.
+struct VoiceClusterer {
+  struct Cluster {
+    var centroid: [Float]
+    var weight: Double = 0
+    var embeddings: [[Float]] = []
+    var speechSeconds: Double = 0
+    var conversationIds: Set<String> = []
+    var lastHeardAt: Date?
+    /// Longest clips first, at most `clipsToKeep`.
+    var clips: [[Float]] = []
+    var labeledAsUserSeconds: Double = 0
+  }
+
+  var matchThreshold: Float = 0.60
+  var clipsToKeep = 3
+  var embeddingsToKeep = 200
+  private(set) var clusters: [Cluster] = []
+
+  init(matchThreshold: Float = 0.60) {
+    self.matchThreshold = matchThreshold
+  }
+
+  mutating func add(
+    embedding: [Float], seconds: Double, conversationId: String, date: Date?, clip: [Float]?, labeledAsUser: Bool
+  ) {
+    guard let normalized = LocalSpeakerRegistry.normalized(embedding) else { return }
+    var best: (index: Int, distance: Float)?
+    for (index, cluster) in clusters.enumerated() {
+      let distance = LocalSpeakerRegistry.cosineDistance(normalized, cluster.centroid)
+      if distance < (best?.distance ?? .infinity) { best = (index, distance) }
+    }
+    let index: Int
+    if let best, best.distance <= matchThreshold {
+      index = best.index
+      let total = clusters[index].weight + seconds
+      var blended = clusters[index].centroid
+      let keep = Float(clusters[index].weight / total)
+      let add = Float(seconds / total)
+      for i in blended.indices { blended[i] = blended[i] * keep + normalized[i] * add }
+      clusters[index].centroid = LocalSpeakerRegistry.normalized(blended) ?? clusters[index].centroid
+      clusters[index].weight = total
+    } else {
+      clusters.append(Cluster(centroid: normalized, weight: seconds))
+      index = clusters.count - 1
+    }
+    if clusters[index].embeddings.count < embeddingsToKeep { clusters[index].embeddings.append(normalized) }
+    clusters[index].speechSeconds += seconds
+    clusters[index].conversationIds.insert(conversationId)
+    clusters[index].lastHeardAt = [clusters[index].lastHeardAt, date].compactMap { $0 }.max()
+    if labeledAsUser { clusters[index].labeledAsUserSeconds += seconds }
+    if let clip {
+      clusters[index].clips.append(clip)
+      clusters[index].clips.sort { $0.count > $1.count }
+      if clusters[index].clips.count > clipsToKeep {
+        clusters[index].clips.removeLast(clusters[index].clips.count - clipsToKeep)
+      }
+    }
+  }
+
+  /// The user: heard in the most conversations; on a tie, the most speech.
+  var userCluster: Cluster? {
+    clusters.max { lhs, rhs in
+      if lhs.conversationIds.count != rhs.conversationIds.count {
+        return lhs.conversationIds.count < rhs.conversationIds.count
+      }
+      return lhs.speechSeconds < rhs.speechSeconds
+    }
+  }
+}
+
 /// A voice rebuilt from conversation audio, ready for the diarizer to remember.
 struct RebuiltVoice: Sendable {
   let personId: String?
@@ -112,6 +190,8 @@ struct PeopleRebuildSummary: Equatable, Sendable {
   /// Conversations whose audio the backend is still preparing; a later Refresh picks them up.
   var audioPending = 0
   var audioLocked = 0
+  /// Conversations the voice chosen as "You" was heard in.
+  var userConversations: Int?
   var activity: [String: PersonActivity] = [:]
   var failure: String?
 
@@ -122,6 +202,9 @@ struct PeopleRebuildSummary: Equatable, Sendable {
     parts.append(
       voicesRebuilt == 0 ? "no voices rebuilt" : "\(voicesRebuilt) voice\(voicesRebuilt == 1 ? "" : "s") rebuilt")
     if clipsSaved > 0 { parts.append("\(clipsSaved) clip\(clipsSaved == 1 ? "" : "s") saved") }
+    if let userConversations, userConversations > 0 {
+      parts.append("you = the voice in \(userConversations) of them")
+    }
     if audioPending > 0 { parts.append("\(audioPending) still preparing audio") }
     if audioLocked > 0 { parts.append("\(audioLocked) locked") }
     return parts.joined(separator: " · ")
@@ -178,7 +261,8 @@ actor PeopleRebuilder {
 
     await diarizer.prepare()
     let canEmbed = await diarizer.isAvailable
-    var voices: [String: RebuiltVoice] = [:]
+    var people: [String: RebuiltVoice] = [:]
+    var clusterer = VoiceClusterer()
     var seen: [(segments: [TranscriptSegment], date: Date)] = []
 
     for listed in conversations {
@@ -191,7 +275,7 @@ actor PeopleRebuilder {
       let segments = conversation.transcriptSegments
       seen.append((segments, conversation.startedAt ?? conversation.createdAt))
 
-      guard canEmbed, segments.contains(where: { $0.isUser || $0.personId != nil }) else { continue }
+      guard canEmbed, !segments.isEmpty else { continue }
       guard !conversation.isLocked else {
         summary.audioLocked += 1
         continue
@@ -227,6 +311,7 @@ actor PeopleRebuilder {
 
       guard let audio = await Self.downloadAndDecode(artifact.signedURL) else { continue }
       let rate = Double(LocalVoiceprintStore.sampleRate)
+      let date = conversation.startedAt ?? conversation.createdAt
       var touched: Set<String> = []
       for cut in cuts {
         let from = max(0, Int(cut.artifactStart * rate))
@@ -234,27 +319,41 @@ actor PeopleRebuilder {
         guard to - from >= Int(PeopleRebuildPlanner.minCutSeconds * rate) else { continue }
         let samples = Array(audio[from..<to])
         guard let embedding = await diarizer.embedding(for: samples) else { continue }
-        let key = LocalVoiceprintStore.sampleOwner(cut.personId)
-        var voice = voices[key] ?? RebuiltVoice(personId: cut.personId)
+        state.cutsEmbedded += 1
+        // Every voice goes into the clustering; the biggest cluster across conversations is you.
+        clusterer.add(
+          embedding: embedding, seconds: cut.length, conversationId: conversation.id, date: date,
+          clip: samples, labeledAsUser: cut.labeledAsUser)
+        // Named people are rebuilt from exactly the segments that name them.
+        guard let personId = cut.personId else { continue }
+        var voice = people[personId] ?? RebuiltVoice(personId: personId)
         voice.embeddings.append(embedding)
         voice.speechSeconds += cut.length
         voice.clips.append(samples)
         voice.clips.sort { $0.count > $1.count }
         if voice.clips.count > Self.clipsPerVoice { voice.clips.removeLast(voice.clips.count - Self.clipsPerVoice) }
-        if !touched.contains(key) {
-          touched.insert(key)
+        if !touched.contains(personId) {
+          touched.insert(personId)
           voice.conversationCount += 1
-          let date = conversation.startedAt ?? conversation.createdAt
           voice.lastHeardAt = [voice.lastHeardAt, date].compactMap { $0 }.max()
         }
-        voices[key] = voice
-        state.cutsEmbedded += 1
+        people[personId] = voice
       }
     }
 
     summary.withAudio = state.withAudio
     summary.activity = PeopleRebuildPlanner.activity(in: seen)
-    let rebuilt = Array(voices.values).filter { !$0.embeddings.isEmpty }
+    var rebuilt = Array(people.values).filter { !$0.embeddings.isEmpty }
+    if let user = clusterer.userCluster {
+      rebuilt.append(
+        RebuiltVoice(
+          personId: nil, embeddings: user.embeddings, speechSeconds: user.speechSeconds, clips: user.clips,
+          conversationCount: user.conversationIds.count, lastHeardAt: user.lastHeardAt))
+      summary.userConversations = user.conversationIds.count
+      log(
+        "PeopleRebuilder: you = cluster heard in \(user.conversationIds.count) conversations, \(Int(user.speechSeconds)) s (\(Int(user.labeledAsUserSeconds)) s labeled is_user); \(clusterer.clusters.count) voices in total"
+      )
+    }
     if !rebuilt.isEmpty {
       let saved = await diarizer.applyRebuild(rebuilt)
       summary.voicesRebuilt = rebuilt.count

--- a/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
@@ -54,6 +54,25 @@ enum PeopleRebuildPlanner {
     return result
   }
 
+  /// A single cached part placed on the conversation's wall clock: it begins at its first chunk,
+  /// which lands 30–60 s after `startedAt` on real captures, so treating media time as
+  /// transcript time would cut the wrong moments.
+  static func singlePartArtifact(
+    file: CapturePlaybackFile,
+    firstChunkTimestamp: TimeInterval?,
+    conversationStartedAt: Date?
+  ) -> CapturePlaybackArtifact? {
+    guard let firstChunkTimestamp, let conversationStartedAt else { return nil }
+    let wallOffset = firstChunkTimestamp - conversationStartedAt.timeIntervalSince1970
+    guard wallOffset >= -1, file.duration > 0 else { return nil }
+    return CapturePlaybackArtifact(
+      signedURL: file.signedURL,
+      duration: file.duration,
+      spans: [
+        CaptureAudioURLSpan(fileID: file.id, wallOffset: max(0, wallOffset), artifactOffset: 0, length: file.duration)
+      ])
+  }
+
   static func merge(_ local: [String: PersonActivity], _ remote: [String: PersonActivity]) -> [String: PersonActivity] {
     var merged = local
     for (personId, activity) in remote {
@@ -90,6 +109,9 @@ struct PeopleRebuildSummary: Equatable, Sendable {
   var withAudio = 0
   var voicesRebuilt = 0
   var clipsSaved = 0
+  /// Conversations whose audio the backend is still preparing; a later Refresh picks them up.
+  var audioPending = 0
+  var audioLocked = 0
   var activity: [String: PersonActivity] = [:]
   var failure: String?
 
@@ -100,6 +122,8 @@ struct PeopleRebuildSummary: Equatable, Sendable {
     parts.append(
       voicesRebuilt == 0 ? "no voices rebuilt" : "\(voicesRebuilt) voice\(voicesRebuilt == 1 ? "" : "s") rebuilt")
     if clipsSaved > 0 { parts.append("\(clipsSaved) clip\(clipsSaved == 1 ? "" : "s") saved") }
+    if audioPending > 0 { parts.append("\(audioPending) still preparing audio") }
+    if audioLocked > 0 { parts.append("\(audioLocked) locked") }
     return parts.joined(separator: " · ")
   }
 }
@@ -110,7 +134,10 @@ struct PeopleRebuildSummary: Equatable, Sendable {
 actor PeopleRebuilder {
   static let shared = PeopleRebuilder()
 
-  static let conversationLimit = 100
+  /// Page size for the backend list; pages are walked until one comes back short.
+  static let pageSize = 100
+  /// Upper bound so a very long history stays a bounded job.
+  static let maxConversations = 2000
   static let clipsPerVoice = 3
 
   private var isRunning = false
@@ -127,13 +154,24 @@ actor PeopleRebuilder {
     var state = PeopleRebuildProgress(message: "Loading conversations…")
     progress(state)
 
-    let conversations: [ServerConversation]
+    var conversations: [ServerConversation] = []
     do {
-      conversations = try await APIClient.shared.getConversations(limit: Self.conversationLimit)
+      var offset = 0
+      while conversations.count < Self.maxConversations {
+        let page = try await APIClient.shared.getConversations(limit: Self.pageSize, offset: offset)
+        conversations.append(contentsOf: page)
+        offset += page.count
+        state.total = conversations.count
+        state.message = "Loading conversations… \(conversations.count)"
+        progress(state)
+        if page.count < Self.pageSize { break }
+      }
     } catch {
       logError("PeopleRebuilder: could not load conversations", error: error)
-      summary.failure = "Couldn't load conversations"
-      return summary
+      guard !conversations.isEmpty else {
+        summary.failure = "Couldn't load conversations"
+        return summary
+      }
     }
     state.total = conversations.count
     summary.conversations = conversations.count
@@ -143,20 +181,44 @@ actor PeopleRebuilder {
     var voices: [String: RebuiltVoice] = [:]
     var seen: [(segments: [TranscriptSegment], date: Date)] = []
 
-    for conversation in conversations {
+    for listed in conversations {
       state.scanned += 1
       state.message = "Checking \(state.scanned) of \(state.total)…"
       progress(state)
 
-      let segments = await transcriptSegments(of: conversation)
+      // The list omits audio metadata (and sometimes the transcript); the detail has both.
+      let conversation = await detail(of: listed)
+      let segments = conversation.transcriptSegments
       seen.append((segments, conversation.startedAt ?? conversation.createdAt))
 
-      guard canEmbed, !conversation.isLocked,
-        !conversation.audioFiles.isEmpty || conversation.conversationAudio != nil,
-        segments.contains(where: { $0.isUser || $0.personId != nil })
-      else { continue }
-      guard case .readyAggregate(let artifact) = await LiveCapturePlaybackProvider().resolvePlayback(for: conversation)
-      else { continue }
+      guard canEmbed, segments.contains(where: { $0.isUser || $0.personId != nil }) else { continue }
+      guard !conversation.isLocked else {
+        summary.audioLocked += 1
+        continue
+      }
+      guard !conversation.audioFiles.isEmpty || conversation.conversationAudio != nil else { continue }
+
+      let artifact: CapturePlaybackArtifact
+      switch await LiveCapturePlaybackProvider().resolvePlayback(for: conversation) {
+      case .readyAggregate(let ready):
+        artifact = ready
+      case .fileFallback(let file):
+        guard
+          let placed = PeopleRebuildPlanner.singlePartArtifact(
+            file: file,
+            firstChunkTimestamp: conversation.audioFiles.first(where: { $0.id == file.id })?.firstChunkTimestamp,
+            conversationStartedAt: conversation.startedAt)
+        else { continue }
+        artifact = placed
+      case .pending:
+        summary.audioPending += 1
+        continue
+      case .locked:
+        summary.audioLocked += 1
+        continue
+      case .unavailable, .noAudio:
+        continue
+      }
       let cuts = PeopleRebuildPlanner.cuts(segments: segments, artifact: artifact)
       guard !cuts.isEmpty else { continue }
       state.withAudio += 1
@@ -204,12 +266,9 @@ actor PeopleRebuilder {
     return summary
   }
 
-  private func transcriptSegments(of conversation: ServerConversation) async -> [TranscriptSegment] {
-    if conversation.transcriptSegmentsIncluded || !conversation.transcriptSegments.isEmpty {
-      return conversation.transcriptSegments
-    }
-    guard let detail = try? await APIClient.shared.getConversation(id: conversation.id) else { return [] }
-    return detail.transcriptSegments
+  private func detail(of listed: ServerConversation) async -> ServerConversation {
+    guard let detail = try? await APIClient.shared.getConversation(id: listed.id) else { return listed }
+    return detail
   }
 
   /// Fetch a signed audio URL to a temp file and decode it to 16 kHz mono. The file is deleted

--- a/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
@@ -95,20 +95,27 @@ enum PeopleRebuildPlanner {
 /// as the voice present in the most conversations. Pure, so the choice is testable.
 struct VoiceClusterer {
   struct Cluster {
+    /// Duration-weighted running mean of every embedding folded in — the voiceprint itself, so
+    /// the individual embeddings never have to be kept.
     var centroid: [Float]
     var weight: Double = 0
-    var embeddings: [[Float]] = []
     var speechSeconds: Double = 0
     var conversationIds: Set<String> = []
     var lastHeardAt: Date?
-    /// Longest clips first, at most `clipsToKeep`.
-    var clips: [[Float]] = []
+    /// Longest clips first, at most `clipsToKeep`, stored as 16-bit so a long history with
+    /// dozens of voices stays tens of megabytes rather than hundreds.
+    var compactClips: [[Int16]] = []
     var labeledAsUserSeconds: Double = 0
+
+    var clips: [[Float]] { compactClips.map { $0.map { Float($0) / 32768 } } }
   }
 
   var matchThreshold: Float = 0.60
   var clipsToKeep = 3
-  var embeddingsToKeep = 200
+  /// Only the most-present voices keep audio: a long history can hold dozens of one-off voices,
+  /// and three 12 s clips each would be hundreds of megabytes of samples for voices that can
+  /// never be chosen as the user.
+  var clipHoldingClusters = 5
   private(set) var clusters: [Cluster] = []
 
   init(matchThreshold: Float = 0.60) {
@@ -138,17 +145,33 @@ struct VoiceClusterer {
       clusters.append(Cluster(centroid: normalized, weight: seconds))
       index = clusters.count - 1
     }
-    if clusters[index].embeddings.count < embeddingsToKeep { clusters[index].embeddings.append(normalized) }
     clusters[index].speechSeconds += seconds
     clusters[index].conversationIds.insert(conversationId)
     clusters[index].lastHeardAt = [clusters[index].lastHeardAt, date].compactMap { $0 }.max()
     if labeledAsUser { clusters[index].labeledAsUserSeconds += seconds }
     if let clip {
-      clusters[index].clips.append(clip)
-      clusters[index].clips.sort { $0.count > $1.count }
-      if clusters[index].clips.count > clipsToKeep {
-        clusters[index].clips.removeLast(clusters[index].clips.count - clipsToKeep)
+      clusters[index].compactClips.append(clip.map { Int16(max(-1, min(1, $0)) * 32767) })
+      clusters[index].compactClips.sort { $0.count > $1.count }
+      if clusters[index].compactClips.count > clipsToKeep {
+        clusters[index].compactClips.removeLast(clusters[index].compactClips.count - clipsToKeep)
       }
+    }
+    pruneClipsBeyondTopClusters()
+  }
+
+  /// Drop audio from every voice outside the leading `clipHoldingClusters`, so memory stays
+  /// flat however many voices a history contains.
+  private mutating func pruneClipsBeyondTopClusters() {
+    let holders = clusters.indices.filter { !clusters[$0].compactClips.isEmpty }
+    guard holders.count > clipHoldingClusters else { return }
+    let ranked = holders.sorted { lhs, rhs in
+      if clusters[lhs].conversationIds.count != clusters[rhs].conversationIds.count {
+        return clusters[lhs].conversationIds.count > clusters[rhs].conversationIds.count
+      }
+      return clusters[lhs].speechSeconds > clusters[rhs].speechSeconds
+    }
+    for index in ranked.dropFirst(clipHoldingClusters) {
+      clusters[index].compactClips.removeAll()
     }
   }
 
@@ -222,6 +245,9 @@ actor PeopleRebuilder {
   /// Upper bound so a very long history stays a bounded job.
   static let maxConversations = 2000
   static let clipsPerVoice = 3
+  /// Embeddings averaged per named person. More than this adds nothing to the mean and only
+  /// costs memory on a long history.
+  static let embeddingsPerPerson = 100
 
   private var isRunning = false
 
@@ -309,15 +335,18 @@ actor PeopleRebuilder {
       state.message = "Listening to \(state.scanned) of \(state.total)…"
       progress(state)
 
-      guard let audio = await Self.downloadAndDecode(artifact.signedURL) else { continue }
+      guard let localAudio = await Self.download(artifact.signedURL) else { continue }
+      defer { try? FileManager.default.removeItem(at: localAudio) }
+      guard let reader = try? AudioClipDecoder.Reader(url: localAudio) else { continue }
       let rate = Double(LocalVoiceprintStore.sampleRate)
       let date = conversation.startedAt ?? conversation.createdAt
       var touched: Set<String> = []
       for cut in cuts {
-        let from = max(0, Int(cut.artifactStart * rate))
-        let to = min(audio.count, Int(cut.artifactEnd * rate))
-        guard to - from >= Int(PeopleRebuildPlanner.minCutSeconds * rate) else { continue }
-        let samples = Array(audio[from..<to])
+        // Only the cut is decoded, never the whole file: a two-hour capture would otherwise be
+        // hundreds of megabytes of floats.
+        guard let samples = try? reader.read(fromSeconds: cut.artifactStart, toSeconds: cut.artifactEnd),
+          samples.count >= Int(PeopleRebuildPlanner.minCutSeconds * rate)
+        else { continue }
         guard let embedding = await diarizer.embedding(for: samples) else { continue }
         state.cutsEmbedded += 1
         // Every voice goes into the clustering; the biggest cluster across conversations is you.
@@ -327,7 +356,7 @@ actor PeopleRebuilder {
         // Named people are rebuilt from exactly the segments that name them.
         guard let personId = cut.personId else { continue }
         var voice = people[personId] ?? RebuiltVoice(personId: personId)
-        voice.embeddings.append(embedding)
+        if voice.embeddings.count < Self.embeddingsPerPerson { voice.embeddings.append(embedding) }
         voice.speechSeconds += cut.length
         voice.clips.append(samples)
         voice.clips.sort { $0.count > $1.count }
@@ -347,7 +376,7 @@ actor PeopleRebuilder {
     if let user = clusterer.userCluster {
       rebuilt.append(
         RebuiltVoice(
-          personId: nil, embeddings: user.embeddings, speechSeconds: user.speechSeconds, clips: user.clips,
+          personId: nil, embeddings: [user.centroid], speechSeconds: user.speechSeconds, clips: user.clips,
           conversationCount: user.conversationIds.count, lastHeardAt: user.lastHeardAt))
       summary.userConversations = user.conversationIds.count
       log(
@@ -370,25 +399,23 @@ actor PeopleRebuilder {
     return detail
   }
 
-  /// Fetch a signed audio URL to a temp file and decode it to 16 kHz mono. The file is deleted
-  /// afterwards; the URL is never logged.
-  private static func downloadAndDecode(_ url: URL) async -> [Float]? {
+  /// Fetch a signed audio URL to a temp file the caller deletes. The URL is never logged.
+  private static func download(_ url: URL) async -> URL? {
     do {
       let (temp, _) = try await URLSession.shared.download(from: url)
       let ext = url.pathExtension.isEmpty ? "wav" : url.pathExtension
       let local = FileManager.default.temporaryDirectory
         .appendingPathComponent("people-rebuild-\(UUID().uuidString)").appendingPathExtension(ext)
       try FileManager.default.moveItem(at: temp, to: local)
-      defer { try? FileManager.default.removeItem(at: local) }
-      return try AudioClipDecoder.decode16kMono(url: local)
+      return local
     } catch {
-      logError("PeopleRebuilder: audio download/decode failed", error: error)
+      logError("PeopleRebuilder: audio download failed", error: error)
       return nil
     }
   }
 }
 
-/// Reads any AVFoundation-decodable audio file into 16 kHz mono Float32 samples.
+/// Reads ranges of any AVFoundation-decodable audio file as 16 kHz mono Float32 samples.
 enum AudioClipDecoder {
   /// Hands one input buffer to the converter per call, then reports end of stream.
   private final class SingleBufferFeed: @unchecked Sendable {
@@ -405,33 +432,53 @@ enum AudioClipDecoder {
     }
   }
 
-  static func decode16kMono(url: URL) throws -> [Float] {
-    let file = try AVAudioFile(forReading: url)
-    let source = file.processingFormat
-    guard
-      let target = AVAudioFormat(
-        commonFormat: .pcmFormatFloat32, sampleRate: Double(LocalVoiceprintStore.sampleRate), channels: 1,
-        interleaved: false),
-      let converter = AVAudioConverter(from: source, to: target)
-    else { throw CocoaError(.fileReadCorruptFile) }
+  /// An open file that decodes one time range at a time, so a long capture never has to be
+  /// held in memory whole.
+  final class Reader {
+    private let file: AVAudioFile
+    private let target: AVAudioFormat
+    private let converter: AVAudioConverter
 
-    var output: [Float] = []
-    let chunkFrames: AVAudioFrameCount = 65_536
-    let ratio = target.sampleRate / source.sampleRate
-    while file.framePosition < file.length {
-      guard let input = AVAudioPCMBuffer(pcmFormat: source, frameCapacity: chunkFrames) else { break }
-      try file.read(into: input, frameCount: chunkFrames)
-      if input.frameLength == 0 { break }
+    init(url: URL) throws {
+      file = try AVAudioFile(forReading: url)
+      guard
+        let target = AVAudioFormat(
+          commonFormat: .pcmFormatFloat32, sampleRate: Double(LocalVoiceprintStore.sampleRate), channels: 1,
+          interleaved: false),
+        let converter = AVAudioConverter(from: file.processingFormat, to: target)
+      else { throw CocoaError(.fileReadCorruptFile) }
+      self.target = target
+      self.converter = converter
+    }
+
+    var durationSeconds: Double { Double(file.length) / file.processingFormat.sampleRate }
+
+    func read(fromSeconds start: Double, toSeconds end: Double) throws -> [Float] {
+      let sourceRate = file.processingFormat.sampleRate
+      let firstFrame = max(0, AVAudioFramePosition(start * sourceRate))
+      let lastFrame = min(file.length, AVAudioFramePosition(end * sourceRate))
+      guard lastFrame > firstFrame else { return [] }
+      file.framePosition = firstFrame
+      let frames = AVAudioFrameCount(lastFrame - firstFrame)
+      guard let input = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frames) else { return [] }
+      try file.read(into: input, frameCount: frames)
+      guard input.frameLength > 0 else { return [] }
+      let ratio = target.sampleRate / sourceRate
       let capacity = AVAudioFrameCount(Double(input.frameLength) * ratio) + 1024
-      guard let converted = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: capacity) else { break }
+      guard let converted = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: capacity) else { return [] }
+      converter.reset()
       let feed = SingleBufferFeed(input)
       var conversionError: NSError?
       converter.convert(to: converted, error: &conversionError) { _, status in feed.next(status) }
       if let conversionError { throw conversionError }
-      if let channel = converted.floatChannelData {
-        output.append(contentsOf: UnsafeBufferPointer(start: channel[0], count: Int(converted.frameLength)))
-      }
+      guard let channel = converted.floatChannelData else { return [] }
+      return Array(UnsafeBufferPointer(start: channel[0], count: Int(converted.frameLength)))
     }
-    return output
+  }
+
+  /// The whole file, for callers that know it is short.
+  static func decode16kMono(url: URL) throws -> [Float] {
+    let reader = try Reader(url: url)
+    return try reader.read(fromSeconds: 0, toSeconds: reader.durationSeconds + 1)
   }
 }

--- a/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
@@ -1,0 +1,279 @@
+import AVFoundation
+import Foundation
+
+/// One stretch of a conversation's audio that belongs to a known voice.
+struct PeopleRebuildCut: Equatable, Sendable {
+  /// nil is the user.
+  let personId: String?
+  let artifactStart: TimeInterval
+  let artifactEnd: TimeInterval
+
+  var length: TimeInterval { artifactEnd - artifactStart }
+}
+
+/// Pure planning for a People refresh: which parts of which conversations to listen to again.
+enum PeopleRebuildPlanner {
+  /// Shortest cut worth embedding; the WeSpeaker front end needs about half a second and
+  /// anything shorter is mostly a breath.
+  static let minCutSeconds: TimeInterval = 1.0
+  /// Longest cut kept: enough voice for a stable embedding and a listenable clip.
+  static let maxCutSeconds: TimeInterval = 12.0
+
+  /// The transcript segments of a conversation that name a person (or the user), mapped onto
+  /// the aggregate artifact's media time. Segments across a gap in captured audio are skipped
+  /// rather than guessed at.
+  static func cuts(
+    segments: [TranscriptSegment],
+    artifact: CapturePlaybackArtifact
+  ) -> [PeopleRebuildCut] {
+    segments.compactMap { segment in
+      guard segment.isUser || segment.personId != nil else { return nil }
+      let wallEnd = min(segment.end, segment.start + maxCutSeconds)
+      guard wallEnd - segment.start >= minCutSeconds,
+        let start = artifact.artifactOffset(forWallOffset: segment.start),
+        let end = artifact.artifactOffset(forWallOffset: wallEnd - 0.001)
+      else { return nil }
+      guard end - start >= minCutSeconds else { return nil }
+      return PeopleRebuildCut(
+        personId: segment.isUser ? nil : segment.personId, artifactStart: start, artifactEnd: end)
+    }
+  }
+
+  /// How often, and how recently, each named person appears across conversations.
+  static func activity(in conversations: [(segments: [TranscriptSegment], date: Date)]) -> [String: PersonActivity] {
+    var result: [String: PersonActivity] = [:]
+    for conversation in conversations {
+      let people = Set(conversation.segments.compactMap { $0.isUser ? nil : $0.personId })
+      for personId in people {
+        let existing = result[personId]
+        result[personId] = PersonActivity(
+          conversationCount: (existing?.conversationCount ?? 0) + 1,
+          lastTalkedAt: [existing?.lastTalkedAt, conversation.date].compactMap { $0 }.max())
+      }
+    }
+    return result
+  }
+
+  static func merge(_ local: [String: PersonActivity], _ remote: [String: PersonActivity]) -> [String: PersonActivity] {
+    var merged = local
+    for (personId, activity) in remote {
+      let existing = merged[personId]
+      merged[personId] = PersonActivity(
+        conversationCount: max(existing?.conversationCount ?? 0, activity.conversationCount),
+        lastTalkedAt: [existing?.lastTalkedAt, activity.lastTalkedAt].compactMap { $0 }.max())
+    }
+    return merged
+  }
+}
+
+/// A voice rebuilt from conversation audio, ready for the diarizer to remember.
+struct RebuiltVoice: Sendable {
+  let personId: String?
+  var embeddings: [[Float]] = []
+  var speechSeconds: Double = 0
+  /// Longest cuts first, at most a handful.
+  var clips: [[Float]] = []
+  var conversationCount = 0
+  var lastHeardAt: Date?
+}
+
+struct PeopleRebuildProgress: Equatable, Sendable {
+  var scanned = 0
+  var total = 0
+  var withAudio = 0
+  var cutsEmbedded = 0
+  var message = ""
+}
+
+struct PeopleRebuildSummary: Equatable, Sendable {
+  var conversations = 0
+  var withAudio = 0
+  var voicesRebuilt = 0
+  var clipsSaved = 0
+  var activity: [String: PersonActivity] = [:]
+  var failure: String?
+
+  var message: String {
+    if let failure { return failure }
+    var parts = ["\(conversations) conversation\(conversations == 1 ? "" : "s") checked"]
+    if withAudio > 0 { parts.append("\(withAudio) with audio") }
+    parts.append(
+      voicesRebuilt == 0 ? "no voices rebuilt" : "\(voicesRebuilt) voice\(voicesRebuilt == 1 ? "" : "s") rebuilt")
+    if clipsSaved > 0 { parts.append("\(clipsSaved) clip\(clipsSaved == 1 ? "" : "s") saved") }
+    return parts.joined(separator: " · ")
+  }
+}
+
+/// The People page's Refresh: walks recent conversations on the backend, re-listens to every
+/// stretch labeled as a known person or as the user, and rebuilds the remembered voices and
+/// clips from that. Conversations without cached audio still count toward who was talked to.
+actor PeopleRebuilder {
+  static let shared = PeopleRebuilder()
+
+  static let conversationLimit = 100
+  static let clipsPerVoice = 3
+
+  private var isRunning = false
+
+  func run(
+    diarizer: LocalSpeakerDiarizer = .shared,
+    progress: @escaping @Sendable (PeopleRebuildProgress) -> Void
+  ) async -> PeopleRebuildSummary {
+    guard !isRunning else { return PeopleRebuildSummary(failure: "A refresh is already running") }
+    isRunning = true
+    defer { isRunning = false }
+
+    var summary = PeopleRebuildSummary()
+    var state = PeopleRebuildProgress(message: "Loading conversations…")
+    progress(state)
+
+    let conversations: [ServerConversation]
+    do {
+      conversations = try await APIClient.shared.getConversations(limit: Self.conversationLimit)
+    } catch {
+      logError("PeopleRebuilder: could not load conversations", error: error)
+      summary.failure = "Couldn't load conversations"
+      return summary
+    }
+    state.total = conversations.count
+    summary.conversations = conversations.count
+
+    await diarizer.prepare()
+    let canEmbed = await diarizer.isAvailable
+    var voices: [String: RebuiltVoice] = [:]
+    var seen: [(segments: [TranscriptSegment], date: Date)] = []
+
+    for conversation in conversations {
+      state.scanned += 1
+      state.message = "Checking \(state.scanned) of \(state.total)…"
+      progress(state)
+
+      let segments = await transcriptSegments(of: conversation)
+      seen.append((segments, conversation.startedAt ?? conversation.createdAt))
+
+      guard canEmbed, !conversation.isLocked,
+        !conversation.audioFiles.isEmpty || conversation.conversationAudio != nil,
+        segments.contains(where: { $0.isUser || $0.personId != nil })
+      else { continue }
+      guard case .readyAggregate(let artifact) = await LiveCapturePlaybackProvider().resolvePlayback(for: conversation)
+      else { continue }
+      let cuts = PeopleRebuildPlanner.cuts(segments: segments, artifact: artifact)
+      guard !cuts.isEmpty else { continue }
+      state.withAudio += 1
+      state.message = "Listening to \(state.scanned) of \(state.total)…"
+      progress(state)
+
+      guard let audio = await Self.downloadAndDecode(artifact.signedURL) else { continue }
+      let rate = Double(LocalVoiceprintStore.sampleRate)
+      var touched: Set<String> = []
+      for cut in cuts {
+        let from = max(0, Int(cut.artifactStart * rate))
+        let to = min(audio.count, Int(cut.artifactEnd * rate))
+        guard to - from >= Int(PeopleRebuildPlanner.minCutSeconds * rate) else { continue }
+        let samples = Array(audio[from..<to])
+        guard let embedding = await diarizer.embedding(for: samples) else { continue }
+        let key = LocalVoiceprintStore.sampleOwner(cut.personId)
+        var voice = voices[key] ?? RebuiltVoice(personId: cut.personId)
+        voice.embeddings.append(embedding)
+        voice.speechSeconds += cut.length
+        voice.clips.append(samples)
+        voice.clips.sort { $0.count > $1.count }
+        if voice.clips.count > Self.clipsPerVoice { voice.clips.removeLast(voice.clips.count - Self.clipsPerVoice) }
+        if !touched.contains(key) {
+          touched.insert(key)
+          voice.conversationCount += 1
+          let date = conversation.startedAt ?? conversation.createdAt
+          voice.lastHeardAt = [voice.lastHeardAt, date].compactMap { $0 }.max()
+        }
+        voices[key] = voice
+        state.cutsEmbedded += 1
+      }
+    }
+
+    summary.withAudio = state.withAudio
+    summary.activity = PeopleRebuildPlanner.activity(in: seen)
+    let rebuilt = Array(voices.values).filter { !$0.embeddings.isEmpty }
+    if !rebuilt.isEmpty {
+      let saved = await diarizer.applyRebuild(rebuilt)
+      summary.voicesRebuilt = rebuilt.count
+      summary.clipsSaved = saved
+    }
+    state.message = summary.message
+    progress(state)
+    log("PeopleRebuilder: \(summary.message)")
+    return summary
+  }
+
+  private func transcriptSegments(of conversation: ServerConversation) async -> [TranscriptSegment] {
+    if conversation.transcriptSegmentsIncluded || !conversation.transcriptSegments.isEmpty {
+      return conversation.transcriptSegments
+    }
+    guard let detail = try? await APIClient.shared.getConversation(id: conversation.id) else { return [] }
+    return detail.transcriptSegments
+  }
+
+  /// Fetch a signed audio URL to a temp file and decode it to 16 kHz mono. The file is deleted
+  /// afterwards; the URL is never logged.
+  private static func downloadAndDecode(_ url: URL) async -> [Float]? {
+    do {
+      let (temp, _) = try await URLSession.shared.download(from: url)
+      let ext = url.pathExtension.isEmpty ? "wav" : url.pathExtension
+      let local = FileManager.default.temporaryDirectory
+        .appendingPathComponent("people-rebuild-\(UUID().uuidString)").appendingPathExtension(ext)
+      try FileManager.default.moveItem(at: temp, to: local)
+      defer { try? FileManager.default.removeItem(at: local) }
+      return try AudioClipDecoder.decode16kMono(url: local)
+    } catch {
+      logError("PeopleRebuilder: audio download/decode failed", error: error)
+      return nil
+    }
+  }
+}
+
+/// Reads any AVFoundation-decodable audio file into 16 kHz mono Float32 samples.
+enum AudioClipDecoder {
+  /// Hands one input buffer to the converter per call, then reports end of stream.
+  private final class SingleBufferFeed: @unchecked Sendable {
+    private var pending: AVAudioPCMBuffer?
+    init(_ buffer: AVAudioPCMBuffer) { pending = buffer }
+    func next(_ status: UnsafeMutablePointer<AVAudioConverterInputStatus>) -> AVAudioBuffer? {
+      guard let buffer = pending else {
+        status.pointee = .noDataNow
+        return nil
+      }
+      pending = nil
+      status.pointee = .haveData
+      return buffer
+    }
+  }
+
+  static func decode16kMono(url: URL) throws -> [Float] {
+    let file = try AVAudioFile(forReading: url)
+    let source = file.processingFormat
+    guard
+      let target = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32, sampleRate: Double(LocalVoiceprintStore.sampleRate), channels: 1,
+        interleaved: false),
+      let converter = AVAudioConverter(from: source, to: target)
+    else { throw CocoaError(.fileReadCorruptFile) }
+
+    var output: [Float] = []
+    let chunkFrames: AVAudioFrameCount = 65_536
+    let ratio = target.sampleRate / source.sampleRate
+    while file.framePosition < file.length {
+      guard let input = AVAudioPCMBuffer(pcmFormat: source, frameCapacity: chunkFrames) else { break }
+      try file.read(into: input, frameCount: chunkFrames)
+      if input.frameLength == 0 { break }
+      let capacity = AVAudioFrameCount(Double(input.frameLength) * ratio) + 1024
+      guard let converted = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: capacity) else { break }
+      let feed = SingleBufferFeed(input)
+      var conversionError: NSError?
+      converter.convert(to: converted, error: &conversionError) { _, status in feed.next(status) }
+      if let conversionError { throw conversionError }
+      if let channel = converted.floatChannelData {
+        output.append(contentsOf: UnsafeBufferPointer(start: channel[0], count: Int(converted.frameLength)))
+      }
+    }
+    return output
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Which remembered voices to keep when there are more people than the store should hold.
+///
+/// **LFU with exponential aging**, favorites pinned. Every session a person is heard in bumps
+/// their use score by one; the score halves every `halfLifeDays`. So someone heard weekly
+/// outranks a one-off from yesterday (plain LRU would keep the one-off), and someone heard a
+/// lot last year fades instead of squatting on a slot forever (plain LFU would keep them).
+/// One number per person, decayed lazily, so it is cheap and deterministic to test.
+struct VoiceEnrollmentPolicy: Sendable {
+  /// Remembered people (the user's own voice is never counted or evicted).
+  var capacity: Int = 30
+  var halfLifeDays: Double = 14
+  /// Audio kept per voice: the most recent clips, newest first.
+  var maxSamplesPerVoice: Int = 5
+  /// Longest clip kept; a longer window is trimmed to its end (the freshest speech).
+  var maxSampleSeconds: Double = 12
+  /// Minimum gap between two automatically saved clips of one voice.
+  var sampleIntervalSeconds: Double = 60
+
+  init() {}
+
+  /// `score` as of `now`, given it was last touched at `lastUsedAt`.
+  func decayedScore(_ score: Double, lastUsedAt: Date?, now: Date) -> Double {
+    guard let lastUsedAt, score > 0 else { return 0 }
+    let days = max(0, now.timeIntervalSince(lastUsedAt) / 86_400)
+    return score * pow(0.5, days / halfLifeDays)
+  }
+
+  /// One more session this voice was heard in.
+  func recordingUse(of voiceprint: StoredVoiceprint, now: Date) -> StoredVoiceprint {
+    var next = voiceprint
+    next.useScore = decayedScore(voiceprint.useScore, lastUsedAt: voiceprint.lastUsedAt, now: now) + 1
+    next.lastUsedAt = now
+    return next
+  }
+
+  /// Person ids to drop so that at most `capacity` non-favorite people remain: the lowest
+  /// current scores go first, ties broken by the oldest last use. Favorites and the user are
+  /// never returned.
+  func evictions(from voiceprints: [StoredVoiceprint], now: Date) -> [String] {
+    let people = voiceprints.filter { $0.personId != nil }
+    let overflow = people.count - capacity
+    guard overflow > 0 else { return [] }
+    let candidates =
+      people
+      .filter { !$0.isFavorite }
+      .map { (id: $0.personId ?? "", score: decayedScore($0.useScore, lastUsedAt: $0.lastUsedAt, now: now), last: $0.lastUsedAt ?? .distantPast) }
+      .sorted { lhs, rhs in
+        if lhs.score != rhs.score { return lhs.score < rhs.score }
+        return lhs.last < rhs.last
+      }
+    return candidates.prefix(overflow).map(\.id)
+  }
+}

--- a/desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
@@ -45,7 +45,12 @@ struct VoiceEnrollmentPolicy: Sendable {
     let candidates =
       people
       .filter { !$0.isFavorite }
-      .map { (id: $0.personId ?? "", score: decayedScore($0.useScore, lastUsedAt: $0.lastUsedAt, now: now), last: $0.lastUsedAt ?? .distantPast) }
+      .map {
+        (
+          id: $0.personId ?? "", score: decayedScore($0.useScore, lastUsedAt: $0.lastUsedAt, now: now),
+          last: $0.lastUsedAt ?? .distantPast
+        )
+      }
       .sorted { lhs, rhs in
         if lhs.score != rhs.score { return lhs.score < rhs.score }
         return lhs.last < rhs.last

--- a/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
@@ -48,11 +48,21 @@ final class LocalTranscriptionService: @unchecked Sendable {
     let durSec: Double
   }
 
+  typealias SpeakerRelabelHandler = @MainActor ([Int: LocalSpeakerRegistry.Resolution]) -> Void
+
   private let language: String
-  /// Source-based diarization: mic = the user ("You"), system audio = another speaker.
+  /// Which capture lane this instance transcribes. Speaker identity comes from
+  /// `speakerDiarizer`; when it is unavailable the lane itself is the label
+  /// (mic = the user "You", system audio = Speaker 1), as before on-device diarization.
   private let isUser: Bool
-  private let speakerLabel: String
-  private let speakerId: Int
+  private let lane: LocalTranscriptionLane
+  private let speakerDiarizer: LocalSpeakerDiarizer?
+  private var fallbackResolution: LocalSpeakerRegistry.Resolution {
+    LocalSpeakerRegistry.Resolution(speakerId: isUser ? 0 : 1, isUser: isUser)
+  }
+  /// Longest the first window waits for the speaker models once Parakeet is ready. Past it,
+  /// windows go out with lane labels and pick up real speaker ids when the models arrive.
+  private let diarizerReadyGraceSeconds = 20.0
   private let sampleRate = 16000
   /// Longest stretch transcribed at once. A window also closes early when the speaker
   /// pauses — see `silenceTailSeconds` — so this is the ceiling, not the cadence.
@@ -76,6 +86,9 @@ final class LocalTranscriptionService: @unchecked Sendable {
   /// Fired (on the main actor) if the Parakeet model fails to download/load. Lets AppState
   /// fall back to cloud STT instead of silently producing a blank transcript.
   private var onModelLoadFailed: (@MainActor () -> Void)?
+  /// Fired (on the main actor) when the diarizer moves already-emitted segments to another
+  /// speaker — e.g. the provisional "You" turned out to be the other person in the room.
+  private var onSpeakerRelabel: SpeakerRelabelHandler?
 
   // 16 kHz mono Float32 sample buffer, guarded by `lock`.
   private let lock = NSLock()
@@ -91,22 +104,33 @@ final class LocalTranscriptionService: @unchecked Sendable {
 
   private var pumpTask: Task<Void, Never>?
 
-  init(language: String = "en", isUser: Bool = true) {
+  init(language: String = "en", isUser: Bool = true, speakerDiarizer: LocalSpeakerDiarizer? = .shared) {
     self.language = language
     self.isUser = isUser
-    self.speakerLabel = isUser ? "SPEAKER_00" : "SPEAKER_01"
-    self.speakerId = isUser ? 0 : 1
+    self.lane = isUser ? .microphone : .systemAudio
+    self.speakerDiarizer = speakerDiarizer
   }
 
   /// Begin loading the model (async) and start the periodic flush loop.
   /// `onModelLoadFailed` fires once if the model can't load, so the caller can fall back
   /// to cloud transcription instead of recording into a void.
-  func start(onSegments: @escaping SegmentsHandler, onModelLoadFailed: (@MainActor () -> Void)? = nil) {
+  func start(
+    onSegments: @escaping SegmentsHandler,
+    onModelLoadFailed: (@MainActor () -> Void)? = nil,
+    onSpeakerRelabel: SpeakerRelabelHandler? = nil
+  ) {
     self.onSegments = onSegments
     self.onModelLoadFailed = onModelLoadFailed
+    self.onSpeakerRelabel = onSpeakerRelabel
 
     Task { [weak self] in
       guard let self else { return }
+      // Speaker models load alongside Parakeet (both are cached after the first run).
+      let diarizer = self.speakerDiarizer
+      let diarizerLoad = Task<Void, Never> {
+        guard let diarizer else { return }
+        await diarizer.prepare()
+      }
       do {
         // Test hook: force a model-load failure to exercise the cloud fallback path.
         // Toggle with env OMI_FORCE_PARAKEET_FAIL=1 or `defaults write <bundle> forceParakeetFail -bool true`.
@@ -123,6 +147,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
         let models = try await AsrModels.downloadAndLoad(version: version)
         let manager = AsrManager()
         try await manager.loadModels(models)
+        await Self.wait(for: diarizerLoad, upTo: self.diarizerReadyGraceSeconds)
         self.lock.withLock {
           self.asrManager = manager
           self.isReady = true
@@ -277,12 +302,23 @@ final class LocalTranscriptionService: @unchecked Sendable {
         text.removeFirst()
       }
 
+      // Who said it: the shared on-device diarizer, or the lane itself when it is unavailable.
+      // Only windows with real text reach here, so silence and hallucinations never enter the
+      // speaker clusters.
+      let outcome = await speakerDiarizer?.resolve(
+        window: snapshot.window, durationSeconds: snapshot.durSec, rms: rms, lane: lane)
+      let resolution = outcome?.resolution ?? fallbackResolution
+      if let relabels = outcome?.relabels, !relabels.isEmpty, self.onSpeakerRelabel != nil {
+        // Earlier segments move first so the transcript never shows two "You"s at once.
+        await MainActor.run { self.onSpeakerRelabel?(relabels) }
+      }
+
       let segment = TranscriptionService.BackendSegment(
         id: UUID().uuidString,
         text: text,
-        speaker: speakerLabel,
-        speaker_id: speakerId,
-        is_user: isUser,
+        speaker: resolution.speakerLabel,
+        speaker_id: resolution.speakerId,
+        is_user: resolution.isUser,
         person_id: nil,
         start: snapshot.startSec,
         end: snapshot.startSec + snapshot.durSec,
@@ -296,10 +332,23 @@ final class LocalTranscriptionService: @unchecked Sendable {
       }
       log(
         String(
-          format: "LocalTranscriptionService[%@]: %.1fs rms=%.4f conf=%.2f rtfx=%.0fx → %@",
-          isUser ? "mic" : "sys", snapshot.durSec, rms, result.confidence, result.rtfx, text))
+          format: "LocalTranscriptionService[%@]: %.1fs rms=%.4f conf=%.2f rtfx=%.0fx spk=%d%@ d=%.2f → %@",
+          isUser ? "mic" : "sys", snapshot.durSec, rms, result.confidence, result.rtfx,
+          resolution.speakerId, resolution.isUser ? "(you)" : (outcome == nil ? "(lane)" : ""),
+          outcome?.nearestDistance ?? -1, text))
     } catch {
       logError("LocalTranscriptionService: transcribe failed", error: error)
+    }
+  }
+
+  /// Await `task` for at most `seconds`; the task keeps running if the deadline passes.
+  private static func wait(for task: Task<Void, Never>, upTo seconds: Double) async {
+    let deadline = Task { try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { await task.value }
+      group.addTask { await deadline.value }
+      await group.next()
+      group.cancelAll()
     }
   }
 

--- a/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
@@ -60,9 +60,6 @@ final class LocalTranscriptionService: @unchecked Sendable {
   private var fallbackResolution: LocalSpeakerRegistry.Resolution {
     LocalSpeakerRegistry.Resolution(speakerId: isUser ? 0 : 1, isUser: isUser)
   }
-  /// Longest the first window waits for the speaker models once Parakeet is ready. Past it,
-  /// windows go out with lane labels and pick up real speaker ids when the models arrive.
-  private let diarizerReadyGraceSeconds = 20.0
   private let sampleRate = 16000
   /// Longest stretch transcribed at once. A window also closes early when the speaker
   /// pauses — see `silenceTailSeconds` — so this is the ceiling, not the cadence.
@@ -125,12 +122,6 @@ final class LocalTranscriptionService: @unchecked Sendable {
 
     Task { [weak self] in
       guard let self else { return }
-      // Speaker models load alongside Parakeet (both are cached after the first run).
-      let diarizer = self.speakerDiarizer
-      let diarizerLoad = Task<Void, Never> {
-        guard let diarizer else { return }
-        await diarizer.prepare()
-      }
       do {
         // Test hook: force a model-load failure to exercise the cloud fallback path.
         // Toggle with env OMI_FORCE_PARAKEET_FAIL=1 or `defaults write <bundle> forceParakeetFail -bool true`.
@@ -144,10 +135,15 @@ final class LocalTranscriptionService: @unchecked Sendable {
         // v2 = English-only (better recall); v3 = 25 European languages.
         let version: AsrModelVersion = self.language.hasPrefix("en") ? .v2 : .v3
         let started = Date()
-        let models = try await AsrModels.downloadAndLoad(version: version)
-        let manager = AsrManager()
-        try await manager.loadModels(models)
-        await Self.wait(for: diarizerLoad, upTo: self.diarizerReadyGraceSeconds)
+        let diarizer = self.speakerDiarizer
+        let manager = try await Self.loadASRManagerWithSpeakerWarmup(
+          loadASR: {
+            let models = try await AsrModels.downloadAndLoad(version: version)
+            let manager = AsrManager()
+            try await manager.loadModels(models)
+            return manager
+          },
+          warmSpeakerModels: { await diarizer?.prepare() })
         self.lock.withLock {
           self.asrManager = manager
           self.isReady = true
@@ -341,15 +337,21 @@ final class LocalTranscriptionService: @unchecked Sendable {
     }
   }
 
-  /// Await `task` for at most `seconds`; the task keeps running if the deadline passes.
-  private static func wait(for task: Task<Void, Never>, upTo seconds: Double) async {
-    let deadline = Task { try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)) }
-    await withTaskGroup(of: Void.self) { group in
-      group.addTask { await task.value }
-      group.addTask { await deadline.value }
-      await group.next()
-      group.cancelAll()
-    }
+  /// Load the Parakeet ASR manager and warm the shared speaker models alongside.
+  ///
+  /// Warmup runs concurrently and never gates the returned readiness: windows transcribed
+  /// before the diarizer is ready go out with lane labels (mic = "You", system = Speaker 1)
+  /// and are moved by registry relabels once real speaker ids arrive. Readiness once awaited
+  /// this warmup behind a "grace" deadline — but `withTaskGroup` implicitly awaits an
+  /// unfinished `Task.value` child, and `Task.value` ignores cancellation, so the deadline
+  /// could not fire: readiness blocked for exactly as long as the speaker models took, and
+  /// QA measured ~20s of silent transcript at every capture-session start on a warm cache.
+  static func loadASRManagerWithSpeakerWarmup<Model: Sendable>(
+    loadASR: @escaping @Sendable () async throws -> Model,
+    warmSpeakerModels: @escaping @Sendable () async -> Void
+  ) async throws -> Model {
+    _ = Task { await warmSpeakerModels() }
+    return try await loadASR()
   }
 
   static func rms(_ samples: ArraySlice<Float>) -> Float {

--- a/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
@@ -319,7 +319,7 @@ final class LocalTranscriptionService: @unchecked Sendable {
         speaker: resolution.speakerLabel,
         speaker_id: resolution.speakerId,
         is_user: resolution.isUser,
-        person_id: nil,
+        person_id: resolution.personId,
         start: snapshot.startSec,
         end: snapshot.startSec + snapshot.durSec,
         translations: nil

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/LiveNameSpeakerSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/LiveNameSpeakerSheet.swift
@@ -10,6 +10,9 @@ struct LiveNameSpeakerSheet: View {
   let onSave: (_ personId: String) -> Void
   let onCreatePerson: (_ name: String) async -> Person?
   let onDismiss: () -> Void
+  /// On-device transcription only: this speaker is the user. Fixes a wrong "You" on the spot
+  /// and teaches Omi the user's voice.
+  var onMarkAsUser: (() -> Void)? = nil
 
   @State private var selectedPersonId: String? = nil
   @State private var isAddingNewPerson: Bool = false
@@ -214,6 +217,34 @@ struct LiveNameSpeakerSheet: View {
       .scaledFont(size: OmiType.caption)
       .foregroundColor(Ink.secondary)
       .padding(.top, OmiSpacing.xxs)
+
+      if let onMarkAsUser {
+        Divider()
+          .background(Ink.separator)
+          .padding(.vertical, OmiSpacing.xs)
+        Button(action: onMarkAsUser) {
+          HStack(spacing: OmiSpacing.sm) {
+            Image(systemName: "person.crop.circle.badge.checkmark")
+              .scaledFont(size: OmiType.body)
+            VStack(alignment: .leading, spacing: 2) {
+              Text("This is me")
+                .scaledFont(size: OmiType.body, weight: .medium)
+              Text("Label this speaker as you and remember your voice")
+                .scaledFont(size: OmiType.caption)
+                .foregroundColor(Ink.secondary)
+            }
+            Spacer()
+          }
+          .padding(OmiSpacing.md)
+          .background(
+            RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+              .fill(Ink.rowFill)
+          )
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(Ink.primary)
+        .accessibilityIdentifier("live-speaker-this-is-me")
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -16,6 +16,9 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
   case activity
   /// The visual screen-history player. Appended to preserve every persisted raw value above.
   case rewind
+  /// Everyone Omi has heard you talk to, with the voices it remembers for them (and for you).
+  /// Appended last so every persisted raw value above keeps its meaning.
+  case people
 
   var id: Int { rawValue }
 
@@ -26,6 +29,7 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .brainMap: return "Brain Map"
     case .activity: return "Activity"
     case .rewind: return "Rewind"
+    case .people: return "People"
     }
   }
 
@@ -36,6 +40,7 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .brainMap: return "point.3.connected.trianglepath.dotted"
     case .activity: return "clock.arrow.circlepath"
     case .rewind: return "clock.arrow.circlepath"
+    case .people: return "person.2"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
@@ -153,6 +153,13 @@ struct MemoryHubPage: View {
         onSelectBrainDestination: select
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
+    case .people:
+      PeoplePage(
+        appState: appState,
+        brainDestination: destination,
+        onSelectBrainDestination: select
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     case .brainMap:
       BrainSectionPageLayout(
         selected: destination,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -39,8 +39,9 @@ struct PersonOverview: Identifiable {
       }
   }
 
-  static func voiceCaption(_ voice: LocalSpeakerDiarizer.VoiceSummary?) -> String {
-    guard let voice else { return "No voice yet — name them in a live transcript" }
+  /// Nil when no voice is known: the row says nothing rather than nagging.
+  static func voiceCaption(_ voice: LocalSpeakerDiarizer.VoiceSummary?) -> String? {
+    guard let voice else { return nil }
     let minutes = Int(voice.speechSeconds / 60)
     let amount = minutes >= 1 ? "\(minutes) min heard" : "\(Int(voice.speechSeconds)) s heard"
     let clips =
@@ -192,11 +193,6 @@ struct PeoplePage: View {
         snippetRow(owner: LocalVoiceprintStore.sampleOwner(nil))
       }
       Spacer(minLength: 0)
-      if userVoice != nil {
-        pillButton(title: "Forget my voice", identifier: "people-forget-user-voice") {
-          await LocalSpeakerDiarizer.shared.forgetVoice(personId: nil)
-        }
-      }
     }
     .padding(OmiSpacing.md)
     .background(
@@ -261,9 +257,11 @@ struct PeoplePage: View {
         Text(PersonOverview.conversationCaption(count: row.conversationCount, last: row.lastTalkedAt))
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
-        Text(PersonOverview.voiceCaption(row.voice))
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(row.hasVoice ? Ink.secondary : Ink.tertiary)
+        if let caption = PersonOverview.voiceCaption(row.voice) {
+          Text(caption)
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+        }
         snippetRow(owner: LocalVoiceprintStore.sampleOwner(row.id))
       }
       Spacer(minLength: 0)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -1,0 +1,235 @@
+import OmiTheme
+import SwiftUI
+
+/// One row of the People page, assembled from the backend's people list, the local transcript
+/// store, and the voices the on-device diarizer remembers. Pure so the ordering and copy can be
+/// unit-tested without a database or a model.
+struct PersonOverview: Identifiable {
+  let person: Person
+  let activity: PersonActivity?
+  let voice: LocalSpeakerDiarizer.VoiceSummary?
+
+  var id: String { person.id }
+
+  var conversationCount: Int { activity?.conversationCount ?? 0 }
+  var lastTalkedAt: Date? { activity?.lastTalkedAt }
+  var hasVoice: Bool { voice != nil }
+
+  /// Most recently talked to first; never-heard people by name at the end.
+  static func ordered(
+    people: [Person],
+    activity: [String: PersonActivity],
+    voices: [LocalSpeakerDiarizer.VoiceSummary]
+  ) -> [PersonOverview] {
+    let voiceByPerson = Dictionary(
+      voices.compactMap { voice in voice.personId.map { ($0, voice) } },
+      uniquingKeysWith: { _, latest in latest })
+    return
+      people.map { PersonOverview(person: $0, activity: activity[$0.id], voice: voiceByPerson[$0.id]) }
+      .sorted { lhs, rhs in
+        switch (lhs.lastTalkedAt, rhs.lastTalkedAt) {
+        case let (l?, r?) where l != r: return l > r
+        case (.some, .none): return true
+        case (.none, .some): return false
+        default: return lhs.person.name.localizedCaseInsensitiveCompare(rhs.person.name) == .orderedAscending
+        }
+      }
+  }
+
+  static func voiceCaption(_ voice: LocalSpeakerDiarizer.VoiceSummary?) -> String {
+    guard let voice else { return "No voice yet — name them in a live transcript" }
+    let minutes = Int(voice.speechSeconds / 60)
+    let amount = minutes >= 1 ? "\(minutes) min heard" : "\(Int(voice.speechSeconds)) s heard"
+    return voice.isEnrolled ? "Voice known · \(amount)" : "Voice guessed · \(amount)"
+  }
+
+  static func conversationCaption(count: Int, last: Date?, now: Date = Date()) -> String {
+    guard count > 0, let last else { return "Not heard in a conversation yet" }
+    let noun = count == 1 ? "conversation" : "conversations"
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return "\(count) \(noun) · last \(formatter.localizedString(for: last, relativeTo: now))"
+  }
+}
+
+/// Everyone Omi has heard you talk to, and the voices it remembers for them and for you.
+///
+/// The voices are what make on-device speaker labels stick: a person named once in a live
+/// transcript is recognised by voice in the next conversation, and "You" follows the user's
+/// own remembered print instead of a guess.
+struct PeoplePage: View {
+  @ObservedObject var appState: AppState
+  let brainDestination: MemoryHubDestination
+  let onSelectBrainDestination: (MemoryHubDestination) -> Void
+
+  @State private var searchText = ""
+  @State private var activity: [String: PersonActivity] = [:]
+  @State private var voices: [LocalSpeakerDiarizer.VoiceSummary] = []
+
+  private var userVoice: LocalSpeakerDiarizer.VoiceSummary? {
+    voices.first { $0.personId == nil }
+  }
+
+  private var rows: [PersonOverview] {
+    let all = PersonOverview.ordered(people: appState.people, activity: activity, voices: voices)
+    let query = searchText.trimmingCharacters(in: .whitespaces)
+    guard !query.isEmpty else { return all }
+    return all.filter { $0.person.name.localizedCaseInsensitiveContains(query) }
+  }
+
+  var body: some View {
+    BrainSectionPageLayout(
+      selected: brainDestination,
+      onSelect: onSelectBrainDestination,
+      search: {
+        QuerySearchBar(
+          text: $searchText,
+          accessibilityID: "people-search-field",
+          placeholder: "Search people…",
+          searchSurface: .people
+        )
+      },
+      content: {
+        ScrollView {
+          VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+            youCard
+            peopleSection
+          }
+          .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
+          .padding(.bottom, OmiSpacing.xl)
+        }
+      }
+    )
+    .task { await reload() }
+    .accessibilityIdentifier("people-page")
+  }
+
+  // MARK: - You
+
+  private var youCard: some View {
+    HStack(alignment: .top, spacing: OmiSpacing.md) {
+      avatar(initial: "Y", isUser: true)
+      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+        Text("You")
+          .scaledFont(size: OmiType.body, weight: .semibold)
+          .foregroundColor(Ink.primary)
+        Text(userVoiceCaption)
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.secondary)
+        Text("Omi learns your voice from push-to-talk and from “This is me” on a live transcript bubble.")
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.tertiary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer(minLength: 0)
+      if userVoice != nil {
+        forgetButton(title: "Forget my voice", identifier: "people-forget-user-voice") {
+          await LocalSpeakerDiarizer.shared.forgetVoice(personId: nil)
+        }
+      }
+    }
+    .padding(OmiSpacing.md)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+        .fill(Ink.rowFill)
+    )
+    .accessibilityIdentifier("people-you-card")
+  }
+
+  private var userVoiceCaption: String {
+    guard let userVoice else { return "Voice not learned yet" }
+    let minutes = Int(userVoice.speechSeconds / 60)
+    let amount = minutes >= 1 ? "\(minutes) min" : "\(Int(userVoice.speechSeconds)) s"
+    return userVoice.isEnrolled ? "Voice known · \(amount) heard" : "Voice guessed from who talks most · \(amount) heard"
+  }
+
+  // MARK: - People
+
+  @ViewBuilder
+  private var peopleSection: some View {
+    if rows.isEmpty {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        Text(appState.people.isEmpty ? "No people yet" : "No one matches")
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundColor(Ink.primary)
+        if appState.people.isEmpty {
+          Text("Tap a speaker in a live transcript to name them. Omi remembers their voice for next time.")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+        }
+      }
+      .padding(.vertical, OmiSpacing.lg)
+      .accessibilityIdentifier("people-empty")
+    } else {
+      VStack(spacing: OmiSpacing.xs) {
+        ForEach(rows) { row in
+          personRow(row)
+        }
+      }
+    }
+  }
+
+  private func personRow(_ row: PersonOverview) -> some View {
+    HStack(alignment: .center, spacing: OmiSpacing.md) {
+      avatar(initial: String(row.person.name.prefix(1)).uppercased(), isUser: false)
+      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+        Text(row.person.name)
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundColor(Ink.primary)
+        Text(PersonOverview.conversationCaption(count: row.conversationCount, last: row.lastTalkedAt))
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.secondary)
+        Text(PersonOverview.voiceCaption(row.voice))
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(row.hasVoice ? Ink.secondary : Ink.tertiary)
+      }
+      Spacer(minLength: 0)
+      if row.hasVoice {
+        forgetButton(title: "Forget voice", identifier: "people-forget-voice-\(row.id)") {
+          await LocalSpeakerDiarizer.shared.forgetVoice(personId: row.id)
+        }
+      }
+    }
+    .padding(OmiSpacing.md)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+        .fill(Ink.rowFill)
+    )
+    .accessibilityIdentifier("people-row-\(row.id)")
+  }
+
+  private func avatar(initial: String, isUser: Bool) -> some View {
+    Circle()
+      .fill(isUser ? Ink.primary : Ink.rowFillHover)
+      .frame(width: 36, height: 36)
+      .overlay(
+        Text(initial)
+          .scaledFont(size: OmiType.body, weight: .semibold)
+          .foregroundColor(isUser ? Ink.surface : Ink.primary)
+      )
+  }
+
+  private func forgetButton(title: String, identifier: String, action: @escaping () async -> Void) -> some View {
+    Button {
+      Task {
+        await action()
+        await reload()
+      }
+    } label: {
+      Text(title)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .foregroundColor(Ink.secondary)
+        .padding(.horizontal, OmiSpacing.md)
+        .padding(.vertical, OmiSpacing.xs)
+        .background(Capsule().fill(Ink.rowFillHover))
+    }
+    .buttonStyle(.plain)
+    .accessibilityIdentifier(identifier)
+  }
+
+  private func reload() async {
+    await appState.fetchPeople()
+    voices = await LocalSpeakerDiarizer.shared.voiceSummaries()
+    activity = (try? await TranscriptionStorage.shared.personActivity()) ?? [:]
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -51,8 +51,11 @@ struct PersonOverview: Identifiable {
   }
 
   static func conversationCaption(count: Int, last: Date?, now: Date = Date()) -> String {
-    guard count > 0, let last else { return "Not heard in a conversation yet" }
+    guard count > 0 else { return "Not heard in a conversation yet" }
     let noun = count == 1 ? "conversation" : "conversations"
+    // A count without a usable date still means Omi heard them; saying "not heard yet" beside a
+    // real count would be the page contradicting itself.
+    guard let last else { return "\(count) \(noun)" }
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .short
     return "\(count) \(noun) · last \(formatter.localizedString(for: last, relativeTo: now))"

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -119,9 +119,21 @@ struct PeoplePage: View {
   @State private var snippets: [String: [VoiceSnippet]] = [:]
   @StateObject private var samplePlayer = VoiceSamplePlayer()
 
+  /// The signed-in name; the row for the user shows it, never the word "You".
+  private var userName: String {
+    let name = AuthService.shared.displayName.trimmingCharacters(in: .whitespaces)
+    return name.isEmpty ? "Me" : name
+  }
+
+  /// A person entry that is the user themselves (same name) is not listed twice.
+  private func isTheUser(_ person: Person) -> Bool {
+    person.name.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare(userName) == .orderedSame
+  }
+
   private var rows: [PersonOverview] {
     let merged = PeopleRebuildPlanner.merge(activity, remoteActivity)
-    let all = PersonOverview.ordered(people: appState.people, activity: merged, voices: voices)
+    let others = appState.people.filter { !isTheUser($0) }
+    let all = PersonOverview.ordered(people: others, activity: merged, voices: voices)
     let query = searchText.trimmingCharacters(in: .whitespaces)
     guard !query.isEmpty else { return all }
     return all.filter { $0.person.name.localizedCaseInsensitiveContains(query) }
@@ -234,9 +246,9 @@ struct PeoplePage: View {
   /// Always first: the user, styled like everyone else, with their clips when there are any.
   private var userRow: some View {
     HStack(alignment: .center, spacing: OmiSpacing.md) {
-      avatar(initial: "Y", isUser: true)
+      avatar(initial: String(userName.prefix(1)).uppercased(), isUser: true)
       VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text("You")
+        Text(userName)
           .scaledFont(size: OmiType.body, weight: .medium)
           .foregroundColor(Ink.primary)
         if let caption = PersonOverview.voiceCaption(userVoice) {
@@ -259,7 +271,7 @@ struct PeoplePage: View {
   @ViewBuilder
   private var peopleSection: some View {
     let query = searchText.trimmingCharacters(in: .whitespaces)
-    if query.isEmpty || "you".localizedCaseInsensitiveContains(query) {
+    if query.isEmpty || userName.localizedCaseInsensitiveContains(query) {
       userRow
     }
     if rows.isEmpty {
@@ -384,8 +396,9 @@ struct PeoplePage: View {
   }
 
   private func avatar(initial: String, isUser: Bool) -> some View {
+    // The user's avatar is the grey one; everyone else keeps the light fill.
     Circle()
-      .fill(isUser ? Ink.primary : Ink.rowFillHover)
+      .fill(isUser ? Ink.tertiary : Ink.rowFillHover)
       .frame(width: 36, height: 36)
       .overlay(
         Text(initial)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -200,10 +200,10 @@ struct PeoplePage: View {
           Text(isRefreshing ? "Refreshing" : "Refresh")
             .scaledFont(size: OmiType.caption, weight: .medium)
         }
-        .foregroundColor(isRefreshing ? Ink.secondary : Ink.surface)
+        .foregroundStyle(GlassShell.controlLabel(isProminent: !isRefreshing))
         .padding(.horizontal, OmiSpacing.md)
-        .padding(.vertical, OmiSpacing.xs)
-        .background(Capsule().fill(isRefreshing ? Ink.rowFillHover : Ink.primary))
+        .frame(height: QueryShellLayout.chipHeight)
+        .glassChip(isActive: isRefreshing)
       }
       .buttonStyle(.plain)
       .disabled(isRefreshing)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -106,12 +106,18 @@ struct PeoplePage: View {
   @State private var activity: [String: PersonActivity] = [:]
   @State private var voices: [LocalSpeakerDiarizer.VoiceSummary] = []
   @State private var personPendingDeletion: Person?
+  /// Who was talked to according to the backend's conversations (from the last Refresh),
+  /// merged with the local transcript store.
+  @State private var remoteActivity: [String: PersonActivity] = [:]
+  @State private var isRefreshing = false
+  @State private var refreshStatus: String?
   /// Clips per voice owner ("user" or the person id), loaded with the summaries.
   @State private var snippets: [String: [VoiceSnippet]] = [:]
   @StateObject private var samplePlayer = VoiceSamplePlayer()
 
   private var rows: [PersonOverview] {
-    let all = PersonOverview.ordered(people: appState.people, activity: activity, voices: voices)
+    let merged = PeopleRebuildPlanner.merge(activity, remoteActivity)
+    let all = PersonOverview.ordered(people: appState.people, activity: merged, voices: voices)
     let query = searchText.trimmingCharacters(in: .whitespaces)
     guard !query.isEmpty else { return all }
     return all.filter { $0.person.name.localizedCaseInsensitiveContains(query) }
@@ -132,6 +138,7 @@ struct PeoplePage: View {
       content: {
         ScrollView {
           VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+            refreshRow
             peopleSection
           }
           .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
@@ -158,6 +165,68 @@ struct PeoplePage: View {
       Text("Removes them from your people, their speaker labels in future conversations, and the voice Omi remembered.")
     }
     .accessibilityIdentifier("people-page")
+  }
+
+  // MARK: - Refresh
+
+  /// Re-listens to recent conversations and rebuilds every remembered voice from them.
+  private var refreshRow: some View {
+    HStack(spacing: OmiSpacing.md) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(refreshStatus ?? "Rebuild people from your conversations")
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.secondary)
+          .lineLimit(2)
+        if refreshStatus == nil {
+          Text(
+            "Goes through recent transcripts, listens again to everyone you've named and to you, and refreshes their voices and clips."
+          )
+          .scaledFont(size: OmiType.caption)
+          .foregroundColor(Ink.tertiary)
+          .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      Spacer(minLength: 0)
+      Button {
+        Task { await refreshPeople() }
+      } label: {
+        HStack(spacing: OmiSpacing.xs) {
+          if isRefreshing {
+            ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
+          } else {
+            Image(systemName: "arrow.clockwise")
+              .scaledFont(size: OmiType.caption, weight: .semibold)
+          }
+          Text(isRefreshing ? "Refreshing" : "Refresh")
+            .scaledFont(size: OmiType.caption, weight: .medium)
+        }
+        .foregroundColor(isRefreshing ? Ink.secondary : Ink.surface)
+        .padding(.horizontal, OmiSpacing.md)
+        .padding(.vertical, OmiSpacing.xs)
+        .background(Capsule().fill(isRefreshing ? Ink.rowFillHover : Ink.primary))
+      }
+      .buttonStyle(.plain)
+      .disabled(isRefreshing)
+      .accessibilityIdentifier("people-refresh")
+    }
+    .padding(OmiSpacing.md)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+        .fill(Ink.rowFill)
+    )
+  }
+
+  private func refreshPeople() async {
+    guard !isRefreshing else { return }
+    isRefreshing = true
+    await appState.fetchPeople()
+    let summary = await PeopleRebuilder.shared.run { progress in
+      Task { @MainActor in refreshStatus = progress.message }
+    }
+    remoteActivity = summary.activity
+    refreshStatus = summary.message
+    isRefreshing = false
+    await reload()
   }
 
   // MARK: - People

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -106,6 +106,9 @@ struct PeoplePage: View {
   @State private var activity: [String: PersonActivity] = [:]
   @State private var voices: [LocalSpeakerDiarizer.VoiceSummary] = []
   @State private var personPendingDeletion: Person?
+  @State private var editingPersonId: String?
+  @State private var editedName = ""
+  @FocusState private var nameFieldFocused: Bool
   /// Who was talked to according to the backend's conversations (from the last Refresh),
   /// merged with the local transcript store.
   @State private var remoteActivity: [String: PersonActivity] = [:]
@@ -251,9 +254,7 @@ struct PeoplePage: View {
     HStack(alignment: .center, spacing: OmiSpacing.md) {
       avatar(initial: String(row.person.name.prefix(1)).uppercased(), isUser: false)
       VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text(row.person.name)
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundColor(Ink.primary)
+        nameField(row)
         Text(PersonOverview.conversationCaption(count: row.conversationCount, last: row.lastTalkedAt))
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
@@ -306,6 +307,46 @@ struct PeoplePage: View {
         .fill(Ink.rowFill)
     )
     .accessibilityIdentifier("people-row-\(row.id)")
+  }
+
+  /// The name, editable in place: click it to type, Return saves, Escape cancels.
+  @ViewBuilder
+  private func nameField(_ row: PersonOverview) -> some View {
+    if editingPersonId == row.id {
+      TextField("Name", text: $editedName)
+        .textFieldStyle(.plain)
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .foregroundColor(Ink.primary)
+        .focused($nameFieldFocused)
+        .onSubmit { Task { await commitRename(row) } }
+        .onExitCommand { editingPersonId = nil }
+        .onChange(of: nameFieldFocused) { _, focused in
+          if !focused, editingPersonId == row.id { Task { await commitRename(row) } }
+        }
+        .frame(maxWidth: 260)
+        .accessibilityIdentifier("people-name-field-\(row.id)")
+    } else {
+      Button {
+        editedName = row.person.name
+        editingPersonId = row.id
+        nameFieldFocused = true
+      } label: {
+        Text(row.person.name)
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundColor(Ink.primary)
+      }
+      .buttonStyle(.plain)
+      .help("Click to rename")
+      .accessibilityIdentifier("people-name-\(row.id)")
+    }
+  }
+
+  private func commitRename(_ row: PersonOverview) async {
+    guard editingPersonId == row.id else { return }
+    editingPersonId = nil
+    let name = editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty, name != row.person.name else { return }
+    _ = await appState.renamePerson(id: row.id, name: name)
   }
 
   private func avatar(initial: String, isUser: Bool) -> some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -16,7 +16,6 @@ struct PersonOverview: Identifiable {
   var lastTalkedAt: Date? { activity?.lastTalkedAt }
   var hasVoice: Bool { voice != nil }
   var isFavorite: Bool { voice?.isFavorite ?? false }
-  var sampleURL: URL? { voice?.sampleURLs.first }
 
   /// Favorites first, then most recently talked to; never-heard people by name at the end.
   static func ordered(
@@ -32,7 +31,7 @@ struct PersonOverview: Identifiable {
       .sorted { lhs, rhs in
         if lhs.isFavorite != rhs.isFavorite { return lhs.isFavorite }
         switch (lhs.lastTalkedAt, rhs.lastTalkedAt) {
-        case let (l?, r?) where l != r: return l > r
+        case (let l?, let r?) where l != r: return l > r
         case (.some, .none): return true
         case (.none, .some): return false
         default: return lhs.person.name.localizedCaseInsensitiveCompare(rhs.person.name) == .orderedAscending
@@ -44,7 +43,8 @@ struct PersonOverview: Identifiable {
     guard let voice else { return "No voice yet — name them in a live transcript" }
     let minutes = Int(voice.speechSeconds / 60)
     let amount = minutes >= 1 ? "\(minutes) min heard" : "\(Int(voice.speechSeconds)) s heard"
-    let clips = voice.sampleURLs.isEmpty ? "" : " · \(voice.sampleURLs.count) clip\(voice.sampleURLs.count == 1 ? "" : "s")"
+    let clips =
+      voice.sampleURLs.isEmpty ? "" : " · \(voice.sampleURLs.count) clip\(voice.sampleURLs.count == 1 ? "" : "s")"
     return (voice.isEnrolled ? "Voice known · \(amount)" : "Voice guessed · \(amount)") + clips
   }
 
@@ -54,6 +54,40 @@ struct PersonOverview: Identifiable {
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .short
     return "\(count) \(noun) · last \(formatter.localizedString(for: last, relativeTo: now))"
+  }
+}
+
+/// One saved clip of a voice: what the person sounds like.
+struct VoiceSnippet: Identifiable, Equatable {
+  let url: URL
+  let durationSeconds: Double
+  let recordedAt: Date?
+
+  var id: URL { url }
+
+  /// Clip files are named by their millisecond timestamp (`LocalVoiceprintStore.addSample`).
+  static func recordedAt(from url: URL) -> Date? {
+    guard let millis = Double(url.deletingPathExtension().lastPathComponent) else { return nil }
+    return Date(timeIntervalSince1970: millis / 1000)
+  }
+
+  static func caption(durationSeconds: Double, recordedAt: Date?, now: Date = Date()) -> String {
+    let seconds = max(1, Int(durationSeconds.rounded()))
+    guard let recordedAt else { return "\(seconds)s" }
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return "\(seconds)s · \(formatter.localizedString(for: recordedAt, relativeTo: now))"
+  }
+
+  /// Read each clip's length; a clip that cannot be opened is left out.
+  static func load(_ urls: [URL]) -> [VoiceSnippet] {
+    urls.compactMap { url in
+      guard let file = try? AVAudioFile(forReading: url), file.fileFormat.sampleRate > 0 else { return nil }
+      return VoiceSnippet(
+        url: url,
+        durationSeconds: Double(file.length) / file.fileFormat.sampleRate,
+        recordedAt: recordedAt(from: url))
+    }
   }
 }
 
@@ -71,6 +105,8 @@ struct PeoplePage: View {
   @State private var activity: [String: PersonActivity] = [:]
   @State private var voices: [LocalSpeakerDiarizer.VoiceSummary] = []
   @State private var personPendingDeletion: Person?
+  /// Clips per voice owner ("user" or the person id), loaded with the summaries.
+  @State private var snippets: [String: [VoiceSnippet]] = [:]
   @StateObject private var samplePlayer = VoiceSamplePlayer()
 
   private var userVoice: LocalSpeakerDiarizer.VoiceSummary? {
@@ -132,11 +168,20 @@ struct PeoplePage: View {
 
   private var youCard: some View {
     HStack(alignment: .top, spacing: OmiSpacing.md) {
-      avatar(initial: "Y", isUser: true)
+      avatar(initial: userInitial, isUser: true)
       VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        Text("You")
-          .scaledFont(size: OmiType.body, weight: .semibold)
-          .foregroundColor(Ink.primary)
+        HStack(spacing: OmiSpacing.sm) {
+          Text(userName)
+            .scaledFont(size: OmiType.body, weight: .semibold)
+            .foregroundColor(Ink.primary)
+          Text("You")
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundColor(Ink.surface)
+            .padding(.horizontal, OmiSpacing.sm)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Ink.primary))
+            .accessibilityIdentifier("people-you-capsule")
+        }
         Text(userVoiceCaption)
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
@@ -144,11 +189,9 @@ struct PeoplePage: View {
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.tertiary)
           .fixedSize(horizontal: false, vertical: true)
+        snippetRow(owner: LocalVoiceprintStore.sampleOwner(nil))
       }
       Spacer(minLength: 0)
-      if let url = userVoice?.sampleURLs.first {
-        playButton(url: url, identifier: "people-play-user-voice")
-      }
       if userVoice != nil {
         pillButton(title: "Forget my voice", identifier: "people-forget-user-voice") {
           await LocalSpeakerDiarizer.shared.forgetVoice(personId: nil)
@@ -163,11 +206,23 @@ struct PeoplePage: View {
     .accessibilityIdentifier("people-you-card")
   }
 
+  /// The signed-in name; "You" alone when the account has none.
+  private var userName: String {
+    let name = AuthService.shared.displayName
+    return name.isEmpty ? "You" : name
+  }
+
+  private var userInitial: String {
+    let name = AuthService.shared.displayName
+    return name.isEmpty ? "Y" : String(name.prefix(1)).uppercased()
+  }
+
   private var userVoiceCaption: String {
     guard let userVoice else { return "Voice not learned yet" }
     let minutes = Int(userVoice.speechSeconds / 60)
     let amount = minutes >= 1 ? "\(minutes) min" : "\(Int(userVoice.speechSeconds)) s"
-    return userVoice.isEnrolled ? "Voice known · \(amount) heard" : "Voice guessed from who talks most · \(amount) heard"
+    return userVoice.isEnrolled
+      ? "Voice known · \(amount) heard" : "Voice guessed from who talks most · \(amount) heard"
   }
 
   // MARK: - People
@@ -209,6 +264,7 @@ struct PeoplePage: View {
         Text(PersonOverview.voiceCaption(row.voice))
           .scaledFont(size: OmiType.caption)
           .foregroundColor(row.hasVoice ? Ink.secondary : Ink.tertiary)
+        snippetRow(owner: LocalVoiceprintStore.sampleOwner(row.id))
       }
       Spacer(minLength: 0)
       if row.hasVoice {
@@ -224,11 +280,10 @@ struct PeoplePage: View {
             .frame(width: 24, height: 24)
         }
         .buttonStyle(.plain)
-        .help(row.isFavorite ? "Unpin — this voice can be forgotten when space runs out" : "Pin — never forget this voice")
+        .help(
+          row.isFavorite ? "Unpin — this voice can be forgotten when space runs out" : "Pin — never forget this voice"
+        )
         .accessibilityIdentifier("people-favorite-\(row.id)")
-      }
-      if let url = row.sampleURL {
-        playButton(url: url, identifier: "people-play-\(row.id)")
       }
       if row.hasVoice {
         pillButton(title: "Forget voice", identifier: "people-forget-voice-\(row.id)") {
@@ -266,19 +321,40 @@ struct PeoplePage: View {
       )
   }
 
-  private func playButton(url: URL, identifier: String) -> some View {
-    let isPlaying = samplePlayer.playingURL == url
+  /// What this voice sounds like: one chip per saved clip, newest first.
+  @ViewBuilder
+  private func snippetRow(owner: String) -> some View {
+    if let clips = snippets[owner], !clips.isEmpty {
+      FlowLayout(spacing: OmiSpacing.xs) {
+        ForEach(clips) { clip in
+          snippetChip(clip, owner: owner)
+        }
+      }
+      .padding(.top, OmiSpacing.xxs)
+      .accessibilityIdentifier("people-snippets-\(owner)")
+    }
+  }
+
+  private func snippetChip(_ clip: VoiceSnippet, owner: String) -> some View {
+    let isPlaying = samplePlayer.playingURL == clip.url
     return Button {
-      samplePlayer.toggle(url)
+      samplePlayer.toggle(clip.url)
     } label: {
-      Image(systemName: isPlaying ? "stop.circle" : "play.circle")
-        .scaledFont(size: OmiType.body)
-        .foregroundColor(Ink.secondary)
-        .frame(width: 24, height: 24)
+      HStack(spacing: 4) {
+        Image(systemName: isPlaying ? "stop.fill" : "play.fill")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+        Text(VoiceSnippet.caption(durationSeconds: clip.durationSeconds, recordedAt: clip.recordedAt))
+          .scaledFont(size: OmiType.micro, weight: .medium)
+          .monospacedDigit()
+      }
+      .foregroundColor(isPlaying ? Ink.surface : Ink.secondary)
+      .padding(.horizontal, OmiSpacing.sm)
+      .padding(.vertical, 3)
+      .background(Capsule().fill(isPlaying ? Ink.primary : Ink.rowFillHover))
     }
     .buttonStyle(.plain)
-    .help(isPlaying ? "Stop" : "Play a clip of this voice")
-    .accessibilityIdentifier(identifier)
+    .help(isPlaying ? "Stop" : "Hear what this voice sounds like")
+    .accessibilityIdentifier("people-snippet-\(owner)-\(clip.url.lastPathComponent)")
   }
 
   private func pillButton(title: String, identifier: String, action: @escaping () async -> Void) -> some View {
@@ -303,6 +379,11 @@ struct PeoplePage: View {
     await appState.fetchPeople()
     voices = await LocalSpeakerDiarizer.shared.voiceSummaries()
     activity = (try? await TranscriptionStorage.shared.personActivity()) ?? [:]
+    var loaded: [String: [VoiceSnippet]] = [:]
+    for voice in voices {
+      loaded[LocalVoiceprintStore.sampleOwner(voice.personId)] = VoiceSnippet.load(voice.sampleURLs)
+    }
+    snippets = loaded
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import OmiTheme
 import SwiftUI
 
@@ -14,8 +15,10 @@ struct PersonOverview: Identifiable {
   var conversationCount: Int { activity?.conversationCount ?? 0 }
   var lastTalkedAt: Date? { activity?.lastTalkedAt }
   var hasVoice: Bool { voice != nil }
+  var isFavorite: Bool { voice?.isFavorite ?? false }
+  var sampleURL: URL? { voice?.sampleURLs.first }
 
-  /// Most recently talked to first; never-heard people by name at the end.
+  /// Favorites first, then most recently talked to; never-heard people by name at the end.
   static func ordered(
     people: [Person],
     activity: [String: PersonActivity],
@@ -27,6 +30,7 @@ struct PersonOverview: Identifiable {
     return
       people.map { PersonOverview(person: $0, activity: activity[$0.id], voice: voiceByPerson[$0.id]) }
       .sorted { lhs, rhs in
+        if lhs.isFavorite != rhs.isFavorite { return lhs.isFavorite }
         switch (lhs.lastTalkedAt, rhs.lastTalkedAt) {
         case let (l?, r?) where l != r: return l > r
         case (.some, .none): return true
@@ -40,7 +44,8 @@ struct PersonOverview: Identifiable {
     guard let voice else { return "No voice yet — name them in a live transcript" }
     let minutes = Int(voice.speechSeconds / 60)
     let amount = minutes >= 1 ? "\(minutes) min heard" : "\(Int(voice.speechSeconds)) s heard"
-    return voice.isEnrolled ? "Voice known · \(amount)" : "Voice guessed · \(amount)"
+    let clips = voice.sampleURLs.isEmpty ? "" : " · \(voice.sampleURLs.count) clip\(voice.sampleURLs.count == 1 ? "" : "s")"
+    return (voice.isEnrolled ? "Voice known · \(amount)" : "Voice guessed · \(amount)") + clips
   }
 
   static func conversationCaption(count: Int, last: Date?, now: Date = Date()) -> String {
@@ -65,6 +70,8 @@ struct PeoplePage: View {
   @State private var searchText = ""
   @State private var activity: [String: PersonActivity] = [:]
   @State private var voices: [LocalSpeakerDiarizer.VoiceSummary] = []
+  @State private var personPendingDeletion: Person?
+  @StateObject private var samplePlayer = VoiceSamplePlayer()
 
   private var userVoice: LocalSpeakerDiarizer.VoiceSummary? {
     voices.first { $0.personId == nil }
@@ -101,6 +108,23 @@ struct PeoplePage: View {
       }
     )
     .task { await reload() }
+    .confirmationDialog(
+      "Delete \(personPendingDeletion?.name ?? "this person")?",
+      isPresented: Binding(get: { personPendingDeletion != nil }, set: { if !$0 { personPendingDeletion = nil } }),
+      titleVisibility: .visible
+    ) {
+      Button("Delete", role: .destructive) {
+        guard let person = personPendingDeletion else { return }
+        personPendingDeletion = nil
+        Task {
+          _ = await appState.deletePerson(id: person.id)
+          await reload()
+        }
+      }
+      Button("Cancel", role: .cancel) { personPendingDeletion = nil }
+    } message: {
+      Text("Removes them from your people, their speaker labels in future conversations, and the voice Omi remembered.")
+    }
     .accessibilityIdentifier("people-page")
   }
 
@@ -122,8 +146,11 @@ struct PeoplePage: View {
           .fixedSize(horizontal: false, vertical: true)
       }
       Spacer(minLength: 0)
+      if let url = userVoice?.sampleURLs.first {
+        playButton(url: url, identifier: "people-play-user-voice")
+      }
       if userVoice != nil {
-        forgetButton(title: "Forget my voice", identifier: "people-forget-user-voice") {
+        pillButton(title: "Forget my voice", identifier: "people-forget-user-voice") {
           await LocalSpeakerDiarizer.shared.forgetVoice(personId: nil)
         }
       }
@@ -185,10 +212,40 @@ struct PeoplePage: View {
       }
       Spacer(minLength: 0)
       if row.hasVoice {
-        forgetButton(title: "Forget voice", identifier: "people-forget-voice-\(row.id)") {
+        Button {
+          Task {
+            await LocalSpeakerDiarizer.shared.setFavorite(personId: row.id, !row.isFavorite)
+            await reload()
+          }
+        } label: {
+          Image(systemName: row.isFavorite ? "star.fill" : "star")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(row.isFavorite ? Ink.primary : Ink.tertiary)
+            .frame(width: 24, height: 24)
+        }
+        .buttonStyle(.plain)
+        .help(row.isFavorite ? "Unpin — this voice can be forgotten when space runs out" : "Pin — never forget this voice")
+        .accessibilityIdentifier("people-favorite-\(row.id)")
+      }
+      if let url = row.sampleURL {
+        playButton(url: url, identifier: "people-play-\(row.id)")
+      }
+      if row.hasVoice {
+        pillButton(title: "Forget voice", identifier: "people-forget-voice-\(row.id)") {
           await LocalSpeakerDiarizer.shared.forgetVoice(personId: row.id)
         }
       }
+      Button {
+        personPendingDeletion = row.person
+      } label: {
+        Image(systemName: "trash")
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.tertiary)
+          .frame(width: 24, height: 24)
+      }
+      .buttonStyle(.plain)
+      .help("Delete this person")
+      .accessibilityIdentifier("people-delete-\(row.id)")
     }
     .padding(OmiSpacing.md)
     .background(
@@ -209,7 +266,22 @@ struct PeoplePage: View {
       )
   }
 
-  private func forgetButton(title: String, identifier: String, action: @escaping () async -> Void) -> some View {
+  private func playButton(url: URL, identifier: String) -> some View {
+    let isPlaying = samplePlayer.playingURL == url
+    return Button {
+      samplePlayer.toggle(url)
+    } label: {
+      Image(systemName: isPlaying ? "stop.circle" : "play.circle")
+        .scaledFont(size: OmiType.body)
+        .foregroundColor(Ink.secondary)
+        .frame(width: 24, height: 24)
+    }
+    .buttonStyle(.plain)
+    .help(isPlaying ? "Stop" : "Play a clip of this voice")
+    .accessibilityIdentifier(identifier)
+  }
+
+  private func pillButton(title: String, identifier: String, action: @escaping () async -> Void) -> some View {
     Button {
       Task {
         await action()
@@ -231,5 +303,39 @@ struct PeoplePage: View {
     await appState.fetchPeople()
     voices = await LocalSpeakerDiarizer.shared.voiceSummaries()
     activity = (try? await TranscriptionStorage.shared.personActivity()) ?? [:]
+  }
+}
+
+/// Plays one remembered voice clip at a time.
+@MainActor
+final class VoiceSamplePlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
+  @Published private(set) var playingURL: URL?
+  private var player: AVAudioPlayer?
+
+  func toggle(_ url: URL) {
+    if playingURL == url {
+      stop()
+      return
+    }
+    stop()
+    do {
+      let player = try AVAudioPlayer(contentsOf: url)
+      player.delegate = self
+      self.player = player
+      playingURL = url
+      player.play()
+    } catch {
+      logError("VoiceSamplePlayer: could not play clip", error: error)
+    }
+  }
+
+  func stop() {
+    player?.stop()
+    player = nil
+    playingURL = nil
+  }
+
+  nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+    Task { @MainActor in self.stop() }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -39,9 +39,10 @@ struct PersonOverview: Identifiable {
       }
   }
 
-  /// Nil when no voice is known: the row says nothing rather than nagging.
+  /// Nil when no voice is known or no clip of it is kept: the row says nothing rather than
+  /// claiming a voice you cannot hear.
   static func voiceCaption(_ voice: LocalSpeakerDiarizer.VoiceSummary?) -> String? {
-    guard let voice else { return nil }
+    guard let voice, !voice.sampleURLs.isEmpty else { return nil }
     let minutes = Int(voice.speechSeconds / 60)
     let amount = minutes >= 1 ? "\(minutes) min heard" : "\(Int(voice.speechSeconds)) s heard"
     let clips =

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -110,10 +110,6 @@ struct PeoplePage: View {
   @State private var snippets: [String: [VoiceSnippet]] = [:]
   @StateObject private var samplePlayer = VoiceSamplePlayer()
 
-  private var userVoice: LocalSpeakerDiarizer.VoiceSummary? {
-    voices.first { $0.personId == nil }
-  }
-
   private var rows: [PersonOverview] {
     let all = PersonOverview.ordered(people: appState.people, activity: activity, voices: voices)
     let query = searchText.trimmingCharacters(in: .whitespaces)
@@ -129,14 +125,13 @@ struct PeoplePage: View {
         QuerySearchBar(
           text: $searchText,
           accessibilityID: "people-search-field",
-          placeholder: "Search people…",
+          placeholder: "Search people",
           searchSurface: .people
         )
       },
       content: {
         ScrollView {
           VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-            youCard
             peopleSection
           }
           .padding(.horizontal, QueryShellLayout.panelPaddingHorizontal)
@@ -163,62 +158,6 @@ struct PeoplePage: View {
       Text("Removes them from your people, their speaker labels in future conversations, and the voice Omi remembered.")
     }
     .accessibilityIdentifier("people-page")
-  }
-
-  // MARK: - You
-
-  private var youCard: some View {
-    HStack(alignment: .top, spacing: OmiSpacing.md) {
-      avatar(initial: userInitial, isUser: true)
-      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-        HStack(spacing: OmiSpacing.sm) {
-          Text(userName)
-            .scaledFont(size: OmiType.body, weight: .semibold)
-            .foregroundColor(Ink.primary)
-          Text("You")
-            .scaledFont(size: OmiType.micro, weight: .semibold)
-            .foregroundColor(Ink.surface)
-            .padding(.horizontal, OmiSpacing.sm)
-            .padding(.vertical, 2)
-            .background(Capsule().fill(Ink.primary))
-            .accessibilityIdentifier("people-you-capsule")
-        }
-        Text(userVoiceCaption)
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.secondary)
-        Text("Omi learns your voice from push-to-talk and from “This is me” on a live transcript bubble.")
-          .scaledFont(size: OmiType.caption)
-          .foregroundColor(Ink.tertiary)
-          .fixedSize(horizontal: false, vertical: true)
-        snippetRow(owner: LocalVoiceprintStore.sampleOwner(nil))
-      }
-      Spacer(minLength: 0)
-    }
-    .padding(OmiSpacing.md)
-    .background(
-      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
-        .fill(Ink.rowFill)
-    )
-    .accessibilityIdentifier("people-you-card")
-  }
-
-  /// The signed-in name; "You" alone when the account has none.
-  private var userName: String {
-    let name = AuthService.shared.displayName
-    return name.isEmpty ? "You" : name
-  }
-
-  private var userInitial: String {
-    let name = AuthService.shared.displayName
-    return name.isEmpty ? "Y" : String(name.prefix(1)).uppercased()
-  }
-
-  private var userVoiceCaption: String {
-    guard let userVoice else { return "Voice not learned yet" }
-    let minutes = Int(userVoice.speechSeconds / 60)
-    let amount = minutes >= 1 ? "\(minutes) min" : "\(Int(userVoice.speechSeconds)) s"
-    return userVoice.isEnrolled
-      ? "Voice known · \(amount) heard" : "Voice guessed from who talks most · \(amount) heard"
   }
 
   // MARK: - People

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -227,8 +227,41 @@ struct PeoplePage: View {
 
   // MARK: - People
 
+  private var userVoice: LocalSpeakerDiarizer.VoiceSummary? {
+    voices.first { $0.personId == nil }
+  }
+
+  /// Always first: the user, styled like everyone else, with their clips when there are any.
+  private var userRow: some View {
+    HStack(alignment: .center, spacing: OmiSpacing.md) {
+      avatar(initial: "Y", isUser: true)
+      VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+        Text("You")
+          .scaledFont(size: OmiType.body, weight: .medium)
+          .foregroundColor(Ink.primary)
+        if let caption = PersonOverview.voiceCaption(userVoice) {
+          Text(caption)
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+        }
+        snippetRow(owner: LocalVoiceprintStore.sampleOwner(nil))
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(OmiSpacing.md)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+        .fill(Ink.rowFill)
+    )
+    .accessibilityIdentifier("people-row-you")
+  }
+
   @ViewBuilder
   private var peopleSection: some View {
+    let query = searchText.trimmingCharacters(in: .whitespaces)
+    if query.isEmpty || "you".localizedCaseInsensitiveContains(query) {
+      userRow
+    }
     if rows.isEmpty {
       VStack(alignment: .leading, spacing: OmiSpacing.xs) {
         Text(appState.people.isEmpty ? "No people yet" : "No one matches")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
@@ -190,24 +190,16 @@ struct PeoplePage: View {
       Button {
         Task { await refreshPeople() }
       } label: {
-        HStack(spacing: OmiSpacing.xs) {
-          if isRefreshing {
-            ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
-          } else {
-            Image(systemName: "arrow.clockwise")
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-          }
-          Text(isRefreshing ? "Refreshing" : "Refresh")
-            .scaledFont(size: OmiType.caption, weight: .medium)
-        }
-        .foregroundStyle(GlassShell.controlLabel(isProminent: !isRefreshing))
-        .padding(.horizontal, OmiSpacing.md)
-        .frame(height: QueryShellLayout.chipHeight)
-        .glassChip(isActive: isRefreshing)
+        Text(isRefreshing ? "Rebuilding" : "Rebuild")
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundStyle(GlassShell.controlLabel(isProminent: !isRefreshing))
+          .padding(.horizontal, OmiSpacing.md)
+          .frame(height: QueryShellLayout.chipHeight)
+          .glassChip(isActive: isRefreshing)
       }
       .buttonStyle(.plain)
       .disabled(isRefreshing)
-      .accessibilityIdentifier("people-refresh")
+      .accessibilityIdentifier("people-rebuild")
     }
     .padding(OmiSpacing.md)
     .background(

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -27,8 +27,8 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
   case conversations
   case memories
   case rewind
-  case brainMap
   case people
+  case brainMap
 
   var id: String { rawValue }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -28,6 +28,7 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
   case memories
   case rewind
   case brainMap
+  case people
 
   var id: String { rawValue }
 
@@ -38,6 +39,7 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
     case .memories: return "Memories"
     case .rewind: return "Rewind"
     case .brainMap: return "Brain Map"
+    case .people: return "People"
     }
   }
 
@@ -54,6 +56,7 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
     case .memories: return .memories
     case .rewind: return .rewind
     case .brainMap: return .brainMap
+    case .people: return .people
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -62,8 +62,10 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
   case apps
   case permissions
   /// The chronological activity spine — Home's former landing surface, now the Memory hub's first
-  /// view. Appended last so the established cases keep their raw values.
+  /// view. Appended so the established cases keep their raw values.
   case activity
+  /// Everyone Omi has heard you talk to, and the voices it remembers. A Brain peer view.
+  case people
 
   /// The one mechanism that reaches a destination. Not a description of the UI — a claim about
   /// reachability that `ShellDestination.unreachable` checks.
@@ -100,6 +102,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     case .apps: return "Apps"
     case .permissions: return "Permissions"
     case .activity: return "Memories"
+    case .people: return "People"
     }
   }
 
@@ -107,7 +110,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
   var navItem: SidebarNavItem {
     switch self {
     case .home: return .dashboard
-    case .conversations, .memories, .brainMap, .rewind, .activity: return .conversations
+    case .conversations, .memories, .brainMap, .rewind, .activity, .people: return .conversations
     case .tasks: return .tasks
     case .apps: return .apps
     case .permissions: return .permissions
@@ -122,6 +125,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     case .brainMap: return .brainMap
     case .activity: return .activity
     case .rewind: return .rewind
+    case .people: return .people
     case .home, .tasks, .apps, .permissions: return nil
     }
   }
@@ -130,7 +134,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
   var settingsSection: SettingsContentView.SettingsSection? {
     switch self {
     case .permissions: return .permissions
-    case .home, .conversations, .memories, .brainMap, .activity, .tasks, .rewind, .apps: return nil
+    case .home, .conversations, .memories, .brainMap, .activity, .tasks, .rewind, .apps, .people: return nil
     }
   }
 
@@ -138,7 +142,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     switch self {
     /// `Activity` is what the hub's pill opens, so its door is the bar itself — the other four
     /// hub views are reached from Activity's chip row once you are there.
-    case .conversations, .memories, .brainMap, .rewind: return .activityChipRow
+    case .conversations, .memories, .brainMap, .rewind, .people: return .activityChipRow
     case .permissions: return .settingsSidebar
     case .home, .tasks, .apps, .activity: return .topBar
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionModels.swift
@@ -680,3 +680,9 @@ extension TranscriptionSessionRecord {
     )
   }
 }
+
+/// A named person's footprint in the local transcript store (People page).
+struct PersonActivity: Equatable, Sendable {
+  let conversationCount: Int
+  let lastTalkedAt: Date?
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -618,8 +618,8 @@ actor TranscriptionStorage {
     }
   }
   /// Move every segment of `sessionId` whose speaker id is a key of `relabels` to that key's
-  /// new speaker id / label / isUser, in one statement so a swap (0↔1) cannot double-map.
-  /// `personId` is kept unless the row becomes the user. Returns the number of rows moved.
+  /// new speaker id / label / isUser / personId, in one statement so a swap (0↔1) cannot
+  /// double-map. Returns the number of rows moved.
   @discardableResult
   func relabelSpeakers(
     sessionId: Int64,
@@ -634,7 +634,7 @@ actor TranscriptionStorage {
     for (from, to) in entries { arguments += [from, to.speakerId] }
     for (from, to) in entries { arguments += [from, to.speakerLabel] }
     for (from, to) in entries { arguments += [from, to.isUser] }
-    for (from, to) in entries { arguments += [from, to.isUser] }
+    for (from, to) in entries { arguments += [from, to.personId] }
     arguments.append(sessionId)
     for (from, _) in entries { arguments.append(from) }
     let statementArguments = StatementArguments(arguments)
@@ -646,12 +646,36 @@ actor TranscriptionStorage {
           SET speaker = CASE speaker \(speakerCase) ELSE speaker END,
               speakerLabel = CASE speaker \(speakerCase) ELSE speakerLabel END,
               isUser = CASE speaker \(speakerCase) ELSE isUser END,
-              personId = CASE WHEN (CASE speaker \(speakerCase) ELSE 0 END) THEN NULL ELSE personId END
+              personId = CASE speaker \(speakerCase) ELSE personId END
           WHERE sessionId = ? AND speaker IN (\(placeholders))
           """,
         arguments: statementArguments
       )
       return database.changesCount
+    }
+  }
+
+  /// How often, and how recently, each named person appears in local sessions.
+  func personActivity() async throws -> [String: PersonActivity] {
+    let db = try await ensureInitialized()
+    return try await db.read { database in
+      let rows = try Row.fetchAll(
+        database,
+        sql: """
+          SELECT s.personId AS personId, COUNT(DISTINCT s.sessionId) AS sessions, MAX(t.startedAt) AS lastStartedAt
+          FROM transcription_segments s
+          JOIN transcription_sessions t ON t.id = s.sessionId
+          WHERE s.personId IS NOT NULL AND s.personId != ''
+          GROUP BY s.personId
+          """)
+      var activity: [String: PersonActivity] = [:]
+      for row in rows {
+        guard let personId: String = row["personId"] else { continue }
+        activity[personId] = PersonActivity(
+          conversationCount: row["sessions"] ?? 0,
+          lastTalkedAt: row["lastStartedAt"])
+      }
+      return activity
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -617,6 +617,44 @@ actor TranscriptionStorage {
       return updatedRows
     }
   }
+  /// Move every segment of `sessionId` whose speaker id is a key of `relabels` to that key's
+  /// new speaker id / label / isUser, in one statement so a swap (0↔1) cannot double-map.
+  /// `personId` is kept unless the row becomes the user. Returns the number of rows moved.
+  @discardableResult
+  func relabelSpeakers(
+    sessionId: Int64,
+    relabels: [Int: LocalSpeakerRegistry.Resolution]
+  ) async throws -> Int {
+    guard !relabels.isEmpty else { return 0 }
+    let db = try await ensureInitialized()
+    let entries = relabels.sorted { $0.key < $1.key }
+    let speakerCase = entries.map { _ in "WHEN ? THEN ?" }.joined(separator: " ")
+    let placeholders = entries.map { _ in "?" }.joined(separator: ", ")
+    var arguments: [DatabaseValueConvertible?] = []
+    for (from, to) in entries { arguments += [from, to.speakerId] }
+    for (from, to) in entries { arguments += [from, to.speakerLabel] }
+    for (from, to) in entries { arguments += [from, to.isUser] }
+    for (from, to) in entries { arguments += [from, to.isUser] }
+    arguments.append(sessionId)
+    for (from, _) in entries { arguments.append(from) }
+    let statementArguments = StatementArguments(arguments)
+
+    return try await db.write { database -> Int in
+      try database.execute(
+        sql: """
+          UPDATE transcription_segments
+          SET speaker = CASE speaker \(speakerCase) ELSE speaker END,
+              speakerLabel = CASE speaker \(speakerCase) ELSE speakerLabel END,
+              isUser = CASE speaker \(speakerCase) ELSE isUser END,
+              personId = CASE WHEN (CASE speaker \(speakerCase) ELSE 0 END) THEN NULL ELSE personId END
+          WHERE sessionId = ? AND speaker IN (\(placeholders))
+          """,
+        arguments: statementArguments
+      )
+      return database.changesCount
+    }
+  }
+
   /// Get all segments for a session ordered by segmentOrder
   func getSegments(sessionId: Int64) async throws -> [TranscriptionSegmentRecord] {
     let db = try await ensureInitialized()

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -1595,7 +1595,7 @@ struct RewindPage: View {
           people: appState.people,
           currentPersonId: appState.liveSpeakerPersonMap[segment.speaker],
           onSave: { personId in
-            appState.liveSpeakerPersonMap[segment.speaker] = personId
+            appState.assignLiveSpeaker(segment.speaker, toPerson: personId)
             selectedSpeakerSegment = nil
           },
           onCreatePerson: { name in
@@ -1603,7 +1603,12 @@ struct RewindPage: View {
           },
           onDismiss: {
             selectedSpeakerSegment = nil
-          }
+          },
+          onMarkAsUser: appState.sttSession.useLocalSTT
+            ? {
+              appState.markLiveSpeakerAsUser(segment.speaker)
+              selectedSpeakerSegment = nil
+            } : nil
         )
       }
     }

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
@@ -101,10 +101,20 @@ enum TranscriptPresenceState: Equatable {
 struct CaptureAudioFile: Codable, Equatable, Identifiable {
   let id: String
   let duration: TimeInterval
+  /// Epoch seconds of the file's first captured chunk. A per-part file starts there, not at
+  /// the conversation's `startedAt`, so this is what places its media time on the wall clock.
+  let firstChunkTimestamp: TimeInterval?
 
   init(_ wire: OmiAPI.AudioFile) {
     id = wire.id
     duration = wire.duration
+    firstChunkTimestamp = wire.chunkTimestamps.min()
+  }
+
+  init(id: String, duration: TimeInterval, firstChunkTimestamp: TimeInterval? = nil) {
+    self.id = id
+    self.duration = duration
+    self.firstChunkTimestamp = firstChunkTimestamp
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
@@ -135,6 +135,21 @@ extension APIClient {
     return try await get("v1/users/people")
   }
 
+  /// Renames a person. The backend answers with an untyped acknowledgement, so only the status
+  /// is checked.
+  func renamePerson(id: String, name: String) async throws {
+    var components = URLComponents(string: baseURL + "v1/users/people/\(id)/name")
+    components?.queryItems = [URLQueryItem(name: "value", value: name)]
+    guard let url = components?.url else { throw APIError.invalidResponse }
+    var request = URLRequest(url: url)
+    request.httpMethod = "PATCH"
+    request.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
+    let (data, response) = try await performAuthenticatedData(for: request)
+    guard (200..<300).contains(response.statusCode) else {
+      throw APIError.httpError(statusCode: response.statusCode, detail: String(data: data, encoding: .utf8))
+    }
+  }
+
   /// Deletes a person (their speech profile goes with them on the backend).
   func deletePerson(id: String) async throws {
     try await delete("v1/users/people/\(id)")

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
@@ -135,6 +135,11 @@ extension APIClient {
     return try await get("v1/users/people")
   }
 
+  /// Deletes a person (their speech profile goes with them on the backend).
+  func deletePerson(id: String) async throws {
+    try await delete("v1/users/people/\(id)")
+  }
+
   /// Creates a new person
   func createPerson(name: String) async throws -> Person {
     struct CreatePersonRequest: Encodable {

--- a/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
@@ -70,7 +70,7 @@ final class ChatFirstDestinationParityTests: XCTestCase {
   func testTheActivityChipRowOffersEveryHubPageAndNothingElse() {
     XCTAssertEqual(
       ActivityDestinationChip.allCases.map(\.title),
-      ["Activity", "Conversations", "Memories", "Rewind", "Brain Map"])
+      ["Activity", "Conversations", "Memories", "Rewind", "People", "Brain Map"])
 
     XCTAssertEqual(
       Set(ActivityDestinationChip.reachableHubDestinations), Set(MemoryHubDestination.allCases),

--- a/desktop/macos/Desktop/Tests/LocalSpeakerDiarizerRebuildTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalSpeakerDiarizerRebuildTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// What a People "Rebuild" is allowed to change about a remembered voice, and what belongs to
+/// the person and must survive it.
+final class LocalSpeakerDiarizerRebuildTests: XCTestCase {
+  private let now = Date(timeIntervalSince1970: 1_800_000_000)
+  private var directory: URL?
+
+  private func makeStore() throws -> LocalVoiceprintStore {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("diarizer-rebuild-\(UUID().uuidString)", isDirectory: true)
+    directory = root
+    return LocalVoiceprintStore(fileURL: root.appendingPathComponent(LocalVoiceprintStore.fileName))
+  }
+
+  override func tearDown() async throws {
+    if let directory { try? FileManager.default.removeItem(at: directory) }
+    try await super.tearDown()
+  }
+
+  private func vector(_ axis: Int) -> [Float] {
+    var v = [Float](repeating: 0, count: 256)
+    v[axis] = 1
+    return v
+  }
+
+  private func diarizer(_ store: LocalVoiceprintStore) -> LocalSpeakerDiarizer {
+    let fixedNow = now
+    return LocalSpeakerDiarizer(
+      store: store,
+      loadModels: { throw CocoaError(.featureUnsupported) },
+      now: { fixedNow })
+  }
+
+  func testRebuildKeepsAPinnedVoicePinnedAndItsClipsWhenItHeardNone() async throws {
+    let store = try makeStore()
+    let clip = try XCTUnwrap(store.addSample(personId: "anna", samples: [Float](repeating: 0.2, count: 16_000)))
+    store.save([
+      StoredVoiceprint(
+        personId: "anna", embedding: vector(0), speechSeconds: 40, updatedAt: now.addingTimeInterval(-86_400),
+        isEnrolled: true, isFavorite: true, useScore: 9, lastUsedAt: now.addingTimeInterval(-86_400),
+        sampleFiles: [clip])
+    ])
+
+    let subject = diarizer(store)
+    let saved = await subject.applyRebuild([
+      RebuiltVoice(
+        personId: "anna", embeddings: [vector(1)], speechSeconds: 120, clips: [], conversationCount: 3, lastHeardAt: now
+      )
+    ])
+
+    XCTAssertEqual(saved, 0)
+    let summaries = await subject.voiceSummaries()
+    let summary = try XCTUnwrap(summaries.first { $0.personId == "anna" })
+    XCTAssertTrue(summary.isFavorite, "a pin is the person's choice and survives a rebuild")
+    XCTAssertEqual(summary.speechSeconds, 120, "the voiceprint itself is replaced by what the rebuild heard")
+    XCTAssertEqual(summary.sampleURLs.count, 1, "a rebuild that heard no audio must not leave the voice mute")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: summary.sampleURLs[0].path))
+    XCTAssertEqual(summary.lastHeardAt, now)
+    // Reloading the store sees the same thing: the change was persisted, not just in memory.
+    XCTAssertEqual(store.load().first?.isFavorite, true)
+    // Carried over and aged one day (9 × 2^(-1/14) ≈ 8.57), not reset to the rebuild's count of 3.
+    XCTAssertEqual(try XCTUnwrap(store.load().first).useScore, 8.57, accuracy: 0.02)
+  }
+
+  func testRebuildWithAudioReplacesTheClips() async throws {
+    let store = try makeStore()
+    let stale = try XCTUnwrap(store.addSample(personId: "bob", samples: [Float](repeating: 0.2, count: 16_000)))
+    store.save([
+      StoredVoiceprint(
+        personId: "bob", embedding: vector(0), speechSeconds: 10, updatedAt: now, isEnrolled: true,
+        sampleFiles: [stale])
+    ])
+
+    let subject = diarizer(store)
+    let saved = await subject.applyRebuild([
+      RebuiltVoice(
+        personId: "bob", embeddings: [vector(2)], speechSeconds: 30,
+        clips: [[Float](repeating: 0.1, count: 32_000), [Float](repeating: 0.1, count: 16_000)],
+        conversationCount: 2, lastHeardAt: now)
+    ])
+
+    XCTAssertEqual(saved, 2)
+    let summaries = await subject.voiceSummaries()
+    let summary = try XCTUnwrap(summaries.first { $0.personId == "bob" })
+    XCTAssertEqual(summary.sampleURLs.count, 2)
+    XCTAssertFalse(
+      FileManager.default.fileExists(atPath: store.sampleURL(for: stale).path),
+      "the clips the rebuild replaced are deleted, not orphaned on disk")
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalSpeakerDiarizerRebuildTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalSpeakerDiarizerRebuildTests.swift
@@ -6,17 +6,18 @@ import XCTest
 /// the person and must survive it.
 final class LocalSpeakerDiarizerRebuildTests: XCTestCase {
   private let now = Date(timeIntervalSince1970: 1_800_000_000)
-  private var directory: URL?
+  private var directories: [URL] = []
 
   private func makeStore() throws -> LocalVoiceprintStore {
     let root = FileManager.default.temporaryDirectory
       .appendingPathComponent("diarizer-rebuild-\(UUID().uuidString)", isDirectory: true)
-    directory = root
+    directories.append(root)
     return LocalVoiceprintStore(fileURL: root.appendingPathComponent(LocalVoiceprintStore.fileName))
   }
 
   override func tearDown() async throws {
-    if let directory { try? FileManager.default.removeItem(at: directory) }
+    for directory in directories { try? FileManager.default.removeItem(at: directory) }
+    directories = []
     try await super.tearDown()
   }
 
@@ -89,5 +90,35 @@ final class LocalSpeakerDiarizerRebuildTests: XCTestCase {
     XCTAssertFalse(
       FileManager.default.fileExists(atPath: store.sampleURL(for: stale).path),
       "the clips the rebuild replaced are deleted, not orphaned on disk")
+  }
+
+  /// Remembered voices are per-account. Signing in as someone else retargets the diarizer
+  /// with the rest of the owner-bound local storage, so the previous owner's voices are
+  /// neither listed on the next owner's People page nor written into their file.
+  func testRetargetingTheEffectiveOwnerSwapsTheRememberedVoices() async throws {
+    let first = try makeStore()
+    first.save([
+      StoredVoiceprint(
+        personId: "anna", embedding: vector(0), speechSeconds: 40, updatedAt: now, isEnrolled: true)
+    ])
+    let second = try makeStore()
+    second.save([
+      StoredVoiceprint(
+        personId: "bob", embedding: vector(1), speechSeconds: 12, updatedAt: now, isEnrolled: true)
+    ])
+
+    let subject = diarizer(first)
+    let before = await subject.voiceSummaries()
+    XCTAssertEqual(before.map(\.personId), ["anna"])
+
+    await subject.retargetEffectiveOwner(to: second)
+    let summaries = await subject.voiceSummaries()
+    XCTAssertEqual(summaries.map(\.personId), ["bob"])
+
+    // A change under the new owner lands in their file, and leaves the previous owner's alone.
+    await subject.setFavorite(personId: "bob", true)
+    XCTAssertEqual(second.load().first?.isFavorite, true)
+    XCTAssertEqual(first.load().map(\.personId), ["anna"])
+    XCTAssertEqual(first.load().first?.isFavorite, false)
   }
 }

--- a/desktop/macos/Desktop/Tests/LocalSpeakerRegistryTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalSpeakerRegistryTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Pins who the on-device transcriber calls "You" once speaker embeddings replace the old
+/// mic-is-always-the-user rule. Embeddings are synthetic: each voice is a unit axis plus a
+/// little deterministic noise, so distinct voices are orthogonal (distance 1.0) and repeats
+/// of one voice stay well inside the match threshold.
+final class LocalSpeakerRegistryTests: XCTestCase {
+  private typealias Lane = LocalTranscriptionLane
+  private typealias Resolution = LocalSpeakerRegistry.Resolution
+
+  private var noiseState: UInt64 = 0x9E37_79B9_7F4A_7C15
+
+  private func voice(_ axis: Int) -> [Float] {
+    var vector = [Float](repeating: 0, count: 256)
+    vector[axis] = 1
+    for i in vector.indices {
+      noiseState = noiseState &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+      let unit = Float(noiseState >> 40) / Float(1 << 24)  // 0..<1
+      vector[i] += (unit - 0.5) * 0.02
+    }
+    return vector
+  }
+
+  private func hear(
+    _ registry: inout LocalSpeakerRegistry,
+    _ axis: Int,
+    lane: Lane = .microphone,
+    seconds: Double = 3,
+    rms: Float = 0.02
+  ) -> LocalSpeakerRegistry.Outcome {
+    let outcome = registry.observe(
+      LocalSpeakerRegistry.Observation(embedding: voice(axis), durationSeconds: seconds, loudness: rms, lane: lane))
+    XCTAssertNotNil(outcome)
+    return outcome
+      ?? LocalSpeakerRegistry.Outcome(
+        resolution: Resolution(speakerId: -1, isUser: false), relabels: [:], voiceprintToPersist: nil,
+        nearestDistance: .infinity)
+  }
+
+  func testFirstMicVoiceIsYouAndASecondMicVoiceIsAnotherSpeaker() {
+    var registry = LocalSpeakerRegistry()
+
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+    let other = hear(&registry, 1)
+    XCTAssertEqual(other.resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertGreaterThan(other.nearestDistance, 0.9, "orthogonal voices are a full unit apart")
+    XCTAssertTrue(other.relabels.isEmpty, "an equally loud, equally long rival does not displace the user")
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(hear(&registry, 1).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(registry.clusters.count, 2)
+  }
+
+  func testSystemAudioVoiceIsNeverYouAndItsMicEchoSharesItsId() {
+    var registry = LocalSpeakerRegistry()
+
+    XCTAssertEqual(
+      hear(&registry, 1, lane: .systemAudio, seconds: 8).resolution, Resolution(speakerId: 1, isUser: false))
+    let user = hear(&registry, 0)
+    XCTAssertEqual(user.resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertTrue(user.relabels.isEmpty, "a brand-new cluster has no earlier segments to move")
+    // The remote voice bleeding from the speakers into the mic is the same person, not "You".
+    XCTAssertEqual(
+      hear(&registry, 1, lane: .microphone, seconds: 2).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(hear(&registry, 2, lane: .systemAudio).resolution, Resolution(speakerId: 2, isUser: false))
+  }
+
+  func testDominantMicVoiceTakesOverAndEarlierSegmentsAreRelabeled() {
+    var registry = LocalSpeakerRegistry()
+
+    // A quiet voice far from the mic opens the conversation and is provisionally "You".
+    XCTAssertEqual(hear(&registry, 1, seconds: 2, rms: 0.005).resolution, Resolution(speakerId: 0, isUser: true))
+    // The Mac's owner, close and loud, out-scores it: the two swap public ids.
+    let owner = hear(&registry, 0, seconds: 4, rms: 0.02)
+    XCTAssertEqual(owner.resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(owner.relabels, [0: Resolution(speakerId: 1, isUser: false)])
+    XCTAssertEqual(hear(&registry, 1, seconds: 2, rms: 0.005).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+  }
+
+  func testStoredVoiceprintIdentifiesYouEvenWhenSomeoneElseSpeaksFirstAndMore() {
+    var registry = LocalSpeakerRegistry(userVoiceprint: voice(0))
+
+    XCTAssertEqual(hear(&registry, 1, seconds: 10, rms: 0.05).resolution, Resolution(speakerId: 1, isUser: false))
+    let user = hear(&registry, 0, seconds: 2, rms: 0.005)
+    XCTAssertEqual(user.resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertTrue(registry.userIsConfirmed)
+    // A confirmed identity is not up for grabs, however much the other person talks.
+    XCTAssertEqual(hear(&registry, 1, seconds: 120, rms: 0.05).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+  }
+
+  func testStaleVoiceprintFallsBackToTheDominantMicVoiceAfterTheGracePeriod() {
+    var registry = LocalSpeakerRegistry(userVoiceprint: voice(7))
+
+    XCTAssertEqual(hear(&registry, 0, seconds: 10).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(hear(&registry, 0, seconds: 10).resolution, Resolution(speakerId: 1, isUser: false))
+    let promoted = hear(&registry, 0, seconds: 10)
+    XCTAssertEqual(promoted.resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(promoted.relabels, [1: Resolution(speakerId: 0, isUser: true)])
+    XCTAssertFalse(registry.userIsConfirmed)
+  }
+
+  func testVoiceprintIsHandedBackOnceTheUserHasSpokenEnough() throws {
+    var registry = LocalSpeakerRegistry()
+
+    for _ in 0..<3 {
+      let outcome = hear(&registry, 0, seconds: 5)
+      XCTAssertNil(outcome.voiceprintToPersist, "15 s is not enough to persist")
+    }
+    let voiceprint = try XCTUnwrap(hear(&registry, 0, seconds: 5).voiceprintToPersist)
+    XCTAssertEqual(voiceprint.count, 256)
+    XCTAssertLessThan(LocalSpeakerRegistry.cosineDistance(voiceprint, voice(0)), 0.05)
+    XCTAssertNil(hear(&registry, 0, seconds: 5).voiceprintToPersist, "re-persist only after another minute")
+  }
+
+  func testClusterCapJoinsTheNearestVoiceInsteadOfGrowing() {
+    var config = LocalSpeakerRegistry.Config()
+    config.maxClusters = 2
+    var registry = LocalSpeakerRegistry(config: config)
+
+    _ = hear(&registry, 0)
+    _ = hear(&registry, 1)
+    let third = hear(&registry, 2)
+    XCTAssertEqual(registry.clusters.count, 2)
+    XCTAssertTrue([0, 1].contains(third.resolution.speakerId))
+  }
+
+  /// A 1.7 s echo fragment produced a phantom "Speaker 4" live; short windows may only join.
+  func testShortWindowJoinsTheNearestVoiceInsteadOfOpeningACluster() {
+    var registry = LocalSpeakerRegistry()
+
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(
+      hear(&registry, 1, lane: .systemAudio, seconds: 6).resolution, Resolution(speakerId: 1, isUser: false))
+    let fragment = hear(&registry, 5, lane: .microphone, seconds: 1.7)
+    XCTAssertEqual(registry.clusters.count, 2)
+    XCTAssertTrue([0, 1].contains(fragment.resolution.speakerId))
+    // A full-length window of that voice still gets its own id.
+    XCTAssertEqual(hear(&registry, 5, seconds: 3).resolution, Resolution(speakerId: 2, isUser: false))
+  }
+
+  func testUnusableEmbeddingIsIgnored() {
+    var registry = LocalSpeakerRegistry()
+    let zero = registry.observe(
+      LocalSpeakerRegistry.Observation(
+        embedding: [Float](repeating: 0, count: 256), durationSeconds: 3, loudness: 0.02, lane: .microphone))
+    XCTAssertNil(zero)
+    XCTAssertTrue(registry.clusters.isEmpty)
+    XCTAssertEqual(LocalSpeakerRegistry.cosineDistance([1, 0], [0, 1]), 1, accuracy: 1e-6)
+    XCTAssertEqual(LocalSpeakerRegistry.cosineDistance([1, 0], [2, 0]), 0, accuracy: 1e-6)
+  }
+
+  func testResolutionLabelMatchesBackendFormat() {
+    XCTAssertEqual(Resolution(speakerId: 0, isUser: true).speakerLabel, "SPEAKER_00")
+    XCTAssertEqual(Resolution(speakerId: 12, isUser: false).speakerLabel, "SPEAKER_12")
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalSpeakerRegistryTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalSpeakerRegistryTests.swift
@@ -35,8 +35,12 @@ final class LocalSpeakerRegistryTests: XCTestCase {
     XCTAssertNotNil(outcome)
     return outcome
       ?? LocalSpeakerRegistry.Outcome(
-        resolution: Resolution(speakerId: -1, isUser: false), relabels: [:], voiceprintToPersist: nil,
+        resolution: Resolution(speakerId: -1, isUser: false), relabels: [:], voiceprintsToPersist: [],
         nearestDistance: .infinity)
+  }
+
+  private func userUpdate(_ outcome: LocalSpeakerRegistry.Outcome) -> VoiceprintUpdate? {
+    outcome.voiceprintsToPersist.first { $0.personId == nil }
   }
 
   func testFirstMicVoiceIsYouAndASecondMicVoiceIsAnotherSpeaker() {
@@ -80,7 +84,7 @@ final class LocalSpeakerRegistryTests: XCTestCase {
   }
 
   func testStoredVoiceprintIdentifiesYouEvenWhenSomeoneElseSpeaksFirstAndMore() {
-    var registry = LocalSpeakerRegistry(userVoiceprint: voice(0))
+    var registry = LocalSpeakerRegistry(userVoiceprint: voice(0), userIsEnrolled: true)
 
     XCTAssertEqual(hear(&registry, 1, seconds: 10, rms: 0.05).resolution, Resolution(speakerId: 1, isUser: false))
     let user = hear(&registry, 0, seconds: 2, rms: 0.005)
@@ -107,12 +111,92 @@ final class LocalSpeakerRegistryTests: XCTestCase {
 
     for _ in 0..<3 {
       let outcome = hear(&registry, 0, seconds: 5)
-      XCTAssertNil(outcome.voiceprintToPersist, "15 s is not enough to persist")
+      XCTAssertNil(userUpdate(outcome), "15 s is not enough to persist")
     }
-    let voiceprint = try XCTUnwrap(hear(&registry, 0, seconds: 5).voiceprintToPersist)
-    XCTAssertEqual(voiceprint.count, 256)
-    XCTAssertLessThan(LocalSpeakerRegistry.cosineDistance(voiceprint, voice(0)), 0.05)
-    XCTAssertNil(hear(&registry, 0, seconds: 5).voiceprintToPersist, "re-persist only after another minute")
+    let update = try XCTUnwrap(userUpdate(hear(&registry, 0, seconds: 5)))
+    XCTAssertEqual(update.embedding.count, 256)
+    XCTAssertLessThan(LocalSpeakerRegistry.cosineDistance(update.embedding, voice(0)), 0.05)
+    XCTAssertFalse(update.isEnrolled, "a bootstrap guess is remembered as a guess, not a confirmed identity")
+    XCTAssertNil(userUpdate(hear(&registry, 0, seconds: 5)), "re-persist only after another minute")
+  }
+
+  /// The learned print from a previous session identifies the user early but does not lock them
+  /// in: the live session that motivated this had stored the *other* person as "You".
+  func testALearnedVoiceprintStillYieldsToADominantMicVoice() {
+    var registry = LocalSpeakerRegistry(userVoiceprint: voice(1), userIsEnrolled: false)
+
+    XCTAssertEqual(hear(&registry, 1, seconds: 3, rms: 0.005).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertFalse(registry.userIsConfirmed)
+    let owner = hear(&registry, 0, seconds: 6, rms: 0.03)
+    XCTAssertEqual(owner.resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(owner.relabels, [0: Resolution(speakerId: 1, isUser: false)])
+  }
+
+  func testThisIsMeMovesTheUserLabelAndRemembersAnEnrolledVoice() throws {
+    var registry = LocalSpeakerRegistry()
+    XCTAssertEqual(hear(&registry, 1).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 1, isUser: false))
+
+    let result = try XCTUnwrap(registry.markAsUser(speakerId: 1))
+    XCTAssertEqual(
+      result.relabels,
+      [0: Resolution(speakerId: 1, isUser: false), 1: Resolution(speakerId: 0, isUser: true)])
+    XCTAssertTrue(result.persist.isEnrolled)
+    XCTAssertNil(result.persist.personId)
+    XCTAssertLessThan(LocalSpeakerRegistry.cosineDistance(result.persist.embedding, voice(0)), 0.05)
+    XCTAssertTrue(registry.userIsConfirmed)
+    // Locked: however much the other voice talks now, it stays Speaker 1.
+    XCTAssertEqual(hear(&registry, 1, seconds: 200, rms: 0.05).resolution, Resolution(speakerId: 1, isUser: false))
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+  }
+
+  func testNamingASpeakerTeachesTheirVoiceForTheNextSession() throws {
+    var registry = LocalSpeakerRegistry()
+    _ = hear(&registry, 0)
+    XCTAssertEqual(hear(&registry, 1, seconds: 4).resolution, Resolution(speakerId: 1, isUser: false))
+
+    let named = try XCTUnwrap(registry.assignPerson("person-anna", toSpeakerId: 1))
+    XCTAssertEqual(named.relabels, [1: Resolution(speakerId: 1, isUser: false, personId: "person-anna")])
+    let update = try XCTUnwrap(named.persist)
+    XCTAssertEqual(update.personId, "person-anna")
+    XCTAssertTrue(update.isEnrolled)
+    XCTAssertEqual(
+      hear(&registry, 1).resolution, Resolution(speakerId: 1, isUser: false, personId: "person-anna"))
+    XCTAssertNil(registry.assignPerson("person-anna", toSpeakerId: 0), "the user is never a named person")
+
+    // Next session: Anna is recognised the moment she speaks.
+    var next = LocalSpeakerRegistry(knownVoices: [
+      .init(personId: nil, embedding: voice(0), isEnrolled: true),
+      .init(personId: "person-anna", embedding: update.embedding, isEnrolled: true),
+    ])
+    XCTAssertEqual(
+      hear(&next, 1, lane: .systemAudio, seconds: 4).resolution,
+      Resolution(speakerId: 1, isUser: false, personId: "person-anna"))
+    XCTAssertEqual(hear(&next, 0).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertTrue(next.userIsConfirmed, "an enrolled user print confirms on match")
+  }
+
+  func testPushToTalkEnrollmentIdentifiesALiveSpeakerAsTheUser() throws {
+    var registry = LocalSpeakerRegistry()
+    XCTAssertEqual(hear(&registry, 1, seconds: 8, rms: 0.03).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertEqual(hear(&registry, 0, seconds: 3, rms: 0.01).resolution, Resolution(speakerId: 1, isUser: false))
+
+    let enrolled = try XCTUnwrap(registry.enrollUser(embedding: voice(0), speechSeconds: 3))
+    XCTAssertEqual(
+      enrolled.relabels,
+      [0: Resolution(speakerId: 1, isUser: false), 1: Resolution(speakerId: 0, isUser: true)])
+    XCTAssertTrue(enrolled.persist.isEnrolled)
+    XCTAssertTrue(registry.userIsConfirmed)
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+  }
+
+  func testForgettingTheUserVoiceReopensTheBootstrap() {
+    var registry = LocalSpeakerRegistry(userVoiceprint: voice(0), userIsEnrolled: true)
+    XCTAssertEqual(hear(&registry, 0).resolution, Resolution(speakerId: 0, isUser: true))
+    XCTAssertTrue(registry.userIsConfirmed)
+    registry.forgetVoice(personId: nil)
+    XCTAssertFalse(registry.userIsConfirmed)
+    XCTAssertNil(registry.knownUserVoice)
   }
 
   func testClusterCapJoinsTheNearestVoiceInsteadOfGrowing() {

--- a/desktop/macos/Desktop/Tests/LocalTranscriptionDuplicatePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalTranscriptionDuplicatePolicyTests.swift
@@ -62,6 +62,38 @@ final class LocalTranscriptionDuplicatePolicyTests: XCTestCase {
     XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: second, existing: [first]), .accept)
   }
 
+  // MARK: - Lane-tagged segments (on-device diarization)
+
+  private func lanedSegment(
+    text: String, lane: LocalTranscriptionLane, speaker: Int, isUser: Bool = false, id: String
+  ) -> SpeakerSegment {
+    var segment = SpeakerSegment(segmentId: id, speaker: speaker, text: text, start: 0, end: 10, isUser: isUser)
+    segment.lane = lane
+    return segment
+  }
+
+  /// With diarization a remote voice and its mic echo share a speaker id and neither is the
+  /// user, so the lane — not `isUser` — has to tell the two copies apart.
+  func testEchoOfTheSameRemoteSpeakerAcrossLanesIsStillDeduplicated() {
+    let system = lanedSegment(text: "This is the video transcript", lane: .systemAudio, speaker: 3, id: "system")
+    let micEcho = lanedSegment(text: "This is the video transcript.", lane: .microphone, speaker: 3, id: "mic")
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: micEcho, existing: [system]), .suppressIncoming)
+    XCTAssertEqual(
+      LocalTranscriptionDuplicatePolicy.decision(for: system, existing: [micEcho]),
+      .replaceExisting(segmentId: "mic")
+    )
+  }
+
+  /// Two mic-lane rows from different people are never echo of each other, even when one is
+  /// "You" and the other is not — the old `isUser`-as-lane shortcut would have dropped one.
+  func testTwoPeopleOnTheMicLaneAreNeverDeduplicated() {
+    let user = lanedSegment(text: "This is the video transcript", lane: .microphone, speaker: 0, isUser: true, id: "u")
+    let guest = lanedSegment(text: "This is the video transcript", lane: .microphone, speaker: 1, id: "g")
+
+    XCTAssertEqual(LocalTranscriptionDuplicatePolicy.decision(for: guest, existing: [user]), .accept)
+  }
+
   // MARK: - Rolling-window playback echoes
 
   private func hopperEchoText() -> (mic: String, system: String) {

--- a/desktop/macos/Desktop/Tests/LocalTranscriptionReadinessTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalTranscriptionReadinessTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Warming the on-device speaker models runs alongside the Parakeet load but must never gate
+/// transcription readiness. QA measured ~20s of silent transcript at every capture-session
+/// start when readiness awaited the diarizer behind a "grace" deadline: `withTaskGroup`
+/// implicitly awaits an unfinished `Task.value` child and `Task.value` ignores cancellation,
+/// so the deadline could not fire — readiness blocked for exactly as long as the speaker
+/// models took, on every capture session.
+final class LocalTranscriptionReadinessTests: XCTestCase {
+  /// Minimal deterministic event: `wait` resolves once (or after) `signal` happened.
+  private final class OneShotEvent: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+      lock.lock()
+      isSignaled = true
+      let waiters = self.waiters
+      self.waiters = []
+      lock.unlock()
+      waiters.forEach { $0.resume() }
+    }
+
+    func wait() async {
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        lock.lock()
+        if isSignaled {
+          lock.unlock()
+          continuation.resume()
+          return
+        }
+        waiters.append(continuation)
+        lock.unlock()
+      }
+    }
+  }
+
+  private actor WarmupState {
+    private(set) var finished = false
+    func markFinished() { finished = true }
+  }
+
+  func testReadinessIsGrantedWhileSpeakerWarmupIsStillInFlight() async throws {
+    let warmupBlocked = OneShotEvent()
+    let releaseWarmup = OneShotEvent()
+    let state = WarmupState()
+
+    let warmup: @Sendable () async -> Void = {
+      warmupBlocked.signal()
+      await releaseWarmup.wait()
+      await state.markFinished()
+    }
+
+    struct LoadedASR: Sendable {}
+    let manager = try await LocalTranscriptionService.loadASRManagerWithSpeakerWarmup(
+      loadASR: { LoadedASR() },
+      warmSpeakerModels: warmup)
+
+    // The load returned on its own; only then does the test let the warmup pass its gate.
+    // If readiness awaited the warmup, the warmup would still be blocked on
+    // `releaseWarmup`, this function could never have returned, and the test would hang.
+    await warmupBlocked.wait()
+    let finished = await state.finished
+    XCTAssertFalse(finished, "speaker warmup must still be in flight when readiness is granted")
+    XCTAssertNotNil(manager)
+
+    releaseWarmup.signal()
+    // Nothing dangles: the warmup runs to completion now that it is released.
+    while !(await state.finished) {
+      await Task.yield()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
@@ -46,6 +46,39 @@ final class LocalVoiceprintStoreTests: XCTestCase {
     XCTAssertEqual(enrolled.count, 1)
   }
 
+  /// Files written before favorites, usage and samples existed must still load.
+  func testLegacyFileWithoutTheNewFieldsStillDecodes() throws {
+    let json = """
+      [{"personId":null,"embedding":[1,0],"speechSeconds":30,"updatedAt":"2026-09-07T22:00:00Z","isEnrolled":false}]
+      """
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let prints = try decoder.decode([StoredVoiceprint].self, from: Data(json.utf8))
+    XCTAssertEqual(prints.count, 1)
+    XCTAssertFalse(prints[0].isFavorite)
+    XCTAssertEqual(prints[0].useScore, 0)
+    XCTAssertNil(prints[0].lastUsedAt)
+    XCTAssertEqual(prints[0].sampleFiles, [])
+  }
+
+  func testSamplesAreWrittenAsWavAndRemovedWithTheVoice() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voiceprint-samples-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent(LocalVoiceprintStore.fileName)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let store = LocalVoiceprintStore(fileURL: url)
+    let tone = (0..<16_000).map { Float(sin(Double($0) * 0.05)) * 0.3 }
+
+    let file = try XCTUnwrap(store.addSample(personId: "anna", samples: tone))
+    XCTAssertTrue(file.hasPrefix("anna/"))
+    let written = store.sampleURL(for: file)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: written.path))
+    XCTAssertGreaterThan(try Data(contentsOf: written).count, 30_000, "one second of 16-bit mono audio")
+
+    store.removeAllSamples(personId: "anna")
+    XCTAssertFalse(FileManager.default.fileExists(atPath: written.path))
+  }
+
   func testPeopleAreKeptApartFromTheUser() {
     var prints = LocalVoiceprintStore.applying(
       VoiceprintUpdate(personId: nil, embedding: vector(0), speechSeconds: 20, isEnrolled: true), to: [])

--- a/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
@@ -87,3 +87,28 @@ final class LocalVoiceprintStoreTests: XCTestCase {
     XCTAssertEqual(prints.map(\.personId), [nil, "anna"])
   }
 }
+
+extension LocalVoiceprintStoreTests {
+  /// Rebuild decodes only the cut it needs; a range in the middle of a file comes back at the
+  /// right length and with the right audio.
+  func testDecoderReadsOneRangeOfAFile() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("range-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent(LocalVoiceprintStore.fileName)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let store = LocalVoiceprintStore(fileURL: url)
+    // 3 s: silence, then a tone for the middle second, then silence.
+    var samples = [Float](repeating: 0, count: 48_000)
+    for i in 16_000..<32_000 { samples[i] = Float(sin(Double(i) * 0.05)) * 0.5 }
+    let file = try XCTUnwrap(store.addSample(personId: "range", samples: samples))
+
+    let reader = try AudioClipDecoder.Reader(url: store.sampleURL(for: file))
+    XCTAssertEqual(reader.durationSeconds, 3, accuracy: 0.01)
+    let middle = try reader.read(fromSeconds: 1, toSeconds: 2)
+    XCTAssertEqual(middle.count, 16_000, accuracy: 64)
+    XCTAssertGreaterThan(middle.map { abs($0) }.max() ?? 0, 0.3, "the tone is in the middle second")
+    let leading = try reader.read(fromSeconds: 0, toSeconds: 0.5)
+    XCTAssertLessThan(leading.map { abs($0) }.max() ?? 1, 0.01, "the first half second is silent")
+    XCTAssertEqual(try AudioClipDecoder.decode16kMono(url: store.sampleURL(for: file)).count, 48_000, accuracy: 64)
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
@@ -112,3 +112,18 @@ extension LocalVoiceprintStoreTests {
     XCTAssertEqual(try AudioClipDecoder.decode16kMono(url: store.sampleURL(for: file)).count, 48_000, accuracy: 64)
   }
 }
+
+extension LocalVoiceprintStoreTests {
+  /// A person id becomes a directory name, so it may never climb out of the samples directory
+  /// or collide with the user's own clips.
+  func testSampleOwnerNamesAreSafePathComponents() {
+    XCTAssertEqual(LocalVoiceprintStore.sampleOwner(nil), "user")
+    XCTAssertEqual(
+      LocalVoiceprintStore.sampleOwner("2f6c1f0e-9a3d-4c5b-8e21-7d0b5a1c3e44"),
+      "2f6c1f0e-9a3d-4c5b-8e21-7d0b5a1c3e44", "a backend id passes through unchanged")
+    let climbing = LocalVoiceprintStore.sampleOwner("../../../../etc/passwd")
+    XCTAssertFalse(climbing.contains("/"))
+    XCTAssertFalse(climbing.contains(".."))
+    XCTAssertNotEqual(LocalVoiceprintStore.sampleOwner("user"), "user", "a person cannot claim the user's clips")
+  }
+}

--- a/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/LocalVoiceprintStoreTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LocalVoiceprintStoreTests: XCTestCase {
+  private func vector(_ axis: Int) -> [Float] {
+    var v = [Float](repeating: 0, count: 256)
+    v[axis] = 1
+    return v
+  }
+
+  func testRoundTripsThroughTheFile() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voiceprint-store-\(UUID().uuidString)", isDirectory: true)
+      .appendingPathComponent(LocalVoiceprintStore.fileName)
+    defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+    let store = LocalVoiceprintStore(fileURL: url)
+    XCTAssertEqual(store.load(), [])
+
+    let saved = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: nil, embedding: vector(0), speechSeconds: 30, isEnrolled: true), to: [])
+    store.save(saved)
+    let loaded = store.load()
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertNil(loaded.first?.personId)
+    XCTAssertEqual(loaded.first?.isEnrolled, true)
+    XCTAssertEqual(loaded.first?.embedding.count, 256)
+  }
+
+  func testAGuessBlendsIntoAnExistingPrintButAnEnrollmentReplacesAGuess() throws {
+    let guessed = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: nil, embedding: vector(0), speechSeconds: 20, isEnrolled: false), to: [])
+    let stillGuessed = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: nil, embedding: vector(1), speechSeconds: 20, isEnrolled: false), to: guessed)
+    let blended = try XCTUnwrap(stillGuessed.first)
+    XCTAssertFalse(blended.isEnrolled)
+    XCTAssertEqual(blended.speechSeconds, 40)
+    XCTAssertEqual(blended.embedding[0], blended.embedding[1], accuracy: 1e-5, "a guess blends 50/50")
+
+    let enrolled = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: nil, embedding: vector(2), speechSeconds: 5, isEnrolled: true), to: stillGuessed)
+    let replaced = try XCTUnwrap(enrolled.first)
+    XCTAssertTrue(replaced.isEnrolled)
+    XCTAssertEqual(replaced.speechSeconds, 5)
+    XCTAssertEqual(replaced.embedding[2], 1, accuracy: 1e-5, "an enrollment replaces a guess outright")
+    XCTAssertEqual(enrolled.count, 1)
+  }
+
+  func testPeopleAreKeptApartFromTheUser() {
+    var prints = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: nil, embedding: vector(0), speechSeconds: 20, isEnrolled: true), to: [])
+    prints = LocalVoiceprintStore.applying(
+      VoiceprintUpdate(personId: "anna", embedding: vector(1), speechSeconds: 8, isEnrolled: true), to: prints)
+    XCTAssertEqual(prints.map(\.personId), [nil, "anna"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -37,7 +37,7 @@ final class MemoryGraphRevisitTests: XCTestCase {
   func testMemoryHubDestinationMenuHasStableRoutes() {
     XCTAssertEqual(
       MemoryHubDestination.allCases,
-      [.memories, .conversations, .brainMap, .activity, .rewind]
+      [.memories, .conversations, .brainMap, .activity, .rewind, .people]
     )
     // Storage identity, pinned: these raw values are persisted, so the enum may not be reordered.
     // Reading order is a different list and lives with the control that presents it — see

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -16,26 +16,34 @@ final class PeoplePageOverviewTests: XCTestCase {
       "zed": PersonActivity(conversationCount: 1, lastTalkedAt: now),
     ]
     let voices = [
-      LocalSpeakerDiarizer.VoiceSummary(personId: "anna", speechSeconds: 90, updatedAt: now, isEnrolled: true),
-      LocalSpeakerDiarizer.VoiceSummary(personId: nil, speechSeconds: 30, updatedAt: now, isEnrolled: false),
+      summary("anna", seconds: 90, favorite: true),
+      summary(nil, seconds: 30),
     ]
 
     let rows = PersonOverview.ordered(people: people, activity: activity, voices: voices)
 
-    XCTAssertEqual(rows.map(\.id), ["zed", "bob", "anna", "cara"])
-    XCTAssertTrue(rows[2].hasVoice)
-    XCTAssertFalse(rows[0].hasVoice, "the user's own voice is not a person's")
-    XCTAssertEqual(rows[1].conversationCount, 2)
+    XCTAssertEqual(rows.map(\.id), ["anna", "zed", "bob", "cara"], "favorites first, then recency, then name")
+    XCTAssertTrue(rows[0].hasVoice)
+    XCTAssertTrue(rows[0].isFavorite)
+    XCTAssertFalse(rows[1].hasVoice, "the user's own voice is not a person's")
+    XCTAssertEqual(rows[2].conversationCount, 2)
+  }
+
+  private func summary(_ personId: String?, seconds: Double, favorite: Bool = false, clips: Int = 0)
+    -> LocalSpeakerDiarizer.VoiceSummary
+  {
+    LocalSpeakerDiarizer.VoiceSummary(
+      personId: personId, speechSeconds: seconds, updatedAt: Date(), isEnrolled: true, isFavorite: favorite,
+      lastHeardAt: nil, sampleURLs: (0..<clips).map { URL(fileURLWithPath: "/tmp/clip-\($0).wav") })
   }
 
   func testCaptionsSayWhatOmiKnows() {
     let now = Date()
     XCTAssertEqual(
       PersonOverview.voiceCaption(nil), "No voice yet — name them in a live transcript")
+    XCTAssertEqual(PersonOverview.voiceCaption(summary("a", seconds: 125)), "Voice known · 2 min heard")
     XCTAssertEqual(
-      PersonOverview.voiceCaption(
-        LocalSpeakerDiarizer.VoiceSummary(personId: "a", speechSeconds: 125, updatedAt: now, isEnrolled: true)),
-      "Voice known · 2 min heard")
+      PersonOverview.voiceCaption(summary("a", seconds: 125, clips: 2)), "Voice known · 2 min heard · 2 clips")
     XCTAssertEqual(
       PersonOverview.conversationCaption(count: 0, last: nil), "Not heard in a conversation yet")
     XCTAssertTrue(

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -50,8 +50,7 @@ final class PeoplePageOverviewTests: XCTestCase {
 
   func testCaptionsSayWhatOmiKnows() {
     let now = Date()
-    XCTAssertEqual(
-      PersonOverview.voiceCaption(nil), "No voice yet — name them in a live transcript")
+    XCTAssertNil(PersonOverview.voiceCaption(nil), "an unknown voice shows no caption")
     XCTAssertEqual(PersonOverview.voiceCaption(summary("a", seconds: 125)), "Voice known · 2 min heard")
     XCTAssertEqual(
       PersonOverview.voiceCaption(summary("a", seconds: 125, clips: 2)), "Voice known · 2 min heard · 2 clips")

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -56,6 +56,9 @@ final class PeoplePageOverviewTests: XCTestCase {
       PersonOverview.voiceCaption(summary("a", seconds: 125, clips: 2)), "Voice known · 2 min heard · 2 clips")
     XCTAssertEqual(
       PersonOverview.conversationCaption(count: 0, last: nil), "Not heard in a conversation yet")
+    XCTAssertEqual(
+      PersonOverview.conversationCaption(count: 4, last: nil), "4 conversations",
+      "a count with no usable date still says Omi heard them")
     XCTAssertTrue(
       PersonOverview.conversationCaption(count: 1, last: now.addingTimeInterval(-7200), now: now)
         .hasPrefix("1 conversation · last"))

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -51,7 +51,7 @@ final class PeoplePageOverviewTests: XCTestCase {
   func testCaptionsSayWhatOmiKnows() {
     let now = Date()
     XCTAssertNil(PersonOverview.voiceCaption(nil), "an unknown voice shows no caption")
-    XCTAssertEqual(PersonOverview.voiceCaption(summary("a", seconds: 125)), "Voice known · 2 min heard")
+    XCTAssertNil(PersonOverview.voiceCaption(summary("a", seconds: 125)), "a voice without a clip shows no caption")
     XCTAssertEqual(
       PersonOverview.voiceCaption(summary("a", seconds: 125, clips: 2)), "Voice known · 2 min heard · 2 clips")
     XCTAssertEqual(

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -37,6 +37,17 @@ final class PeoplePageOverviewTests: XCTestCase {
       lastHeardAt: nil, sampleURLs: (0..<clips).map { URL(fileURLWithPath: "/tmp/clip-\($0).wav") })
   }
 
+  func testSnippetsReadTheirTimestampFromTheFileNameAndCaptionLengthAndAge() {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let url = URL(fileURLWithPath: "/tmp/voice-samples/anna/1799996400000.wav")
+    XCTAssertEqual(VoiceSnippet.recordedAt(from: url), Date(timeIntervalSince1970: 1_799_996_400))
+    XCTAssertNil(VoiceSnippet.recordedAt(from: URL(fileURLWithPath: "/tmp/clip.wav")))
+    let caption = VoiceSnippet.caption(durationSeconds: 7.6, recordedAt: VoiceSnippet.recordedAt(from: url), now: now)
+    XCTAssertTrue(caption.hasPrefix("8s · "), caption)
+    XCTAssertEqual(VoiceSnippet.caption(durationSeconds: 0.2, recordedAt: nil), "1s")
+    XCTAssertEqual(VoiceSnippet.load([URL(fileURLWithPath: "/tmp/does-not-exist.wav")]), [])
+  }
+
   func testCaptionsSayWhatOmiKnows() {
     let now = Date()
     XCTAssertEqual(

--- a/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
+++ b/desktop/macos/Desktop/Tests/PeoplePageOverviewTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PeoplePageOverviewTests: XCTestCase {
+  func testPeopleAreOrderedByMostRecentConversationThenName() {
+    let now = Date()
+    let people = [
+      Person(id: "zed", name: "Zed"),
+      Person(id: "anna", name: "Anna"),
+      Person(id: "bob", name: "Bob"),
+      Person(id: "cara", name: "cara"),
+    ]
+    let activity: [String: PersonActivity] = [
+      "bob": PersonActivity(conversationCount: 2, lastTalkedAt: now.addingTimeInterval(-3600)),
+      "zed": PersonActivity(conversationCount: 1, lastTalkedAt: now),
+    ]
+    let voices = [
+      LocalSpeakerDiarizer.VoiceSummary(personId: "anna", speechSeconds: 90, updatedAt: now, isEnrolled: true),
+      LocalSpeakerDiarizer.VoiceSummary(personId: nil, speechSeconds: 30, updatedAt: now, isEnrolled: false),
+    ]
+
+    let rows = PersonOverview.ordered(people: people, activity: activity, voices: voices)
+
+    XCTAssertEqual(rows.map(\.id), ["zed", "bob", "anna", "cara"])
+    XCTAssertTrue(rows[2].hasVoice)
+    XCTAssertFalse(rows[0].hasVoice, "the user's own voice is not a person's")
+    XCTAssertEqual(rows[1].conversationCount, 2)
+  }
+
+  func testCaptionsSayWhatOmiKnows() {
+    let now = Date()
+    XCTAssertEqual(
+      PersonOverview.voiceCaption(nil), "No voice yet — name them in a live transcript")
+    XCTAssertEqual(
+      PersonOverview.voiceCaption(
+        LocalSpeakerDiarizer.VoiceSummary(personId: "a", speechSeconds: 125, updatedAt: now, isEnrolled: true)),
+      "Voice known · 2 min heard")
+    XCTAssertEqual(
+      PersonOverview.conversationCaption(count: 0, last: nil), "Not heard in a conversation yet")
+    XCTAssertTrue(
+      PersonOverview.conversationCaption(count: 1, last: now.addingTimeInterval(-7200), now: now)
+        .hasPrefix("1 conversation · last"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
+++ b/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
@@ -122,3 +122,34 @@ extension PeopleRebuildPlannerTests {
       "without a chunk timestamp the part cannot be placed and must not be guessed")
   }
 }
+
+extension PeopleRebuildPlannerTests {
+  /// A long history holds dozens of one-off voices; only the leading few may keep audio, or the
+  /// rebuild would carry hundreds of megabytes of samples it can never use.
+  func testOnlyTheLeadingVoicesKeepAudio() {
+    func voice(_ axis: Int) -> [Float] {
+      var v = [Float](repeating: 0, count: 16)
+      v[axis] = 1
+      return v
+    }
+    var clusterer = VoiceClusterer()
+    clusterer.clipHoldingClusters = 2
+    let clip = [Float](repeating: 0.1, count: 1600)
+    // Voice 0 in three conversations, voice 1 in two, voices 2 and 3 in one each.
+    for conversation in ["c1", "c2", "c3"] {
+      clusterer.add(
+        embedding: voice(0), seconds: 4, conversationId: conversation, date: nil, clip: clip, labeledAsUser: false)
+    }
+    for conversation in ["c1", "c2"] {
+      clusterer.add(
+        embedding: voice(1), seconds: 4, conversationId: conversation, date: nil, clip: clip, labeledAsUser: false)
+    }
+    clusterer.add(embedding: voice(2), seconds: 4, conversationId: "c1", date: nil, clip: clip, labeledAsUser: false)
+    clusterer.add(embedding: voice(3), seconds: 4, conversationId: "c2", date: nil, clip: clip, labeledAsUser: false)
+
+    XCTAssertEqual(clusterer.clusters.count, 4)
+    let withAudio = clusterer.clusters.filter { !$0.clips.isEmpty }
+    XCTAssertEqual(withAudio.count, 2, "only the two most-present voices keep clips")
+    XCTAssertEqual(clusterer.userCluster?.clips.isEmpty, false, "the user's own audio survives")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
+++ b/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
@@ -75,3 +75,20 @@ final class PeopleRebuildPlannerTests: XCTestCase {
     XCTAssertEqual(PeopleRebuildSummary(failure: "Couldn't load conversations").message, "Couldn't load conversations")
   }
 }
+
+extension PeopleRebuildPlannerTests {
+  /// The dev backend never builds the aggregate artifact; the one cached part begins at its
+  /// first chunk, 30–60 s after the conversation started. The synthesized span carries that.
+  func testASinglePartIsPlacedAtItsFirstChunkNotAtTheConversationStart() throws {
+    let startedAt = Date(timeIntervalSince1970: 1_800_000_000)
+    let file = CapturePlaybackFile(id: "part", signedURL: URL(fileURLWithPath: "/tmp/part.wav"), duration: 120)
+    let artifact = try XCTUnwrap(
+      PeopleRebuildPlanner.singlePartArtifact(
+        file: file, firstChunkTimestamp: 1_800_000_033, conversationStartedAt: startedAt))
+    XCTAssertEqual(try XCTUnwrap(artifact.artifactOffset(forWallOffset: 40)), 7, accuracy: 1e-6)
+    XCTAssertNil(artifact.artifactOffset(forWallOffset: 10), "speech before the first chunk was never captured")
+    XCTAssertNil(
+      PeopleRebuildPlanner.singlePartArtifact(file: file, firstChunkTimestamp: nil, conversationStartedAt: startedAt),
+      "without a chunk timestamp the part cannot be placed and must not be guessed")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
+++ b/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class PeopleRebuildPlannerTests: XCTestCase {
+  private func segment(_ text: String, start: Double, end: Double, isUser: Bool = false, personId: String? = nil)
+    -> TranscriptSegment
+  {
+    TranscriptSegment(
+      id: UUID().uuidString, backendId: nil, text: text, speaker: "SPEAKER_01", isUser: isUser, personId: personId,
+      start: start, end: end, translations: [])
+  }
+
+  /// Two captured spans with a 100 s gap between them in wall time.
+  private var artifact: CapturePlaybackArtifact {
+    CapturePlaybackArtifact(
+      signedURL: URL(fileURLWithPath: "/tmp/a.wav"), duration: 60,
+      spans: [
+        CaptureAudioURLSpan(fileID: "f1", wallOffset: 0, artifactOffset: 0, length: 30),
+        CaptureAudioURLSpan(fileID: "f2", wallOffset: 130, artifactOffset: 30, length: 30),
+      ])
+  }
+
+  func testOnlyNamedOrUserSegmentsInsideCapturedAudioBecomeCuts() {
+    let cuts = PeopleRebuildPlanner.cuts(
+      segments: [
+        segment("me", start: 2, end: 6, isUser: true),
+        segment("anna", start: 10, end: 14, personId: "anna"),
+        segment("unknown", start: 15, end: 20),
+        segment("too short", start: 20, end: 20.5, personId: "anna"),
+        segment("in the gap", start: 60, end: 70, personId: "anna"),
+        segment("second span", start: 135, end: 160, personId: "bob"),
+      ],
+      artifact: artifact)
+
+    XCTAssertEqual(cuts.map(\.personId), [nil, "anna", "bob"])
+    XCTAssertEqual(cuts[0].artifactStart, 2, accuracy: 1e-6)
+    XCTAssertEqual(cuts[0].artifactEnd, 6, accuracy: 0.01)
+    XCTAssertEqual(cuts[2].artifactStart, 35, accuracy: 1e-6, "second span maps through its artifact offset")
+    XCTAssertEqual(cuts[2].length, PeopleRebuildPlanner.maxCutSeconds, accuracy: 0.01, "long segments are capped")
+  }
+
+  func testActivityCountsConversationsPerPersonAndMergesWithLocal() {
+    let day: TimeInterval = 86_400
+    let now = Date()
+    let remote = PeopleRebuildPlanner.activity(in: [
+      (
+        segments: [
+          segment("a", start: 0, end: 2, personId: "anna"), segment("a2", start: 2, end: 4, personId: "anna"),
+        ], date: now.addingTimeInterval(-day)
+      ),
+      (
+        segments: [segment("b", start: 0, end: 2, personId: "bob"), segment("me", start: 2, end: 4, isUser: true)],
+        date: now
+      ),
+      (segments: [segment("a", start: 0, end: 2, personId: "anna")], date: now.addingTimeInterval(-3 * day)),
+    ])
+    XCTAssertEqual(remote["anna"]?.conversationCount, 2, "two conversations, not three segments")
+    XCTAssertEqual(remote["anna"]?.lastTalkedAt, now.addingTimeInterval(-day))
+    XCTAssertEqual(remote["bob"]?.conversationCount, 1)
+    XCTAssertEqual(remote.count, 2, "the user is not a person")
+
+    let merged = PeopleRebuildPlanner.merge(
+      ["anna": PersonActivity(conversationCount: 5, lastTalkedAt: now.addingTimeInterval(-10 * day))], remote)
+    XCTAssertEqual(merged["anna"]?.conversationCount, 5)
+    XCTAssertEqual(merged["anna"]?.lastTalkedAt, now.addingTimeInterval(-day))
+    XCTAssertEqual(merged["bob"]?.conversationCount, 1)
+  }
+
+  func testSummaryMessageReadsNaturally() {
+    var summary = PeopleRebuildSummary(conversations: 12, withAudio: 3, voicesRebuilt: 2, clipsSaved: 5)
+    XCTAssertEqual(summary.message, "12 conversations checked · 3 with audio · 2 voices rebuilt · 5 clips saved")
+    summary = PeopleRebuildSummary(conversations: 1)
+    XCTAssertEqual(summary.message, "1 conversation checked · no voices rebuilt")
+    XCTAssertEqual(PeopleRebuildSummary(failure: "Couldn't load conversations").message, "Couldn't load conversations")
+  }
+}

--- a/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
+++ b/desktop/macos/Desktop/Tests/PeopleRebuildPlannerTests.swift
@@ -21,7 +21,7 @@ final class PeopleRebuildPlannerTests: XCTestCase {
       ])
   }
 
-  func testOnlyNamedOrUserSegmentsInsideCapturedAudioBecomeCuts() {
+  func testEverySegmentInsideCapturedAudioBecomesACutLongestFirst() throws {
     let cuts = PeopleRebuildPlanner.cuts(
       segments: [
         segment("me", start: 2, end: 6, isUser: true),
@@ -33,11 +33,41 @@ final class PeopleRebuildPlannerTests: XCTestCase {
       ],
       artifact: artifact)
 
-    XCTAssertEqual(cuts.map(\.personId), [nil, "anna", "bob"])
-    XCTAssertEqual(cuts[0].artifactStart, 2, accuracy: 1e-6)
-    XCTAssertEqual(cuts[0].artifactEnd, 6, accuracy: 0.01)
-    XCTAssertEqual(cuts[2].artifactStart, 35, accuracy: 1e-6, "second span maps through its artifact offset")
-    XCTAssertEqual(cuts[2].length, PeopleRebuildPlanner.maxCutSeconds, accuracy: 0.01, "long segments are capped")
+    XCTAssertEqual(cuts.count, 4, "unnamed voices count too; the gap and the blip do not")
+    XCTAssertEqual(cuts.map(\.personId).prefix(2), ["bob", nil], "longest first")
+    XCTAssertEqual(Set(cuts.map(\.personId)), Set(["bob", nil, "anna"]))
+    XCTAssertEqual(cuts[0].artifactStart, 35, accuracy: 1e-6, "second span maps through its artifact offset")
+    XCTAssertEqual(cuts[0].length, PeopleRebuildPlanner.maxCutSeconds, accuracy: 0.01, "long segments are capped")
+    let me = try XCTUnwrap(cuts.first { $0.labeledAsUser })
+    XCTAssertEqual(me.artifactStart, 2, accuracy: 1e-6)
+    XCTAssertEqual(me.artifactEnd, 6, accuracy: 0.01)
+  }
+
+  /// "You" is whoever is heard in the most conversations, not whoever the backend flagged.
+  func testTheVoiceInTheMostConversationsIsTheUser() {
+    func voice(_ axis: Int) -> [Float] {
+      var v = [Float](repeating: 0, count: 8)
+      v[axis] = 1
+      return v
+    }
+    var clusterer = VoiceClusterer()
+    // Voice 0: three conversations, little speech. Voice 1: one conversation, lots of speech,
+    // flagged is_user by the backend. Voice 2: two conversations.
+    for (conversation, seconds) in [("c1", 3.0), ("c2", 3.0), ("c3", 3.0)] {
+      clusterer.add(
+        embedding: voice(0), seconds: seconds, conversationId: conversation, date: nil, clip: nil, labeledAsUser: false)
+    }
+    clusterer.add(embedding: voice(1), seconds: 300, conversationId: "c1", date: nil, clip: nil, labeledAsUser: true)
+    for conversation in ["c1", "c2"] {
+      clusterer.add(
+        embedding: voice(2), seconds: 50, conversationId: conversation, date: nil, clip: nil, labeledAsUser: false)
+    }
+
+    XCTAssertEqual(clusterer.clusters.count, 3)
+    let user = clusterer.userCluster
+    XCTAssertEqual(user?.conversationIds.count, 3)
+    XCTAssertEqual(user?.speechSeconds ?? 0, 9, accuracy: 1e-6)
+    XCTAssertEqual(user?.labeledAsUserSeconds, 0, "the backend's flag did not decide it")
   }
 
   func testActivityCountsConversationsPerPersonAndMergesWithLocal() {

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -162,7 +162,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     )
     XCTAssertEqual(
       TopNavigationRoutes.memoryDestinations,
-      [.memories, .conversations, .brainMap, .activity, .rewind])
+      [.memories, .conversations, .brainMap, .activity, .rewind, .people])
 
     // No pill may instruct the user how to operate it. The retired menu's tooltip read "hover for
     // conversations, memories, tasks, Rewind", which is chrome apologising for itself.
@@ -182,7 +182,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertEqual(
       ShellDestination.allCases.filter { $0.reach == .activityChipRow }
         .compactMap(\.memoryDestination),
-      [.conversations, .memories, .brainMap, .rewind])
+      [.conversations, .memories, .brainMap, .rewind, .people])
     // The claim is checkable because the row and the model read one value. A page dropped from the
     // chip row is unreachable here rather than silently stranded in the app.
     for destination in ShellDestination.allCases where destination.reach == .activityChipRow {
@@ -309,7 +309,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     }
     XCTAssertEqual(
       Set(ShellDestination.unreachable(fromBarItems: barWithoutLibrary)),
-      [.conversations, .memories, .brainMap, .rewind, .activity],
+      [.conversations, .memories, .brainMap, .rewind, .activity, .people],
       "without the Brain pill the section's views have no way in")
   }
 

--- a/desktop/macos/Desktop/Tests/TranscriptSessionTimingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptSessionTimingPersistenceTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Segments and speaker relabels can outrun the DB session: `currentSessionId` is installed
+/// only after the async session-creation task finishes, and on a real meeting boundary that
+/// has lagged capture resume by tens of seconds. Work arriving in that window must be held
+/// and flushed into the session once it exists — not silently dropped. A live meeting's
+/// transcript was lost exactly this way: every segment persisted only in memory, the empty
+/// session was deleted at meeting end, and nothing uploaded.
+@MainActor
+final class TranscriptSessionTimingPersistenceTests: XCTestCase {
+  private var testUserId = ""
+  private var userDir: URL?
+  private var state: AppState?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "transcript-session-timing-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = try XCTUnwrap(
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+
+    let state = AppState()
+    state.isTranscribing = true
+    self.state = state
+  }
+
+  override func tearDown() async throws {
+    state?.isTranscribing = false
+    state = nil
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = nil
+    if let userDir {
+      try? FileManager.default.removeItem(at: userDir)
+    }
+    try await super.tearDown()
+  }
+
+  private func segment(_ text: String, speaker: Int = 0, isUser: Bool = true)
+    -> TranscriptionService.BackendSegment
+  {
+    TranscriptionService.BackendSegment(
+      id: UUID().uuidString.lowercased(),
+      text: text,
+      speaker: String(format: "SPEAKER_%02d", speaker),
+      speaker_id: speaker,
+      is_user: isUser,
+      person_id: nil,
+      start: 0,
+      end: 1,
+      translations: nil
+    )
+  }
+
+  /// Simulates the session-creation task completing: a storage row is created and the app
+  /// installs its id, which is where held work must flush.
+  private func createAndInstallSession(_ state: AppState) async throws -> Int64 {
+    let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+    state.currentSessionId = sessionId
+    state.flushHeldTranscriptWork(sessionId: sessionId)
+    return sessionId
+  }
+
+  func testSegmentsArrivingBeforeTheSessionExistsLandInTheCreatedSession() async throws {
+    let state = try XCTUnwrap(state)
+    state.handleBackendSegments([segment("held before the session existed")])
+    XCTAssertEqual(state.totalSegmentCount, 1, "the segment still enters the live transcript")
+    await state.flushTranscriptPersistence()
+
+    let sessionId = try await createAndInstallSession(state)
+    await state.flushTranscriptPersistence()
+
+    let rows = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+    XCTAssertEqual(rows.map(\.text), ["held before the session existed"])
+    XCTAssertEqual(rows.first?.speaker, 0)
+    XCTAssertEqual(rows.first?.isUser, true)
+  }
+
+  func testRelabelsArrivingBeforeTheSessionExistsApplyToTheHeldRowsInOrder() async throws {
+    let state = try XCTUnwrap(state)
+    state.handleBackendSegments([segment("provisional you")])
+    // The diarizer bootstrap decides the mic voice was the other person — while the session
+    // id is still nil, exactly as in the lost-meeting run.
+    state.applyLocalSpeakerRelabels([
+      0: LocalSpeakerRegistry.Resolution(speakerId: 1, isUser: false)
+    ])
+    await state.flushTranscriptPersistence()
+
+    let sessionId = try await createAndInstallSession(state)
+    await state.flushTranscriptPersistence()
+
+    let rows = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+    XCTAssertEqual(rows.map(\.text), ["provisional you"])
+    XCTAssertEqual(rows.first?.speaker, 1, "the held relabel lands after the held segment's upsert")
+    XCTAssertEqual(rows.first?.isUser, false)
+  }
+
+  func testSegmentsAfterTheRecordingStopsAreNotHeldForAFutureSession() async throws {
+    let state = try XCTUnwrap(state)
+    state.isTranscribing = false
+    state.handleBackendSegments([segment("arrived after stop")])
+    XCTAssertEqual(state.totalSegmentCount, 1)
+
+    let sessionId = try await createAndInstallSession(state)
+    await state.flushTranscriptPersistence()
+
+    let rows = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+    XCTAssertTrue(rows.isEmpty, "work from a stopped recording must not leak into a later session")
+  }
+
+  func testHeldWorkIsDiscardedWhenTheRecordingEndsWithoutASession() async throws {
+    let state = try XCTUnwrap(state)
+    state.handleBackendSegments([segment("never got a session")])
+    state.discardHeldTranscriptWork()
+
+    let sessionId = try await createAndInstallSession(state)
+    await state.flushTranscriptPersistence()
+
+    let rows = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+    XCTAssertTrue(rows.isEmpty)
+  }
+}

--- a/desktop/macos/Desktop/Tests/TranscriptSessionTimingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptSessionTimingPersistenceTests.swift
@@ -15,7 +15,6 @@ final class TranscriptSessionTimingPersistenceTests: XCTestCase {
   private var state: AppState?
 
   override func setUp() async throws {
-    try await super.setUp()
     testUserId = "transcript-session-timing-test-\(UUID().uuidString)"
     await RewindDatabase.shared.close()
     await TranscriptionStorage.shared.invalidateCache()
@@ -44,7 +43,6 @@ final class TranscriptSessionTimingPersistenceTests: XCTestCase {
     if let userDir {
       try? FileManager.default.removeItem(at: userDir)
     }
-    try await super.tearDown()
   }
 
   private func segment(_ text: String, speaker: Int = 0, isUser: Bool = true)

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -1013,6 +1013,33 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
     XCTAssertTrue(compacted.contains { $0.speaker == "MIXED" })
   }
 
+  /// The mic and system-audio lanes keep independent clocks, and with on-device diarization
+  /// a remote voice and its mic echo share one speaker id. Joining a system row onto a mic row
+  /// that started later produced `end < start` and the backend rejected the conversation.
+  func testSameSpeakerRunsNeverMergeBackwardInTime() {
+    func segment(_ text: String, speaker: Int, start: Double, end: Double) -> APIClient.UploadSegment {
+      APIClient.UploadSegment(
+        text: text, speaker: String(format: "SPEAKER_%02d", speaker), speaker_id: speaker,
+        is_user: speaker == 0, person_id: nil, start: start, end: end)
+    }
+    let merged = ConversationFinalizationService.mergeConsecutiveSpeakerRuns([
+      segment("hello", speaker: 0, start: 0, end: 10),
+      segment("there", speaker: 0, start: 10, end: 20),
+      segment("mic echo of the remote voice", speaker: 2, start: 40, end: 50),
+      segment("the remote voice on its own clock", speaker: 2, start: 0.1, end: 9.1),
+      segment("and later", speaker: 2, start: 9.1, end: 15),
+    ])
+
+    XCTAssertEqual(
+      merged.map(\.text),
+      ["hello there", "mic echo of the remote voice", "the remote voice on its own clock and later"])
+    XCTAssertEqual(merged.map(\.start), [0, 40, 0.1])
+    XCTAssertEqual(merged.map(\.end), [20, 50, 15])
+    for upload in merged {
+      XCTAssertGreaterThan(upload.end, upload.start, "the backend rejects end <= start with a 422")
+    }
+  }
+
   func testCompactionLeavesBackendSizedUploadsUnchanged() {
     let segments = (0..<3).map { index in
       APIClient.UploadSegment(

--- a/desktop/macos/Desktop/Tests/TranscriptionStorageSpeakerRelabelTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionStorageSpeakerRelabelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// other person in the room. The stored rows of the current session must swap with it in
 /// one statement — a naive two-step update would map 0→1 and then 1→0 back again.
 final class TranscriptionStorageSpeakerRelabelTests: XCTestCase {
-  private var testUserId: String!
+  private var testUserId = ""
   private var userDir: URL?
 
   override func setUp() async throws {

--- a/desktop/macos/Desktop/Tests/TranscriptionStorageSpeakerRelabelTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionStorageSpeakerRelabelTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// On-device diarization can decide, a few sentences in, that the provisional "You" was the
+/// other person in the room. The stored rows of the current session must swap with it in
+/// one statement — a naive two-step update would map 0→1 and then 1→0 back again.
+final class TranscriptionStorageSpeakerRelabelTests: XCTestCase {
+  private var testUserId: String!
+  private var userDir: URL?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "transcription-storage-relabel-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = try XCTUnwrap(
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await RewindDatabase.shared.close()
+    await TranscriptionStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = nil
+    if let userDir {
+      try? FileManager.default.removeItem(at: userDir)
+    }
+    try await super.tearDown()
+  }
+
+  func testSwapRelabelMovesBothSpeakersOnceAndLeavesOthersAlone() async throws {
+    let storage = TranscriptionStorage.shared
+    let sessionId = try await storage.startSession(source: "desktop")
+    let otherSession = try await storage.startSession(source: "desktop")
+    _ = try await storage.upsertSegment(
+      sessionId: sessionId, backendSegmentId: "a", speaker: 0, text: "provisional you",
+      startTime: 0, endTime: 2, isUser: true, speakerLabel: "SPEAKER_00")
+    _ = try await storage.upsertSegment(
+      sessionId: sessionId, backendSegmentId: "b", speaker: 1, text: "the real user",
+      startTime: 2, endTime: 5, isUser: false, personId: "person-guess", speakerLabel: "SPEAKER_01")
+    _ = try await storage.upsertSegment(
+      sessionId: sessionId, backendSegmentId: "c", speaker: 2, text: "someone on the call",
+      startTime: 5, endTime: 7, isUser: false, speakerLabel: "SPEAKER_02")
+    _ = try await storage.upsertSegment(
+      sessionId: otherSession, backendSegmentId: "d", speaker: 0, text: "another session",
+      startTime: 0, endTime: 1, isUser: true, speakerLabel: "SPEAKER_00")
+
+    let moved = try await storage.relabelSpeakers(
+      sessionId: sessionId,
+      relabels: [
+        0: LocalSpeakerRegistry.Resolution(speakerId: 1, isUser: false),
+        1: LocalSpeakerRegistry.Resolution(speakerId: 0, isUser: true),
+      ])
+
+    XCTAssertEqual(moved, 2)
+    let rows = try await storage.getSegments(sessionId: sessionId)
+    let byId = Dictionary(rows.map { ($0.segmentId ?? "", $0) }, uniquingKeysWith: { first, _ in first })
+    XCTAssertEqual(byId["a"]?.speaker, 1)
+    XCTAssertEqual(byId["a"]?.speakerLabel, "SPEAKER_01")
+    XCTAssertEqual(byId["a"]?.isUser, false)
+    XCTAssertEqual(byId["b"]?.speaker, 0)
+    XCTAssertEqual(byId["b"]?.speakerLabel, "SPEAKER_00")
+    XCTAssertEqual(byId["b"]?.isUser, true)
+    XCTAssertNil(byId["b"]?.personId, "a row that became the user drops its person guess")
+    XCTAssertEqual(byId["c"]?.speaker, 2)
+    XCTAssertEqual(byId["c"]?.isUser, false)
+
+    let untouched = try await storage.getSegments(sessionId: otherSession)
+    XCTAssertEqual(untouched.first?.speaker, 0)
+    XCTAssertEqual(untouched.first?.isUser, true)
+  }
+
+  func testEmptyRelabelIsANoOp() async throws {
+    let sessionId = try await TranscriptionStorage.shared.startSession(source: "desktop")
+    let moved = try await TranscriptionStorage.shared.relabelSpeakers(sessionId: sessionId, relabels: [:])
+    XCTAssertEqual(moved, 0)
+  }
+}

--- a/desktop/macos/Desktop/Tests/VoiceEnrollmentPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceEnrollmentPolicyTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Aged frequency with favorites pinned: who stays remembered when the store is full.
+final class VoiceEnrollmentPolicyTests: XCTestCase {
+  private let policy = VoiceEnrollmentPolicy()
+  private let day: TimeInterval = 86_400
+
+  private func voice(_ id: String?, score: Double, lastUsed: Date?, favorite: Bool = false) -> StoredVoiceprint {
+    StoredVoiceprint(
+      personId: id, embedding: [1, 0], speechSeconds: 10, updatedAt: lastUsed ?? .distantPast, isEnrolled: true,
+      isFavorite: favorite, useScore: score, lastUsedAt: lastUsed)
+  }
+
+  func testScoreHalvesEveryHalfLife() {
+    let now = Date()
+    XCTAssertEqual(policy.decayedScore(8, lastUsedAt: now.addingTimeInterval(-14 * day), now: now), 4, accuracy: 1e-9)
+    XCTAssertEqual(policy.decayedScore(8, lastUsedAt: now.addingTimeInterval(-28 * day), now: now), 2, accuracy: 1e-9)
+    XCTAssertEqual(policy.decayedScore(8, lastUsedAt: nil, now: now), 0)
+  }
+
+  func testAUseBumpsTheDecayedScoreByOne() {
+    let now = Date()
+    let stale = voice("a", score: 4, lastUsed: now.addingTimeInterval(-14 * day))
+    let used = policy.recordingUse(of: stale, now: now)
+    XCTAssertEqual(used.useScore, 3, accuracy: 1e-9)
+    XCTAssertEqual(used.lastUsedAt, now)
+  }
+
+  /// Weekly regular beats yesterday's one-off (LRU would get this wrong); a voice heard a lot
+  /// long ago fades (LFU would get this wrong).
+  func testEvictionDropsTheLeastValuableNonFavorites() {
+    var policy = VoiceEnrollmentPolicy()
+    policy.capacity = 2
+    let now = Date()
+    let prints = [
+      voice(nil, score: 100, lastUsed: now),
+      voice("weekly", score: 6, lastUsed: now.addingTimeInterval(-7 * day)),
+      voice("one-off", score: 1, lastUsed: now.addingTimeInterval(-1 * day)),
+      voice("last-year", score: 40, lastUsed: now.addingTimeInterval(-365 * day)),
+      voice("pinned", score: 0, lastUsed: nil, favorite: true),
+    ]
+
+    let evicted = policy.evictions(from: prints, now: now)
+
+    XCTAssertEqual(Set(evicted), ["one-off", "last-year"], "the user and the favorite are untouchable")
+    XCTAssertEqual(policy.evictions(from: prints.filter { !evicted.contains($0.personId ?? "") }, now: now), [])
+  }
+
+  func testNothingIsEvictedUnderCapacity() {
+    let prints = [voice("a", score: 0, lastUsed: nil), voice("b", score: 0, lastUsed: nil)]
+    XCTAssertEqual(policy.evictions(from: prints, now: Date()), [])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260907-on-device-speaker-diarization.json
+++ b/desktop/macos/changelog/unreleased/20260907-on-device-speaker-diarization.json
@@ -1,3 +1,3 @@
 {
-  "change": "Improved live transcription on Apple Silicon so other people talking near your Mac are labeled as separate speakers instead of as you, and your own voice is recognised across sessions"
+  "change": "Added a People view to Memories that remembers the voices of you and the people you name, so on-device live transcription labels other people in the room as separate speakers, recognises them by voice next time, and lets you mark a speaker as \"This is me\""
 }

--- a/desktop/macos/changelog/unreleased/20260907-on-device-speaker-diarization.json
+++ b/desktop/macos/changelog/unreleased/20260907-on-device-speaker-diarization.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved live transcription on Apple Silicon so other people talking near your Mac are labeled as separate speakers instead of as you, and your own voice is recognised across sessions"
+}

--- a/desktop/macos/changelog/unreleased/20260910-held-transcript-survives-session-timing.json
+++ b/desktop/macos/changelog/unreleased/20260910-held-transcript-survives-session-timing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a live meeting's transcript being silently lost when the recording session was slow to start, so words spoken right after a meeting begins now upload with that meeting"
+}

--- a/desktop/macos/changelog/unreleased/20260910-parakeet-ready-without-diarizer-wait.json
+++ b/desktop/macos/changelog/unreleased/20260910-parakeet-ready-without-diarizer-wait.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed on-device transcription staying silent for up to 20 seconds at the start of every capture session while speaker-recognition models warmed up"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -14,6 +14,8 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
   - desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
   - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
+  - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
+  - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/Services/OmiHTTPTransport.swift

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+  - desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/VoiceEnrollmentPolicy.swift
+  - desktop/macos/Desktop/Sources/LocalTranscription/PeopleRebuilder.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -16,6 +16,8 @@ covers:
   - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerRegistry.swift
   - desktop/macos/Desktop/Sources/LocalTranscription/LocalSpeakerDiarizer.swift
+  - desktop/macos/Desktop/Sources/LocalTranscription/LocalVoiceprintStore.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/People/PeoplePage.swift
   - desktop/macos/Desktop/Sources/TranscriptionService.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/Services/OmiHTTPTransport.swift


### PR DESCRIPTION
## What

On-device live transcription now tells voices apart and knows who you are, and a new **People** view in Memories keeps the voices Omi has learned.

Before, the local (Parakeet) path labeled by capture lane only — every mic window was `SPEAKER_00` / "You" and every system-audio window "Speaker 1" — so a second person talking near the Mac was transcribed as the user (six consecutive bubbles from two people, all "You", in the report that started this).

## How

**Speaker identity (on-device, both lanes)**
- `LocalSpeakerDiarizer` (actor): FluidAudio's pyannote segmentation + WeSpeaker embeddings (CoreML/ANE; FluidAudio was already a dependency) embed the dominant voice of every transcribed window. Fails open to lane labels with `recordFallback(area: "stt_selection", …)`.
- `LocalSpeakerRegistry` (pure, tested): greedy cosine clustering shared by mic and system-audio lanes, running-mean centroids, matching against remembered voices, and the "who is You" policy:
  1. a remembered *enrolled* voice of the user locks "You" for the session; a merely *learned* one seeds it but stays open to correction;
  2. otherwise the dominant mic voice (speech × loudness) is the provisional user, swapped with a 1.5× margin; system-audio voices are never the user; a remote voice and its mic echo share one id;
  3. explicit paths: **"This is me"** in the live speaker sheet, naming a speaker (teaches that person's voice), and any push-to-talk turn ≥ 2 s (the user beyond doubt).
- Relabels move already-emitted segments in memory, in `LiveTranscriptMonitor`, and in SQLite via a single-statement `TranscriptionStorage.relabelSpeakers` (a 0↔1 swap must not double-map), queued behind pending upserts. The live name map is cleared in a pass of its own before it is rewritten, so a swap cannot let dictionary order decide which end keeps its name.
- `SpeakerSegment.lane` makes echo dedup lane-aware now that a speaker id no longer implies a lane; finalization no longer merges same-speaker runs backward in time (the two lanes keep independent clocks — the backend rejected `end < start` with a 422).
- Speaker id 0 stays the user (`VoiceBargeInPolicy`, `EnvironmentalSpeakerContext` rely on it).

**Remembered voices**
- `LocalVoiceprintStore`: per-user `voiceprints.json` + `voice-samples/<owner>/*.wav` (≤ 5 clips, ≤ 12 s each). Backward-compatible decoding.
- `VoiceEnrollmentPolicy`: LFU with exponential aging (one bump per app run heard, 14-day half-life), capacity 30 people, favorites pinned, user never evicted.

**People view** (Memories chip row, before Brain Map)
- Rows: the user first (account name, grey avatar), then favorites, then most recently talked to. Conversation count/last-talked from the local transcript store merged with the backend's conversations. Voice line and snippet chips (one per clip, play/stop) only when clips exist.
- Actions: star (pin), click-to-rename (PATCH `v1/users/people/{id}/name`), forget voice, delete person (backend + local voice/audio, with confirmation).
- **Rebuild**: pages through every conversation, fetches each detail, and for those with audio (aggregate artifact, or the single cached part placed by its first-chunk timestamp) cuts every segment, embeds it, clusters across conversations; the cluster heard in the most conversations becomes the user's voiceprint and clips, named people are rebuilt from the segments that name them. Summary reports counts, pending/locked audio, and which voice was taken as you.

## Tests

New: `LocalSpeakerRegistryTests` (15), `LocalVoiceprintStoreTests` (6), `VoiceEnrollmentPolicyTests` (4), `PeoplePageOverviewTests` (3), `PeopleRebuildPlannerTests` (6), `LocalSpeakerDiarizerRebuildTests` (3), `TranscriptionStorageSpeakerRelabelTests` (2). Extended: `LocalTranscriptionDuplicatePolicyTests` (+2 lane cases), `TranscriptionFinalizationStateMachineTests` (+1 backward merge), navigation suites for the new hub view.

Commands run (green on the rebased branch):
- `xcrun swift build -c debug --package-path Desktop`
- `xcrun swift test --package-path Desktop --filter "LocalSpeakerRegistryTests|LocalVoiceprintStoreTests|VoiceEnrollmentPolicyTests|PeoplePageOverviewTests|PeopleRebuildPlannerTests|TranscriptionStorageSpeakerRelabelTests|LocalTranscriptionDuplicatePolicyTests|LocalTranscriptionEndpointTests|TranscriptSpeakerAssignmentTests|TopNavigationBarLayoutTests|QueryShellTests|ChatFirstDestinationParityTests|MemoryHubSidebarRoutingTests|ChatFirstShellTests|MemoryGraphRevisitTests|TranscriptionFinalizationStateMachineTests|CaptureArchiveTests|TranscriptionStorageRecoveryTests"`

## Live verification (named bundle `omi-speaker-diarization`)

- Two synthetic voices (`say -v Samantha` / `-v Daniel`) played through the speakers got Speaker 2 and Speaker 3, consistently on the system lane and their mic echo, neither "You"; real room speech split into "You" and "Speaker 1".
- Measured WeSpeaker cosine distances: same voice 0.06–0.26 (mixed 10 s windows ≈ 0.5), different voices 0.68–0.94 — the 0.60 match threshold holds.
- The failure mode that motivated the identity work was reproduced live: a bootstrap guess stored after 20 s locked the other person in as "You" on the next launch. Guessed prints no longer lock; "This is me" / push-to-talk do.
- The first Rebuild finished in 5 s with nothing rebuilt (one page, no detail fetch, aggregate-only); the log showed it and it now walks every conversation and accepts the single cached part.
- A full Rebuild on the real account then ran end to end: `263 conversations checked · 62 with audio · 4 voices rebuilt · 11 clips saved · you = the voice in 55 of them · 8 still preparing audio`, with the user cluster at 1732 s across 55 conversations out of 68 voices total — and 0 s of it carried the backend's `is_user` flag, which is why the most-present rule (not the flag) decides "You".

Not exercised live: person rename/delete against the backend (the endpoints' shapes were checked against `backend/routers/users.py`: `PATCH /v1/users/people/{id}/name?value=` and `DELETE /v1/users/people/{id}`).

## Hardening after the first live run

The live Rebuild above surfaced two things a review pass then fixed, and a pre-merge review pass found a third — all three with regression tests:

- **Memory.** 68 distinct voices across 263 conversations, and the first cut of the rebuilder decoded each capture whole and held every embedding and clip for every voice — hundreds of megabytes on a real account. Now the decoder reads only the cut it is asked for, cluster clips are 16-bit and only the leading few voices keep any, and a cluster's voiceprint is its duration-weighted running centroid so per-cluster embedding arrays are gone.
- **A rebuild used to unpin a voice.** `applyRebuild` removed the stored row before reading it back, so a pinned person came out unpinned with their aged use score reset; it also deleted every clip before writing the rebuilt ones, so a voice the rebuild heard no audio for ended up with none — and a voice without clips shows no voice line, so it read as forgotten. The pin and the use score carry over now, and clips are only traded for clips.
- **Voices followed the app, not the account.** `LocalSpeakerDiarizer` is a singleton that resolved the signed-in user's profile once, at first touch, and was absent from the effective-owner transition's list of owner-bound local storage. Signing in as someone else kept the previous owner's prints in memory: their voices would be listed on the next owner's People page, their clips playable there, and the next owner's learned voices written back into the previous owner's file. It now retargets with `RewindDatabase` and the storage caches, under the transition reservation.

## Follow-ups (not in this PR)

- The mic and system-audio lanes keep independent clocks (the system lane's clock only advances while audio plays), which predates this change and still defeats echo-dedup timing.
- Uploading learned voice samples to the backend's speech profiles so mobile benefits.

## Failure class

The one `fix:` commit repairs a defect introduced earlier in this same PR (a rebuild read back the row it had just replaced), so it is not an instance of a recurring class in the registry.

Failure-Class: none

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift | 1785 -> 1808 | one helper that builds the two lane-tagged local transcription services; the diarizer logic itself lives in the new LocalTranscription/ files
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 4193 -> 4202 | nine lines handing the accepted turn's PCM to the diarizer as the user's voice sample
Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift | 1783 -> 1788 | wires the live speaker sheet's "This is me" and naming callbacks

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-NAV-1
- INV-VOICE-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoZMbwdDio6Vcy3xvz2CrX
