### PR TITLE
Fix external integration URL updates not reflecting without app restart

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -36,6 +36,7 @@ import 'package:omi/widgets/extensions/string.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/backend/http/api/payment.dart';
 import 'package:omi/backend/schema/app.dart';
+import 'package:omi/pages/apps/app_detail/app_detail_config.dart';
 import 'package:omi/pages/apps/widgets/show_app_options_sheet.dart';
 import 'widgets/capabilities_card.dart';
 import 'widgets/info_card_widget.dart';
@@ -263,6 +264,30 @@ class _AppDetailPageState extends State<AppDetailPage> {
     }
   }
 
+  void _onExternalIntegrationUpdated() {
+    if (!app.worksExternally()) return;
+    checkSetupCompleted();
+    final path = app.externalIntegration?.setupInstructionsFilePath;
+    if (path?.isNotEmpty == true && path!.contains('raw.githubusercontent.com')) {
+      getAppMarkdown(path).then((value) {
+        value = value.replaceAll(
+          '](assets/',
+          '](https://raw.githubusercontent.com/BasedHardware/Omi/main/plugins/instructions/${app.id}/assets/',
+        );
+        if (mounted) {
+          setState(() => instructionsMarkdown = value);
+        }
+      });
+    }
+  }
+
+  void _applyProviderAppUpdate(App updatedApp) {
+    setState(() {
+      app = updatedApp;
+    });
+    _onExternalIntegrationUpdated();
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -272,16 +297,10 @@ class _AppDetailPageState extends State<AppDetailPage> {
       // Check if app has been updated in the provider
       final appProvider = context.read<AppProvider>();
       final updatedApp = appProvider.apps.firstWhereOrNull((a) => a.id == app.id);
-      if (updatedApp != null) {
-        // Compare critical fields to detect if app was updated
-        final appHomeUrlChanged = updatedApp.externalIntegration?.appHomeUrl != app.externalIntegration?.appHomeUrl;
-        final nameChanged = updatedApp.name != app.name;
-        final descriptionChanged = updatedApp.description != app.description;
-
-        if (appHomeUrlChanged || nameChanged || descriptionChanged) {
-          // App was updated, refresh the details
-          await _refreshAppDetails();
-        }
+      if (updatedApp != null && hasAppDetailConfigChanged(app, updatedApp)) {
+        // App was updated, refresh the details
+        await _refreshAppDetails();
+        _onExternalIntegrationUpdated();
       }
     });
   }
@@ -541,22 +560,13 @@ class _AppDetailPageState extends State<AppDetailPage> {
       builder: (context, appProvider, child) {
         // Check if app has been updated in the provider
         final updatedApp = appProvider.apps.firstWhereOrNull((a) => a.id == app.id);
-        if (updatedApp != null) {
-          // Compare critical fields to detect if app was actually updated
-          final appHomeUrlChanged = updatedApp.externalIntegration?.appHomeUrl != app.externalIntegration?.appHomeUrl;
-          final nameChanged = updatedApp.name != app.name;
-          final descriptionChanged = updatedApp.description != app.description;
-
-          if (appHomeUrlChanged || nameChanged || descriptionChanged) {
-            // Update local app state when provider's app changes
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) {
-                setState(() {
-                  app = updatedApp;
-                });
-              }
-            });
-          }
+        if (updatedApp != null && hasAppDetailConfigChanged(app, updatedApp)) {
+          // Update local app state when provider's app changes
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              _applyProviderAppUpdate(updatedApp);
+            }
+          });
         }
 
         bool isIntegration = app.worksExternally();

--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -62,6 +62,8 @@ class _AppDetailPageState extends State<AppDetailPage> {
   bool _isCancelingSubscription = false;
   Timer? _paymentCheckTimer;
   Timer? _setupCheckTimer;
+  int _setupCheckGeneration = 0;
+  int _markdownLoadGeneration = 0;
   late App app;
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _reviewsSectionKey = GlobalKey();
@@ -95,16 +97,44 @@ class _AppDetailPageState extends State<AppDetailPage> {
   }
 
   checkSetupCompleted({bool autoInstallIfCompleted = false}) {
-    if (app.externalIntegration == null) return;
+    if (app.externalIntegration == null) {
+      _setupCheckGeneration++;
+      return;
+    }
     // TODO: move check to backend
-    isAppSetupCompleted(app.externalIntegration!.setupCompletedUrl).then((value) {
-      if (mounted) {
-        setState(() => setupCompleted = value);
+    final generation = ++_setupCheckGeneration;
+    final requestedUrl = app.externalIntegration!.setupCompletedUrl;
+    isAppSetupCompleted(requestedUrl).then((value) {
+      if (!mounted) return;
+      if (generation != _setupCheckGeneration) return;
+      if (app.externalIntegration?.setupCompletedUrl != requestedUrl) return;
 
-        if (autoInstallIfCompleted && value && !app.enabled) {
-          _tryAutoInstallAfterSetup();
-        }
+      setState(() => setupCompleted = value);
+
+      if (autoInstallIfCompleted && value && !app.enabled) {
+        _tryAutoInstallAfterSetup();
       }
+    });
+  }
+
+  void _loadSetupInstructionsMarkdown() {
+    final generation = ++_markdownLoadGeneration;
+    final path = app.externalIntegration?.setupInstructionsFilePath;
+    if (path == null || path.isEmpty || !path.contains('raw.githubusercontent.com')) {
+      return;
+    }
+
+    final appId = app.id;
+    getAppMarkdown(path).then((value) {
+      if (!mounted) return;
+      if (generation != _markdownLoadGeneration) return;
+      if (app.externalIntegration?.setupInstructionsFilePath != path) return;
+
+      value = value.replaceAll(
+        '](assets/',
+        '](https://raw.githubusercontent.com/BasedHardware/Omi/main/plugins/instructions/$appId/assets/',
+      );
+      setState(() => instructionsMarkdown = value);
     });
   }
 
@@ -227,17 +257,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
     });
     if (app.worksExternally()) {
       checkSetupCompleted();
-      if (app.externalIntegration!.setupInstructionsFilePath?.isNotEmpty == true) {
-        if (app.externalIntegration!.setupInstructionsFilePath?.contains('raw.githubusercontent.com') == true) {
-          getAppMarkdown(app.externalIntegration!.setupInstructionsFilePath ?? '').then((value) {
-            value = value.replaceAll(
-              '](assets/',
-              '](https://raw.githubusercontent.com/BasedHardware/Omi/main/plugins/instructions/${app.id}/assets/',
-            );
-            if (mounted) setState(() => instructionsMarkdown = value);
-          });
-        }
-      }
+      _loadSetupInstructionsMarkdown();
     }
 
     super.initState();
@@ -265,20 +285,13 @@ class _AppDetailPageState extends State<AppDetailPage> {
   }
 
   void _onExternalIntegrationUpdated() {
-    if (!app.worksExternally()) return;
-    checkSetupCompleted();
-    final path = app.externalIntegration?.setupInstructionsFilePath;
-    if (path?.isNotEmpty == true && path!.contains('raw.githubusercontent.com')) {
-      getAppMarkdown(path).then((value) {
-        value = value.replaceAll(
-          '](assets/',
-          '](https://raw.githubusercontent.com/BasedHardware/Omi/main/plugins/instructions/${app.id}/assets/',
-        );
-        if (mounted) {
-          setState(() => instructionsMarkdown = value);
-        }
-      });
+    if (!app.worksExternally()) {
+      _setupCheckGeneration++;
+      _markdownLoadGeneration++;
+      return;
     }
+    checkSetupCompleted();
+    _loadSetupInstructionsMarkdown();
   }
 
   void _applyProviderAppUpdate(App updatedApp) {

--- a/app/lib/pages/apps/app_detail/app_detail_config.dart
+++ b/app/lib/pages/apps/app_detail/app_detail_config.dart
@@ -1,0 +1,15 @@
+import 'package:collection/collection.dart';
+import 'package:omi/backend/schema/app.dart';
+
+/// Returns true when [updated] differs from [current] in fields shown on the app detail page.
+bool hasAppDetailConfigChanged(App current, App updated) {
+  if (current.name != updated.name) return true;
+  if (current.description != updated.description) return true;
+  return hasExternalIntegrationChanged(current.externalIntegration, updated.externalIntegration);
+}
+
+/// Returns true when external integration configuration differs between [current] and [updated].
+bool hasExternalIntegrationChanged(ExternalIntegration? current, ExternalIntegration? updated) {
+  const equality = DeepCollectionEquality();
+  return !equality.equals(current?.toJson(), updated?.toJson());
+}

--- a/app/lib/pages/apps/app_detail/app_detail_config.dart
+++ b/app/lib/pages/apps/app_detail/app_detail_config.dart
@@ -1,6 +1,7 @@
 import 'package:omi/backend/schema/app.dart';
 
-/// Returns true when [updated] differs from [current] in fields shown on the app detail page.
+/// Returns true when [updated] differs from [current] in name, description, or
+/// user-visible/editable external integration URL fields shown on the app detail page.
 bool hasAppDetailConfigChanged(App current, App updated) {
   if (current.name != updated.name) return true;
   if (current.description != updated.description) return true;

--- a/app/lib/pages/apps/app_detail/app_detail_config.dart
+++ b/app/lib/pages/apps/app_detail/app_detail_config.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:omi/backend/schema/app.dart';
 
 /// Returns true when [updated] differs from [current] in fields shown on the app detail page.
@@ -8,8 +7,27 @@ bool hasAppDetailConfigChanged(App current, App updated) {
   return hasExternalIntegrationChanged(current.externalIntegration, updated.externalIntegration);
 }
 
-/// Returns true when external integration configuration differs between [current] and [updated].
+/// Returns true when user-visible/editable external integration URL fields differ.
+///
+/// Compares only fields relevant to app-detail refresh for integration URL updates
+/// (#3309): appHomeUrl, setupCompletedUrl, webhookUrl, setupInstructionsFilePath,
+/// and auth step names/urls. Hidden fields (triggersOn, actions, chatToolsManifestUrl,
+/// mcpServerUrl, isInstructionsUrl) are intentionally ignored.
 bool hasExternalIntegrationChanged(ExternalIntegration? current, ExternalIntegration? updated) {
-  const equality = DeepCollectionEquality();
-  return !equality.equals(current?.toJson(), updated?.toJson());
+  if (identical(current, updated)) return false;
+  if (current == null || updated == null) return current != updated;
+
+  if (current.appHomeUrl != updated.appHomeUrl) return true;
+  if (current.setupCompletedUrl != updated.setupCompletedUrl) return true;
+  if (current.webhookUrl != updated.webhookUrl) return true;
+  if (current.setupInstructionsFilePath != updated.setupInstructionsFilePath) {
+    return true;
+  }
+
+  if (current.authSteps.length != updated.authSteps.length) return true;
+  for (var i = 0; i < current.authSteps.length; i++) {
+    if (current.authSteps[i].name != updated.authSteps[i].name) return true;
+    if (current.authSteps[i].url != updated.authSteps[i].url) return true;
+  }
+  return false;
 }

--- a/app/test/unit/app_detail_config_changed_test.dart
+++ b/app/test/unit/app_detail_config_changed_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/pages/apps/app_detail/app_detail_config.dart';
+
+Map<String, dynamic> _appJson(Map<String, dynamic> externalIntegration, {String name = 'Test App'}) {
+  return {
+    'id': 'app-1',
+    'uid': 'user-1',
+    'name': name,
+    'author': 'Author',
+    'description': 'Desc',
+    'image': 'https://example.com/icon.png',
+    'capabilities': ['external_integration'],
+    'status': 'approved',
+    'approved': true,
+    'rating_count': 0,
+    'enabled': true,
+    'deleted': false,
+    'is_paid': false,
+    'category': 'productivity-and-organization',
+    'external_integration': externalIntegration,
+  };
+}
+
+Map<String, dynamic> _integrationJson({
+  String appHomeUrl = 'https://example.com/home',
+  String setupCompletedUrl = 'https://example.com/setup-done',
+  String webhookUrl = 'https://example.com/webhook',
+  List<Map<String, String>> authSteps = const [],
+}) {
+  return {
+    'triggers_on': 'memory_creation',
+    'webhook_url': webhookUrl,
+    'setup_completed_url': setupCompletedUrl,
+    'app_home_url': appHomeUrl,
+    'auth_steps': authSteps,
+  };
+}
+
+void main() {
+  group('hasExternalIntegrationChanged', () {
+    test('returns false for identical integration configs', () {
+      final integration = _integrationJson(
+        authSteps: [
+          {'name': 'Setup', 'url': 'https://example.com/auth'},
+        ],
+      );
+      final current = ExternalIntegration.fromJson(integration);
+      final updated = ExternalIntegration.fromJson(integration);
+      expect(hasExternalIntegrationChanged(current, updated), isFalse);
+    });
+
+    test('returns true when auth step URL changes', () {
+      final current = ExternalIntegration.fromJson(
+        _integrationJson(authSteps: [
+          {'name': 'Setup', 'url': 'https://example.com/old-auth'},
+        ]),
+      );
+      final updated = ExternalIntegration.fromJson(
+        _integrationJson(authSteps: [
+          {'name': 'Setup', 'url': 'https://example.com/new-auth'},
+        ]),
+      );
+      expect(hasExternalIntegrationChanged(current, updated), isTrue);
+    });
+
+    test('returns true when setup completed URL changes', () {
+      final current = ExternalIntegration.fromJson(_integrationJson(setupCompletedUrl: 'https://example.com/old-setup'));
+      final updated = ExternalIntegration.fromJson(_integrationJson(setupCompletedUrl: 'https://example.com/new-setup'));
+      expect(hasExternalIntegrationChanged(current, updated), isTrue);
+    });
+
+    test('returns true when webhook URL changes', () {
+      final current = ExternalIntegration.fromJson(_integrationJson(webhookUrl: 'https://example.com/old-webhook'));
+      final updated = ExternalIntegration.fromJson(_integrationJson(webhookUrl: 'https://example.com/new-webhook'));
+      expect(hasExternalIntegrationChanged(current, updated), isTrue);
+    });
+
+    test('returns true when one side has no integration', () {
+      expect(hasExternalIntegrationChanged(null, ExternalIntegration.fromJson(_integrationJson())), isTrue);
+      expect(hasExternalIntegrationChanged(ExternalIntegration.fromJson(_integrationJson()), null), isTrue);
+    });
+  });
+
+  group('hasAppDetailConfigChanged', () {
+    test('returns false when only unrelated app fields change', () {
+      final integration = _integrationJson();
+      final current = App.fromJson(_appJson(integration));
+      final updatedJson = _appJson(integration);
+      updatedJson['rating_avg'] = 4.5;
+      final updated = App.fromJson(updatedJson);
+      expect(hasAppDetailConfigChanged(current, updated), isFalse);
+    });
+
+    test('returns true when name changes', () {
+      final integration = _integrationJson();
+      final current = App.fromJson(_appJson(integration));
+      final updated = App.fromJson(_appJson(integration, name: 'Renamed App'));
+      expect(hasAppDetailConfigChanged(current, updated), isTrue);
+    });
+
+    test('returns true when auth step URL changes without name or home URL changes', () {
+      final current = App.fromJson(_appJson(_integrationJson(authSteps: [
+        {'name': 'Setup', 'url': 'https://example.com/old-auth'},
+      ])));
+      final updated = App.fromJson(_appJson(_integrationJson(authSteps: [
+        {'name': 'Setup', 'url': 'https://example.com/new-auth'},
+      ])));
+      expect(hasAppDetailConfigChanged(current, updated), isTrue);
+    });
+
+    test('returns true when setup completed URL changes without name or home URL changes', () {
+      final current = App.fromJson(_appJson(_integrationJson(setupCompletedUrl: 'https://example.com/old-setup')));
+      final updated = App.fromJson(_appJson(_integrationJson(setupCompletedUrl: 'https://example.com/new-setup')));
+      expect(hasAppDetailConfigChanged(current, updated), isTrue);
+    });
+  });
+}

--- a/app/test/unit/app_detail_config_changed_test.dart
+++ b/app/test/unit/app_detail_config_changed_test.dart
@@ -27,14 +27,17 @@ Map<String, dynamic> _integrationJson({
   String appHomeUrl = 'https://example.com/home',
   String setupCompletedUrl = 'https://example.com/setup-done',
   String webhookUrl = 'https://example.com/webhook',
+  String? setupInstructionsFilePath,
+  String triggersOn = 'memory_creation',
   List<Map<String, String>> authSteps = const [],
 }) {
   return {
-    'triggers_on': 'memory_creation',
+    'triggers_on': triggersOn,
     'webhook_url': webhookUrl,
     'setup_completed_url': setupCompletedUrl,
     'app_home_url': appHomeUrl,
     'auth_steps': authSteps,
+    if (setupInstructionsFilePath != null) 'setup_instructions_file_path': setupInstructionsFilePath,
   };
 }
 
@@ -53,21 +56,29 @@ void main() {
 
     test('returns true when auth step URL changes', () {
       final current = ExternalIntegration.fromJson(
-        _integrationJson(authSteps: [
-          {'name': 'Setup', 'url': 'https://example.com/old-auth'},
-        ]),
+        _integrationJson(
+          authSteps: [
+            {'name': 'Setup', 'url': 'https://example.com/old-auth'},
+          ],
+        ),
       );
       final updated = ExternalIntegration.fromJson(
-        _integrationJson(authSteps: [
-          {'name': 'Setup', 'url': 'https://example.com/new-auth'},
-        ]),
+        _integrationJson(
+          authSteps: [
+            {'name': 'Setup', 'url': 'https://example.com/new-auth'},
+          ],
+        ),
       );
       expect(hasExternalIntegrationChanged(current, updated), isTrue);
     });
 
     test('returns true when setup completed URL changes', () {
-      final current = ExternalIntegration.fromJson(_integrationJson(setupCompletedUrl: 'https://example.com/old-setup'));
-      final updated = ExternalIntegration.fromJson(_integrationJson(setupCompletedUrl: 'https://example.com/new-setup'));
+      final current = ExternalIntegration.fromJson(
+        _integrationJson(setupCompletedUrl: 'https://example.com/old-setup'),
+      );
+      final updated = ExternalIntegration.fromJson(
+        _integrationJson(setupCompletedUrl: 'https://example.com/new-setup'),
+      );
       expect(hasExternalIntegrationChanged(current, updated), isTrue);
     });
 
@@ -75,6 +86,22 @@ void main() {
       final current = ExternalIntegration.fromJson(_integrationJson(webhookUrl: 'https://example.com/old-webhook'));
       final updated = ExternalIntegration.fromJson(_integrationJson(webhookUrl: 'https://example.com/new-webhook'));
       expect(hasExternalIntegrationChanged(current, updated), isTrue);
+    });
+
+    test('returns true when setup instructions path changes', () {
+      final current = ExternalIntegration.fromJson(
+        _integrationJson(setupInstructionsFilePath: 'https://raw.githubusercontent.com/old.md'),
+      );
+      final updated = ExternalIntegration.fromJson(
+        _integrationJson(setupInstructionsFilePath: 'https://raw.githubusercontent.com/new.md'),
+      );
+      expect(hasExternalIntegrationChanged(current, updated), isTrue);
+    });
+
+    test('returns false when only hidden integration fields change', () {
+      final current = ExternalIntegration.fromJson(_integrationJson(triggersOn: 'memory_creation'));
+      final updated = ExternalIntegration.fromJson(_integrationJson(triggersOn: 'transcript_processed'));
+      expect(hasExternalIntegrationChanged(current, updated), isFalse);
     });
 
     test('returns true when one side has no integration', () {
@@ -101,12 +128,24 @@ void main() {
     });
 
     test('returns true when auth step URL changes without name or home URL changes', () {
-      final current = App.fromJson(_appJson(_integrationJson(authSteps: [
-        {'name': 'Setup', 'url': 'https://example.com/old-auth'},
-      ])));
-      final updated = App.fromJson(_appJson(_integrationJson(authSteps: [
-        {'name': 'Setup', 'url': 'https://example.com/new-auth'},
-      ])));
+      final current = App.fromJson(
+        _appJson(
+          _integrationJson(
+            authSteps: [
+              {'name': 'Setup', 'url': 'https://example.com/old-auth'},
+            ],
+          ),
+        ),
+      );
+      final updated = App.fromJson(
+        _appJson(
+          _integrationJson(
+            authSteps: [
+              {'name': 'Setup', 'url': 'https://example.com/new-auth'},
+            ],
+          ),
+        ),
+      );
       expect(hasAppDetailConfigChanged(current, updated), isTrue);
     });
 


### PR DESCRIPTION
## What changed and why

Fixes #3309. After saving integration URL changes on the update-app screen, the app detail page kept using a stale local `App` object because both refresh paths only compared `appHomeUrl`, `name`, and `description`. Edits limited to auth-step URLs, setup-completed URLs, webhook URLs, or setup-instructions paths therefore did not trigger a refresh until a full app restart.

This PR:
- Detects user-visible/editable external-integration URL field changes and refreshes the detail page.
- Re-runs setup-completion and instructions loading after those changes.
- Extracts a shared `_loadSetupInstructionsMarkdown` helper used by `initState` and `_onExternalIntegrationUpdated`.
- Guards in-flight `checkSetupCompleted` / `getAppMarkdown` callbacks with generation counters plus requested URL/path checks so a stale response cannot overwrite newer config.

An accidental later push had truncated `app_detail.dart`; that file is restored. Diff is the intended 3-file set only.

## Product invariants affected

none

## How it was verified

- Local line-length check: `app/test/unit/app_detail_config_changed_test.dart` lines 69–70 are now well under 120 columns (the Formatting failure).
- `git diff --stat` vs BasedHardware/omi `main` is 3 files, +259 / −44 (`app_detail.dart`, `app_detail_config.dart`, the unit test).
- Bounded pre-push against upstream `main` passed. Flutter SDK is not in this VM, so Dart Analyze and `dart format` were not executed here; CI is the authority.
- `local_segment_store_test.dart` is out of scope; if Dart Analyze & Tests still fails on that capture/WAL flake, it is unrelated.

**Manual verify path:**
1. Open an external integration app you own.
2. Edit the app and change only the auth-step URL or setup-completed URL (leave name/home URL unchanged).
3. Save and return to the app detail page.
4. Confirm the setup button/link and setup-completed check use the new URLs without force-quitting the app.

## Tests

`app/test/unit/app_detail_config_changed_test.dart` covers auth-step URL-only changes, setup-completed URL-only changes, webhook URL changes, hidden-field no-ops, and name changes.

## Failure class (fixes)

Failure-Class: none
