### PR TITLE
feat: add OSV advisory lookup chat tools

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: omi-osv-app-tests
+    command: ["bash", "plugins/omi-osv-app/test.sh"]
+    triggers: ["plugins/omi-osv-app/**", ".github/workflows/repo-checks.yml", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "Exercise the OSV chat-tool API and advisory semantics without live services"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -15,6 +15,7 @@ import time
 import unittest
 import urllib.error
 from pathlib import Path
+from typing import TextIO
 from unittest.mock import Mock, patch
 
 import preflight_runner
@@ -815,6 +816,7 @@ class SingleFlightTests(unittest.TestCase):
         command: list[str],
         *,
         extra_env: dict[str, str] | None = None,
+        stdout: int | TextIO = subprocess.PIPE,
     ) -> subprocess.Popen[str]:
         env = {**os.environ, "OMI_PREFLIGHT_STATE_DIR": str(state_root)}
         if extra_env:
@@ -824,7 +826,7 @@ class SingleFlightTests(unittest.TestCase):
             cwd=REPO_ROOT,
             env=env,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            stdout=stdout,
             stderr=subprocess.STDOUT,
             text=True,
             encoding="utf-8",
@@ -871,25 +873,44 @@ class SingleFlightTests(unittest.TestCase):
                 "    time.sleep(0.02)\n"
             )
             command = [sys.executable, "-c", script]
-            first = self.run_runner(temp, command)
-            assert first.stdin is not None
-            first.stdin.write("same\n")
-            first.stdin.close()
-            self.wait_for_lock(temp)
-            second = self.run_runner(temp, command)
-            assert second.stdin is not None
-            second.stdin.write("same\n")
-            second.stdin.close()
-            time.sleep(0.3)
-            hold.unlink(missing_ok=True)
-            first_output = first.stdout.read() if first.stdout else ""
-            second_output = second.stdout.read() if second.stdout else ""
-            self.assertEqual(first.wait(), 0, first_output)
-            self.assertEqual(second.wait(), 0, second_output)
-            if first.stdout:
-                first.stdout.close()
-            if second.stdout:
-                second.stdout.close()
+            joined_log = temp / "joined.log"
+            processes: list[subprocess.Popen[str]] = []
+            outputs: list[str] = []
+            with joined_log.open("w", encoding="utf-8") as log:
+                try:
+                    first = self.run_runner(temp, command)
+                    processes.append(first)
+                    assert first.stdin is not None
+                    first.stdin.write("same\n")
+                    first.stdin.close()
+                    self.wait_for_lock(temp)
+                    second = self.run_runner(temp, command, stdout=log)
+                    processes.append(second)
+                    assert second.stdin is not None
+                    second.stdin.write("same\n")
+                    second.stdin.close()
+                    # Observe the flushed join message before releasing the owner.
+                    deadline = time.monotonic() + 5
+                    while "Joining identical preflight" not in joined_log.read_text(encoding="utf-8"):
+                        if second.poll() is not None or time.monotonic() >= deadline:
+                            self.fail("second runner did not join: " + joined_log.read_text(encoding="utf-8"))
+                        time.sleep(0.02)
+                finally:
+                    hold.unlink(missing_ok=True)
+                    for process in processes:
+                        try:
+                            process.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                            process.wait(timeout=5)
+                        if process.stdin and not process.stdin.closed:
+                            process.stdin.close()
+                        outputs.append(process.stdout.read() if process.stdout else "")
+                        if process.stdout:
+                            process.stdout.close()
+            second_output = joined_log.read_text(encoding="utf-8")
+            self.assertEqual(first.returncode, 0, outputs[0])
+            self.assertEqual(second.returncode, 0, second_output)
             self.assertEqual(counter.read_text(), "x")
             self.assertIn("Joining identical preflight", second_output)
             status = json.loads((temp / "test" / "status.json").read_text())

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -119,6 +119,27 @@ jobs:
           scripts/changed-files "${{ needs.changes.outputs.diff_base }}"...HEAD > /tmp/changed-files.txt
           cat /tmp/changed-files.txt
 
+      - name: Install manifest-selected OSV app test dependencies
+        run: |
+          python3 .github/scripts/run_checks.py \
+            --lane ci \
+            --base "${{ needs.changes.outputs.diff_base }}" \
+            --output json > "$RUNNER_TEMP/omi-osv-check-selection.json"
+          python3 - "$RUNNER_TEMP/omi-osv-check-selection.json" <<'PYTHON'
+          import json
+          import subprocess
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as source:
+              selected = json.load(source)["checks"]
+          if any(check["id"] == "omi-osv-app-tests" for check in selected):
+              subprocess.run(
+                  ["uv", "pip", "install", "--system", "-r",
+                   "plugins/omi-osv-app/requirements-test.txt"],
+                  check=True,
+              )
+          PYTHON
+
       - name: Run shared PR contract preflight
         if: github.event_name == 'pull_request'
         env:

--- a/plugins/omi-osv-app/.gitignore
+++ b/plugins/omi-osv-app/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+.cache/
+.tmp/
+__pycache__/
+*.pyc

--- a/plugins/omi-osv-app/Procfile
+++ b/plugins/omi-osv-app/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8080} --no-access-log

--- a/plugins/omi-osv-app/README.md
+++ b/plugins/omi-osv-app/README.md
@@ -71,6 +71,20 @@ PATH="$PWD/.venv/bin:$PATH" bash test.sh
 
 `test.sh` runs Python `unittest` using already-installed dependencies. It never installs packages, skips the suite or contacts the network. Tests use FastAPI's real `TestClient`, Pydantic validation and `httpx.MockTransport` to exercise manifest-based invocation, package-scoped fix output, empty/unknown semantics, pagination, withdrawal, input validation, provider failures and response bounds. Omi metadata and exception-body canaries must not leak upstream or into tool responses.
 
+### Repository preflight prerequisites
+
+The repository manifest runs this suite in both local and CI lanes. CI installs the app dependencies when the check is selected. For local `make preflight` or pre-push checks, first complete the repository's normal setup and prepare this app's environment. From the repository root:
+
+```bash
+python3 -m venv plugins/omi-osv-app/.venv
+plugins/omi-osv-app/.venv/bin/python -m pip install -r plugins/omi-osv-app/requirements-test.txt
+export PATH="$PWD/plugins/omi-osv-app/.venv/bin:$PATH"
+export PYTHON="$PWD/plugins/omi-osv-app/.venv/bin/python"
+make preflight
+```
+
+The `uv` setup alternative above also applies, using the repository-relative paths. Supply your PR body as described in the repository contribution guide. Keep this environment selected when pushing so `test.sh` finds FastAPI, HTTPX and Pydantic; the check intentionally does not download dependencies during test execution.
+
 Local HTTP/API validation does not establish that this app is deployed, registered, approved or funded by Omi. Those steps remain separate from this service.
 
 API references: [POST /v1/query](https://google.github.io/osv.dev/post-v1-query/), [GET /v1/vulns](https://google.github.io/osv.dev/get-v1-vulns/).

--- a/plugins/omi-osv-app/README.md
+++ b/plugins/omi-osv-app/README.md
@@ -1,0 +1,76 @@
+# Omi OSV Advisory Lookup
+
+Two read-only Omi chat tools query the [OSV API](https://google.github.io/osv.dev/) for public package advisories. An exact package/version lookup returns affected ranges, reported fixes and source links across **PyPI, npm, Go, Maven, RubyGems, crates.io, NuGet, Packagist and Pub**. It does not install packages, scan a machine or require an API key.
+
+| Tool | Input | Result |
+|---|---|---|
+| `query_package_vulnerabilities` | `ecosystem`, `package_name`, exact `version`, optional `limit` (1–10, default 5) | Matching OSV advisory records for that package version |
+| `get_vulnerability` | `vulnerability_id` | An OSV record, including affected packages, ranges, reported fixes, withdrawal status and references |
+
+Use the ecosystem's package name, such as `@scope/package` for npm or `group:artifact` for Maven. Supply an exact version, not a range like `>=1` or `^2.0`. Use an ID returned by the first tool for details: a CVE alias is not necessarily a separately retrievable OSV record.
+
+## Run locally
+
+Requires Python 3.11 or newer. From this directory:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements-test.txt
+.venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port 8080 --no-access-log
+```
+
+If your Python installation lacks `venv` support, `uv venv .venv` and `uv pip install --python .venv/bin/python -r requirements-test.txt` are equivalent setup commands.
+
+In a second terminal:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/.well-known/omi-tools.json
+
+curl http://127.0.0.1:8080/tools/query_package_vulnerabilities \
+  -H 'Content-Type: application/json' \
+  -d '{"ecosystem":"PyPI","package_name":"requests","version":"2.31.0","limit":2}'
+
+curl http://127.0.0.1:8080/tools/get_vulnerability \
+  -H 'Content-Type: application/json' \
+  -d '{"vulnerability_id":"PYSEC-2023-74"}'
+```
+
+The two tool calls use the live OSV API. Results change as its advisory database changes.
+
+## Connect to Omi
+
+This is an independently deployed service, following the [Omi Chat Tools protocol](https://docs.omi.me/doc/developer/apps/ChatTools); it does not modify the legacy plugin monolith.
+
+1. Deploy the service on an HTTPS host you operate. The included `Procfile` runs Uvicorn on `PORT`, defaulting to 8080.
+2. In Omi **Apps → Create App**, choose **External Integration**. Set **App Home URL** to the service's HTTPS origin.
+3. Set **Chat Tools Manifest URL** to `https://YOUR-HOST/.well-known/omi-tools.json`, then save the app. Omi resolves the relative tool endpoints against App Home URL and fetches the manifest when the app is saved.
+
+Both manifest entries explicitly set `auth_required: false`. The endpoints accept Omi's additional `uid`, `app_id`, `tool_name` and optional `geolocation` fields, but ignore them. Only the explicit public package coordinates or advisory ID are sent to OSV. No Omi identity, location, authorization header or unrelated input is forwarded.
+
+The service follows Omi's [error-handling contract](https://docs.omi.me/doc/developer/apps/ChatTools#error-handling-best-practices): a successful tool response is HTTP 200 with `result`; a failure has `error` and a non-2xx status. Invalid input or an OSV-rejected query returns 400, a missing advisory returns 404, rate limiting returns 429, upstream failure/malformed data returns 502, and timeout returns 504. Omi's caller uses these error statuses to distinguish failed invocations from successful results. Invalid inputs are rejected before making an OSV request. Provider error bodies and transport exception details are not returned to callers.
+
+## Interpret results
+
+- **No matches is not a safety verdict.** OSV cannot distinguish an unknown package/version from one with no indexed advisories. The response says this explicitly.
+- Counts refer to **advisory records**, not unique vulnerabilities. Different records can share CVE/GHSA aliases; aliases are included for comparison.
+- Package queries display fixes only from matching `affected.package` entries. Detail lookups group ranges by package. A `fixed` marker is a version in an `ECOSYSTEM`/`SEMVER` range or a commit in a `GIT` range. Multiple markers can represent different branches; they are not a universal upgrade recommendation. `last_affected` and `limit` are not labeled as fixes. See the [OSV schema](https://ossf.github.io/osv-schema/) for range semantics.
+- Withdrawn records are labeled. Missing fix data means OSV supplied no fix marker, not that no fix exists.
+- Each invocation makes **one OSV request**, with a 15-second overall deadline, a 2 MB decoded-response limit and a 20,000-character output limit. Package results show at most 10 records. Pagination, omitted records/packages/ranges and output truncation are disclosed. This is a chat summary, not a complete dependency audit.
+- OSV errors, timeouts, malformed responses and missing advisory IDs produce `error`, never a successful empty-match response. HTTPS redirects are not followed.
+
+The application has no database or cache and does not log request bodies or OSV responses. The supplied launch command disables access logs. Only use public package coordinates; hosting providers may have their own request logging policies.
+
+## Tests
+
+After installing `requirements-test.txt`, run:
+
+```bash
+PATH="$PWD/.venv/bin:$PATH" bash test.sh
+```
+
+`test.sh` runs Python `unittest` using already-installed dependencies. It never installs packages, skips the suite or contacts the network. Tests use FastAPI's real `TestClient`, Pydantic validation and `httpx.MockTransport` to exercise manifest-based invocation, package-scoped fix output, empty/unknown semantics, pagination, withdrawal, input validation, provider failures and response bounds. Omi metadata and exception-body canaries must not leak upstream or into tool responses.
+
+Local HTTP/API validation does not establish that this app is deployed, registered, approved or funded by Omi. Those steps remain separate from this service.
+
+API references: [POST /v1/query](https://google.github.io/osv.dev/post-v1-query/), [GET /v1/vulns](https://google.github.io/osv.dev/get-v1-vulns/).

--- a/plugins/omi-osv-app/main.py
+++ b/plugins/omi-osv-app/main.py
@@ -1,0 +1,118 @@
+"""Standalone, unauthenticated Omi chat tools for public OSV advisories."""
+
+from contextlib import asynccontextmanager
+from urllib.parse import quote
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException
+
+from models import QueryPackageRequest, VulnerabilityRequest
+from osv_service import OSVError, bounded_result, fetch_osv, format_advisory, format_query
+
+
+def create_app(transport: httpx.AsyncBaseTransport | None = None) -> FastAPI:
+    """The optional HTTP transport lets tests exercise real handlers offline."""
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        async with httpx.AsyncClient(
+            base_url="https://api.osv.dev",
+            timeout=10.0,
+            follow_redirects=False,
+            headers={"User-Agent": "omi-osv-app/1.0", "Accept": "application/json"},
+            transport=transport,
+        ) as client:
+            application.state.osv_client = client
+            yield
+
+    application = FastAPI(title="Omi OSV Advisory Lookup", version="1.0.0", lifespan=lifespan)
+
+    @application.exception_handler(HTTPException)
+    async def invalid_body(request: Request, exc: HTTPException):
+        if exc.status_code == 400:
+            # Body decoding can fail before Pydantic (for example invalid UTF-8).
+            return JSONResponse(
+                {"error": "Invalid JSON tool request. Send a UTF-8 encoded JSON object."}, status_code=400
+            )
+        return await http_exception_handler(request, exc)
+
+    @application.exception_handler(RequestValidationError)
+    async def invalid_request(_: Request, exc: RequestValidationError) -> JSONResponse:
+        # Pydantic errors can contain raw input, including Omi identity fields.
+        # Return only a known parameter name, never the input or exception text.
+        fields = {"ecosystem", "package_name", "version", "limit", "vulnerability_id"}
+        location = next((part for error in exc.errors() for part in error.get("loc", ()) if part in fields), None)
+        detail = f"Invalid {location}." if location else "Invalid JSON tool request."
+        return JSONResponse(
+            {"error": f"{detail} Use the parameter types and limits in the tool manifest."}, status_code=400
+        )
+
+    @application.get("/")
+    async def home() -> dict[str, str]:
+        return {
+            "service": "Omi OSV Advisory Lookup",
+            "manifest": "/.well-known/omi-tools.json",
+            "privacy": "Only public package coordinates or advisory IDs are sent to OSV. Omi identity and location fields are ignored.",
+        }
+
+    @application.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @application.get("/.well-known/omi-tools.json")
+    async def manifest() -> dict:
+        return {
+            "tools": [
+                {
+                    "name": "query_package_vulnerabilities",
+                    "description": "Look up OSV advisories for an exact public package version across PyPI, npm, Go, Maven and other supported ecosystems. Returns affected ranges, reported fixed markers and source links. No matches does not prove safety or package existence. Use public package coordinates only.",
+                    "endpoint": "/tools/query_package_vulnerabilities",
+                    "method": "POST",
+                    "parameters": QueryPackageRequest.model_json_schema(),
+                    "auth_required": False,
+                    "status_message": "Looking up public package advisories...",
+                },
+                {
+                    "name": "get_vulnerability",
+                    "description": "Read an OSV advisory by its exact ID (for example GHSA-9hjg-9r4m-mvj7 or PYSEC-2023-74). Returns affected packages, reported fixed markers, withdrawn status and source links. A CVE alias may not be an OSV record ID; use IDs returned by the package lookup.",
+                    "endpoint": "/tools/get_vulnerability",
+                    "method": "POST",
+                    "parameters": VulnerabilityRequest.model_json_schema(),
+                    "auth_required": False,
+                    "status_message": "Reading the OSV advisory...",
+                },
+            ]
+        }
+
+    @application.post("/tools/query_package_vulnerabilities")
+    async def query_package_vulnerabilities(payload: QueryPackageRequest) -> JSONResponse:
+        body = {
+            "package": {"ecosystem": payload.ecosystem, "name": payload.package_name},
+            "version": payload.version,
+        }
+        try:
+            data = await fetch_osv(application.state.osv_client, "/v1/query", body)
+            return JSONResponse({"result": format_query(data, payload)})
+        except OSVError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=exc.status_code)
+
+    @application.post("/tools/get_vulnerability")
+    async def get_vulnerability(payload: VulnerabilityRequest) -> JSONResponse:
+        try:
+            data = await fetch_osv(
+                application.state.osv_client, f"/v1/vulns/{quote(payload.vulnerability_id, safe='')}"
+            )
+            result = format_advisory(data)
+            result += "\nFixed markers are source data, not a recommendation across release branches. See the complete advisory before upgrading."
+            return JSONResponse({"result": bounded_result(result)})
+        except OSVError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=exc.status_code)
+
+    return application
+
+
+app = create_app()

--- a/plugins/omi-osv-app/models.py
+++ b/plugins/omi-osv-app/models.py
@@ -1,0 +1,44 @@
+"""Public package lookup inputs; Omi identity/location metadata is ignored."""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+
+Ecosystem = Literal["PyPI", "npm", "Go", "Maven", "RubyGems", "crates.io", "NuGet", "Packagist", "Pub"]
+PackageName = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True, min_length=1, max_length=200, pattern=r"^[A-Za-z0-9@][A-Za-z0-9._:/@+-]*$"
+    ),
+]
+Version = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=100, pattern=r"^[A-Za-z0-9][A-Za-z0-9._+!~:-]*$"),
+]
+VulnerabilityID = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$"),
+]
+
+
+class QueryPackageRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    ecosystem: Ecosystem
+    package_name: PackageName
+    version: Version
+    limit: int = Field(default=5, ge=1, le=10, strict=True)
+
+    @field_validator("ecosystem", mode="before")
+    @classmethod
+    def normalize_ecosystem(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        names = ("PyPI", "npm", "Go", "Maven", "RubyGems", "crates.io", "NuGet", "Packagist", "Pub")
+        return next((name for name in names if name.casefold() == value.strip().casefold()), value)
+
+
+class VulnerabilityRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    vulnerability_id: VulnerabilityID

--- a/plugins/omi-osv-app/models.py
+++ b/plugins/omi-osv-app/models.py
@@ -1,6 +1,6 @@
 """Public package lookup inputs; Omi identity/location metadata is ignored."""
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
@@ -34,7 +34,7 @@ class QueryPackageRequest(BaseModel):
     def normalize_ecosystem(cls, value: object) -> object:
         if not isinstance(value, str):
             return value
-        names = ("PyPI", "npm", "Go", "Maven", "RubyGems", "crates.io", "NuGet", "Packagist", "Pub")
+        names = get_args(Ecosystem)
         return next((name for name in names if name.casefold() == value.strip().casefold()), value)
 
 

--- a/plugins/omi-osv-app/osv_service.py
+++ b/plugins/omi-osv-app/osv_service.py
@@ -1,0 +1,217 @@
+"""Bounded OSV API reads and summaries; no package execution or scanning."""
+
+import asyncio
+import json
+import re
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+import httpx
+
+from models import QueryPackageRequest
+
+MAX_RESPONSE_BYTES = 2_000_000
+MAX_RESULT_CHARS = 20_000
+ADVISORY_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class OSVError(Exception):
+    """A public, non-sensitive error suitable for a chat tool response."""
+
+    def __init__(self, message: str, status_code: int = 502):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+async def fetch_osv(client: httpx.AsyncClient, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Read one OSV page with a deadline and byte limit; never follow redirects."""
+    try:
+        async with asyncio.timeout(15):
+            async with client.stream("POST" if body is not None else "GET", path, json=body) as response:
+                if response.status_code == 404:
+                    raise OSVError(
+                        "OSV did not find this advisory or endpoint. Check the identifier; no safety conclusion can be drawn.",
+                        404,
+                    )
+                if response.status_code == 400:
+                    raise OSVError(
+                        "OSV rejected the lookup. Check the ecosystem, exact package name/version, or advisory ID.",
+                        400,
+                    )
+                if response.status_code == 429:
+                    raise OSVError("OSV is rate limiting requests. Try again later; the lookup was not completed.", 429)
+                if response.status_code != 200:
+                    raise OSVError("OSV is unavailable or returned an unexpected status. The lookup was not completed.")
+                chunks = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(chunks) + len(chunk) > MAX_RESPONSE_BYTES:
+                        raise OSVError(
+                            "OSV's response exceeded the lookup size limit. No complete result is available."
+                        )
+                    chunks.extend(chunk)
+        data = json.loads(chunks)
+    except (TimeoutError, httpx.TimeoutException) as exc:
+        raise OSVError("OSV timed out. Try again later; the lookup was not completed.", 504) from exc
+    except httpx.HTTPError as exc:
+        raise OSVError("Could not reach OSV. Try again later; the lookup was not completed.") from exc
+    except (ValueError, UnicodeError) as exc:
+        raise OSVError("OSV returned an invalid response. The lookup was not completed.") from exc
+    if not isinstance(data, dict) or "error" in data:
+        raise OSVError("OSV returned an invalid response. The lookup was not completed.")
+    return data
+
+
+def text(value: object, length: int = 200) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = " ".join(value.split())
+    return value if len(value) <= length else value[: length - 1] + "…"
+
+
+def bounded_result(value: str) -> str:
+    suffix = "\n[Output truncated. Follow the OSV source links for complete records.]"
+    return value if len(value) <= MAX_RESULT_CHARS else value[: MAX_RESULT_CHARS - len(suffix)] + suffix
+
+
+def advisory_id(record: object) -> str:
+    if not isinstance(record, dict) or not isinstance(record.get("id"), str) or not ADVISORY_ID.fullmatch(record["id"]):
+        raise OSVError("OSV returned an invalid advisory record. No complete result is available.")
+    return record["id"]
+
+
+def same_package(affected: dict[str, Any], query: QueryPackageRequest) -> bool:
+    package = affected.get("package")
+    if not isinstance(package, dict) or package.get("ecosystem") != query.ecosystem:
+        return False
+    name = package.get("name")
+    if not isinstance(name, str):
+        return False
+    if query.ecosystem == "PyPI":
+        return re.sub(r"[-_.]+", "-", name).casefold() == re.sub(r"[-_.]+", "-", query.package_name).casefold()
+    if query.ecosystem == "NuGet":
+        return name.casefold() == query.package_name.casefold()
+    return name == query.package_name
+
+
+def affected_summary(affected: dict[str, Any]) -> list[str]:
+    package = affected.get("package")
+    if not isinstance(package, dict):
+        return []
+    lines = [f"Package: {text(package.get('ecosystem'), 40)} / {text(package.get('name'), 200)}"]
+    ranges = affected.get("ranges", [])
+    if not isinstance(ranges, list):
+        ranges = []
+    fixes: list[str] = []
+    for affected_range in ranges:
+        if not isinstance(affected_range, dict):
+            continue
+        events = affected_range.get("events", [])
+        if not isinstance(events, list):
+            continue
+        for event in events:
+            if isinstance(event, dict) and isinstance(event.get("fixed"), str) and event["fixed"] not in fixes:
+                fixes.append(event["fixed"])
+    if fixes:
+        shown = ", ".join(text(value, 80) for value in fixes[:6])
+        lines.append(f"Reported fixed markers: {shown}" + (" (more in source)" if len(fixes) > 6 else ""))
+    else:
+        lines.append(
+            "No fixed marker reported for this package; consult the advisory. This does not mean no fix exists."
+        )
+    for affected_range in ranges[:2]:
+        if not isinstance(affected_range, dict) or not isinstance(affected_range.get("events"), list):
+            continue
+        event_text = []
+        for event in affected_range["events"][:4]:
+            if not isinstance(event, dict):
+                continue
+            for key in ("introduced", "fixed", "last_affected", "limit"):
+                if isinstance(event.get(key), str):
+                    value = (
+                        "beginning of history" if key == "introduced" and event[key] == "0" else text(event[key], 80)
+                    )
+                    event_text.append(f"{key}: {value}")
+        if event_text:
+            suffix = " (more events in source)" if len(affected_range["events"]) > 4 else ""
+            lines.append(f"Range ({text(affected_range.get('type'), 24)}): " + "; ".join(event_text) + suffix)
+    if len(ranges) > 2:
+        lines.append("More affected ranges are available in the source.")
+    return lines
+
+
+def format_advisory(record: dict[str, Any], query: QueryPackageRequest | None = None) -> str:
+    identifier = advisory_id(record)
+    title = text(record.get("summary")) or text(record.get("details")) or "No summary supplied"
+    lines = [f"{identifier} — {title}"]
+    if record.get("withdrawn"):
+        lines.append(f"WITHDRAWN: {text(record['withdrawn'], 80)}. Do not treat this as an active advisory.")
+    aliases = record.get("aliases", [])
+    if isinstance(aliases, list) and aliases:
+        lines.append(
+            "Aliases: "
+            + ", ".join(text(alias, 100) for alias in aliases[:4])
+            + (" (more in source)" if len(aliases) > 4 else "")
+        )
+    affected = record.get("affected", [])
+    if not isinstance(affected, list):
+        raise OSVError("OSV returned invalid affected-package data. No complete result is available.")
+    selected = [
+        entry for entry in affected if isinstance(entry, dict) and (query is None or same_package(entry, query))
+    ]
+    for entry in selected[:2]:
+        lines.extend(affected_summary(entry))
+    if len(selected) > 2:
+        lines.append("More affected packages are available in the source.")
+    if not selected:
+        lines.append("No affected-package range was supplied for this lookup; consult the source for fix information.")
+    lines.append(f"OSV source: https://osv.dev/vulnerability/{quote(identifier, safe='')}")
+    if query is None:
+        references = record.get("references", [])
+        if isinstance(references, list):
+            count = 0
+            for reference in references:
+                url = reference.get("url") if isinstance(reference, dict) else None
+                if not isinstance(url, str) or len(url) > 300:
+                    continue
+                try:
+                    parsed = urlsplit(url)
+                except ValueError:
+                    continue
+                if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+                    continue
+                lines.append(f"Reference: {url}")
+                count += 1
+                if count == 3:
+                    break
+    return "\n".join(lines)
+
+
+def format_query(data: dict[str, Any], query: QueryPackageRequest) -> str:
+    if "vulns" not in data and any(key != "next_page_token" for key in data):
+        raise OSVError("OSV returned an invalid query response. The lookup was not completed.")
+    records = data.get("vulns", [])
+    if not isinstance(records, list):
+        raise OSVError("OSV returned an invalid advisory list. No complete result is available.")
+    for record in records:
+        advisory_id(record)
+    more_pages = bool(data.get("next_page_token"))
+    if not records:
+        if more_pages:
+            return "OSV returned an empty page but indicates more pages. This lookup is incomplete; no safety conclusion can be drawn."
+        return (
+            f"OSV returned no matching advisory records for {query.ecosystem} / {query.package_name} {query.version}. "
+            "OSV does not distinguish an unknown package/version from one with no indexed advisories. "
+            "This is not a confirmation that the package exists or is vulnerability-free."
+        )
+    lines = [
+        f"OSV lookup: {query.ecosystem} / {query.package_name} {query.version}",
+        f"Received {len(records)} advisory record(s) on this page; showing {min(len(records), query.limit)}. "
+        "Records can share CVE/GHSA aliases; this is not a count of unique vulnerabilities.",
+        "Fixed markers can belong to different release branches (or be commits for GIT ranges); verify the affected ranges before upgrading.",
+    ]
+    if more_pages:
+        lines.append("OSV reports additional pages that were not fetched. This result is incomplete.")
+    lines.extend(format_advisory(record, query) for record in records[: query.limit])
+    if len(records) > query.limit:
+        lines.append("Additional records were omitted by the requested display limit.")
+    return bounded_result("\n\n".join(lines))

--- a/plugins/omi-osv-app/osv_service.py
+++ b/plugins/omi-osv-app/osv_service.py
@@ -54,7 +54,7 @@ async def fetch_osv(client: httpx.AsyncClient, path: str, body: dict[str, Any] |
         raise OSVError("OSV timed out. Try again later; the lookup was not completed.", 504) from exc
     except httpx.HTTPError as exc:
         raise OSVError("Could not reach OSV. Try again later; the lookup was not completed.") from exc
-    except (ValueError, UnicodeError) as exc:
+    except (ValueError, UnicodeError, RecursionError) as exc:
         raise OSVError("OSV returned an invalid response. The lookup was not completed.") from exc
     if not isinstance(data, dict) or "error" in data:
         raise OSVError("OSV returned an invalid response. The lookup was not completed.")

--- a/plugins/omi-osv-app/requirements-test.txt
+++ b/plugins/omi-osv-app/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+# The test runner is Python's standard-library unittest; no extra packages.

--- a/plugins/omi-osv-app/requirements.txt
+++ b/plugins/omi-osv-app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+httpx==0.28.1
+pydantic==2.10.4
+uvicorn==0.34.0

--- a/plugins/omi-osv-app/test.sh
+++ b/plugins/omi-osv-app/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+python3 -m unittest discover -s . -p 'test_*.py' -v

--- a/plugins/omi-osv-app/test_app.py
+++ b/plugins/omi-osv-app/test_app.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import sys
 import unittest
 
 import httpx
@@ -235,6 +236,18 @@ class ToolTests(unittest.TestCase):
                 self.assertEqual(response.status_code, 502)
                 self.assertEqual(set(response.json()), {"error"})
                 self.assertNotIn("no matching", response.text)
+
+    def test_deeply_nested_upstream_json_uses_the_error_contract(self):
+        depth = sys.getrecursionlimit() + 100
+        content = b'{"vulns":' + b"[" * depth + b'"provider-canary"' + b"]" * depth + b"}"
+        self.assertLess(len(content), MAX_RESPONSE_BYTES)
+        for path, payload in ((QUERY_PATH, QUERY), (DETAIL_PATH, {"vulnerability_id": ADVISORY["id"]})):
+            with self.subTest(path=path), self.client(lambda request: httpx.Response(200, content=content)) as client:
+                response = client.post(path, json=payload)
+                self.assertEqual(response.status_code, 502)
+                self.assertEqual(set(response.json()), {"error"})
+                self.assertIn("invalid response", response.json()["error"])
+                self.assertNotIn("provider-canary", response.text)
 
 
 if __name__ == "__main__":

--- a/plugins/omi-osv-app/test_app.py
+++ b/plugins/omi-osv-app/test_app.py
@@ -1,0 +1,241 @@
+"""Exercise Omi JSON endpoints against an in-process, network-free OSV API."""
+
+import copy
+import json
+import unittest
+
+import httpx
+from fastapi.testclient import TestClient
+
+from main import create_app
+from osv_service import MAX_RESPONSE_BYTES, MAX_RESULT_CHARS
+
+# Minimal OSV-schema fixtures, not claims about actual packages or releases.
+ADVISORY = {
+    "id": "GHSA-example-0001",
+    "summary": "Example parsing issue",
+    "aliases": ["CVE-2099-0001"],
+    "affected": [
+        {
+            "package": {"ecosystem": "PyPI", "name": "demo-lib"},
+            "ranges": [
+                {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "2.0"}]},
+                {"type": "ECOSYSTEM", "events": [{"introduced": "3.0"}, {"fixed": "3.1"}]},
+            ],
+        },
+        {
+            "package": {"ecosystem": "npm", "name": "different-package"},
+            "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "99.0"}]}],
+        },
+    ],
+    "references": [{"type": "ADVISORY", "url": "https://example.org/advisory/1"}],
+}
+QUERY = {"ecosystem": "PyPI", "package_name": "demo-lib", "version": "1.0"}
+QUERY_PATH = "/tools/query_package_vulnerabilities"
+DETAIL_PATH = "/tools/get_vulnerability"
+
+
+class ToolTests(unittest.TestCase):
+    def client(self, handler):
+        # Every test installs MockTransport. An accidental HTTP request outside
+        # this client cannot be hidden by a fixture returning preformatted text.
+        return TestClient(create_app(transport=httpx.MockTransport(handler)))
+
+    def test_manifest_is_discoverable_and_invocations_drop_omi_metadata(self):
+        upstream = []
+
+        def handler(request):
+            upstream.append(request)
+            self.assertEqual(request.url.scheme, "https")
+            self.assertEqual(request.url.host, "api.osv.dev")
+            self.assertEqual(request.url.path, "/v1/query")
+            self.assertEqual(request.method, "POST")
+            self.assertEqual(
+                json.loads(request.content),
+                {"package": {"ecosystem": "PyPI", "name": "demo-lib"}, "version": "1.0"},
+            )
+            return httpx.Response(200, json={"vulns": [ADVISORY]})
+
+        with self.client(handler) as client:
+            self.assertEqual(client.get("/health").json(), {"status": "ok"})
+            tools = client.get("/.well-known/omi-tools.json").json()["tools"]
+            self.assertEqual({tool["name"] for tool in tools}, {"query_package_vulnerabilities", "get_vulnerability"})
+            for tool in tools:
+                self.assertIs(tool["auth_required"], False)
+                self.assertEqual(tool["method"], "POST")
+                self.assertEqual(tool["parameters"]["type"], "object")
+                self.assertNotIn("uid", tool["parameters"]["properties"])
+            response = client.post(
+                tools[0]["endpoint"],
+                json={
+                    **QUERY,
+                    "ecosystem": " pypi ",
+                    "uid": "private-user",
+                    "app_id": "private-app",
+                    "tool_name": tools[0]["name"],
+                    "geolocation": {"latitude": 42},
+                    "access_token": "private-canary",
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(set(response.json()), {"result"})
+        result = response.json()["result"]
+        self.assertIn("2.0", result)
+        self.assertIn("3.1", result)
+        self.assertIn("different release branches", result)
+        self.assertNotIn("99.0", result)
+        self.assertIn("https://osv.dev/vulnerability/GHSA-example-0001", result)
+        self.assertNotIn("private-", result)
+        self.assertEqual(len(upstream), 1)
+
+    def test_exact_npm_scoped_package_is_not_rewritten(self):
+        def handler(request):
+            self.assertEqual(json.loads(request.content)["package"], {"ecosystem": "npm", "name": "@scope/pkg"})
+            return httpx.Response(200, json={})
+
+        with self.client(handler) as client:
+            data = client.post(QUERY_PATH, json={**QUERY, "ecosystem": "npm", "package_name": "@scope/pkg"}).json()
+        self.assertIn("unknown package/version", data["result"])
+
+    def test_empty_success_does_not_assert_safety_or_package_existence(self):
+        for body in ({}, {"vulns": []}):
+            with self.subTest(body=body), self.client(lambda request: httpx.Response(200, json=body)) as client:
+                result = client.post(QUERY_PATH, json=QUERY).json()["result"]
+                self.assertIn("no matching advisory records", result)
+                self.assertIn("unknown package/version", result)
+                self.assertIn("not a confirmation", result)
+
+    def test_limits_pagination_and_aliases_are_explicit(self):
+        second = {**ADVISORY, "id": "PYSEC-example-0001"}
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            return httpx.Response(200, json={"vulns": [ADVISORY, second], "next_page_token": "private-token"})
+
+        with self.client(handler) as client:
+            result = client.post(QUERY_PATH, json={**QUERY, "limit": 1}).json()["result"]
+        self.assertIn("2 advisory record(s)", result)
+        self.assertIn("not a count of unique vulnerabilities", result)
+        self.assertIn("additional pages", result)
+        self.assertNotIn("private-token", result)
+        self.assertNotIn("PYSEC-example-0001", result)
+        self.assertLessEqual(len(result), MAX_RESULT_CHARS)
+        self.assertEqual(len(requests), 1)
+
+    def test_detail_handles_withdrawn_missing_summary_and_no_fixed_version(self):
+        record = copy.deepcopy(ADVISORY)
+        record.pop("summary")
+        record["details"] = "Advisory explanation"
+        record["withdrawn"] = "2026-01-01T00:00:00Z"
+        record["affected"][0]["ranges"] = [
+            {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"last_affected": "1.1"}]}
+        ]
+        record["references"] += [{"url": "https://user:secret@example.org/"}, {"url": "javascript:alert(1)"}]
+
+        def handler(request):
+            self.assertEqual(request.method, "GET")
+            self.assertEqual(str(request.url), "https://api.osv.dev/v1/vulns/GHSA-example-0001")
+            return httpx.Response(200, json=record)
+
+        with self.client(handler) as client:
+            data = client.post(DETAIL_PATH, json={"vulnerability_id": ADVISORY["id"]}).json()
+        self.assertEqual(set(data), {"result"})
+        self.assertIn("WITHDRAWN", data["result"])
+        self.assertIn("Advisory explanation", data["result"])
+        self.assertIn("No fixed marker reported", data["result"])
+        self.assertIn("last_affected: 1.1", data["result"])
+        self.assertIn("https://example.org/advisory/1", data["result"])
+        self.assertNotIn("secret", data["result"])
+        self.assertNotIn("javascript:", data["result"])
+
+    def test_invalid_inputs_do_not_send_requests_or_echo_sensitive_values(self):
+        def no_request(request):
+            self.fail("Invalid tool input reached OSV")
+
+        cases = [
+            (QUERY_PATH, {**QUERY, "ecosystem": "private-canary"}),
+            (QUERY_PATH, {**QUERY, "package_name": " "}),
+            (QUERY_PATH, {**QUERY, "version": ">=1"}),
+            (QUERY_PATH, {**QUERY, "limit": 11}),
+            (QUERY_PATH, {**QUERY, "limit": True}),
+            (DETAIL_PATH, {"vulnerability_id": "../../private-canary"}),
+        ]
+        with self.client(no_request) as client:
+            for path, payload in cases:
+                with self.subTest(path=path, payload=payload):
+                    response = client.post(path, json=payload)
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(set(response.json()), {"error"})
+                    self.assertNotIn("private-canary", response.text)
+            self.assertIn("error", client.post(QUERY_PATH, content=b'{"uid":"private-canary",').json())
+
+    def test_status_and_transport_failures_are_errors_not_empty_results(self):
+        for status, returned_status, expected in (
+            (400, 400, "rejected"),
+            (404, 404, "did not find"),
+            (429, 429, "rate limiting"),
+            (503, 502, "unavailable"),
+            (302, 502, "unexpected status"),
+        ):
+            with self.subTest(status=status):
+                calls = []
+
+                def handler(request):
+                    calls.append(request)
+                    return httpx.Response(
+                        status, text="private-canary", headers={"Location": "https://other.example/secret"}
+                    )
+
+                with self.client(handler) as client:
+                    response = client.post(DETAIL_PATH, json={"vulnerability_id": ADVISORY["id"]})
+                self.assertEqual(response.status_code, returned_status)
+                self.assertEqual(set(response.json()), {"error"})
+                self.assertIn(expected, response.json()["error"])
+                self.assertNotIn("private-canary", response.text)
+                self.assertEqual(len(calls), 1)
+        for exception, returned_status, expected in (
+            (httpx.ReadTimeout, 504, "timed out"),
+            (httpx.ConnectError, 502, "Could not reach"),
+        ):
+
+            def handler(request):
+                raise exception("private-canary", request=request)
+
+            with self.subTest(exception=exception), self.client(handler) as client:
+                response = client.post(QUERY_PATH, json=QUERY)
+                self.assertEqual(response.status_code, returned_status)
+                self.assertEqual(set(response.json()), {"error"})
+                self.assertIn(expected, response.json()["error"])
+                self.assertNotIn("private-canary", response.text)
+
+    def test_invalid_utf8_body_uses_the_tool_error_contract(self):
+        def no_request(request):
+            self.fail("An undecodable body reached OSV")
+
+        with self.client(no_request) as client:
+            response = client.post(QUERY_PATH, content=b"\xff", headers={"Content-Type": "application/json"})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(set(response.json()), {"error"})
+        self.assertIn("UTF-8", response.json()["error"])
+
+    def test_malformed_and_oversized_upstream_data_are_not_no_matches(self):
+        for content in (
+            b"not-json",
+            b"[]",
+            b'{"vulns":null}',
+            b'{"message":"oops"}',
+            b'{"vulns":[{}]}',
+            b"x" * (MAX_RESPONSE_BYTES + 1),
+        ):
+            with self.subTest(size=len(content)), self.client(
+                lambda request: httpx.Response(200, content=content)
+            ) as client:
+                response = client.post(QUERY_PATH, json=QUERY)
+                self.assertEqual(response.status_code, 502)
+                self.assertEqual(set(response.json()), {"error"})
+                self.assertNotIn("no matching", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why

Adds two standalone Omi chat tools for OSV package/version advisory lookup and advisory details, related to #3120. A developer can ask about a specific npm, PyPI, Go or other supported package version and get package-scoped affected ranges, reported fix markers and source links without an API key or package installation.

Empty results do not claim safety or package existence; pagination and truncation are explicit. Omi identity/location metadata is not forwarded. The service uses bounded requests to the fixed OSV host and preserves non-2xx error semantics.

The existing concurrent-preflight test now waits for the actual join message before releasing its owner, replacing a 0.3-second timing assumption that failed during this PR’s checks. Its execution-count and exit-status assertions remain intact. This test-only fix is kept in a separate commit.

The review follow-up keeps deeply nested OSV JSON inside the documented 502 error contract, derives normalization from the canonical ecosystem type, and documents the app dependencies needed by local repository preflight.

## Product invariants affected

none

## How it was verified

- Ten hermetic FastAPI `TestClient` tests passed through the real handlers with `httpx.MockTransport`.
- Two live calls through the local application succeeded: `PyPI / requests / 2.31.0` and advisory `PYSEC-2023-74`. These live checks are separate from CI.
- Independent agent review caught a non-UTF-8 input error-envelope mismatch; it was fixed and regression-tested.
- The concurrent-preflight failure reproduced on the unchanged upstream test. After synchronizing the fixture, its full suite passed 46 tests with one Windows-only skip on Linux.
- `actionlint` 1.7.12 passed for the workflow change.
- The deep-JSON regression reproduced unhandled `RecursionError` on both routes before the fix; both now return a bounded HTTP 502 error without exposing provider content. Independent review approved the follow-up.
- The workflow change selected `test_changed_files_script.py` and `test_workflow_contracts.py`; both passed through `backend/test.sh` (28 test cases).
- Full `make preflight` exited 0 again after the review fixes: 21 selected checks, including all 15 registered image contracts. The unchanged checks ran against a hash-verified source snapshot in a private local RAM-backed mount to avoid slow filesystem copies. The original staged source remained identical afterward. The history-based failure-class ratchet skipped because this checkout is shallow; full-history CI remains authoritative.

No Omi App Store registration, device test, hosted deployment or payment has been performed.

## Tests

`plugins/omi-osv-app/test.sh` covers discovery, request validation, package-scoped fixes, withdrawn and empty records, pagination, metadata isolation, and provider error/timeout/response limits. It is registered in the existing local/CI check manifest; the existing Repo Checks workflow installs its runtime dependencies only when that check is selected.

## Failure class (fixes)

Failure-Class: none

## Bounty and authorship

This contribution was prepared and independently reviewed with AI coding agents for @sen-ye. Could a maintainer confirm whether this integration is eligible for the $50 app bounty discussed in #3120? No award or payment is assumed. Payment details will remain private through the documented claim process.
