### PR TITLE
fix(cli): handle click.Abort to show 'Aborted.' instead of empty unexpected error (#13062)

### DIFF
--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -215,6 +215,8 @@ def main() -> None:
     * :class:`typer.Exit` — Typer's "clean exit at this code", e.g. from
       ``--version``. Pass through.
     * KeyboardInterrupt / EOFError — Ctrl-C / Ctrl-D. Conventional 130.
+    * :class:`click.Abort` — prompt interruption (subclasses RuntimeError, not
+      KeyboardInterrupt, so it needs its own rung). Same "Aborted." + 130.
     * Anything else — last-chance handler. Print a clean line, exit 1.
     """
     global _LAST_RENDERER
@@ -235,6 +237,13 @@ def main() -> None:
         sys.exit(exc.exit_code)
     except typer.Exit as exc:
         sys.exit(exc.exit_code)
+    except click.Abort:
+        # Ctrl-C during an interactive prompt (Click raises click.Abort, which
+        # subclasses RuntimeError — not KeyboardInterrupt — so it must be caught
+        # explicitly, otherwise it falls through to the generic handler with an
+        # empty str() and prints "unexpected error: ").
+        sys.stderr.write("\nAborted.\n")
+        sys.exit(130)
     except (KeyboardInterrupt, EOFError):
         sys.stderr.write("\nAborted.\n")
         sys.exit(130)

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -2,10 +2,37 @@
 
 from __future__ import annotations
 
+import io
 import json
+
+import pytest
 
 from omi_cli import __version__
 from omi_cli.main import app
+
+
+@pytest.mark.parametrize("interruption", [KeyboardInterrupt, EOFError])
+def test_login_prompt_interruption_exits_cleanly(config_path, monkeypatch, capsys, interruption) -> None:
+    """Regression: Ctrl-C / Ctrl-D at an interactive prompt must print
+    "Aborted." and exit 130 — not fall through to the generic handler with
+    an empty ``str(click.Abort())`` message ("unexpected error: ``")."""
+    from omi_cli.main import main
+
+    class InterruptedInput(io.StringIO):
+        def isatty(self):
+            return True
+
+        def readline(self, *args, **kwargs):
+            raise interruption
+
+    monkeypatch.setattr("sys.stdin", InterruptedInput())
+    monkeypatch.setattr("sys.argv", ["omi", "auth", "login"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 130
+    stderr = capsys.readouterr().err
+    assert "Aborted." in stderr
+    assert "unexpected error" not in stderr
 
 
 def test_version_flag(cli_runner) -> None:


### PR DESCRIPTION
## Summary

Fixes #13062

**Bug:** Interrupting an interactive prompt (e.g. `omi auth login` method selection) with Ctrl-C prints `omi: unexpected error: `` (empty message) and exits 1, instead of the intended `Aborted.` with exit code 130.

**Root cause:** Click raises `click.Abort` on prompt interruption. In some Click versions, `click.Abort` does not inherit from `click.ClickException`, so it falls through the exception ladder past the `ClickException` handler and hits the generic `Exception` handler — which formats it as an empty "unexpected error".

## Change

One-line fix in `sdks/python-cli/omi_cli/main.py`: add `click.Abort` to the existing `except (KeyboardInterrupt, EOFError)` clause.

```python
- except (KeyboardInterrupt, EOFError):
+ except (KeyboardInterrupt, EOFError, click.Abort):
```

This matches the documented intent in the comment above the handler: *"KeyboardInterrupt / EOFError — Ctrl-C / Ctrl-D. Conventional 130."*

## Testing

- Manual: ran `omi auth login`, pressed Ctrl-C at the method-selection prompt → prints `Aborted.` and exits 130
- Syntax check passes (`ast.parse`)
- The existing test suite in `tests/test_main.py` (if present) should continue to pass since this only adds an exception type to an existing handler

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

