### PR TITLE
fix(cli): show full resource IDs in list output

### DIFF
--- a/.github/failure-classes/FC-displayed-identifier-lossy-for-lookup.json
+++ b/.github/failure-classes/FC-displayed-identifier-lossy-for-lookup.json
@@ -1,0 +1,17 @@
+{
+  "canonical_prevention": "Render lookup keys verbatim on every surface that accepts them back; confine lossy shortening to non-key descriptive fields, and pin the full identifier in display output with a regression test through the real command entry point.",
+  "canonical_prevention_artifact": [
+    "sdks/python-cli/tests/test_memory.py",
+    "sdks/python-cli/tests/test_conversation.py",
+    "sdks/python-cli/tests/test_goal.py",
+    "sdks/python-cli/tests/test_action_item.py"
+  ],
+  "evidence_prs": [],
+  "id": "FC-displayed-identifier-lossy-for-lookup",
+  "schema_version": 1,
+  "scope_hints": [
+    "sdks/python-cli/omi_cli/commands/"
+  ],
+  "status": "open",
+  "violated_contract": "An identifier a surface displays for later reuse must round-trip through the surface that resolves it. A lossy display projection (truncation, masking, reformatting) applied to the lookup key itself makes the shown value unresolvable, so copy-paste from list output into the get-by-ID path fails with not-found even though the resource exists."
+}

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -58,7 +58,7 @@ def list_action_items(
     for it in items or []:
         rows.append(
             {
-                "id": shorten(it.get("id"), 14),
+                "id": it.get("id"),
                 "completed": it.get("completed"),
                 "description": shorten(it.get("description"), 60),
                 "due_at": it.get("due_at"),

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -62,7 +62,7 @@ def list_conversations(
         structured = c.get("structured") or {}
         rows.append(
             {
-                "id": shorten(c.get("id"), 14),
+                "id": c.get("id"),
                 "title": shorten(structured.get("title"), 50),
                 "category": structured.get("category"),
                 "started_at": c.get("started_at"),

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -46,7 +46,7 @@ def list_goals(
     for g in items or []:
         rows.append(
             {
-                "id": shorten(g.get("id"), 14),
+                "id": g.get("id"),
                 "title": shorten(g.get("title"), 40),
                 "goal_type": g.get("goal_type"),
                 "current_value": g.get("current_value"),

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -51,7 +51,7 @@ def list_memories(
     for m in items or []:
         rows.append(
             {
-                "id": shorten(m.get("id"), 14),
+                "id": m.get("id"),
                 "category": m.get("category"),
                 "visibility": m.get("visibility"),
                 "content": shorten(m.get("content"), 60),

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -56,3 +56,15 @@ def test_action_item_get_missing_returns_not_found_exit_code(authed_profile, res
     result = cli_runner.invoke(app, ["action-item", "get", "missing"])
     assert result.exit_code == 5  # EXIT_NOT_FOUND
     assert "not found" in result.stderr.lower()
+
+
+def test_action_item_list_pretty_shows_full_id(authed_profile, respx_mock, cli_runner) -> None:
+    """Regression for #13039: pretty list must not truncate IDs (copy -> get)."""
+    full_id = "12345678-1234-4234-8234-123456789abc"
+    respx_mock.get("/v1/dev/user/action-items").respond(
+        json=[{"id": full_id, "description": "ship it", "completed": False}]
+    )
+    result = cli_runner.invoke(app, ["--no-color", "action-item", "list"])
+    assert result.exit_code == 0
+    assert full_id in result.stdout
+    assert "12345678-1234…" not in result.stdout

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -76,3 +76,15 @@ def test_conversation_from_segments_reads_file(authed_profile, respx_mock, cli_r
     body = json.loads(route.calls.last.request.content)
     assert len(body["transcript_segments"]) == 2
     assert body["source"] == "phone"
+
+
+def test_conversation_list_pretty_shows_full_id(authed_profile, respx_mock, cli_runner) -> None:
+    """Regression for #13039: pretty list must not truncate IDs (copy -> get)."""
+    full_id = "12345678-1234-4234-8234-123456789abc"
+    respx_mock.get("/v1/dev/user/conversations").respond(
+        json=[{"id": full_id, "structured": {"title": "hello", "category": "personal"}}]
+    )
+    result = cli_runner.invoke(app, ["--no-color", "conversation", "list"])
+    assert result.exit_code == 0
+    assert full_id in result.stdout
+    assert "12345678-1234…" not in result.stdout

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -96,3 +96,13 @@ def test_goal_delete(authed_profile, respx_mock, cli_runner) -> None:
     respx_mock.delete("/v1/dev/user/goals/g1").respond(json={"success": True})
     result = cli_runner.invoke(app, ["goal", "delete", "g1", "-y"])
     assert result.exit_code == 0
+
+
+def test_goal_list_pretty_shows_full_id(authed_profile, respx_mock, cli_runner) -> None:
+    """Regression for #13039: pretty list must not truncate IDs (copy -> get)."""
+    full_id = "12345678-1234-4234-8234-123456789abc"
+    respx_mock.get("/v1/dev/user/goals").respond(json=[{"id": full_id, "title": "ship cli"}])
+    result = cli_runner.invoke(app, ["--no-color", "goal", "list"])
+    assert result.exit_code == 0
+    assert full_id in result.stdout
+    assert "12345678-1234…" not in result.stdout

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -125,3 +125,15 @@ def test_memory_get_found_in_later_page(authed_profile, respx_mock, cli_runner) 
     )
     result = cli_runner.invoke(app, ["--json", "memory", "get", "target"])
     assert result.exit_code == 0
+
+
+def test_memory_list_pretty_shows_full_id(authed_profile, respx_mock, cli_runner) -> None:
+    """Regression for #13039: pretty list must not truncate IDs (copy -> get)."""
+    full_id = "12345678-1234-4234-8234-123456789abc"
+    respx_mock.get("/v1/dev/user/memories").respond(
+        json=[{"id": full_id, "content": "hello", "category": "core", "visibility": "private", "tags": []}]
+    )
+    result = cli_runner.invoke(app, ["--no-color", "memory", "list"])
+    assert result.exit_code == 0
+    assert full_id in result.stdout
+    assert "12345678-1234…" not in result.stdout


### PR DESCRIPTION
## What changed and why

Pretty `list` tables for `memory`, `conversation`, `action-item`, and `goal`
truncated resource IDs to 14 characters (`shorten(id, 14)`), so copying a
displayed ID into the corresponding `get` command reported the resource as
missing (exit 5). The four list commands now emit the complete ID in
human-readable output; long text fields (`content`, `title`, `description`)
keep their existing truncation. `--json` output already carried full IDs and
is unchanged.

Closes #13039.

## Root cause

The violated contract is identifier round-trip: an ID a surface displays must
be accepted back by the surface that resolves it. Display truncation applied a
lossy projection to the lookup key itself, so the human-readable list and the
`get`-by-ID path disagreed on what an ID looks like.

## Durable guard

The regression tests below pin the full identifier in pretty output for all
four list commands through the real Typer entry point, so any future
re-truncation of the `id` cell fails the suite.

## Verification

- New regression tests (fail before, pass after):
  `test_memory_list_pretty_shows_full_id`,
  `test_conversation_list_pretty_shows_full_id`,
  `test_goal_list_pretty_shows_full_id`,
  `test_action_item_list_pretty_shows_full_id`
- Full `sdks/python-cli` suite: all pass (1 pre-existing skip).
- Manual: `memory list` with a 36-char UUID now renders the complete ID at
  normal terminal widths (narrow terminals still soft-wrap via Rich, which is
  standard table behavior and out of scope).
- `ruff check` / `mypy` on touched files: no new findings (remaining findings
  are pre-existing in untouched code).

## Product invariants

No locked product invariant covers CLI table layout; no invariant citation
applies. No TODO/FIXME added.

## Bounty

Per the issue's proposal and the documented paid-bounty process: this PR
implements the #13039 scope (usable list IDs for subsequent commands, with
regression tests for the four paths and unchanged JSON output).

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

