### PR TITLE
fix(cli): find action items beyond the first 1000 results

### DIFF
--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -76,18 +76,21 @@ def get_action_item(
     ctx = _ctx(typer_ctx)
     with ctx.make_client() as client:
         # Like memories, the dev API has no single-resource GET for action items.
-        # Page through up to 5 pages of 200 to find it; beyond that the user
-        # probably wants `omi action-item list` directly.
-        for offset in range(0, 1000, 200):
-            page = client.get("/v1/dev/user/action-items", params={"limit": 200, "offset": offset})
+        # Continue until the item is found or the list is exhausted; an
+        # arbitrary page budget must not turn an existing ID into a 404.
+        page_size = 200
+        offset = 0
+        while True:
+            page = client.get("/v1/dev/user/action-items", params={"limit": page_size, "offset": offset})
             if not page:
                 break
             for item in page:
                 if item.get("id") == action_item_id:
                     ctx.renderer.emit(item, title="action item")
                     return
-            if len(page) < 200:
+            if len(page) < page_size:
                 break
+            offset += page_size
     # Exit code 5 (NotFoundError) — same contract as a server-side 404,
     # whether or not the dev API exposed a direct GET for this noun.
     raise NotFoundError(message=f"Action item not found: {action_item_id}")

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 
+import httpx
+import pytest
+
 from omi_cli.main import app
 
 
@@ -56,3 +59,33 @@ def test_action_item_get_missing_returns_not_found_exit_code(authed_profile, res
     result = cli_runner.invoke(app, ["action-item", "get", "missing"])
     assert result.exit_code == 5  # EXIT_NOT_FOUND
     assert "not found" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("target_index", [999, 1000, 1200])
+def test_action_item_get_finds_items_beyond_five_pages(authed_profile, respx_mock, cli_runner, target_index) -> None:
+    items = [{"id": f"a{i}", "description": "task", "completed": False} for i in range(target_index + 1)]
+
+    def list_page(request):
+        offset = int(request.url.params["offset"])
+        limit = int(request.url.params["limit"])
+        return httpx.Response(200, json=items[offset : offset + limit])
+
+    route = respx_mock.get("/v1/dev/user/action-items").mock(side_effect=list_page)
+    result = cli_runner.invoke(app, ["--json", "action-item", "get", f"a{target_index}"])
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout) == items[target_index]
+    assert [int(call.request.url.params["offset"]) for call in route.calls] == list(range(0, target_index + 1, 200))
+
+
+def test_action_item_get_exhausts_full_pages_before_reporting_missing(authed_profile, respx_mock, cli_runner) -> None:
+    items = [{"id": f"a{i}", "description": "task", "completed": False} for i in range(1200)]
+
+    def list_page(request):
+        offset = int(request.url.params["offset"])
+        limit = int(request.url.params["limit"])
+        return httpx.Response(200, json=items[offset : offset + limit])
+
+    route = respx_mock.get("/v1/dev/user/action-items").mock(side_effect=list_page)
+    result = cli_runner.invoke(app, ["--json", "action-item", "get", "missing"])
+    assert result.exit_code == 5
+    assert [int(call.request.url.params["offset"]) for call in route.calls] == list(range(0, 1201, 200))


### PR DESCRIPTION
## What changed and why

Fixes #13040. `omi action-item get ID` reported existing tasks as missing once they appeared after the first 1,000 results. Remove the five-page cutoff so the command continues the existing list scan until it finds the requested ID or exhausts the list, matching the memory lookup's behavior.

## Product invariants affected

none

## How it was verified

- `cd sdks/python-cli && python -m pytest`: 132 passed, 1 skipped. Two upstream Click deprecation warnings.
- Before the fix, three new regression cases fail: lookups at zero-based positions 1000 and 1200 return exit code 5, and the missing-item scan stops without exhausting six full pages. The boundary case at position 999 already passes.
- The installed `omi --json action-item get a1200` command, pointed at a loopback HTTP server with 1,201 synthetic tasks and isolated config/credentials, returns `a1200` with exit code 0 after requesting offsets 0, 200, 400, 600, 800, 1000, and 1200.
- `make setup` completed, and `make preflight` accepted all 12 selected checks. The history-dependent failure-class guard explicitly skipped its 90-day scan because this clone is shallow; that scan is not claimed as validated.
- No live Omi service or user data was accessed. This retains the existing short-page termination contract; server-side filtering that returns a short page before exhaustion remains a separate limitation.

## Tests

Added four parameterized/boundary and exhaustion cases in `sdks/python-cli/tests/test_action_item.py`, exercising the real command and HTTP client through the existing mocked transport. No new check or ratchet is introduced.

## Failure class (fixes)

Failure-Class: none

This repairs a fixed client-side scan cutoff. It does not change the server-side visibility filtering primitive covered by `FC-raw-page-limit-before-visibility-filter` or a tool-result representation budget.

## Contribution disclosure

Generated-by: OpenAI Codex (GPT-6)

Codex authored and tested this contribution on the account owner's behalf. The account owner authorized its submission; no claim of separate human code review is made. The optional US$5 bounty proposed in #13040 has not been approved, and no payment is assumed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

