### PR TITLE
fix: preserve Rust Whisper audio until flush succeeds

### DIFF
--- a/sdks/device/rust/README.md
+++ b/sdks/device/rust/README.md
@@ -1,0 +1,75 @@
+# Omi device protocol helpers for Rust
+
+This crate lives in `sdks/device/rust` and provides the shared device protocol
+helpers and optional STT interface. It is separate from the Rust SDK in
+`sdks/rust/omi-device`. See the shared [protocol](../PROTOCOL.md) and
+[STT contract](../STT.md).
+
+## Whisper buffering
+
+Enable `stt-whisper` to use `omi_device::whisper::WhisperTranscriber`. Supply a
+synchronous runner with the signature `Fn(&[u8]) -> Result<String, String>`;
+the crate does not load a Whisper model itself.
+
+Pass raw **PCM16 little-endian, mono, 16 kHz** bytes to `append_pcm`. The existing
+batch threshold is five seconds (160,000 bytes). Once that threshold is reached,
+the runner receives the entire accumulated buffer in one call. An oversized
+append is not split into separate batches.
+
+Call `flush()` when the stream ends to transcribe a shorter final batch.
+Successful transcription clears the buffer and returns nonempty text as
+`Ok(Some(text))`; an empty transcript returns `Ok(None)` and also clears the
+buffer. Flushing an empty buffer returns `Ok(None)` without calling the runner,
+so repeated successful flushes do not submit audio twice. Flushing does not close
+the transcriber: subsequent `append_pcm` calls are supported.
+
+If the runner returns an error from either method, the original audio remains
+buffered. There is no automatic retry. The caller can retry explicitly with
+`flush()`, including for a partial batch. Do not append the failed input again:
+it is already buffered. Appending new audio after an error adds it to the
+retained audio.
+
+## Example
+
+In a consuming project, enable the feature with a path dependency (adjust the
+path to your checkout):
+
+```toml
+[dependencies]
+omi-device = { path = "/path/to/omi/sdks/device/rust", features = ["stt-whisper"] }
+```
+
+This runnable `src/main.rs` example uses a demonstration runner so it needs no
+model or service. Replace the closure with your Whisper inference integration.
+
+```rust
+use omi_device::whisper::WhisperTranscriber;
+
+fn main() -> Result<(), String> {
+    let mut transcriber = WhisperTranscriber::new(|pcm: &[u8]| {
+        Ok(format!("Runner received {} PCM bytes", pcm.len()))
+    });
+
+    // Five seconds of PCM, followed by a shorter final chunk.
+    for pcm in [vec![0_u8; 160_000], vec![0_u8; 640]] {
+        if let Some(text) = transcriber.append_pcm(&pcm)? {
+            println!("{text}");
+        }
+    }
+    if let Some(text) = transcriber.flush()? {
+        println!("{text}");
+    }
+    assert_eq!(transcriber.flush()?, None);
+    Ok(())
+}
+```
+
+Run the crate's hermetic protocol and Whisper buffering tests from
+`sdks/device/rust`:
+
+```sh
+cargo test --features stt-whisper
+```
+
+These tests use injected runners and do not require Bluetooth hardware, a model,
+or a live transcription service.

--- a/sdks/device/rust/src/lib.rs
+++ b/sdks/device/rust/src/lib.rs
@@ -86,13 +86,29 @@ pub mod whisper {
             }
         }
 
+        /// Buffer PCM16 LE mono audio at 16 kHz, transcribing the entire buffer
+        /// once it contains at least five seconds of audio. Call [`Self::flush`]
+        /// at the end of the stream to transcribe any shorter final batch.
         pub fn append_pcm(&mut self, pcm: &[u8]) -> Result<Option<String>, String> {
             self.buf.extend_from_slice(pcm);
             if self.buf.len() < self.batch {
                 return Ok(None);
             }
-            let chunk = std::mem::take(&mut self.buf);
-            let text = (self.runner)(&chunk)?;
+            self.flush()
+        }
+
+        /// Transcribe all buffered audio, regardless of the batch threshold.
+        ///
+        /// An empty buffer returns `Ok(None)` without calling the runner.
+        /// Success clears the buffer, even when the transcript is empty. An
+        /// error retains all audio for an explicit retry with `flush()`; do not
+        /// append the same audio again. More audio may be appended after flushing.
+        pub fn flush(&mut self) -> Result<Option<String>, String> {
+            if self.buf.is_empty() {
+                return Ok(None);
+            }
+            let text = (self.runner)(&self.buf)?;
+            self.buf.clear();
             Ok(if text.is_empty() { None } else { Some(text) })
         }
     }
@@ -123,5 +139,156 @@ mod tests {
             parakeet_ws_url("https://parakeet.example/", 16000),
             "wss://parakeet.example/v3/stream?sample_rate=16000"
         );
+    }
+
+    #[cfg(feature = "stt-whisper")]
+    mod whisper_tests {
+        use super::super::whisper::WhisperTranscriber;
+        use std::cell::{Cell, RefCell};
+
+        #[test]
+        fn failed_batch_is_retained_for_explicit_append_retry() {
+            let pcm: Vec<u8> = (0..160_000).map(|i| (i % 256) as u8).collect();
+            let calls = Cell::new(0);
+            let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                assert_eq!(chunk, pcm.as_slice());
+                calls.set(calls.get() + 1);
+                if calls.get() == 1 {
+                    Err("runner failed".to_string())
+                } else {
+                    Ok("retried batch".to_string())
+                }
+            });
+
+            assert_eq!(
+                transcriber.append_pcm(&pcm),
+                Err("runner failed".to_string())
+            );
+            assert_eq!(calls.get(), 1);
+            assert_eq!(
+                transcriber.append_pcm(&[]),
+                Ok(Some("retried batch".to_string()))
+            );
+            assert_eq!(calls.get(), 2);
+        }
+
+        #[test]
+        fn empty_flush_does_not_call_runner() {
+            let mut transcriber = WhisperTranscriber::new(|_: &[u8]| {
+                panic!("empty buffers must not reach the runner")
+            });
+
+            assert_eq!(transcriber.flush(), Ok(None));
+            assert_eq!(transcriber.flush(), Ok(None));
+        }
+
+        #[test]
+        fn final_tail_is_flushed_once_and_more_audio_can_be_appended() {
+            let chunks = RefCell::new(Vec::new());
+            let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                chunks.borrow_mut().push(chunk.to_vec());
+                Ok("tail".to_string())
+            });
+
+            assert_eq!(transcriber.append_pcm(&[1, 2, 3, 4]), Ok(None));
+            assert!(chunks.borrow().is_empty());
+            assert_eq!(transcriber.flush(), Ok(Some("tail".to_string())));
+            assert_eq!(transcriber.flush(), Ok(None));
+            assert_eq!(*chunks.borrow(), vec![vec![1, 2, 3, 4]]);
+
+            assert_eq!(transcriber.append_pcm(&[5, 6]), Ok(None));
+            assert_eq!(chunks.borrow().len(), 1);
+            assert_eq!(transcriber.flush(), Ok(Some("tail".to_string())));
+            assert_eq!(*chunks.borrow(), vec![vec![1, 2, 3, 4], vec![5, 6]]);
+        }
+
+        #[test]
+        fn successful_empty_transcript_clears_buffer() {
+            let calls = Cell::new(0);
+            let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                assert_eq!(chunk, &[1, 2]);
+                calls.set(calls.get() + 1);
+                Ok(String::new())
+            });
+
+            assert_eq!(transcriber.append_pcm(&[1, 2]), Ok(None));
+            assert_eq!(transcriber.flush(), Ok(None));
+            assert_eq!(calls.get(), 1);
+            assert_eq!(transcriber.flush(), Ok(None));
+            assert_eq!(calls.get(), 1);
+        }
+
+        #[test]
+        fn full_batch_and_final_tail_are_transcribed_separately() {
+            let pcm = vec![7; 160_000];
+            let chunks = RefCell::new(Vec::new());
+            let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                chunks.borrow_mut().push(chunk.to_vec());
+                Ok("transcript".to_string())
+            });
+
+            assert_eq!(transcriber.append_pcm(&pcm[..159_998]), Ok(None));
+            assert!(chunks.borrow().is_empty());
+            assert_eq!(
+                transcriber.append_pcm(&pcm[159_998..]),
+                Ok(Some("transcript".to_string()))
+            );
+            assert_eq!(transcriber.append_pcm(&[8, 9]), Ok(None));
+            assert_eq!(chunks.borrow().len(), 1);
+            assert_eq!(transcriber.flush(), Ok(Some("transcript".to_string())));
+            assert_eq!(*chunks.borrow(), vec![pcm, vec![8, 9]]);
+        }
+
+        #[test]
+        fn failed_partial_or_full_buffer_is_retained_for_explicit_flush_retry() {
+            for length in [4, 160_000] {
+                let pcm: Vec<u8> = (0..length).map(|i| (i % 256) as u8).collect();
+                let calls = Cell::new(0);
+                let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                    assert_eq!(chunk, pcm.as_slice());
+                    calls.set(calls.get() + 1);
+                    if calls.get() == 1 {
+                        Err("runner failed".to_string())
+                    } else {
+                        Ok("retried buffer".to_string())
+                    }
+                });
+
+                if length < 160_000 {
+                    assert_eq!(transcriber.append_pcm(&pcm), Ok(None));
+                    assert_eq!(calls.get(), 0);
+                    assert_eq!(transcriber.flush(), Err("runner failed".to_string()));
+                } else {
+                    assert_eq!(
+                        transcriber.append_pcm(&pcm),
+                        Err("runner failed".to_string())
+                    );
+                }
+                assert_eq!(calls.get(), 1);
+                assert_eq!(transcriber.flush(), Ok(Some("retried buffer".to_string())));
+                assert_eq!(calls.get(), 2);
+                assert_eq!(transcriber.flush(), Ok(None));
+                assert_eq!(calls.get(), 2);
+            }
+        }
+
+        #[test]
+        fn oversized_append_transcribes_entire_buffer_in_one_call() {
+            let pcm: Vec<u8> = (0..160_004).map(|i| (i % 256) as u8).collect();
+            let calls = Cell::new(0);
+            let mut transcriber = WhisperTranscriber::new(|chunk: &[u8]| {
+                assert_eq!(chunk, pcm.as_slice());
+                calls.set(calls.get() + 1);
+                Ok("oversized batch".to_string())
+            });
+
+            assert_eq!(
+                transcriber.append_pcm(&pcm),
+                Ok(Some("oversized batch".to_string()))
+            );
+            assert_eq!(calls.get(), 1);
+            assert_eq!(transcriber.flush(), Ok(None));
+            assert_eq!(calls.get(), 1);
+        }
     }
 }

--- a/sdks/device/rust/src/lib.rs
+++ b/sdks/device/rust/src/lib.rs
@@ -107,9 +107,20 @@ pub mod whisper {
             if self.buf.is_empty() {
                 return Ok(None);
             }
-            let text = (self.runner)(&self.buf)?;
-            self.buf.clear();
+            let chunk = std::mem::take(&mut self.buf);
+            let text = match (self.runner)(&chunk) {
+                Ok(text) => text,
+                Err(err) => {
+                    self.buf = chunk;
+                    return Err(err);
+                }
+            };
             Ok(if text.is_empty() { None } else { Some(text) })
+        }
+
+        #[cfg(test)]
+        pub(crate) fn buffered_capacity(&self) -> usize {
+            self.buf.capacity()
         }
     }
 }
@@ -289,6 +300,15 @@ mod tests {
             assert_eq!(calls.get(), 1);
             assert_eq!(transcriber.flush(), Ok(None));
             assert_eq!(calls.get(), 1);
+        }
+
+        #[test]
+        fn successful_oversized_append_releases_peak_allocation() {
+            let pcm = vec![7; 1_600_000];
+            let mut transcriber = WhisperTranscriber::new(|_: &[u8]| Ok("done".to_string()));
+
+            assert_eq!(transcriber.append_pcm(&pcm), Ok(Some("done".to_string())));
+            assert_eq!(transcriber.buffered_capacity(), 0);
         }
     }
 }


### PR DESCRIPTION
## What changed and why

Rust Whisper callers cannot transcribe a final audio buffer shorter than five seconds, and a runner error currently discards a full buffer before the caller can retry. Add a public `flush()` that clears audio only after success and share that path with `append_pcm`. Related to #13011; this PR covers only the Rust Whisper buffer, not the full cross-language issue.

## Product invariants affected

none

## How it was verified

From `sdks/device/rust`, `cargo test --features stt-whisper` passed all 10 tests, `cargo fmt --check` passed, and `cargo clippy --features stt-whisper -- -D warnings` passed. The README example was compiled and executed against the production library; its injected runner received the full 160,000-byte batch and then the 640-byte final tail.

Default-feature Cargo tests also passed (3 tests). The original API regression was run against the original production implementation before changing it: the retry returned `Ok(None)` instead of the retained batch's transcript. A separate public API executable reproduces that failure against the baseline and succeeds against the patch. No Bluetooth hardware, real Whisper model, or live provider was exercised.

`scripts/pr-preflight --lane local --metadata-only --pr-body-file <draft>` exited 0; its 90-day failure-class guard skipped because the checkout is shallow. Full `make preflight` did not pass: the workflow apt-bounds wrapper tried to provision the canonical backend Python environment and stopped at a missing `backend/.python-version` in this sparse checkout. Running the underlying apt-bounds tests directly with the available Python/PyYAML passed all 18 tests. This is not a claim that the full repository gate passed; rerun it in a provisioned checkout before submission.

## Tests

Seven feature-gated tests cover failed-batch retention, empty flush, final-tail delivery and subsequent appends, empty-transcript clearing, full batch plus tail, explicit retry for partial/full buffers, and oversized-append compatibility. Exact PCM bytes and runner call counts are asserted on the error/retry paths.

## Failure class (fixes)

Failure-Class: none

This is a localized in-memory SDK buffer lifetime fix. The existing durable-store replacement and teardown-finalizer classes have different owners and prevention primitives; this change does not alter their registries or claim to close the cross-language lifecycle work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

