### PR TITLE
feat(sdks/python): allow language selection for local Whisper transcription

### DIFF
--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'sdks/python-cli/**'
+      - 'sdks/python/**'
       - '.github/workflows/python-cli-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'sdks/python-cli/**'
+      - 'sdks/python/**'
       - '.github/workflows/python-cli-ci.yml'
 
 permissions:
@@ -20,6 +22,24 @@ defaults:
     working-directory: sdks/python-cli
 
 jobs:
+  sdk-tests:
+    name: Python SDK / Whisper language
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Install hermetic SDK test dependencies
+        run: python -m pip install pytest numpy
+      - name: Run SDK tests without devices or model downloads
+        run: python -m pytest -q
+        env:
+          PYTHONPATH: .
+
   tests:
     name: ${{ matrix.label }}
     strategy:

--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -141,6 +141,31 @@ The SDK requires the Opus audio codec library:
   </Step>
 </Steps>
 
+### Local Whisper language selection
+
+Install the optional local engine with `pip install 'omi-sdk[whisper]'`.
+Whisper defaults to the English-only `tiny.en` model and `language="en"`.
+For another language, select a multilingual model (without the `.en` suffix)
+and pass its language code through the transcription wrapper:
+
+```python
+from omi.transcribe import transcribe
+
+await transcribe(
+    audio_queue,
+    "",  # The shared wrapper requires this argument; Whisper does not use it.
+    on_transcript=print,
+    engine="whisper",
+    model_name="tiny",
+    language="de",
+)
+```
+
+Pass `language=None` with a multilingual model to let Whisper detect the language
+for each audio batch. The local engine batches approximately five seconds of
+16 kHz mono PCM before transcription. When supplying a custom `runner=`, the
+runner still receives only PCM bytes and controls its own language selection.
+
 ---
 
 ## API Reference

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -87,6 +87,31 @@ A pip-installable Python SDK for connecting to Omi wearable devices over Bluetoo
   </Step>
 </Steps>
 
+### Local Whisper language selection
+
+Install the optional local engine with `pip install 'omi-sdk[whisper]'`.
+Whisper defaults to the English-only `tiny.en` model and `language="en"`.
+For another language, select a multilingual model (without the `.en` suffix)
+and pass its language code through the transcription wrapper:
+
+```python
+from omi.transcribe import transcribe
+
+await transcribe(
+    audio_queue,
+    "",  # The shared wrapper requires this argument; Whisper does not use it.
+    on_transcript=print,
+    engine="whisper",
+    model_name="tiny",
+    language="de",
+)
+```
+
+Pass `language=None` with a multilingual model to let Whisper detect the language
+for each audio batch. The local engine batches approximately five seconds of
+16 kHz mono PCM before transcription. When supplying a custom `runner=`, the
+runner still receives only PCM bytes and controls its own language selection.
+
 
 ## Development
 

--- a/sdks/python/omi/stt/whisper.py
+++ b/sdks/python/omi/stt/whisper.py
@@ -11,9 +11,22 @@ class WhisperTranscriber:
     Feature gate: only importable/usable when a runner is provided or whisper is installed.
     """
 
-    def __init__(self, *, model_name: str = "tiny.en", runner: Optional[Callable[[bytes], str]] = None) -> None:
+    def __init__(
+        self,
+        *,
+        model_name: str = "tiny.en",
+        runner: Optional[Callable[[bytes], str]] = None,
+        language: Optional[str] = "en",
+    ) -> None:
+        """Use a language code or None for Whisper's language detection.
+
+        Non-English audio requires a multilingual model (for example, "tiny").
+        An injected runner continues to receive only PCM bytes and owns its
+        own language configuration.
+        """
         self.model_name = model_name
         self.runner = runner
+        self.language = language
         self._model = None
         if runner is None:
             try:
@@ -53,5 +66,5 @@ class WhisperTranscriber:
         import numpy as np  # type: ignore
 
         audio = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
-        result = self._model.transcribe(audio, fp16=False, language="en")
+        result = self._model.transcribe(audio, fp16=False, language=self.language)
         return (result.get("text") or "").strip()

--- a/sdks/python/tests/test_whisper_language.py
+++ b/sdks/python/tests/test_whisper_language.py
@@ -1,0 +1,84 @@
+import asyncio
+import contextlib
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from omi.transcribe import transcribe
+
+
+@pytest.mark.parametrize(
+    "options, expected_model, expected_language",
+    [
+        ({}, "tiny.en", "en"),
+        ({"model_name": "tiny", "language": "de"}, "tiny", "de"),
+        ({"model_name": "tiny", "language": None}, "tiny", None),
+    ],
+)
+def test_whisper_language_through_audio_queue(
+    monkeypatch, options, expected_model, expected_language
+):
+    calls = []
+    loaded_models = []
+
+    def model_transcribe(audio, **kwargs):
+        calls.append((audio, kwargs))
+        return {"text": "  Guten Tag  "}
+
+    def load_model(name):
+        loaded_models.append(name)
+        return SimpleNamespace(transcribe=model_transcribe)
+
+    monkeypatch.setitem(sys.modules, "whisper", SimpleNamespace(load_model=load_model))
+
+    async def exercise():
+        queue = asyncio.Queue()
+        # Five seconds of mono s16le PCM, split across two queue entries.
+        pcm = b"\x00\x40" * (16000 * 5)
+        queue.put_nowait(pcm[:32000])
+        queue.put_nowait(pcm[32000:])
+        received = asyncio.get_running_loop().create_future()
+        task = asyncio.create_task(
+            transcribe(
+                queue, "", received.set_result, engine="whisper", **options
+            )
+        )
+        try:
+            # Surface constructor errors immediately rather than waiting for a timeout.
+            done, _ = await asyncio.wait(
+                {task, received}, timeout=2, return_when=asyncio.FIRST_COMPLETED
+            )
+            if task in done:
+                await task
+            assert received in done, "Whisper did not deliver the queued transcript"
+            assert received.result() == "Guten Tag"
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    asyncio.run(exercise())
+    assert loaded_models == [expected_model]
+    assert len(calls) == 1
+    audio, kwargs = calls[0]
+    assert audio.shape == (16000 * 5,)
+    assert audio.dtype == np.float32
+    np.testing.assert_array_equal(audio, 0.5)
+    assert kwargs == {"fp16": False, "language": expected_language}
+
+
+def test_whisper_runner_keeps_bytes_only_contract():
+    from omi.stt import create_transcriber
+
+    chunks = []
+
+    def runner(pcm):
+        chunks.append(pcm)
+        return "custom transcript"
+
+    engine = create_transcriber("whisper", language="de", runner=runner)
+    pcm = b"\x00\x00" * 16
+    assert engine._transcribe_pcm(pcm) == "custom transcript"
+    assert chunks == [pcm]


### PR DESCRIPTION
## Summary

This PR enables language selection when using local Whisper transcription via the Python SDK, resolving #13071.

Previously, `sdks/python/omi/stt/whisper.py` hardcoded `language="en"` in calls to `model.transcribe()`, preventing callers from selecting other languages (e.g., German, Spanish) or requesting automatic language detection (`language=None`) even when using multilingual models.

## Changes

- **Python SDK (`sdks/python/omi/stt/whisper.py`)**:
  - Added keyword-only `language: Optional[str] = "en"` to `WhisperTranscriber.__init__`.
  - Saved `self.language` and forwarded it as `language=self.language` to `self._model.transcribe(audio, fp16=False, language=self.language)`.
  - Preserved the injected custom `runner` contract (receives raw PCM bytes and manages its own language).
- **Unit Tests (`sdks/python/tests/test_whisper_language.py`)**:
  - Added hermetic unit tests using a mocked `whisper` module covering default (`"en"`), explicit multilingual code (`"de"`), and automatic detection (`None`).
  - Added verification that custom `runner` continues to receive raw PCM bytes only.
- **Documentation (`docs/doc/developer/sdk/python.mdx`, `sdks/python/README.md`)**:
  - Added `Local Whisper language selection` documentation and usage examples.
- **CI Workflow (`.github/workflows/python-cli-ci.yml`)**:
  - Added `sdks/python/**` path triggers to pull requests and push events.
  - Added `sdk-tests` job to run hermetic Python SDK unit tests using pytest.

## Verification

- Ran `PYTHONPATH=sdks/python pytest sdks/python/tests/` locally: all 11 tests passed.
- Ran `make preflight`: all 18 local manifest checks passed.

Fixes #13071


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

