### PR TITLE
fix(cli): map exhausted transport retries to ServerError

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -158,6 +158,11 @@ class OmiClient:
         except _RetryableHttp as exc:
             # We exhausted retries — convert to the proper CliError now.
             raise self._error_from_response(exc.response)
+        except httpx.TransportError as exc:
+            raise ServerError(
+                message="Connection failed",
+                detail="Unable to reach the Omi API. Check your network connection or try again shortly.",
+            ) from exc
         # Unreachable — Retrying always either returns or raises — but the type
         # checker doesn't know that.
         raise RuntimeError("unreachable")

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -238,3 +238,89 @@ def test_validation_error_detail_string_is_formatted(authed_profile, respx_mock)
     detail = info.value.detail or ""
     assert "body.content" in detail
     assert "body.tags" in detail
+
+
+def test_transport_connect_error_retries_and_surfaces_server_error(authed_profile, respx_mock, monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    route = respx_mock.get("/v1/dev/user/goals").mock(side_effect=[httpx.ConnectError("Connection refused")] * 4)
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError) as info:
+            client.get("/v1/dev/user/goals")
+    assert route.call_count == 4
+    err = info.value
+    assert err.exit_code == 3
+    assert err.message == "Connection failed"
+    assert "Unable to reach the Omi API" in (err.detail or "")
+    assert isinstance(err.__cause__, httpx.ConnectError)
+
+
+def test_transport_read_timeout_surfaces_server_error(authed_profile, respx_mock, monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    respx_mock.get("/v1/dev/user/goals").mock(side_effect=[httpx.ReadTimeout("The read operation timed out")] * 4)
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError) as info:
+            client.get("/v1/dev/user/goals")
+    err = info.value
+    assert err.exit_code == 3
+    assert err.message == "Connection failed"
+    assert isinstance(err.__cause__, httpx.ReadTimeout)
+
+
+def test_transport_protocol_error_surfaces_server_error(authed_profile, respx_mock, monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    respx_mock.get("/v1/dev/user/goals").mock(side_effect=[httpx.ProtocolError("protocol error")] * 4)
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError) as info:
+            client.get("/v1/dev/user/goals")
+    err = info.value
+    assert err.exit_code == 3
+    assert err.message == "Connection failed"
+    assert isinstance(err.__cause__, httpx.ProtocolError)
+
+
+def test_transport_error_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
+    respx_mock.get("/v1/dev/user/goals").mock(
+        side_effect=[
+            httpx.ConnectError("Connection refused"),
+            httpx.Response(200, json=[{"id": "g1"}]),
+        ]
+    )
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/goals")
+    assert result == [{"id": "g1"}]
+
+
+def test_main_cli_transport_error_plain_mode(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    import sys
+
+    from omi_cli.main import main
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    respx_mock.get("/v1/dev/user/memories").mock(side_effect=[httpx.ConnectError("Connection refused")] * 4)
+    monkeypatch.setattr(sys, "argv", ["omi", "memory", "list"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 3
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Connection failed" in captured.err
+    assert "Unable to reach the Omi API" in captured.err
+
+
+def test_main_cli_transport_error_json_mode(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    import json
+    import sys
+
+    from omi_cli.main import main
+
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    respx_mock.get("/v1/dev/user/memories").mock(side_effect=[httpx.ConnectError("Connection refused")] * 4)
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "memory", "list"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 3
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"] == "Connection failed"
+    assert "Unable to reach the Omi API" in payload["detail"]


### PR DESCRIPTION
## Summary

This PR maps exhausted `httpx.TransportError` exceptions in `OmiClient._request()` to `ServerError(message="Connection failed", detail="Unable to reach the Omi API. Check your network connection or try again shortly.")`, resolving #12961.

Previously, exhausted transport retries (such as connection refused, read timeout, or protocol error) escaped `_request()` unmapped and fell through to the generic exception handler in `main()`. This caused commands to exit with code `1` and emit unformatted plain text on `stderr` even when `--json` was requested, violating the documented stable CLI exit code contract (`3: server error / connection failure`).

## Changes

- **`sdks/python-cli/omi_cli/client.py`**:
  - Catch `httpx.TransportError` after the retry loop in `OmiClient._request()`.
  - Raise `ServerError(message="Connection failed", detail="Unable to reach the Omi API. Check your network connection or try again shortly.") from exc`.
  - Preserves retries, recovery on transient errors, and chains the underlying exception as `__cause__`.
- **`sdks/python-cli/tests/test_client_retry.py`**:
  - Added regression test verifying `ConnectError` exhausts 4 retries and raises `ServerError` (exit code 3).
  - Added regression test for `ReadTimeout`.
  - Added regression test for `ProtocolError`.
  - Added test verifying transient `ConnectError` recovers on retry and returns data.
  - Added tests verifying `main()` exits with code 3 in both plain and `--json` modes and outputs the expected error structures to stderr.

## Verification

- `sdks/python-cli/venv/bin/pytest sdks/python-cli/tests/`: all 134 passed, 1 skipped.
- Real loopback reproduction:
  - `omi --api-base http://127.0.0.1:54321 memory list`: exits 3 with readable error on stderr.
  - `omi --api-base http://127.0.0.1:54321 --json memory list`: exits 3 with JSON error payload on stderr and clean stdout.
- `make preflight`: all 12 local checks passed.

Fixes #12961

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

