### PR TITLE
fix(sdk): clean up parakeet tasks and prevent hang on websocket close

### DIFF
--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -59,7 +59,20 @@ class ParakeetTranscriber:
                         else:
                             print(text)
 
-            await asyncio.gather(send_audio(), receive())
+            tasks = (
+                asyncio.create_task(send_audio()),
+                asyncio.create_task(receive()),
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    tasks, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    task.result()
+            finally:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _extract_text(data: object) -> str:

--- a/sdks/python/tests/test_parakeet_lifecycle.py
+++ b/sdks/python/tests/test_parakeet_lifecycle.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from omi.stt.parakeet import ParakeetTranscriber
+
+
+class FakeWebSocket:
+    def __init__(
+        self,
+        ready_message: str = '{"type": "ready"}',
+        messages: list[str | bytes] | None = None,
+        send_error: Exception | None = None,
+        receive_error: Exception | None = None,
+    ) -> None:
+        self.ready_message = ready_message
+        self.messages = list(messages or [])
+        self.send_error = send_error
+        self.receive_error = receive_error
+        self.sent_chunks: list[bytes] = []
+        self.closed = False
+
+    async def recv(self) -> str:
+        return self.ready_message
+
+    async def send(self, chunk: bytes) -> None:
+        if self.send_error:
+            raise self.send_error
+        self.sent_chunks.append(chunk)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        if self.receive_error:
+            raise self.receive_error
+        if self.messages:
+            return self.messages.pop(0)
+        raise StopAsyncIteration
+
+    async def __aenter__(self) -> FakeWebSocket:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.closed = True
+
+
+def test_parakeet_normal_close_idle_queue():
+    """When server closes normally and queue is idle, run() must return cleanly without hanging."""
+    async def _test():
+        fake_ws = FakeWebSocket(messages=[json.dumps({"text": "initial transcript"})])
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        received = []
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            await asyncio.wait_for(
+                transcriber.run(queue, on_transcript=lambda t: received.append(t)),
+                timeout=1.0,
+            )
+
+        assert received == ["initial transcript"]
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())
+
+
+def test_parakeet_audio_and_transcript_delivery():
+    """Audio in queue is transmitted, transcript is dispatched, and session closes cleanly."""
+    async def _test():
+        fake_ws = FakeWebSocket(messages=[json.dumps({"text": "transcribed audio"})])
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        await queue.put(b"\x00\x01\x02\x03")
+        received = []
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            await asyncio.wait_for(
+                transcriber.run(queue, on_transcript=lambda t: received.append(t)),
+                timeout=1.0,
+            )
+
+        assert b"\x00\x01\x02\x03" in fake_ws.sent_chunks
+        assert received == ["transcribed audio"]
+
+    asyncio.run(_test())
+
+
+def test_parakeet_send_error_cancels_sibling():
+    """Send errors raise out of run() and cancel the receive task."""
+    async def _test():
+        fake_ws = FakeWebSocket(
+            messages=[json.dumps({"text": "ignored"})],
+            send_error=ConnectionResetError("send reset"),
+        )
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        await queue.put(b"bad-data")
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            with pytest.raises(ConnectionResetError, match="send reset"):
+                await asyncio.wait_for(transcriber.run(queue), timeout=1.0)
+
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())
+
+
+def test_parakeet_receive_error_cancels_sibling():
+    """Receive errors raise out of run() and cancel the sender task."""
+    async def _test():
+        fake_ws = FakeWebSocket(receive_error=RuntimeError("connection dropped unexpectedly"))
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            with pytest.raises(RuntimeError, match="connection dropped unexpectedly"):
+                await asyncio.wait_for(transcriber.run(queue), timeout=1.0)
+
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())
+
+
+def test_parakeet_callback_exception_cancels_sibling():
+    """Exceptions in on_transcript callback raise out of run() and cancel the sender."""
+    async def _test():
+        fake_ws = FakeWebSocket(messages=[json.dumps({"text": "crash me"})])
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        def crashing_callback(_text: str):
+            raise ValueError("callback crashed")
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            with pytest.raises(ValueError, match="callback crashed"):
+                await asyncio.wait_for(
+                    transcriber.run(queue, on_transcript=crashing_callback),
+                    timeout=1.0,
+                )
+
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())
+
+
+def test_parakeet_caller_cancellation():
+    """Cancelling run() task cleans up internal send and receive tasks."""
+    async def _test():
+        class HangingWebSocket(FakeWebSocket):
+            async def __anext__(self):
+                await asyncio.sleep(100)
+
+        fake_ws = HangingWebSocket()
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary

In `sdks/python/omi/stt/parakeet.py`, `ParakeetTranscriber.run()` hung indefinitely when the remote WebSocket closed normally while the audio queue was idle. Furthermore, if either the audio sender or receiver encountered an error, the sibling streaming task was left running due to `await asyncio.gather(send_audio(), receive())`.

This PR explicitly manages the `send_audio` and `receive` tasks with `asyncio.wait(..., return_when=asyncio.FIRST_COMPLETED)`, cancels both tasks in `finally:`, and awaits task completion with `asyncio.gather(*tasks, return_exceptions=True)`. This allows clean exit on normal close, propagates any exceptions, and ensures no orphan tasks remain.

Fixes #12952

## Changes

- **`sdks/python/omi/stt/parakeet.py`**:
  - Explicitly wrap `send_audio()` and `receive()` in `asyncio.create_task`.
  - Wait for `FIRST_COMPLETED`.
  - Cancel sibling tasks and await in `finally:`.
  - Propagate task exceptions via `task.result()`.
- **`sdks/python/tests/test_parakeet_lifecycle.py`**:
  - Added 6 hermetic lifecycle unit tests:
    - Normal server close with idle audio queue (verifies no hang).
    - Audio chunk transmission and transcript callback delivery before close.
    - Send error cancels sibling receiver and propagates exception.
    - Receive error cancels sibling sender and propagates exception.
    - Transcript callback exception cancels sibling sender and propagates exception.
    - Caller task cancellation cleanly cancels both internal tasks.

## Verification

- **Automated Tests**:
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/test_parakeet_lifecycle.py -v`: 6/6 passed in 0.09s.
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/`: 13/13 passed.
- **Standalone Reproduction**:
  - Tested against local loopback `websockets.serve` server on 127.0.0.1: unpatched code hangs indefinitely on normal server close; patched code exits cleanly.
- **Manifest Preflight**:
  - Verified with `scripts/pr-preflight`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

