### PR TITLE
fix(sdk): clean up deepgram tasks and allow reconnect on normal close

### DIFF
--- a/sdks/python/omi/stt/deepgram.py
+++ b/sdks/python/omi/stt/deepgram.py
@@ -48,7 +48,22 @@ class DeepgramTranscriber:
                                 else:
                                     print(alt)
 
-                    await asyncio.gather(send_audio(), receive())
+                    tasks = (
+                        asyncio.create_task(send_audio()),
+                        asyncio.create_task(receive()),
+                    )
+                    try:
+                        done, _ = await asyncio.wait(
+                            tasks, return_when=asyncio.FIRST_COMPLETED
+                        )
+                        for task in done:
+                            task.result()
+                        # A clean receive EOF must also trigger the retry loop.
+                        raise ConnectionError("Deepgram connection closed")
+                    finally:
+                        for task in tasks:
+                            task.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
             except Exception as exc:
                 print(f"Deepgram error: {exc}")
                 await asyncio.sleep(1)

--- a/sdks/python/tests/test_deepgram_lifecycle.py
+++ b/sdks/python/tests/test_deepgram_lifecycle.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from omi.stt.deepgram import DeepgramTranscriber
+
+
+class FakeWebSocket:
+    def __init__(
+        self,
+        messages: list[str | bytes] | None = None,
+        send_error: Exception | None = None,
+        receive_error: Exception | None = None,
+    ) -> None:
+        self.messages = list(messages or [])
+        self.send_error = send_error
+        self.receive_error = receive_error
+        self.sent_chunks: list[bytes] = []
+        self.closed = False
+
+    async def send(self, chunk: bytes) -> None:
+        if self.send_error:
+            raise self.send_error
+        self.sent_chunks.append(chunk)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str | bytes:
+        if self.receive_error:
+            raise self.receive_error
+        if self.messages:
+            return self.messages.pop(0)
+        raise StopAsyncIteration
+
+    async def __aenter__(self) -> FakeWebSocket:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.closed = True
+
+
+def test_deepgram_normal_close_idle_queue_reconnects():
+    """When server closes normally and queue is idle, connection is drained and retry loop triggers."""
+    async def _test():
+        connections = 0
+        reconnected = asyncio.Event()
+
+        def make_fake_ws(*args, **kwargs):
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                # First connection closes normally with empty queue
+                return FakeWebSocket()
+            # Second connection reached
+            reconnected.set()
+            return FakeWebSocket()
+
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        with patch("websockets.connect", side_effect=make_fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.wait_for(reconnected.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert connections >= 2
+
+    asyncio.run(_test())
+
+
+def test_deepgram_audio_and_transcript_delivery():
+    """Audio chunks are transmitted and transcripts are delivered to callback."""
+    async def _test():
+        transcript_msg = json.dumps({
+            "channel": {"alternatives": [{"transcript": "hello world"}]}
+        })
+        received = []
+        delivered = asyncio.Event()
+
+        def on_transcript(t: str):
+            received.append(t)
+            delivered.set()
+
+        fake_ws = FakeWebSocket(messages=[transcript_msg])
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        await queue.put(b"\x00\x01\x02\x03")
+
+        with patch("websockets.connect", return_value=fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue, on_transcript=on_transcript))
+            await asyncio.wait_for(delivered.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert b"\x00\x01\x02\x03" in fake_ws.sent_chunks
+        assert received == ["hello world"]
+
+    asyncio.run(_test())
+
+
+def test_deepgram_send_error_cancels_sibling():
+    """Send error cancels sibling receiver and initiates reconnection."""
+    async def _test():
+        connections = 0
+        reconnected = asyncio.Event()
+
+        def make_fake_ws(*args, **kwargs):
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                return FakeWebSocket(send_error=ConnectionResetError("send failed"))
+            reconnected.set()
+            return FakeWebSocket()
+
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        await queue.put(b"chunk")
+
+        with patch("websockets.connect", side_effect=make_fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.wait_for(reconnected.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert connections >= 2
+
+    asyncio.run(_test())
+
+
+def test_deepgram_receive_error_cancels_sibling():
+    """Receive error cancels sibling sender and initiates reconnection."""
+    async def _test():
+        connections = 0
+        reconnected = asyncio.Event()
+
+        def make_fake_ws(*args, **kwargs):
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                return FakeWebSocket(receive_error=RuntimeError("connection dropped"))
+            reconnected.set()
+            return FakeWebSocket()
+
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", side_effect=make_fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.wait_for(reconnected.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert connections >= 2
+
+    asyncio.run(_test())
+
+
+def test_deepgram_callback_exception_cancels_sibling():
+    """Callback exception cancels sibling sender and initiates reconnection."""
+    async def _test():
+        connections = 0
+        reconnected = asyncio.Event()
+
+        transcript_msg = json.dumps({
+            "channel": {"alternatives": [{"transcript": "crash"}]}
+        })
+
+        def crashing_callback(_text: str):
+            raise ValueError("callback crashed")
+
+        def make_fake_ws(*args, **kwargs):
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                return FakeWebSocket(messages=[transcript_msg])
+            reconnected.set()
+            return FakeWebSocket()
+
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", side_effect=make_fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue, on_transcript=crashing_callback))
+            await asyncio.wait_for(reconnected.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert connections >= 2
+
+    asyncio.run(_test())
+
+
+def test_deepgram_caller_cancellation():
+    """Cancelling caller task cleanly terminates run() and cleans up internal tasks."""
+    async def _test():
+        class HangingWebSocket(FakeWebSocket):
+            async def __anext__(self):
+                await asyncio.sleep(100)
+
+        fake_ws = HangingWebSocket()
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert fake_ws.closed is True
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary

In `sdks/python/omi/stt/deepgram.py`, `DeepgramTranscriber.run()` hung indefinitely when the remote WebSocket closed normally while the audio queue was idle, preventing reconnects. Furthermore, send/receive errors left sibling streaming tasks orphaned and continuing to consume audio from the shared queue.

This PR explicitly manages the `send_audio` and `receive` tasks with `asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)`. On normal close (EOF), it raises `ConnectionError("Deepgram connection closed")` to trigger the retry/backoff reconnect loop, and in `finally:` it cancels all tasks and drains them with `await asyncio.gather(*tasks, return_exceptions=True)`.

Fixes #12945

## Changes

- **`sdks/python/omi/stt/deepgram.py`**:
  - Replaced `asyncio.gather(send_audio(), receive())` with `asyncio.create_task` and `asyncio.wait(..., return_when=FIRST_COMPLETED)`.
  - Raised `ConnectionError` on clean completion of `receive()` to trigger reconnect and throttling.
  - Ensured both tasks are cancelled and drained before reconnecting.
- **`sdks/python/tests/test_deepgram_lifecycle.py`**:
  - Added 6 hermetic lifecycle unit tests:
    - Normal server close with idle audio queue triggers reconnect and cleanup.
    - Audio chunk transmission and transcript callback delivery.
    - Send error cancels sibling receiver and triggers reconnect.
    - Receive error cancels sibling sender and triggers reconnect.
    - Transcript callback exception cancels sibling sender and triggers reconnect.
    - Caller cancellation terminates `run()` and cleans up internal tasks.

## Verification

- **Automated Tests**:
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/test_deepgram_lifecycle.py -v`: 6/6 passed.
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/`: 13/13 passed.
- **Local Reproduction**:
  - Real loopback WebSocket server confirmed unpatched code hung on normal close (1 connection total), and patched code cleanly reconnected (2 connections).
- **Manifest Preflight**:
  - Validated with `scripts/pr-preflight`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

