### PR TITLE
fix(cli): enforce utf-8 encoding for screenshot text outputs

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -233,7 +233,7 @@ def _write_screenshot_result(result: Any, output: Path) -> Path:
         if source:
             shutil.copyfile(source, output)
         else:
-            output.write_text(result)
+            output.write_text(result, encoding="utf-8")
         return output
 
     if isinstance(result, Mapping):
@@ -251,10 +251,10 @@ def _write_screenshot_result(result: Any, output: Path) -> Path:
 
         content = result.get("content")
         if isinstance(content, str):
-            output.write_text(content)
+            output.write_text(content, encoding="utf-8")
             return output
 
-    output.write_text(json.dumps(result, indent=2, sort_keys=False))
+    output.write_text(json.dumps(result, indent=2, sort_keys=False), encoding="utf-8")
     return output
 
 

--- a/sdks/python-cli/tests/test_local_screenshot_encoding.py
+++ b/sdks/python-cli/tests/test_local_screenshot_encoding.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from omi_cli.commands.local import _write_screenshot_result
+from omi_cli.main import app
+from .test_local import FAKE_LOCAL_URL, _configure_local_profile, _tool_response
+
+
+def test_write_screenshot_result_plain_string_utf8(tmp_path: Path):
+    text = "Screenshot OCR: café 東京"
+    output = tmp_path / "shot.txt"
+
+    with patch("locale.getpreferredencoding", return_value="cp1252"):
+        written = _write_screenshot_result(text, output)
+
+    assert written == output
+    assert output.read_text(encoding="utf-8") == text
+
+
+def test_write_screenshot_result_mapping_content_utf8(tmp_path: Path):
+    text = "Screenshot OCR: café 東京"
+    data = {"content": text, "screenshot_id": "42"}
+    output = tmp_path / "shot.txt"
+
+    with patch("locale.getpreferredencoding", return_value="cp1252"):
+        written = _write_screenshot_result(data, output)
+
+    assert written == output
+    assert output.read_text(encoding="utf-8") == text
+
+
+def test_write_screenshot_result_fallback_json_utf8(tmp_path: Path):
+    data = {"screenshot_id": "42", "label": "café 東京"}
+    output = tmp_path / "shot.json"
+
+    with patch("locale.getpreferredencoding", return_value="cp1252"):
+        written = _write_screenshot_result(data, output)
+
+    assert written == output
+    assert json.loads(output.read_text(encoding="utf-8")) == data
+
+
+def test_screenshot_command_writes_multilingual_content(config_path: Path, cli_runner, tmp_path: Path):
+    _configure_local_profile(config_path)
+    text = "Screenshot OCR: café 東京"
+    response = {"content": text, "screenshot_id": "9"}
+    output = tmp_path / "shot.txt"
+
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(
+            return_value=httpx.Response(200, json={"ok": True, "name": "get_screenshot", **response})
+        )
+        with patch("locale.getpreferredencoding", return_value="cp1252"):
+            result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(output)])
+
+    assert result.exit_code == 0, result.output
+    assert output.read_text(encoding="utf-8") == text
+    payload = json.loads(result.stdout)
+    assert payload["path"] == str(output)
+    assert payload["screenshot_id"] == "9"


### PR DESCRIPTION
## Summary

In `sdks/python-cli/omi_cli/commands/local.py`, `_write_screenshot_result()` invoked `Path.write_text()` without specifying `encoding="utf-8"`. On Windows locales using legacy non-UTF-8 default encodings (e.g. `cp1252`), saving plain-text OCR or metadata containing multilingual characters (e.g. `Screenshot OCR: café 東京`) fails with `UnicodeEncodeError`.

This PR explicitly sets `encoding="utf-8"` on all `output.write_text()` calls in `_write_screenshot_result()`, ensuring reliable UTF-8 screenshot text exports across all platforms and locale settings.

Fixes #13072

## Changes

- **`sdks/python-cli/omi_cli/commands/local.py`**:
  - Specified `encoding="utf-8"` for string outputs, dictionary content outputs, and JSON fallback outputs in `_write_screenshot_result()`.
- **`sdks/python-cli/tests/test_local_screenshot_encoding.py`**:
  - Added unit and CLI command tests verifying UTF-8 encoding behavior for plain strings, content mappings, and JSON fallback payloads when non-UTF-8 preferred encodings (e.g. `cp1252`) are simulated.

## Verification

- **Automated Tests**:
  - `sdks/python-cli/venv/bin/pytest sdks/python-cli/tests/test_local_screenshot_encoding.py -v`: 4/4 passed.
  - `sdks/python-cli/venv/bin/pytest sdks/python-cli/tests/`: 132 passed, 1 skipped.
- **Manifest Preflight**:
  - Validated with `scripts/pr-preflight`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

