### PR TITLE
feat(sdk): allow transcribe() without api_key for whisper and parakeet

### DIFF
--- a/sdks/python/omi/transcribe.py
+++ b/sdks/python/omi/transcribe.py
@@ -7,7 +7,7 @@ from .stt import SttEngine, create_transcriber
 
 async def transcribe(
     audio_queue: Queue[bytes],
-    api_key: str,
+    api_key: Optional[str] = None,
     on_transcript: Optional[Callable[[str], None]] = None,
     *,
     engine: str = SttEngine.DEEPGRAM.value,
@@ -20,8 +20,15 @@ async def transcribe(
       - parakeet: uses HOSTED_PARAKEET_API_URL or engine_kwargs api_url
       - whisper: optional local model / injected runner
     """
+    if callable(api_key) and on_transcript is None:
+        on_transcript = api_key
+        api_key = None
+
     if engine == SttEngine.DEEPGRAM.value:
-        transcriber = create_transcriber(engine, api_key=api_key, **engine_kwargs)
+        key = api_key or engine_kwargs.pop("api_key", None)
+        if not key:
+            raise ValueError("Deepgram api_key is required")
+        transcriber = create_transcriber(engine, api_key=key, **engine_kwargs)
     elif engine == SttEngine.PARAKEET.value:
         transcriber = create_transcriber(engine, **engine_kwargs)
     elif engine == SttEngine.WHISPER.value:

--- a/sdks/python/tests/test_transcribe_wrapper.py
+++ b/sdks/python/tests/test_transcribe_wrapper.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from omi.transcribe import transcribe
+from omi.stt import SttEngine
+
+
+def test_deepgram_requires_api_key():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        with pytest.raises(ValueError, match="Deepgram api_key is required"):
+            await transcribe(queue)
+
+    asyncio.run(_test())
+
+
+def test_deepgram_accepts_positional_api_key():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        fake_transcriber = MagicMock()
+        fake_transcriber.run = MagicMock(side_effect=lambda q, on_transcript=None: asyncio.sleep(0))
+
+        with patch("omi.transcribe.create_transcriber", return_value=fake_transcriber) as mock_create:
+            await transcribe(queue, "test-api-key")
+            mock_create.assert_called_once_with(SttEngine.DEEPGRAM.value, api_key="test-api-key")
+
+    asyncio.run(_test())
+
+
+def test_deepgram_accepts_keyword_api_key():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        fake_transcriber = MagicMock()
+        fake_transcriber.run = MagicMock(side_effect=lambda q, on_transcript=None: asyncio.sleep(0))
+
+        with patch("omi.transcribe.create_transcriber", return_value=fake_transcriber) as mock_create:
+            await transcribe(queue, api_key="kw-api-key")
+            mock_create.assert_called_once_with(SttEngine.DEEPGRAM.value, api_key="kw-api-key")
+
+    asyncio.run(_test())
+
+
+def test_whisper_does_not_require_api_key():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        fake_transcriber = MagicMock()
+        fake_transcriber.run = MagicMock(side_effect=lambda q, on_transcript=None: asyncio.sleep(0))
+
+        with patch("omi.transcribe.create_transcriber", return_value=fake_transcriber) as mock_create:
+            await transcribe(queue, engine="whisper", runner=lambda b: "hello")
+            mock_create.assert_called_once_with(
+                SttEngine.WHISPER.value,
+                runner=mock_create.call_args[1]["runner"]
+            )
+
+    asyncio.run(_test())
+
+
+def test_parakeet_does_not_require_api_key():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        fake_transcriber = MagicMock()
+        fake_transcriber.run = MagicMock(side_effect=lambda q, on_transcript=None: asyncio.sleep(0))
+
+        with patch("omi.transcribe.create_transcriber", return_value=fake_transcriber) as mock_create:
+            await transcribe(queue, engine="parakeet", api_url="https://parakeet.example")
+            mock_create.assert_called_once_with(
+                SttEngine.PARAKEET.value,
+                api_url="https://parakeet.example"
+            )
+
+    asyncio.run(_test())
+
+
+def test_transcribe_callable_positional_as_on_transcript():
+    async def _test():
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        callback = MagicMock()
+        fake_transcriber = MagicMock()
+        fake_transcriber.run = MagicMock(side_effect=lambda q, on_transcript=None: asyncio.sleep(0))
+
+        with patch("omi.transcribe.create_transcriber", return_value=fake_transcriber) as mock_create:
+            await transcribe(queue, callback, engine="whisper", runner=lambda b: "text")
+            mock_create.assert_called_once()
+            fake_transcriber.run.assert_called_once_with(queue, on_transcript=callback)
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary

In `sdks/python/omi/transcribe.py`, the public wrapper function `transcribe()` previously declared `api_key: str` as a required positional argument, even though the Whisper and Parakeet engines do not accept or require an API key. This forced callers using Whisper or Parakeet to provide a dummy API key string, e.g. `await transcribe(queue, "dummy", engine="whisper")`.

This PR makes `api_key` optional (`api_key: Optional[str] = None`) in `transcribe()` and validates that a key is provided only when the Deepgram engine is active. Existing calls passing Deepgram keys positionally or by keyword continue to work unchanged.

Fixes #13042

## Changes

- **`sdks/python/omi/transcribe.py`**:
  - Updated signature to `api_key: Optional[str] = None`.
  - Allowed positional callable arguments to bind to `on_transcript` when no API key is needed.
  - Enforced `ValueError("Deepgram api_key is required")` only when `engine == SttEngine.DEEPGRAM.value`.
- **`sdks/python/tests/test_transcribe_wrapper.py`**:
  - Added unit tests for:
    - Deepgram requiring API key when not provided.
    - Deepgram accepting positional API key.
    - Deepgram accepting keyword API key.
    - Whisper working without an API key.
    - Parakeet working without an API key.
    - Positional callable automatically binding to `on_transcript`.

## Verification

- **Automated Tests**:
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/test_transcribe_wrapper.py -v`: 6/6 passed.
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/`: 13/13 passed.
- **Manifest Preflight**:
  - Validated with `scripts/pr-preflight`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

