### PR TITLE
fix(sdk): await futures and custom awaitables in BLE packet handlers

### DIFF
--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from dataclasses import dataclass
 from typing import Awaitable, Callable, List, Optional, Union
 
@@ -44,7 +45,7 @@ async def listen(
     async def _handler(_sender, data: bytearray) -> None:
         raw = bytes(data)
         result = on_packet(raw)
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             await result
 
     async with BleakClient(device_id) as client:
@@ -63,7 +64,7 @@ async def listen_payload(
         if len(packet) <= PACKET_HEADER_BYTES:
             return
         result = on_payload(packet[PACKET_HEADER_BYTES:])
-        if asyncio.iscoroutine(result):
+        if inspect.isawaitable(result):
             await result
 
     await listen(device_id, wrapped, char_uuid=char_uuid)

--- a/sdks/python/tests/test_ble_callbacks.py
+++ b/sdks/python/tests/test_ble_callbacks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -10,13 +10,13 @@ from omi.constants import PACKET_HEADER_BYTES
 
 
 class CustomAwaitable:
-    def __init__(self, trace: list[str], tag: str):
-        self.trace = trace
-        self.tag = tag
+    def __init__(self):
+        self.awaited = False
 
     def __await__(self):
         async def _run():
-            self.trace.append(f"custom:{self.tag}")
+            self.awaited = True
+
         return _run().__await__()
 
 
@@ -37,35 +37,78 @@ class MockBleakClient:
 
 def test_listen_awaits_futures_and_custom_awaitables():
     async def _test():
-        trace = []
         client_instance = MockBleakClient("fake-device")
+        loop = asyncio.get_running_loop()
 
-        # 1. Test future
-        async def future_handler(data: bytes):
-            fut = asyncio.get_running_loop().create_future()
-            fut.set_result(None)
-            trace.append("future")
-            return fut
+        # 1. Direct Future: created inside callback and completed via call_soon.
+        # If notify_handler awaits the future, fut.done() is True immediately after it returns.
+        active_fut: asyncio.Future | None = None
 
-        # 2. Test custom awaitable
+        def future_handler(data: bytes):
+            nonlocal active_fut
+            active_fut = loop.create_future()
+            loop.call_soon(active_fut.set_result, None)
+            return active_fut
+
+        # 2. Custom awaitable: must have __await__ executed.
+        active_custom: CustomAwaitable | None = None
+
         def custom_handler(data: bytes):
-            return CustomAwaitable(trace, "packet")
+            nonlocal active_custom
+            active_custom = CustomAwaitable()
+            return active_custom
 
-        # 3. Test coroutine
+        # 3. Direct asyncio.Task: must finish upon await.
+        active_task: asyncio.Task | None = None
+
+        def task_handler(data: bytes):
+            nonlocal active_task
+
+            async def _task_work():
+                pass
+
+            active_task = asyncio.create_task(_task_work())
+            return active_task
+
+        # 4. Standard coroutine
+        coro_awaited = False
+
         async def coro_handler(data: bytes):
-            trace.append("coro")
+            nonlocal coro_awaited
+            coro_awaited = True
 
-        # 4. Test sync
+        # 5. Sync callback
+        sync_called = False
+
         def sync_handler(data: bytes):
-            trace.append("sync")
+            nonlocal sync_called
+            sync_called = True
+
+        handlers = [
+            ("future", future_handler),
+            ("custom", custom_handler),
+            ("task", task_handler),
+            ("coro", coro_handler),
+            ("sync", sync_handler),
+        ]
 
         with patch("omi.ble.BleakClient", return_value=client_instance):
-            for handler in (future_handler, custom_handler, coro_handler, sync_handler):
-                notify_captured = []
+            for name, handler in handlers:
 
                 async def fake_sleep(_sec):
-                    # Trigger handler and stop
+                    # Trigger notification handler
                     await client_instance.notify_handler("sender", bytearray(b"\x00\x01\x02\x03\x04"))
+                    # If handler was an awaitable and not awaited, pending items won't be done yet
+                    if name == "future":
+                        assert active_fut is not None and active_fut.done(), "Future was not awaited"
+                    elif name == "custom":
+                        assert active_custom is not None and active_custom.awaited, "Custom awaitable was not awaited"
+                    elif name == "task":
+                        assert active_task is not None and active_task.done(), "Task was not awaited"
+                    elif name == "coro":
+                        assert coro_awaited, "Coroutine was not awaited"
+                    elif name == "sync":
+                        assert sync_called, "Sync handler was not called"
                     raise asyncio.CancelledError()
 
                 with patch("asyncio.sleep", side_effect=fake_sleep):
@@ -74,35 +117,66 @@ def test_listen_awaits_futures_and_custom_awaitables():
                     except asyncio.CancelledError:
                         pass
 
-        assert trace == ["future", "custom:packet", "coro", "sync"]
-
     asyncio.run(_test())
 
 
 def test_listen_payload_awaits_futures_and_custom_awaitables():
     async def _test():
-        trace = []
         client_instance = MockBleakClient("fake-device")
-
-        # Custom awaitable for payload
-        def custom_payload_handler(payload: bytes):
-            assert payload == b"\x03\x04"  # Header bytes stripped
-            return CustomAwaitable(trace, "payload")
+        loop = asyncio.get_running_loop()
 
         # Future for payload
+        active_fut: asyncio.Future | None = None
+
         def future_payload_handler(payload: bytes):
             assert payload == b"\x03\x04"
-            fut = asyncio.get_running_loop().create_future()
-            fut.set_result(None)
-            trace.append("future_payload")
-            return fut
+            nonlocal active_fut
+            active_fut = loop.create_future()
+            loop.call_soon(active_fut.set_result, None)
+            return active_fut
+
+        # Custom awaitable for payload
+        active_custom: CustomAwaitable | None = None
+
+        def custom_payload_handler(payload: bytes):
+            assert payload == b"\x03\x04"
+            nonlocal active_custom
+            active_custom = CustomAwaitable()
+            return active_custom
+
+        # Task for payload
+        active_task: asyncio.Task | None = None
+
+        def task_payload_handler(payload: bytes):
+            assert payload == b"\x03\x04"
+            nonlocal active_task
+
+            async def _task_work():
+                pass
+
+            active_task = asyncio.create_task(_task_work())
+            return active_task
+
+        handlers = [
+            ("future", future_payload_handler),
+            ("custom", custom_payload_handler),
+            ("task", task_payload_handler),
+        ]
 
         with patch("omi.ble.BleakClient", return_value=client_instance):
-            for handler in (custom_payload_handler, future_payload_handler):
+            for name, handler in handlers:
+
                 async def fake_sleep(_sec):
-                    # 3 header bytes + 2 payload bytes
                     packet = b"\x00" * PACKET_HEADER_BYTES + b"\x03\x04"
                     await client_instance.notify_handler("sender", bytearray(packet))
+                    if name == "future":
+                        assert active_fut is not None and active_fut.done(), "Payload Future was not awaited"
+                    elif name == "custom":
+                        assert (
+                            active_custom is not None and active_custom.awaited
+                        ), "Payload Custom awaitable was not awaited"
+                    elif name == "task":
+                        assert active_task is not None and active_task.done(), "Payload Task was not awaited"
                     raise asyncio.CancelledError()
 
                 with patch("asyncio.sleep", side_effect=fake_sleep):
@@ -110,7 +184,5 @@ def test_listen_payload_awaits_futures_and_custom_awaitables():
                         await listen_payload("fake-device", handler)
                     except asyncio.CancelledError:
                         pass
-
-        assert trace == ["custom:payload", "future_payload"]
 
     asyncio.run(_test())

--- a/sdks/python/tests/test_ble_callbacks.py
+++ b/sdks/python/tests/test_ble_callbacks.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from omi.ble import listen, listen_payload
+from omi.constants import PACKET_HEADER_BYTES
+
+
+class CustomAwaitable:
+    def __init__(self, trace: list[str], tag: str):
+        self.trace = trace
+        self.tag = tag
+
+    def __await__(self):
+        async def _run():
+            self.trace.append(f"custom:{self.tag}")
+        return _run().__await__()
+
+
+class MockBleakClient:
+    def __init__(self, device_id: str):
+        self.device_id = device_id
+        self.notify_handler = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def start_notify(self, char_uuid, handler):
+        self.notify_handler = handler
+
+
+def test_listen_awaits_futures_and_custom_awaitables():
+    async def _test():
+        trace = []
+        client_instance = MockBleakClient("fake-device")
+
+        # 1. Test future
+        async def future_handler(data: bytes):
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(None)
+            trace.append("future")
+            return fut
+
+        # 2. Test custom awaitable
+        def custom_handler(data: bytes):
+            return CustomAwaitable(trace, "packet")
+
+        # 3. Test coroutine
+        async def coro_handler(data: bytes):
+            trace.append("coro")
+
+        # 4. Test sync
+        def sync_handler(data: bytes):
+            trace.append("sync")
+
+        with patch("omi.ble.BleakClient", return_value=client_instance):
+            for handler in (future_handler, custom_handler, coro_handler, sync_handler):
+                notify_captured = []
+
+                async def fake_sleep(_sec):
+                    # Trigger handler and stop
+                    await client_instance.notify_handler("sender", bytearray(b"\x00\x01\x02\x03\x04"))
+                    raise asyncio.CancelledError()
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    try:
+                        await listen("fake-device", handler)
+                    except asyncio.CancelledError:
+                        pass
+
+        assert trace == ["future", "custom:packet", "coro", "sync"]
+
+    asyncio.run(_test())
+
+
+def test_listen_payload_awaits_futures_and_custom_awaitables():
+    async def _test():
+        trace = []
+        client_instance = MockBleakClient("fake-device")
+
+        # Custom awaitable for payload
+        def custom_payload_handler(payload: bytes):
+            assert payload == b"\x03\x04"  # Header bytes stripped
+            return CustomAwaitable(trace, "payload")
+
+        # Future for payload
+        def future_payload_handler(payload: bytes):
+            assert payload == b"\x03\x04"
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(None)
+            trace.append("future_payload")
+            return fut
+
+        with patch("omi.ble.BleakClient", return_value=client_instance):
+            for handler in (custom_payload_handler, future_payload_handler):
+                async def fake_sleep(_sec):
+                    # 3 header bytes + 2 payload bytes
+                    packet = b"\x00" * PACKET_HEADER_BYTES + b"\x03\x04"
+                    await client_instance.notify_handler("sender", bytearray(packet))
+                    raise asyncio.CancelledError()
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    try:
+                        await listen_payload("fake-device", handler)
+                    except asyncio.CancelledError:
+                        pass
+
+        assert trace == ["custom:payload", "future_payload"]
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary

In `sdks/python/omi/ble.py`, `AsyncPacketHandler` is typed as `Callable[[bytes], Union[None, Awaitable[None]]]`. However, `listen()` and `listen_payload()` checked callbacks using `asyncio.iscoroutine()`. Because `asyncio.iscoroutine()` returns `False` for `asyncio.Future`, `asyncio.Task`, or custom classes implementing `__await__`, those return values were not awaited, and custom awaitable bodies were never executed.

This PR replaces `asyncio.iscoroutine(result)` with `inspect.isawaitable(result)` in both `listen()` and `listen_payload()`, ensuring all valid `Awaitable` results are properly awaited.

Fixes #12949

## Changes

- **`sdks/python/omi/ble.py`**:
  - Imported `inspect`.
  - Replaced `asyncio.iscoroutine(result)` with `inspect.isawaitable(result)` in `_handler` (`listen`) and `wrapped` (`listen_payload`).
- **`sdks/python/tests/test_ble_callbacks.py`**:
  - Added unit tests asserting that callbacks returning `Future`, coroutine, sync `None`, and custom `__await__` objects are properly handled and awaited.

## Verification

- **Automated Tests**:
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/test_ble_callbacks.py -v`: 2/2 passed.
  - `PYTHONPATH=sdks/python sdks/python/venv/bin/pytest sdks/python/tests/`: 9/9 passed.
- **Manifest Preflight**:
  - Validated with `scripts/pr-preflight`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

