### PR TITLE
feat: allow clearing memory tags from the CLI

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -209,7 +209,7 @@ omi
 │   ├── list [--limit N] [--offset N] [--categories ...]
 │   ├── get <id>
 │   ├── create <content> [--category ...] [--visibility ...] [--tag ...]
-│   ├── update <id> [--content ...] [--category ...] [--visibility ...] [--tag ...]
+│   ├── update <id> [--content ...] [--category ...] [--visibility ...] [--tag ...] [--clear-tags]
 │   └── delete <id> [-y]
 ├── conversation
 │   ├── list [--limit N] [--start-date ...] [--end-date ...] [--include-transcript]

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -116,6 +116,7 @@ def update_memory(
     category: Optional[MemoryCategory] = typer.Option(None, "--category", help="New category."),
     visibility: Optional[MemoryVisibility] = typer.Option(None, "--visibility", help="public or private."),
     tag: Optional[list[str]] = typer.Option(None, "--tag", help="Replace tags (repeat for multiple)."),
+    clear_tags: bool = typer.Option(False, "--clear-tags", help="Remove all tags from the memory."),
 ) -> None:
     ctx = _ctx(typer_ctx)
     body: dict[str, object] = {}
@@ -125,11 +126,16 @@ def update_memory(
         body["category"] = category.value
     if visibility is not None:
         body["visibility"] = visibility.value
-    if tag is not None:
+    if clear_tags and tag is not None:
+        raise UsageError(message="Choose one tag operation", detail="Use either --tag or --clear-tags, not both.")
+    if clear_tags:
+        body["tags"] = []
+    elif tag is not None:
         body["tags"] = list(tag)
     if not body:
         raise UsageError(
-            message="No fields to update", detail="Provide at least one of --content/--category/--visibility/--tag."
+            message="No fields to update",
+            detail="Provide at least one of --content/--category/--visibility/--tag/--clear-tags.",
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/memories/{memory_id}", json_body=body)

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -99,6 +99,50 @@ def test_memory_update_patches_body(authed_profile, respx_mock, cli_runner) -> N
     assert body == {"content": "new"}
 
 
+def test_memory_update_clear_tags_sends_empty_tag_list(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/memories/m1").respond(
+        json={
+            "id": "m1",
+            "content": "new",
+            "category": "core",
+            "visibility": "private",
+            "tags": [],
+        }
+    )
+
+    result = cli_runner.invoke(app, ["--json", "memory", "update", "m1", "--clear-tags"])
+
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"tags": []}
+
+
+def test_memory_update_omit_tags_preserves_existing_tags(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/memories/m1").respond(
+        json={
+            "id": "m1",
+            "content": "new",
+            "category": "core",
+            "visibility": "private",
+            "tags": ["keep"],
+        }
+    )
+
+    result = cli_runner.invoke(app, ["--json", "memory", "update", "m1", "--content", "new"])
+
+    assert result.exit_code == 0
+    body = json.loads(route.calls.last.request.content)
+    assert "tags" not in body
+
+
+def test_memory_update_clear_tags_rejects_tag_values(authed_profile, respx_mock, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["memory", "update", "m1", "--tag", "keep", "--clear-tags"])
+
+    assert result.exit_code == 1
+    assert "choose one tag operation" in result.stderr.lower()
+    assert not respx_mock.calls
+
+
 def test_memory_unauthenticated_is_clear(config_path, cli_runner) -> None:
     result = cli_runner.invoke(app, ["memory", "list"])
     assert result.exit_code == 2  # EXIT_AUTH


### PR DESCRIPTION
`omi memory update` can replace tags with repeated `--tag` options, but it cannot express the Developer API's explicit empty list state. This means a memory's final tag cannot be removed from the CLI without changing the memory another way.

This patch adds `--clear-tags` to `omi memory update`:

- `--clear-tags` sends `{"tags": []}`.
- `--tag` continues to replace tags when provided.
- Omitting both preserves existing tags.
- `--tag` and `--clear-tags` are mutually exclusive.
- The no-field usage error now mentions `--clear-tags`.

Fixes #13014.

Regression coverage added in `sdks/python-cli/tests/test_memory.py`:

- clear tags sends an empty tag list
- content-only updates omit the `tags` field
- combining `--tag` with `--clear-tags` fails before sending a request

This contribution is AI-assisted. Following the contribution guide's bounty-proposal process, would maintainers consider a small US$5 PayPal bounty for this scoped fix after acceptance and merge? No award or payment is assumed, and payout details will remain private unless maintainers approve payment after merge.

Validation: fetched the published branch head `faa693027e3044adcd21cca0b04017ff48924cfd` and Python-compiled the touched files successfully:

- `sdks/python-cli/omi_cli/commands/memory.py`
- `sdks/python-cli/tests/test_memory.py`

Hosted CI remains authoritative for the complete suite.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

