### PR TITLE
feat(python-sdk): support Deepgram language selection

### DIFF
--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -162,6 +162,23 @@ The SDK requires the Opus audio codec library:
 
 ---
 
+## Deepgram language selection
+
+The Deepgram engine defaults to `en-US`. Set `language` to a language supported
+by your chosen Deepgram model when transcribing other languages:
+
+```python
+from omi.stt import create_transcriber
+
+transcriber = create_transcriber("deepgram", api_key=DEEPGRAM_API_KEY, language="es")
+await transcriber.run(audio_queue, on_transcript=handle_transcript)
+```
+
+The `omi.transcribe.transcribe` function also forwards `language="es"` through
+its engine options. This selects a transcription language; it does not translate
+audio or enable automatic language detection. See Deepgram's
+[model and language support](https://developers.deepgram.com/docs/models-languages-overview).
+
 ## Development
 
 ### Local Development Setup

--- a/sdks/python/omi/stt/deepgram.py
+++ b/sdks/python/omi/stt/deepgram.py
@@ -4,15 +4,24 @@ import asyncio
 import json
 from asyncio import Queue
 from typing import Callable, Optional
+from urllib.parse import urlencode
 
 
 class DeepgramTranscriber:
-    def __init__(self, api_key: str, *, sample_rate: int = 16000, model: str = "nova") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        sample_rate: int = 16000,
+        model: str = "nova",
+        language: str = "en-US",
+    ) -> None:
         if not api_key:
             raise ValueError("Deepgram api_key is required")
         self.api_key = api_key
         self.sample_rate = sample_rate
         self.model = model
+        self.language = language
 
     async def run(
         self,
@@ -24,14 +33,22 @@ class DeepgramTranscriber:
         except ImportError as exc:
             raise ImportError("Deepgram engine requires websockets package") from exc
 
-        url = (
-            "wss://api.deepgram.com/v1/listen"
-            f"?punctuate=true&model={self.model}&language=en-US"
-            f"&encoding=linear16&sample_rate={self.sample_rate}&channels=1"
+        query = urlencode(
+            {
+                "punctuate": "true",
+                "model": self.model,
+                "language": self.language,
+                "encoding": "linear16",
+                "sample_rate": self.sample_rate,
+                "channels": 1,
+            }
         )
+        url = f"wss://api.deepgram.com/v1/listen?{query}"
         while True:
             try:
-                async with websockets.connect(url, additional_headers={"Authorization": f"Token {self.api_key}"}) as ws:
+                async with websockets.connect(
+                    url, additional_headers={"Authorization": f"Token {self.api_key}"}
+                ) as ws:
 
                     async def send_audio() -> None:
                         while True:
@@ -41,7 +58,11 @@ class DeepgramTranscriber:
                     async def receive() -> None:
                         async for message in ws:
                             data = json.loads(message)
-                            alt = data.get("channel", {}).get("alternatives", [{}])[0].get("transcript", "")
+                            alt = (
+                                data.get("channel", {})
+                                .get("alternatives", [{}])[0]
+                                .get("transcript", "")
+                            )
                             if alt:
                                 if on_transcript:
                                     on_transcript(alt)

--- a/sdks/python/tests/test_deepgram_language.py
+++ b/sdks/python/tests/test_deepgram_language.py
@@ -1,0 +1,46 @@
+import asyncio
+import sys
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from omi.stt import create_transcriber
+from omi.transcribe import transcribe
+
+
+@pytest.mark.parametrize(
+    "options,expected", [({}, "en-US"), ({"language": "es"}, "es")]
+)
+def test_deepgram_connection_language(monkeypatch, options, expected):
+    calls = []
+
+    def connect(url, **kwargs):
+        calls.append((url, kwargs))
+        raise asyncio.CancelledError()
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(transcribe(asyncio.Queue(), "synthetic-key", **options))
+    assert len(calls) == 1
+    url, kwargs = calls[0]
+    assert parse_qs(urlsplit(url).query)["language"] == [expected]
+    assert kwargs["additional_headers"] == {"Authorization": "Token synthetic-key"}
+
+
+def test_deepgram_language_cannot_add_query_parameters(monkeypatch):
+    calls = []
+
+    def connect(url, **kwargs):
+        calls.append(url)
+        raise asyncio.CancelledError()
+
+    monkeypatch.setitem(sys.modules, "websockets", SimpleNamespace(connect=connect))
+    engine = create_transcriber(
+        "deepgram", api_key="synthetic-key", language="es&channels=2"
+    )
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(engine.run(asyncio.Queue()))
+    query = parse_qs(urlsplit(calls[0]).query)
+    assert query["language"] == ["es&channels=2"]
+    assert query["channels"] == ["1"]


### PR DESCRIPTION
## What changed and why

Closes #13093. Python SDK Deepgram requests previously always selected English and rejected `language="es"`. Add a keyword-only language option, preserving `en-US` by default, and encode the query parameters so option values cannot create extra parameters. Document the factory and wrapper options in the canonical SDK guide (README synchronization is handled by the existing docs workflow).

## Product invariants affected

none

## How it was verified

`PYTHONPATH=sdks/python python -m pytest sdks/python/tests -q`: 10 passed on Python 3.11.6. The new tests intercept the WebSocket connection through the real transcription wrapper and factory; no live connection, API spend, hardware or audio was used. Before implementation, explicit-language tests failed with TypeError and the default-English control passed. No transcription-quality claim. Existing optional-dependency tests can early-return when packages are absent.

## Tests

`sdks/python/tests/test_deepgram_language.py` covers the default language, Spanish through the public wrapper, and query-parameter separation through the factory.

## Failure class (fixes)

Failure-Class: none

AI assistance: implemented and tested with Codex for @BuildThingsThatBuildthings. The proposed $10 bounty is tracked separately in #13093 and is not assumed approved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

