### PR TITLE
fix(python-cli): allow qualitative goal creation without metric options

### DIFF
--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -84,18 +84,33 @@ def create_goal(
     current_value: Optional[float] = typer.Option(None, "--current", help="Current progress value."),
     min_value: Optional[float] = typer.Option(None, "--min", help="Minimum scale value."),
     max_value: Optional[float] = typer.Option(None, "--max", help="Maximum scale value."),
-    unit: Optional[str] = typer.Option(None, "--unit", help="Unit label (e.g. 'users', 'points')."),
+    unit: Optional[str] = typer.Option(
+        None, "--unit", help="Unit label (e.g. 'users', 'points'). Requires a metric option such as --target."
+    ),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    has_metrics = any(value is not None for value in (target_value, goal_type, current_value, min_value, max_value))
+    if unit is not None and not has_metrics:
+        # The backend only persists ``unit`` on metric-backed goals; sending it on a
+        # qualitative goal would silently drop it, so reject the combination instead.
+        raise UsageError(
+            message="--unit requires a metric goal",
+            detail="Add a metric option such as --target, or drop --unit to create a qualitative goal.",
+        )
+    if has_metrics and target_value is None:
+        # ``--target`` was historically required for every metric goal. Partial metric
+        # invocations must not fabricate a target-less scale goal, so keep rejecting them.
+        raise UsageError(
+            message="--target is required when using metric options",
+            detail="Pass --target, or omit --type/--current/--min/--max/--unit to create a qualitative goal.",
+        )
     body: dict[str, object] = {"title": title}
     if unit is not None:
         body["unit"] = unit
-    has_metrics = any(value is not None for value in (target_value, goal_type, current_value, min_value, max_value))
     if has_metrics:
         # Metric goal: keep the historical defaults for options the caller did not set.
         body["goal_type"] = (goal_type if goal_type is not None else GoalType.scale).value
-        if target_value is not None:
-            body["target_value"] = target_value
+        body["target_value"] = target_value
         body["current_value"] = current_value if current_value is not None else 0
         body["min_value"] = min_value if min_value is not None else 0
         body["max_value"] = max_value if max_value is not None else 10

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -69,28 +69,37 @@ def get_goal(
     ctx.renderer.emit(result, title="goal")
 
 
-@app.command("create", help="Create a new goal. Up to 3 active goals per user.")
+@app.command(
+    "create", help="Create a new goal. Up to 3 active goals per user. Omit all metric options for a qualitative goal."
+)
 def create_goal(
     typer_ctx: typer.Context,
     title: str = typer.Argument(..., help="Goal title (1-500 chars)."),
-    target_value: float = typer.Option(..., "--target", help="Target value to achieve."),
-    goal_type: GoalType = typer.Option(GoalType.scale, "--type", help="boolean, scale, or numeric."),
-    current_value: float = typer.Option(0, "--current", help="Current progress value."),
-    min_value: float = typer.Option(0, "--min", help="Minimum scale value."),
-    max_value: float = typer.Option(10, "--max", help="Maximum scale value."),
+    target_value: Optional[float] = typer.Option(
+        None, "--target", help="Target value to achieve. Omit for qualitative goals."
+    ),
+    goal_type: Optional[GoalType] = typer.Option(
+        None, "--type", help="boolean, scale, or numeric. Omit for qualitative goals."
+    ),
+    current_value: Optional[float] = typer.Option(None, "--current", help="Current progress value."),
+    min_value: Optional[float] = typer.Option(None, "--min", help="Minimum scale value."),
+    max_value: Optional[float] = typer.Option(None, "--max", help="Maximum scale value."),
     unit: Optional[str] = typer.Option(None, "--unit", help="Unit label (e.g. 'users', 'points')."),
 ) -> None:
     ctx = _ctx(typer_ctx)
-    body: dict[str, object] = {
-        "title": title,
-        "goal_type": goal_type.value,
-        "target_value": target_value,
-        "current_value": current_value,
-        "min_value": min_value,
-        "max_value": max_value,
-    }
+    body: dict[str, object] = {"title": title}
     if unit is not None:
         body["unit"] = unit
+    has_metrics = any(value is not None for value in (target_value, goal_type, current_value, min_value, max_value))
+    if has_metrics:
+        # Metric goal: keep the historical defaults for options the caller did not set.
+        body["goal_type"] = (goal_type if goal_type is not None else GoalType.scale).value
+        if target_value is not None:
+            body["target_value"] = target_value
+        body["current_value"] = current_value if current_value is not None else 0
+        body["min_value"] = min_value if min_value is not None else 0
+        body["max_value"] = max_value if max_value is not None else 10
+    # No metric options given: send a qualitative goal (the API supports omitting all metric fields).
     with ctx.make_client() as client:
         result = client.post("/v1/dev/user/goals", json_body=body)
     ctx.renderer.success(f"Goal created: [bold]{result.get('id')}[/bold]")

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -64,6 +64,50 @@ def test_goal_create_posts(authed_profile, respx_mock, cli_runner) -> None:
     assert body["unit"] == "liters"
 
 
+def test_goal_create_qualitative_omits_metrics(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g2",
+            "title": "Build stronger relationships",
+            "goal_type": None,
+            "target_value": None,
+            "current_value": None,
+            "min_value": None,
+            "max_value": None,
+            "unit": None,
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "Build stronger relationships"])
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"title": "Build stronger relationships"}
+
+
+def test_goal_create_metric_defaults_preserved(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g3",
+            "title": "drink water",
+            "goal_type": "scale",
+            "target_value": 2.0,
+            "current_value": 0,
+            "min_value": 0,
+            "max_value": 10,
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "drink water", "--target", "2"])
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(route.calls.last.request.content)
+    # Historical defaults still apply when any metric option is given.
+    assert body["goal_type"] == "scale"
+    assert body["target_value"] == 2.0
+    assert body["current_value"] == 0
+    assert body["min_value"] == 0
+    assert body["max_value"] == 10
+
+
 def test_goal_progress_uses_query_param(authed_profile, respx_mock, cli_runner) -> None:
     route = respx_mock.patch("/v1/dev/user/goals/g1/progress").respond(
         json={

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -108,6 +108,38 @@ def test_goal_create_metric_defaults_preserved(authed_profile, respx_mock, cli_r
     assert body["max_value"] == 10
 
 
+def test_goal_create_unit_without_metrics_rejected(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "meditate", "--unit", "sessions"])
+    assert result.exit_code == 1  # EXIT_USAGE
+    assert "--unit requires a metric goal" in result.stderr
+
+
+def test_goal_create_partial_metrics_rejected(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "drink water", "--current", "5"])
+    assert result.exit_code == 1  # EXIT_USAGE
+    assert "--target is required" in result.stderr
+
+
+def test_goal_create_unit_attached_to_metric_goal(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g4",
+            "title": "drink water",
+            "goal_type": "scale",
+            "target_value": 2.0,
+            "current_value": 0,
+            "min_value": 0,
+            "max_value": 10,
+            "unit": "liters",
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "drink water", "--target", "2", "--unit", "liters"])
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(route.calls.last.request.content)
+    assert body["unit"] == "liters"
+
+
 def test_goal_progress_uses_query_param(authed_profile, respx_mock, cli_runner) -> None:
     route = respx_mock.patch("/v1/dev/user/goals/g1/progress").respond(
         json={


### PR DESCRIPTION
## Problem

`omi --json goal create "Build stronger relationships"` exits 2 with a missing `--target` usage error before any HTTP request is sent.

The developer API explicitly supports qualitative goals by omitting all metric fields — `CreateGoalRequest` in `backend/routers/developer.py` declares `goal_type`, `target_value`, `current_value`, `min_value`, `max_value` as `Optional` (all default `None`). The CLI is stricter than the API it wraps, so qualitative goals are impossible to create from the CLI.

Fixes #13085

## Root cause

`create_goal` in `sdks/python-cli/omi_cli/commands/goal.py` declared `--target` as required (`typer.Option(...)`) and always sent every metric field in the request body.

## Implementation

- Make `--target`, `--type`, `--current`, `--min`, `--max` optional (`Optional[float]` / `Optional[GoalType]`, default `None`).
- If **no** metric option is provided, send only `{"title": ...}` — a qualitative goal, exactly what the API accepts.
- If **any** metric option is provided, preserve the historical defaults (`type=scale`, `current=0`, `min=0`, `max=10`) so existing scripts behave identically.
- Validate metric combinations (cubic review follow-up):
  - `--unit` without any metric option is rejected (exit 1) — the backend only persists `unit` on metric-backed goals, so it would be silently dropped on a qualitative goal.
  - Metric options without `--target` are rejected (exit 1) — preserving the historical contract that every metric goal has a target, instead of fabricating a target-less scale goal.
- `--unit` continues to be attached whenever provided alongside a metric goal.

## Testing

- New: `test_goal_create_qualitative_omits_metrics` — qualitative request body contains only the title.
- New: `test_goal_create_metric_defaults_preserved` — `--target 2` alone still produces the historical scale defaults (backward compat).
- New: `test_goal_create_unit_without_metrics_rejected` — `--unit` alone exits 1 with guidance.
- New: `test_goal_create_partial_metrics_rejected` — `--current 5` without `--target` exits 1 with guidance.
- New: `test_goal_create_unit_attached_to_metric_goal` — `--target 2 --unit liters` sends `unit` through.
- Full Python CLI suite: 134 passed, 1 skipped.
- The 4 failures in `tests/test_openapi_contract.py` on older runs are pre-existing on current `main` and unrelated to this change.
- `black` clean on both touched files.

## Compatibility

No breaking change for valid invocations: every command that worked before produces the same request body. The only behavior changes are that omitting metric options now succeeds (qualitative goal) instead of exiting with a usage error, and previously broken partial-metric invocations now fail fast with a clear client-side message instead of creating a malformed goal server-side.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->