### PR TITLE
fix(sdks/device): normalize Noble discovery UUID filters

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -10,6 +10,11 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["linux", "macos"]
     reason: "Parakeet readiness is written by the WebSocket reader and read by PCM submission; execute the in-memory handshake with the race detector"
+  - id: typescript-device-sdk-tests
+    command: ["bun", "test", "sdks/device/typescript"]
+    triggers: ["sdks/device/typescript/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the Noble transport introduced in #10227 passed dashed UUID discovery filters to an undashed-UUID backend; exercise production discovery and audio delivery through a controllable adapter"
   - id: dev-harness-unit-tests
     command: ["bash", "scripts/dev-harness/run-tests.sh"]
     triggers: ["Makefile", "scripts/dev-harness/**", "desktop/macos/scripts/omi-fault-inject.sh", ".github/checks-manifest.yaml"]

--- a/sdks/device/typescript/README.md
+++ b/sdks/device/typescript/README.md
@@ -8,3 +8,20 @@ Shared Omi device BLE constants + packet framing.
 ```ts
 import { AUDIO_DATA_UUID, stripPacketHeader, OmiDeviceSession } from '@basedhardware/omi-device';
 ```
+
+For Node BLE connections, install the optional `@stoprocent/noble` dependency and
+use `connectAndListen(deviceId, onPacket)`. Its service and characteristic discovery
+filters use Noble's lowercase UUID format without dashes; exported protocol UUIDs
+retain their standard dashed format.
+
+Run the component's hermetic tests with the repository CI version, Bun 1.3.14:
+
+```sh
+bun test sdks/device/typescript
+```
+
+The tests include discovery, audio delivery and disconnect through a mocked Noble
+adapter, so they require no native BLE dependency or hardware. This suite is selected
+by the shared local/CI check manifest when this SDK changes. With the package's
+development dependencies installed, `bun run typecheck` from this directory checks
+the production TypeScript source.

--- a/sdks/device/typescript/src/ble/noble.test.ts
+++ b/sdks/device/typescript/src/ble/noble.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
 import { stripPacketHeader, PACKET_HEADER_BYTES } from '../index.ts';
-import { createNobleTransport, NOBLE_MISSING } from './index.ts';
+import { connectAndListen, createNobleTransport, NOBLE_MISSING } from './index.ts';
 
 describe('stripPacketHeader', () => {
   test('strips 3-byte header', () => {
@@ -16,15 +17,73 @@ describe('stripPacketHeader', () => {
 });
 
 describe('createNobleTransport', () => {
-  test('clear error or succeeds if noble present', async () => {
+  test('creates the transport before subscribing to audio', async () => {
+    const { subscribe } = mockNobleDiscovery();
     expect(NOBLE_MISSING.includes('@stoprocent/noble')).toBe(true);
-    try {
-      await createNobleTransport('aa:bb:cc:dd:ee:ff');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      expect(
-        msg.includes('Optional BLE dependency missing') || msg.includes('@stoprocent/noble') || msg.includes('noble')
-      ).toBe(true);
-    }
+    const transport = await createNobleTransport('omi');
+    expect(typeof transport.startAudioNotifications).toBe('function');
+    expect(typeof transport.stopAudioNotifications).toBe('function');
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+});
+
+function mockNobleDiscovery(hasAudio = true) {
+  const audio = new EventEmitter();
+  const subscribe = mock(async () => {});
+  const unsubscribe = mock(async () => {});
+  const disconnect = mock(async () => {});
+  const characteristic = Object.assign(audio, {
+    uuid: '19b10001e8f2537e4f6cd104768a1214',
+    subscribeAsync: subscribe,
+    unsubscribeAsync: unsubscribe,
+  });
+  const peripheral = {
+    state: 'connected',
+    disconnectAsync: disconnect,
+    async discoverSomeServicesAndCharacteristicsAsync(services: string[], characteristics: string[]) {
+      // Noble's HCI GATT decoder returns undashed UUIDs and filters by exact
+      // membership (stoprocent/noble lib/hci-socket/gatt.js).
+      if (!services.includes('19b10000e8f2537e4f6cd104768a1214')) {
+        throw new Error('Could not find all requested services');
+      }
+      return {
+        characteristics: hasAudio && characteristics.includes(characteristic.uuid) ? [characteristic] : [],
+      };
+    },
+  };
+  mock.module('@stoprocent/noble', () => ({
+    default: {
+      state: 'poweredOn',
+      startScanningAsync: async () => {},
+      stopScanningAsync: async () => {},
+      connectAsync: async () => peripheral,
+    },
+  }));
+  return { audio, subscribe, unsubscribe, disconnect };
+}
+
+describe('connectAndListen discovery', () => {
+  test('discovers Omi with Noble UUID filters and receives audio', async () => {
+    const { audio, subscribe, unsubscribe, disconnect } = mockNobleDiscovery();
+    const packets: number[][] = [];
+    const connection = await connectAndListen('omi', (packet) => packets.push([...packet]));
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    audio.emit('data', Buffer.from([1, 2, 3, 10, 20]));
+    expect(packets).toEqual([[1, 2, 3, 10, 20]]);
+
+    await connection.disconnect();
+    audio.emit('data', Buffer.from([1, 2, 3, 30]));
+    expect(packets).toHaveLength(1);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects a device without the audio characteristic', async () => {
+    const { subscribe, disconnect } = mockNobleDiscovery(false);
+
+    await expect(connectAndListen('omi', () => {})).rejects.toThrow('Audio characteristic');
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/sdks/device/typescript/src/ble/noble.test.ts
+++ b/sdks/device/typescript/src/ble/noble.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { stripPacketHeader, PACKET_HEADER_BYTES } from '../index.ts';
-import { connectAndListen, createNobleTransport, NOBLE_MISSING } from './index.ts';
+import { connectAndListen, createNobleTransport } from './index.ts';
 
 describe('stripPacketHeader', () => {
   test('strips 3-byte header', () => {
@@ -17,9 +17,33 @@ describe('stripPacketHeader', () => {
 });
 
 describe('createNobleTransport', () => {
+  test('gives an install hint when the optional Noble import fails', () => {
+    // Isolate the module cache: a throwing mock cannot replace an already loaded
+    // module in Bun, and this path must not initialize a native Bluetooth adapter.
+    const result = Bun.spawnSync([
+      process.execPath,
+      '--eval',
+      `import { mock } from 'bun:test';
+       import { createNobleTransport } from './index.ts';
+       mock.module('@stoprocent/noble', () => {
+         throw Object.assign(new Error("Cannot find module '@stoprocent/noble'"), { code: 'MODULE_NOT_FOUND' });
+       });
+       try {
+         await createNobleTransport('omi');
+         console.log('unexpected success');
+       } catch (error) {
+         console.log(error.message);
+       }`,
+    ], { cwd: import.meta.dir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe(
+      'Optional BLE dependency missing. Install with: bun add @stoprocent/noble (or npm i @stoprocent/noble)'
+    );
+  });
+
   test('creates the transport before subscribing to audio', async () => {
     const { subscribe } = mockNobleDiscovery();
-    expect(NOBLE_MISSING.includes('@stoprocent/noble')).toBe(true);
     const transport = await createNobleTransport('omi');
     expect(typeof transport.startAudioNotifications).toBe('function');
     expect(typeof transport.stopAudioNotifications).toBe('function');

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -146,8 +146,8 @@ export async function connectAndListen(
   let characteristics: any[] = [];
   if (typeof peripheral.discoverSomeServicesAndCharacteristicsAsync === 'function') {
     const found = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
-      [OMI_SERVICE_UUID],
-      [AUDIO_DATA_UUID]
+      [wantService],
+      [wantChar]
     );
     characteristics = found.characteristics ?? [];
   } else {
@@ -165,9 +165,6 @@ export async function connectAndListen(
       `Audio characteristic ${AUDIO_DATA_UUID} not found on ${deviceId} (service ${OMI_SERVICE_UUID})`
     );
   }
-
-  // keep service uuid check soft — some stacks omit parent service on char
-  void wantService;
 
   const onData = (data: ArrayBufferView | ArrayBuffer | number[]) => {
     const u8 =


### PR DESCRIPTION
## What changed and why

Noble's HCI GATT decoder produces undashed UUIDs and filters discovery by exact membership. The TypeScript device SDK passed dashed Omi UUID constants, so a valid service was rejected before audio subscription. Pass the already-normalized service and characteristic values at the dependency boundary. Fixes #13090.

## Product invariants affected

none

## How it was verified

- Bun 1.3.14, `bun test sdks/device/typescript`: the two new discovery regressions fail on the original source; all 15 SDK tests pass after the fix and review follow-up.
- An offline harness executes the actual Noble Peripheral, Service and HCI GATT code with synthetic ATT responses: before, `Could not find all requested services` and zero subscriptions; after, one audio subscription and the expected packet. A normalized-service/dashed-characteristic control confirms that both filters must change. Source behavior: [Noble GATT UUID decoding and filtering](https://github.com/stoprocent/noble/blob/main/lib/hci-socket/gatt.js), [Peripheral discovery service-count check](https://github.com/stoprocent/noble/blob/main/lib/peripheral.js).
- TypeScript 5.9.3, `tsc --noEmit --project sdks/device/typescript/tsconfig.json` with the SDK's declared Node/Bun type dependencies: passes. `python3 .github/scripts/test_run_checks.py`: 52 manifest contract tests pass. `git diff --check`: passes.
- `scripts/pr-preflight --lane local --base ca687553f --head 26debed6 --pr-body-file <draft>`: all 13 selected local checks pass on the final two-commit range, including the 15-test SDK suite. An independent agent reviewed the original fix and repeated the SDK suite, actual-Noble harness and source-provenance checks.
- On published head `26debed60111afd8e8ab2d2855ddb25f808ea078`, author-identity validation and all three PR metadata contracts pass across both commits; its four file blobs exactly match the tested patch.

The initial before/after reproduction used base `8d61be6455fd462cd6ad6b9ef49fb67dd607a060`. The worktree was subsequently fast-forwarded to `ca687553f05c4092f749e1c684cad7ff5c791143`; the SDK sources, tests, manifest and applicable guides are unchanged between those bases. Required `make setup` completed. No hardware or live service was used; the demonstrated dependency path is Noble's HCI GATT implementation. Remote CI remains pending.

## Tests

The regressions call production `connectAndListen` through a controllable Noble adapter, receive an audio packet and verify disconnect. A missing-characteristic control retains the existing error behavior. The former optional-dependency smoke test uses the same mock, preventing native Bluetooth initialization in CI. The suite is registered in the shared local/CI manifest; the SDK README documents its runtime and test requirements.

The missing-dependency error is covered separately: an isolated Bun process uses a throwing Noble module mock, calls production `createNobleTransport`, and asserts the install hint. Isolation prevents previously cached successful mocks from hiding the import failure. This restores deterministic error coverage without initializing native BLE.

## Failure class (fixes)

Failure-Class: none

The existing `asUuid` function owns normalization; this fix applies its output at the existing dependency boundary without introducing a new compatibility layer.

## New guards

The behavioral regression would have caught the transport introduced by PR #10227. It runs through the shared manifest in the existing CI lane. It is a transport contract test, not another discovery implementation; UUID normalization remains owned by the existing helper.

AI disclosure: OpenAI Codex investigated, implemented, tested and reviewed this change on behalf of GitHub account `falseee1`.

## Synchronization with current main

Rebased the two existing commits onto `f42089f53c8010dd971b3702ece05a231c9c0c66`; published head is `b667f41130eb1207d164f577454c80596258c1fa`. The only conflict was concurrent additions to the shared check manifest. Both the Go SDK race-detector check and this TypeScript SDK regression check are retained. The Noble implementation and its tests are byte-identical to reviewed head `26debed`.

On the synchronized head: all 15 SDK tests pass (38 assertions), TypeScript 5.9.3 typecheck passes, all 52 manifest tests pass, all 13 selected local preflight checks pass, and the bounded pre-push gate passes. No hardware test or remote CI success is claimed. The earlier approval applies to the previous head; maintainers decide whether renewed review is needed.
