### PR TITLE
fix(python-cli): allow clearing a goal unit

### DIFF
--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -119,6 +119,10 @@ cat meeting_notes.md | omi conversation create --text - --text-source message
 | `omi goal history ID [--days N]`                       | `GET /v1/dev/user/goals/{id}/history`                   |
 | `omi goal delete ID [-y]`                              | `DELETE /v1/dev/user/goals/{id}`                        |
 
+Use `omi goal update ID --unit liters` to set a unit label or
+`omi goal update ID --clear-unit` to remove it. These options are mutually
+exclusive. Omitting both leaves the unit unchanged.
+
 Goal types: `boolean`, `scale`, `numeric`. Up to **3 active goals per user**;
 the oldest is deactivated automatically when you create a fourth.
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -222,7 +222,7 @@ omi
     ├── list [--limit N] [--include-inactive]
     ├── get <id>
     ├── create <title> --target N [--type ...] [--current N] [--unit ...]
-    ├── update <id> [...]
+    ├── update <id> [--unit ... | --clear-unit] [...]
     ├── progress <id> <value>
     ├── history <id> [--days N]
     └── delete <id> [-y]

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -107,8 +107,11 @@ def update_goal(
     min_value: Optional[float] = typer.Option(None, "--min"),
     max_value: Optional[float] = typer.Option(None, "--max"),
     unit: Optional[str] = typer.Option(None, "--unit"),
+    clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    if clear_unit and unit is not None:
+        raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -120,11 +123,14 @@ def update_goal(
         body["min_value"] = min_value
     if max_value is not None:
         body["max_value"] = max_value
-    if unit is not None:
+    if clear_unit:
+        body["unit"] = None
+    elif unit is not None:
         body["unit"] = unit
     if not body:
         raise UsageError(
-            message="No fields to update", detail="Provide one of --title/--target/--current/--min/--max/--unit."
+            message="No fields to update",
+            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit.",
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import sys
 
-from omi_cli.main import app
+import pytest
+
+from omi_cli.main import app, main
 
 
 def test_goal_list(authed_profile, respx_mock, cli_runner) -> None:
@@ -96,3 +99,35 @@ def test_goal_delete(authed_profile, respx_mock, cli_runner) -> None:
     respx_mock.delete("/v1/dev/user/goals/g1").respond(json={"success": True})
     result = cli_runner.invoke(app, ["goal", "delete", "g1", "-y"])
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        (["--unit", "liters"], {"unit": "liters"}),
+        (["--unit", ""], {"unit": ""}),
+        (["--clear-unit"], {"unit": None}),
+        (["--title", "drink water"], {"title": "drink water"}),
+        (["--clear-unit", "--current", "2"], {"unit": None, "current_value": 2.0}),
+    ],
+)
+def test_goal_update_unit_patch(authed_profile, respx_mock, cli_runner, options, expected) -> None:
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1", **expected})
+    result = cli_runner.invoke(app, ["--json", "goal", "update", "g1", *options])
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content) == expected
+    assert json.loads(result.stdout) == {"id": "g1", **expected}
+
+
+@pytest.mark.parametrize("unit", ["liters", ""])
+def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monkeypatch, capsys, unit) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", "--unit", unit, "--clear-unit"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert "--unit" in error["detail"]
+    assert "--clear-unit" in error["detail"]
+    assert not respx_mock.calls


### PR DESCRIPTION
Fixes #13045.

Adds `omi goal update ID --clear-unit` to remove an existing unit label. It sends `{"unit": null}` to the API. Omitting the option keeps the unit unchanged; combining it with `--unit` returns an error before making a request.

Includes regression tests and updated command docs. Uses the existing PATCH builder and `UsageError` handling.

Tested on macOS with Python 3.13: **135 passed, 1 skipped**. Also checked the installed `omi` command against a local test server.

<details>
<summary>Validation details</summary>

- `python -m pytest -q -o addopts=''`: 135 passed; Windows ACL test skipped.
- Four new cases failed before the fix. All 12 goal tests pass afterward.
- Installed CLI: verified set/clear/omit request bodies and conflicting options (JSON error, exit 1, no request).
- `black --check` on the changed Python files and `git diff --check`: passed.
- `make preflight` and PR metadata checks: passed. The history ratchet skips shallow clones. No matched product invariants.
- `mypy omi_cli`: the same 7 errors in unchanged modules on both base and branch.
- `make setup` installed hooks, but backend setup needs `uv`. CLI dependencies are installed separately. Live API and Windows testing are not covered.

</details>

Failure-Class: none

Built with AI assistance. I'd also be interested in a bounty if this change is eligible.
