### PR TITLE
fix(mcp): convert conversation category strings before calling get_conversations

### DIFF
--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -133,6 +133,18 @@ class SearchConversations(BaseModel):
     end_date: Optional[str] = Field(description="Filter conversations before this date (yyyy-mm-dd).", default=None)
 
 
+def _parse_categories(categories, category_cls: type, logger: logging.Logger) -> list:
+    if not isinstance(categories, list):
+        raise ValueError(f"categories must be a list, got {type(categories)}")
+    parsed = []
+    for category in categories:
+        try:
+            parsed.append(category_cls(category))
+        except ValueError:
+            logger.warning(f"Could not parse category: {category}")
+    return parsed
+
+
 def get_memories(
     logger: logging.Logger,
     api_key: str,
@@ -328,15 +340,7 @@ async def serve(uid: str | None) -> None:
 
         if name == OmiTools.GET_MEMORIES:
             # return [TextContent(type="text", text=json.dumps(arguments, indent=2))]
-            categories: List[str] = arguments.get("categories", [])
-            if not isinstance(categories, list):
-                raise ValueError(f"categories must be a list, got {type(categories)}")
-            categories_enum = []
-            for category in categories:
-                try:
-                    categories_enum.append(MemoryCategory(category))
-                except ValueError:
-                    logger.warning(f"Could not parse category: {category}")
+            categories_enum = _parse_categories(arguments.get("categories", []), MemoryCategory, logger)
 
             result = get_memories(
                 logger,
@@ -381,12 +385,14 @@ async def serve(uid: str | None) -> None:
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
         elif name == OmiTools.GET_CONVERSATIONS:
+            categories_enum = _parse_categories(arguments.get("categories", []), ConversationCategory, logger)
+
             result = get_conversations(
                 logger,
                 api_key,
                 start_date=arguments.get("start_date"),
                 end_date=arguments.get("end_date"),
-                categories=arguments.get("categories", []),
+                categories=categories_enum,
                 limit=arguments.get("limit", 20),
                 offset=arguments.get("offset", 0),
             )

--- a/mcp/tests/test_parse_categories.py
+++ b/mcp/tests/test_parse_categories.py
@@ -1,0 +1,51 @@
+"""
+Tests for the shared _parse_categories helper used by the get_memories and
+get_conversations tool dispatchers.
+
+Regression coverage for a crash where the get_conversations dispatcher passed
+raw JSON strings straight through to get_conversations(), whose category
+serialization calls `c.value` and raised `'str' object has no attribute
+'value'` for any non-empty categories filter.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server_omi.server import ConversationCategory, MemoryCategory, _parse_categories
+
+
+class TestParseCategories:
+    def test_converts_valid_strings_to_conversation_enum(self):
+        logger = logging.getLogger("test")
+        result = _parse_categories(["work", "travel"], ConversationCategory, logger)
+        assert result == [ConversationCategory.work, ConversationCategory.travel]
+
+    def test_converts_valid_strings_to_memory_enum(self):
+        logger = logging.getLogger("test")
+        result = _parse_categories(["work"], MemoryCategory, logger)
+        assert result == [MemoryCategory.work]
+
+    def test_empty_list_returns_empty_list(self):
+        logger = logging.getLogger("test")
+        assert _parse_categories([], ConversationCategory, logger) == []
+
+    def test_invalid_category_is_dropped_and_logged(self):
+        logger = MagicMock(spec=logging.Logger)
+        result = _parse_categories(["not-a-real-category"], ConversationCategory, logger)
+        assert result == []
+        logger.warning.assert_called_once()
+
+    def test_non_list_input_raises_value_error(self):
+        logger = logging.getLogger("test")
+        with pytest.raises(ValueError):
+            _parse_categories("work", ConversationCategory, logger)
+
+    def test_result_values_have_value_attribute(self):
+        # This is the direct regression check: every element returned must be
+        # an enum member (so `.value` works downstream), never a raw string.
+        logger = logging.getLogger("test")
+        result = _parse_categories(["work"], ConversationCategory, logger)
+        assert all(hasattr(c, "value") for c in result)
+        assert result[0].value == "work"


### PR DESCRIPTION
## What

The `get_conversations` MCP tool dispatcher (`mcp/src/mcp_server_omi/server.py`) passed raw JSON category strings straight through to `get_conversations()`, whose category serialization calls `c.value` on each entry, assuming enum members. Any non-empty `categories` filter (e.g. `categories: ["work"]`) crashed with `'str' object has no attribute 'value'`, surfaced to the MCP client as `isError: true`. `categories: []` (the default) worked fine, which is why this was easy to miss.

The `get_memories` dispatcher already did the string→enum conversion correctly for its own category filter — this PR extracts that conversion into a shared `_parse_categories()` helper and applies it to both dispatchers, fixing the crash and removing the duplicated logic.

## Why (evidence from #13032)

Issue #13032 reproduced this through an actual stdio MCP client/server session (mocked HTTP, no live API): `categories: []` succeeds, `categories: ["work"]` raises `AttributeError: 'str' object has no attribute 'value'`. As a control, `get_memories` with `["work"]` already succeeded, confirming the asymmetry between the two dispatchers.

## What I tested

- Reproduced the exact crash from the issue by driving the real `call_tool` request handler registered by `serve()` (via `mcp==1.30.0` in an isolated venv, since this repo's pinned `mcp==2.0.0` test dependency has an unrelated, already-tracked startup incompatibility, #13020, that prevents invoking `serve()` under the repo's own env). Confirmed the crash before the fix and a clean, correctly-serialized response after.
- Added `mcp/tests/test_parse_categories.py`, a hermetic unit test suite for the new shared helper (valid conversion for both category enums, invalid-category warning/drop behavior, non-list rejection, and an explicit check that returned values expose `.value` so the downstream serialization call is safe). Runs under the repo's own pinned `mcp==2.0.0` since it only imports the helper, not `serve()`.
- `uv run pytest tests -q` in `mcp/`: 17 passed (11 pre-existing + 6 new), same 2 pre-existing `uid`-fixture errors as the `main` baseline (unrelated, live-API fixture not available here).

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

