### PR TITLE
fix(desktop): stop resurrecting completed tasks after a failed retry sync (#13102)

### DIFF
--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+TaskCatalog.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+TaskCatalog.swift
@@ -146,6 +146,7 @@ extension APIClient {
     dueConfidence: Double? = nil,
     provenance: [OmiAPI.EvidenceRef]? = nil,
     status: String? = nil,
+    completed: Bool? = nil,
     sortOrder: Int? = nil,
     indentLevel: Int? = nil,
     expectedOwnerId: String? = nil,
@@ -165,7 +166,7 @@ extension APIClient {
 
     let wire = OmiAPI.ActionItemCreateRequest(
       appleReminderId: nil,
-      completed: nil,
+      completed: completed,
       conversationId: nil,
       description_: description,
       dueAt: dueAt.map { formatter.string(from: $0) },

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2476,23 +2476,15 @@ class TasksStore: ObservableObject {
           category: item.category,
           metadataBox: ActionItemMetadataBox(metadata),
           relevanceScore: item.relevanceScore,
+          // Carry completion in the create call itself — a separate follow-up
+          // PATCH here could fail silently (try?) while markSynced still ran,
+          // permanently stranding the backend row as incomplete since a
+          // synced item is never revisited by this retry loop.
+          completed: item.completed ? true : nil,
           expectedOwnerId: ownerID,
           authorizationSnapshot: lease.authorizationSnapshot
         )
         guard isCurrent(lease) else { return }
-        // createActionItem always posts completed:nil, so a task the user
-        // completed while it was still unsynced (offline / failed create) would
-        // be recreated on the backend as incomplete and resurrected on the next
-        // refresh. Push the completed state with a follow-up update.
-        if item.completed {
-          _ = try? await APIClient.shared.updateActionItem(
-            id: response.id,
-            completed: true,
-            expectedOwnerId: ownerID,
-            authorizationSnapshot: lease.authorizationSnapshot
-          )
-          guard isCurrent(lease) else { return }
-        }
         try await ActionItemStorage.shared.markSynced(
           id: localId,
           backendId: response.id,

--- a/desktop/macos/Desktop/Tests/APIClientCreateActionItemCompletedTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientCreateActionItemCompletedTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// `retryUnsyncedItems` used to create the backend row with `completed: nil`, then push
+/// completion via a separate `try?` PATCH. If that PATCH failed (network blip), the local
+/// row was still marked fully synced — since `markSynced` sets `backendSynced = true`, the
+/// item is never revisited by the retry loop — permanently stranding the backend row as
+/// incomplete and resurrecting an already-completed task on the next hydration. Passing
+/// `completed` straight through the create call removes the extra fallible round trip.
+private struct CapturedCreateActionItemRequest {
+  let url: URL
+  let method: String
+  let body: Data?
+}
+
+private final class CreateActionItemURLProtocol: URLProtocol, @unchecked Sendable {
+  private static let lock = NSLock()
+  private nonisolated(unsafe) static var requests: [CapturedCreateActionItemRequest] = []
+
+  static func reset() {
+    lock.withLock { requests.removeAll() }
+  }
+
+  static var capturedRequests: [CapturedCreateActionItemRequest] {
+    lock.withLock { requests }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+    let captured = CapturedCreateActionItemRequest(
+      url: url,
+      method: request.httpMethod ?? "GET",
+      body: Self.bodyData(from: request)
+    )
+    Self.lock.withLock { Self.requests.append(captured) }
+
+    guard
+      let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.cannotParseResponse))
+      return
+    }
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(
+      self,
+      didLoad: Data(
+        #"{"id":"backend-created-1","description":"task","completed":true,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"#
+          .utf8))
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+
+  private static func bodyData(from request: URLRequest) -> Data? {
+    if let body = request.httpBody { return body }
+    guard let stream = request.httpBodyStream else { return nil }
+
+    stream.open()
+    defer { stream.close() }
+    var body = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+      let bytesRead = stream.read(buffer, maxLength: 4096)
+      if bytesRead <= 0 { break }
+      body.append(buffer, count: bytesRead)
+    }
+    return body.isEmpty ? nil : body
+  }
+}
+
+final class APIClientCreateActionItemCompletedTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    CreateActionItemURLProtocol.reset()
+    setenv("OMI_PYTHON_API_URL", "http://python-test:9001", 1)
+  }
+
+  override func tearDown() {
+    unsetenv("OMI_PYTHON_API_URL")
+    CreateActionItemURLProtocol.reset()
+    super.tearDown()
+  }
+
+  private func makeClient() async -> APIClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [CreateActionItemURLProtocol.self]
+    let session = URLSession(configuration: config)
+    let client = APIClient(session: session)
+    await client.setTestAuthHeader("Bearer test-token")
+    return client
+  }
+
+  func testCreateActionItemSendsCompletedTrueInTheSameRequest() async throws {
+    let client = await makeClient()
+
+    _ = try await client.createActionItem(description: "task", completed: true)
+
+    let requests = CreateActionItemURLProtocol.capturedRequests
+    XCTAssertEqual(requests.count, 1, "completion must not require a follow-up request")
+    let request = try XCTUnwrap(requests.first)
+    XCTAssertEqual(request.url.path, "/v1/action-items")
+    XCTAssertEqual(request.method, "POST")
+
+    let body = try XCTUnwrap(request.body)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertEqual(json["completed"] as? Bool, true)
+  }
+
+  func testCreateActionItemOmitsCompletedWhenNotSpecified() async throws {
+    let client = await makeClient()
+
+    _ = try await client.createActionItem(description: "task")
+
+    let request = try XCTUnwrap(CreateActionItemURLProtocol.capturedRequests.first)
+    let body = try XCTUnwrap(request.body)
+    let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertNil(json["completed"], "existing callers must not start sending an explicit completed field")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260908-fix-retry-sync-resurrected-completed-tasks.json
+++ b/desktop/macos/changelog/unreleased/20260908-fix-retry-sync-resurrected-completed-tasks.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a bug where a task completed while offline could reappear as incomplete after the app reconnected"
+}


### PR DESCRIPTION
## Summary
TasksStore.retryUnsyncedItems recreated a locally-completed offline task via
createActionItem (which always sent completed:nil), then pushed the
completion with a separate `try?` PATCH. If that PATCH failed, the code
still called markSynced unconditionally, marking the item backendSynced=true
with the backend row stuck incomplete. Since getUnsyncedActionItems only
selects backendSynced=false rows, that mismatch could never self-heal, and
the next hydration could resurrect the task locally as incomplete.

## Fix
The backend's create endpoint already accepts a `completed` field
(`ActionItemCreateRequest.completed` in the generated OpenAPI client); the
Swift `APIClient.createActionItem` wrapper never exposed it. Threaded
`completed` straight through the create call in retryUnsyncedItems, removing
the extra fallible follow-up PATCH entirely — one request either fully
succeeds or fully fails, so there is no partial-success state to strand.

## Testing
- `xcrun swift build -c debug --package-path Desktop` — clean build.
- Added `APIClientCreateActionItemCompletedTests` (URLProtocol-mocked)
  asserting `createActionItem(completed: true)` sends `"completed": true` in
  the single POST request, and that omitting the parameter keeps existing
  callers' wire shape unchanged (no regression for the 4 other call sites).
- Full `TasksStore`-scoped Swift suite green: 102/102
  (`dev-feedback.py --once swift 'TasksStore'`).

Product invariants affected: INV-TASK-1 (offline-created task must sync
to the backend and remain visible/correct after connectivity returns).

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

