### PR TITLE
fix(cli): no-op when screenshot output path equals source path

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -224,6 +224,14 @@ def _emit_tool(
     ctx.renderer.emit(result, title=tool_name)
 
 
+def _same_file(source: Path, output: Path) -> bool:
+    """True when source and output resolve to the same existing file."""
+    try:
+        return source.exists() and source.resolve() == output.resolve()
+    except OSError:
+        return False
+
+
 def _write_screenshot_result(result: Any, output: Path) -> Path:
     output = output.expanduser()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -231,6 +239,8 @@ def _write_screenshot_result(result: Any, output: Path) -> Path:
     if isinstance(result, str):
         source = existing_path(result)
         if source:
+            if _same_file(source, output):
+                return output
             shutil.copyfile(source, output)
         else:
             output.write_text(result, encoding="utf-8")
@@ -241,6 +251,8 @@ def _write_screenshot_result(result: Any, output: Path) -> Path:
         if source_path:
             source = existing_path(source_path)
             if source:
+                if _same_file(source, output):
+                    return output
                 shutil.copyfile(source, output)
                 return output
 

--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -225,9 +225,13 @@ def _emit_tool(
 
 
 def _same_file(source: Path, output: Path) -> bool:
-    """True when source and output resolve to the same existing file."""
+    """True when source and output refer to the same existing file.
+
+    Uses ``os.path.samefile`` so hard links to the same inode are
+    detected even when their path strings differ.
+    """
     try:
-        return source.exists() and source.resolve() == output.resolve()
+        return source.exists() and os.path.samefile(source, output)
     except OSError:
         return False
 

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -401,6 +401,20 @@ def test_screenshot_copies_existing_file_response(config_path: Path, cli_runner,
     assert output.read_bytes() == source.read_bytes()
 
 
+def test_screenshot_same_source_and_output_is_noop(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    """Writing a screenshot onto its own source path must not raise SameFileError."""
+    _configure_local_profile(config_path)
+    source = tmp_path / "shot.jpg"
+    source.write_bytes(b"synthetic-image")
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(str(source))))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(source)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert source.read_bytes() == b"synthetic-image"
+    assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
+
+
 def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
     _configure_local_profile(config_path)
     output = tmp_path / "pending.jpg"

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -415,6 +415,42 @@ def test_screenshot_same_source_and_output_is_noop(config_path: Path, cli_runner
     assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
 
 
+def test_screenshot_same_source_and_output_is_noop_mapping_path(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    """Same-file no-op must also hold for the mapping-with-path response shape."""
+    _configure_local_profile(config_path)
+    source = tmp_path / "shot.jpg"
+    source.write_bytes(b"synthetic-image")
+    # The Desktop tool may return a structured mapping (path/file_path/...)
+    # rather than a bare path string; the API envelope's result field is then
+    # an object, not a JSON-encoded string.
+    response = {"ok": True, "name": "tool", "content_type": "text/plain", "result": {"path": str(source)}}
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=response))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(source)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert source.read_bytes() == b"synthetic-image"
+    assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
+
+
+def test_screenshot_hard_link_output_is_noop(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    """Writing a screenshot to a hard link of its source must not raise SameFileError."""
+    _configure_local_profile(config_path)
+    import os
+
+    source = tmp_path / "shot.jpg"
+    source.write_bytes(b"synthetic-image")
+    link = tmp_path / "shot-link.jpg"
+    os.link(source, link)
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(str(source))))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(link)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert link.read_bytes() == b"synthetic-image"
+    assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
+
+
 def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
     _configure_local_profile(config_path)
     output = tmp_path / "pending.jpg"


### PR DESCRIPTION
## Summary

Fixes #13137 — `omi local screenshot --output <path>` crashed with `shutil.SameFileError` when the requested output path was the same file the local API returned as the screenshot source.

## Change

In `_write_screenshot_result`, resolve both paths and return early when `source` and `output` point to the same existing file, instead of calling `shutil.copyfile` (which raises `SameFileError` for identical source/destination). Applies to both the string-path and mapping-with-path response shapes.

## Verification

- New regression test `test_screenshot_same_source_and_output_is_noop`: passes with the fix, fails without it (confirmed via stash)
- Existing screenshot/local test group passes (7/7)
- The 5 failures in the full suite (`test_openapi_contract`, one `test_auth_api_key`) also fail on clean `main` — pre-existing, unrelated to this change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

