### PR TITLE
fix(cli): route browser-login status messages to stderr

### DIFF
--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -27,6 +27,7 @@ import http.server
 import secrets
 import socket
 import socketserver
+import sys
 import threading
 import time
 import urllib.parse
@@ -134,8 +135,9 @@ def login_with_browser(
         thread.start()
 
         try:
-            print(f"Opening browser for {provider} sign-in...")
-            print(f"If your browser does not open, visit:\n  {auth_url}")
+            # Status messages go to stderr so --json keeps stdout pristine.
+            print(f"Opening browser for {provider} sign-in...", file=sys.stderr)
+            print(f"If your browser does not open, visit:\n  {auth_url}", file=sys.stderr)
             if open_browser:
                 # webbrowser.open returns False on failure but is otherwise
                 # silent; we always print the URL above as a fallback.

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -155,15 +155,11 @@ def test_browser_login_status_goes_to_stderr_not_stdout(monkeypatch, capsys) -> 
     In --json mode stdout carries only the JSON payload, so the
     "Opening browser…" / fallback-URL messages belong on stderr.
     """
-    import threading
-
     monkeypatch.setattr(oauth.webbrowser, "open", lambda *a, **k: True)
-
-    # Force the OAuth wait to time out right after the status prints, so the
-    # test doesn't block for the real 300s browser timeout.
-    monkeypatch.setattr(threading.Event, "wait", lambda *a, **k: False)
-    # The real serve_forever thread never got a callback; make join() safe.
-    monkeypatch.setattr(threading.Thread, "join", lambda *a, **k: None)
+    # Make the OAuth wait time out quickly (right after the status prints)
+    # instead of the real 300s, without patching Event.wait globally (that
+    # would also affect the server's internal shutdown event).
+    monkeypatch.setattr(oauth, "_BROWSER_TIMEOUT_SECONDS", 0.2)
 
     with pytest.raises(oauth.AuthError):
         oauth.login_with_browser(

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -149,6 +149,36 @@ def test_login_with_browser_rejects_unknown_provider(config_path) -> None:
         )
 
 
+def test_browser_login_status_goes_to_stderr_not_stdout(monkeypatch, capsys) -> None:
+    """Human status messages during browser login must not pollute stdout.
+
+    In --json mode stdout carries only the JSON payload, so the
+    "Opening browser…" / fallback-URL messages belong on stderr.
+    """
+    import threading
+
+    monkeypatch.setattr(oauth.webbrowser, "open", lambda *a, **k: True)
+
+    # Force the OAuth wait to time out right after the status prints, so the
+    # test doesn't block for the real 300s browser timeout.
+    monkeypatch.setattr(threading.Event, "wait", lambda *a, **k: False)
+    # The real serve_forever thread never got a callback; make join() safe.
+    monkeypatch.setattr(threading.Thread, "join", lambda *a, **k: None)
+
+    with pytest.raises(oauth.AuthError):
+        oauth.login_with_browser(
+            "default",
+            api_base="https://api.test.omi.local",
+            provider="google",
+            open_browser=True,
+        )
+
+    captured = capsys.readouterr()
+    assert captured.out == "", f"stdout should stay clean, got: {captured.out!r}"
+    assert "Opening browser for google sign-in..." in captured.err
+    assert "api.test.omi.local" in captured.err
+
+
 # ---- code-exchange wiring -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes #13136 — `omi auth login --browser` in `--json` mode printed human status messages (`Opening browser for google sign-in...`, the fallback URL) to stdout, corrupting the JSON payload.

## Change

In `omi_cli/auth/oauth.py`, `login_with_browser` now writes those two status messages to `sys.stderr` instead of stdout, matching how the `Renderer` already keeps stdout pristine for structured output in JSON mode.

## Verification

- New regression test `test_browser_login_status_goes_to_stderr_not_stdout` asserts stdout stays empty and the hints land on stderr — passes with the fix, fails without it (confirmed via stash)
- Full auth suite passes (20/20)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

