### PR TITLE
fix(sdk): pass undashed UUIDs to Noble discovery

### DIFF
--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -146,8 +146,8 @@ export async function connectAndListen(
   let characteristics: any[] = [];
   if (typeof peripheral.discoverSomeServicesAndCharacteristicsAsync === 'function') {
     const found = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
-      [OMI_SERVICE_UUID],
-      [AUDIO_DATA_UUID]
+      [asUuid(OMI_SERVICE_UUID)],
+      [asUuid(AUDIO_DATA_UUID)]
     );
     characteristics = found.characteristics ?? [];
   } else {


### PR DESCRIPTION
## Summary

Fixes #13090 — the TypeScript device SDK's `connectAndListen()` passed dashed Omi service/characteristic UUIDs into Noble discovery. Noble's HCI GATT decoder produces **undashed** UUIDs and filters discovered services by exact membership, so a valid Omi device was rejected with `Could not find all requested services` before audio subscription.

## Change

`sdks/device/typescript/src/ble/noble.ts`: normalize both UUIDs with the existing `asUuid()` helper (lowercase, dashes stripped) before passing them to `discoverSomeServicesAndCharacteristicsAsync`, matching how the audio characteristic is already matched afterwards.

## Verification

- `asUuid` was already used for the post-discovery matching; the discovery arguments were the only place still passing the raw dashed constants
- Typecheck: change is confined to the two discovery arguments; no new types or imports (this SDK's test suite requires `bun`, not available in this environment)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

