### PR TITLE
fix(cli): raise when local status result embeds a Desktop failure

### DIFF
--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -157,7 +157,15 @@ def _unwrap_tool_response(body: Any) -> Any:
         raise CliError(message=message, detail=json.dumps(body, sort_keys=True), exit_code=1)
 
     result = body["result"] if "result" in body else body
-    return _unwrap_tool_result(result)
+    unwrapped = _unwrap_tool_result(result)
+    if isinstance(unwrapped, Mapping) and unwrapped.get("ok") is False:
+        message = unwrapped.get("message") or unwrapped.get("error") or "Local tool error"
+        raise CliError(
+            message=str(message),
+            detail=json.dumps(unwrapped, sort_keys=True),
+            exit_code=1,
+        )
+    return unwrapped
 
 
 def _unwrap_tool_result(result: Any) -> Any:

--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -159,7 +159,12 @@ def _unwrap_tool_response(body: Any) -> Any:
     result = body["result"] if "result" in body else body
     unwrapped = _unwrap_tool_result(result)
     if isinstance(unwrapped, Mapping) and unwrapped.get("ok") is False:
-        message = unwrapped.get("message") or unwrapped.get("error") or "Local tool error"
+        raw_error = unwrapped.get("error") or unwrapped.get("message") or "Local tool error"
+        if isinstance(raw_error, Mapping):
+            raw_message = raw_error.get("message")
+            message = raw_message if isinstance(raw_message, str) else "Local tool error"
+        else:
+            message = raw_error
         raise CliError(
             message=str(message),
             detail=json.dumps(unwrapped, sort_keys=True),

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -401,20 +401,6 @@ def test_screenshot_copies_existing_file_response(config_path: Path, cli_runner,
     assert output.read_bytes() == source.read_bytes()
 
 
-def test_screenshot_same_source_and_output_is_noop(config_path: Path, cli_runner, tmp_path: Path) -> None:
-    """Writing a screenshot onto its own source path must not raise SameFileError."""
-    _configure_local_profile(config_path)
-    source = tmp_path / "shot.jpg"
-    source.write_bytes(b"synthetic-image")
-    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
-        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(str(source))))
-        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(source)])
-
-    assert result.exit_code == 0, repr(result.exception)
-    assert source.read_bytes() == b"synthetic-image"
-    assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
-
-
 def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
     _configure_local_profile(config_path)
     output = tmp_path / "pending.jpg"
@@ -494,6 +480,28 @@ def test_unwrap_tool_response_passes_healthy_result(config_path: Path) -> None:
     assert isinstance(result, dict)
     assert result["ok"] is True
     assert result["database_available"] is True
+
+
+def test_unwrap_tool_response_extracts_message_from_structured_error(config_path: Path) -> None:
+    """A structured error object must surface its message, not the whole mapping."""
+    from omi_cli.errors import CliError
+    from omi_cli.local_client import _unwrap_tool_response
+
+    failure = {
+        "ok": False,
+        "error": {"message": "Desktop backend unavailable", "code": "ERR_DESKTOP_DOWN"},
+    }
+    envelope = {
+        "ok": True,
+        "name": "get_local_status",
+        "content_type": "text/plain",
+        "result": json.dumps(failure),
+    }
+    with pytest.raises(CliError) as excinfo:
+        _unwrap_tool_response(envelope)
+    # The human message is the extracted error.message, not the whole mapping.
+    assert "Desktop backend unavailable" in excinfo.value.message
+    assert not excinfo.value.message.startswith("{")
 
 
 def test_local_api_error_preserves_not_found_subclass(config_path: Path) -> None:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -401,6 +401,20 @@ def test_screenshot_copies_existing_file_response(config_path: Path, cli_runner,
     assert output.read_bytes() == source.read_bytes()
 
 
+def test_screenshot_same_source_and_output_is_noop(config_path: Path, cli_runner, tmp_path: Path) -> None:
+    """Writing a screenshot onto its own source path must not raise SameFileError."""
+    _configure_local_profile(config_path)
+    source = tmp_path / "shot.jpg"
+    source.write_bytes(b"synthetic-image")
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(str(source))))
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(source)])
+
+    assert result.exit_code == 0, repr(result.exception)
+    assert source.read_bytes() == b"synthetic-image"
+    assert json.loads(result.stdout)["bytes"] == len(b"synthetic-image")
+
+
 def test_screenshot_preserves_structured_local_api_error_in_json(config_path: Path, cli_runner, tmp_path: Path) -> None:
     _configure_local_profile(config_path)
     output = tmp_path / "pending.jpg"
@@ -441,6 +455,45 @@ def test_non_json_error_escapes_structured_extra_markup(capsys: pytest.CaptureFi
     captured = capsys.readouterr()
     assert "hint: Use [safe] text" in captured.err
     assert "[danger]: <value>" in captured.err
+
+
+def test_unwrap_tool_response_raises_on_embedded_failure(config_path: Path) -> None:
+    """A structured Desktop failure inside the result JSON must raise, not pass through."""
+    from omi_cli.errors import CliError
+    from omi_cli.local_client import _unwrap_tool_response
+
+    failure = {
+        "ok": False,
+        "database_available": False,
+        "screen_history_available": False,
+        "message": "Failed to read local Omi status: test",
+    }
+    envelope = {
+        "ok": True,
+        "name": "get_local_status",
+        "content_type": "text/plain",
+        "result": json.dumps(failure),
+    }
+    with pytest.raises(CliError) as excinfo:
+        _unwrap_tool_response(envelope)
+    assert "Failed to read local Omi status" in str(excinfo.value)
+    assert excinfo.value.exit_code == 1
+
+
+def test_unwrap_tool_response_passes_healthy_result(config_path: Path) -> None:
+    """A healthy embedded result must still unwrap to its parsed value."""
+    from omi_cli.local_client import _unwrap_tool_response
+
+    envelope = {
+        "ok": True,
+        "name": "get_local_status",
+        "content_type": "text/plain",
+        "result": json.dumps({"ok": True, "database_available": True, "screen_history_available": True}),
+    }
+    result = _unwrap_tool_response(envelope)
+    assert isinstance(result, dict)
+    assert result["ok"] is True
+    assert result["database_available"] is True
 
 
 def test_local_api_error_preserves_not_found_subclass(config_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #13121 — when the Desktop status failure path returns a JSON string with `ok: false` inside an HTTP-200 envelope whose outer `ok` is `true`, `_unwrap_tool_response` only checked the outer envelope and emitted the failed status as a normal result.

## Change

`sdks/python-cli/omi_cli/local_client.py`: after unwrapping the embedded result, detect a Mapping with `ok: false` and raise `CliError` carrying the Desktop's failure message.

## Verification

- New regression tests: embedded failure raises CliError with the Desktop message (exit 1); healthy embedded result still unwraps normally
- Both tests fail without the fix, pass with it (confirmed via stash)
- Full `test_local` suite passes (43/43)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

