### PR TITLE
fix(cli): escape profile name in local configure status message

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 
 import typer
+from rich.markup import escape
 
 from omi_cli import config as cfg
 from omi_cli.errors import UsageError
@@ -63,7 +64,7 @@ def configure(
         "local_api_url": profile.local_api_url,
         "local_token": _mask_token(profile.local_token),
     }
-    ctx.renderer.success(f"Configured local Omi Desktop API for profile [bold]{profile.name}[/bold].")
+    ctx.renderer.success(f"Configured local Omi Desktop API for profile [bold]{escape(profile.name)}[/bold].")
     ctx.renderer.emit(payload, title="local configuration")
 
 

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -50,6 +50,32 @@ def test_local_configure_persists_profile_config(config_path: Path, cli_runner) 
     assert profile.local_token == FAKE_LOCAL_TOKEN
 
 
+def test_local_configure_escapes_markup_like_profile_name(config_path: Path, cli_runner) -> None:
+    """Rich markup in a profile name must be escaped in the configure message.
+
+    `omi local configure` prints the profile name inside a Rich-markup
+    message; a profile named 'bad[/bold]' would otherwise crash the render
+    after the config had already been saved.
+    """
+    tricky = "bad[/bold]"
+    result = cli_runner.invoke(
+        app,
+        [
+            "--profile",
+            tricky,
+            "local",
+            "configure",
+            "--url",
+            FAKE_LOCAL_URL,
+            "--token",
+            FAKE_LOCAL_TOKEN,
+        ],
+    )
+    assert result.exit_code == 0, repr(result.exception)
+    assert "bad[/bold]" in result.output
+    assert cfg.load().get_profile(tricky).local_api_url == FAKE_LOCAL_URL
+
+
 def test_local_status_without_config_is_json(config_path: Path, cli_runner) -> None:
     result = cli_runner.invoke(app, ["--json", "local", "status"])
 


### PR DESCRIPTION
## Summary

Follow-up to #13086. Upstream #13088 (merged) now escapes the auth status fragments, so this PR has been rebased onto `main` and reduced to the surface that is still unfixed on `main`.

`omi local configure` interpolates `profile.name` into a Rich-markup message, so a profile named `bad[/bold]` raises `MarkupError` while rendering the success line — after the configuration has already been written.

## Change

- `sdks/python-cli/omi_cli/commands/local.py`: pass `profile.name` through `rich.markup.escape` in the `omi local configure` success message (the remaining surface listed in #13086).
- `sdks/python-cli/tests/test_local.py`: regression test — `local configure` on a `bad[/bold]` profile exits 0 and prints the literal name.

## Verification

- `pytest tests/test_local.py tests/test_config.py tests/test_rich_status_escape.py` → `72 passed, 1 skipped`.
- The new test fails with unpatched `local.py` (reverting the single changed line) and passes with the fix.
- Diff against `main`: 2 files, +28/−1.

Failure-Class: none
