### PR TITLE
fix(cli): keep diagnostics available with malformed configuration

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -129,6 +129,10 @@ omi config profile list
 omi config profile delete old-account --yes
 ```
 
+`omi version` and `omi config path` do not parse the configuration file, so
+they remain available when a malformed TOML file needs repair. Commands that
+read or modify configuration still reject malformed files.
+
 ## Local Omi Desktop API
 
 `omi local` talks to a running Omi Desktop local API. Configure the active

--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -54,11 +54,11 @@ def show(typer_ctx: typer.Context) -> None:
 @app.command("path", help="Print the on-disk config path.")
 def path(typer_ctx: typer.Context) -> None:
     ctx = _ctx(typer_ctx)
-    config = ctx.load_config()
+    config_path = cfg.default_config_path()
     if ctx.renderer.json_mode:
-        ctx.renderer.emit({"path": str(config.path)})
+        ctx.renderer.emit({"path": str(config_path)})
     else:
-        typer.echo(str(config.path))
+        typer.echo(str(config_path))
 
 
 _SETTABLE_KEYS = {"api_base", "local_api_url", "local_token"}

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -57,11 +57,19 @@ app = typer.Typer(
 class AppContext:
     """Per-invocation state attached to the Typer context (``ctx.obj``)."""
 
-    profile_name: str
+    profile_override: Optional[str]
     api_base_override: Optional[str]
     renderer: Renderer
     verbose: bool
     _config: Optional[cfg.Config] = field(default=None, init=False)
+    _profile_name: Optional[str] = field(default=None, init=False)
+
+    @property
+    def profile_name(self) -> str:
+        """Resolve configuration only when a command needs a profile."""
+        if self._profile_name is None:
+            self._profile_name = cfg.resolve_profile_name(self.profile_override, self.load_config())
+        return self._profile_name
 
     def load_config(self) -> cfg.Config:
         if self._config is None:
@@ -133,14 +141,11 @@ def _root(
     ),
 ) -> None:
     """Root callback: parse global flags, build per-invocation context."""
-    config = cfg.load()
-    profile_name = cfg.resolve_profile_name(profile, config)
-
     renderer = Renderer(json_mode=json_output, no_color=no_color, verbose=verbose)
     global _LAST_RENDERER
     _LAST_RENDERER = renderer
     ctx.obj = AppContext(
-        profile_name=profile_name,
+        profile_override=profile,
         api_base_override=api_base,
         renderer=renderer,
         verbose=verbose,

--- a/sdks/python-cli/tests/test_diagnostics.py
+++ b/sdks/python-cli/tests/test_diagnostics.py
@@ -1,0 +1,48 @@
+"""Diagnostics must remain available when configuration needs repair."""
+
+import json
+
+import pytest
+
+from omi_cli import __version__
+from omi_cli.main import app
+
+
+@pytest.mark.parametrize("arguments", [["version"], ["config", "path"], ["--json", "config", "path"]])
+def test_diagnostics_with_malformed_config(config_path, cli_runner, arguments):
+    original = b"active_profile = [\n"
+    config_path.write_bytes(original)
+    result = cli_runner.invoke(app, arguments)
+    assert result.exit_code == 0, result.exception
+    if arguments == ["version"]:
+        assert result.stdout.strip() == f"omi-cli {__version__}"
+    elif arguments[0] == "--json":
+        assert json.loads(result.stdout) == {"path": str(config_path)}
+    else:
+        assert result.stdout.strip() == str(config_path)
+    assert config_path.read_bytes() == original
+
+
+def test_config_commands_still_reject_malformed_config(config_path, cli_runner):
+    original = b"active_profile = [\n"
+    config_path.write_bytes(original)
+    result = cli_runner.invoke(app, ["config", "set", "api_base", "https://example.test"])
+    assert result.exit_code != 0
+    assert config_path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    "flag,environment,expected", [(None, None, "saved"), (None, "env", "env"), ("flag", "env", "flag")]
+)
+def test_lazy_profile_keeps_precedence(config_path, cli_runner, monkeypatch, flag, environment, expected):
+    config_path.write_text('active_profile = "saved"\n', encoding="utf-8")
+    if environment:
+        monkeypatch.setenv("OMI_PROFILE", environment)
+    args = ["--profile", flag] if flag else []
+    result = cli_runner.invoke(app, args + ["config", "set", "api_base", "https://example.test"])
+    assert result.exit_code == 0, result.exception
+    from omi_cli import config
+
+    saved = config.load()
+    assert saved.profiles[expected].api_base == "https://example.test"
+    assert set(saved.profiles) == {expected}


### PR DESCRIPTION
Fixes #13161.

Malformed TOML currently prevents `omi version` and `omi config path` from running. Resolve the profile only when a command needs it, and read the configured path without parsing file contents. Config-dependent commands still reject malformed files. README documents the diagnostic behavior.

Validation (Windows/Python 3.12):
- Seven new behavioral tests pass; the three malformed-config diagnostic cases fail before this fix. Tests also cover flag/environment/saved-profile precedence and refusal to overwrite malformed TOML.
- Real `python -m omi_cli` version and text/JSON config-path invocations pass using isolated malformed TOML.
- 38 focused CLI/config/OpenAPI tests pass. The broader run had 279 passes and five failures: four missing OpenAPI fixture failures pass after restoring the exact tracked file omitted by sparse checkout; the remaining auth transport failure is also present on the unchanged base (auth source and test unchanged from 2654b4dc).
- Mypy reports the same seven dependency/errors.py diagnostics on the original CLI and this branch; none in changed source files.

Product invariants affected: none.

Failure-Class: none

Repository preflight: all 12 selected local checks pass (22.56s), using the Makefile's Python entry point on Windows. The historical recurrence ratchet skips its history analysis in this shallow clone. `scripts/failure-class validate` passes. Proposed US$5 bounty in the issue is awaiting approval.

Hosted CI on this head: Linux/Python 3.10, Linux/Python 3.12 and Windows/Python 3.12 each fail only `test_transport_failure_during_login_leaves_saved_config_unchanged` (assert 0 != 0), matching the known baseline failure above. Run: https://github.com/BasedHardware/omi/actions/runs/34254694831 . Repository Hygiene and PR Metadata Preflight pass.
