### PR TITLE
fix(backend): migrate Todoist task creation to API v1 endpoint

### DIFF
--- a/backend/testing/e2e/test_task_integrations.py
+++ b/backend/testing/e2e/test_task_integrations.py
@@ -75,7 +75,7 @@ def test_task_integration_crud_default_and_todoist_task_creation(client, auth_he
     assert created.json() == {"success": True, "external_task_id": "todo-123", "error": None}
     assert len(requests) == 1
     request = requests[0]
-    assert str(request.url) == "https://api.todoist.com/rest/v2/tasks"
+    assert str(request.url) == "https://api.todoist.com/api/v1/tasks"
     assert request.headers["authorization"] == "Bearer todoist-token"
     payload = json.loads(request.content)
     assert payload["content"] == "E2E task"

--- a/backend/utils/task_integrations_ops.py
+++ b/backend/utils/task_integrations_ops.py
@@ -253,7 +253,7 @@ async def create_task_internal(
                 body['due_string'] = due_date.strftime('%Y-%m-%d')
 
             response = await client.post(
-                'https://api.todoist.com/rest/v2/tasks',
+                'https://api.todoist.com/api/v1/tasks',
                 headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'},
                 json=body,
             )


### PR DESCRIPTION
## Summary

Fixes #13158 — the shared Todoist task-creation path in `backend/utils/task_integrations_ops.py` still POSTs to `https://api.todoist.com/rest/v2/tasks`, which now returns **HTTP 410** (deprecated since 2026-09-08). Todoist's current API contract documents task creation at `POST https://api.todoist.com/api/v1/tasks`.

## Change

One-line endpoint swap: `rest/v2/tasks` → `api/v1/tasks`. The v1 API accepts the identical payload (`content`, `description`, `priority`, `due_string`) — verified against the current Todoist API docs — so no body changes are needed.

## Verification

- `python3 -m py_compile` passes
- Only one reference to the retired endpoint existed; no other `todoist.com/rest/v2` references remain in `backend/`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

