### PR TITLE
fix(cli): keep diagnostics working when config TOML is malformed

### DIFF
--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -162,13 +162,22 @@ class Config:
 
 
 def load(path: Optional[Path] = None) -> Config:
-    """Load the config from disk, returning an empty Config if the file is missing."""
+    """Load the config from disk, returning an empty Config if the file is missing.
+
+    A malformed TOML file also yields an empty Config rather than raising:
+    diagnostics such as ``omi version`` and ``omi config path`` must keep
+    working precisely when the config needs repair, and commands that write
+    config can rebuild a healthy default.
+    """
     p = path or default_config_path()
     if not p.exists():
         return Config(path=p, active_profile=DEFAULT_PROFILE_NAME, profiles={})
 
     with p.open("rb") as fh:
-        data = tomllib.load(fh)
+        try:
+            data = tomllib.load(fh)
+        except tomllib.TOMLDecodeError:
+            return Config(path=p, active_profile=DEFAULT_PROFILE_NAME, profiles={})
 
     active = data.get("active_profile", DEFAULT_PROFILE_NAME)
     profiles_data = data.get("profiles", {})

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -142,6 +142,12 @@ class Config:
     active_profile: str = DEFAULT_PROFILE_NAME
     profiles: dict[str, Profile] = field(default_factory=dict)
     extra: dict[str, Any] = field(default_factory=dict)
+    load_error: Optional[str] = None
+
+    @property
+    def was_load_error(self) -> bool:
+        """True when the on-disk file could not be parsed (malformed/corrupt)."""
+        return self.load_error is not None
 
     def get_profile(self, name: Optional[str] = None) -> Profile:
         target = name or self.active_profile
@@ -164,10 +170,12 @@ class Config:
 def load(path: Optional[Path] = None) -> Config:
     """Load the config from disk, returning an empty Config if the file is missing.
 
-    A malformed TOML file also yields an empty Config rather than raising:
-    diagnostics such as ``omi version`` and ``omi config path`` must keep
-    working precisely when the config needs repair, and commands that write
-    config can rebuild a healthy default.
+    A malformed or undecodable TOML file also yields an empty Config rather
+    than raising, so read-only diagnostics such as ``omi version`` and
+    ``omi config path`` keep working precisely when the config needs repair.
+    The parse failure is recorded on :attr:`Config.load_error`, and
+    :func:`save` refuses to overwrite such a file so a write command cannot
+    silently destroy config the user could still repair by hand.
     """
     p = path or default_config_path()
     if not p.exists():
@@ -176,8 +184,20 @@ def load(path: Optional[Path] = None) -> Config:
     with p.open("rb") as fh:
         try:
             data = tomllib.load(fh)
-        except tomllib.TOMLDecodeError:
-            return Config(path=p, active_profile=DEFAULT_PROFILE_NAME, profiles={})
+        except tomllib.TOMLDecodeError as exc:
+            return Config(
+                path=p,
+                active_profile=DEFAULT_PROFILE_NAME,
+                profiles={},
+                load_error=f"config file is not valid TOML: {exc}",
+            )
+        except UnicodeDecodeError as exc:
+            return Config(
+                path=p,
+                active_profile=DEFAULT_PROFILE_NAME,
+                profiles={},
+                load_error=f"config file is not valid UTF-8: {exc}",
+            )
 
     active = data.get("active_profile", DEFAULT_PROFILE_NAME)
     profiles_data = data.get("profiles", {})
@@ -193,7 +213,17 @@ def save(config: Config) -> None:
     The temp file is created with owner-only access before any credential is
     written. POSIX uses mode ``0o600``; Windows uses a protected owner-rights
     DACL supplied directly to ``CreateFileW``.
+
+    Raises PermissionError when the on-disk file failed to parse on load:
+    overwriting it would silently destroy profiles/credentials the user could
+    still repair by hand. The caller (a write command) surfaces that error
+    instead of clobbering the corrupt file.
     """
+    if config.load_error is not None:
+        raise PermissionError(
+            f"refusing to overwrite {config.path}: {config.load_error}. "
+            "Fix or remove the config file and try again."
+        )
     config.path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir perms too — credentials live underneath. Best-effort:
     # don't fail if the user has a custom mode they want to keep.

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -45,13 +45,44 @@ def test_load_missing_file_returns_empty_config(config_path: Path) -> None:
     assert config.profiles == {}
 
 
-def test_load_malformed_toml_returns_empty_config(config_path: Path) -> None:
-    """A broken config must not crash diagnostics — return an empty Config."""
+def test_load_malformed_toml_returns_empty_config_with_error(config_path: Path) -> None:
+    """A broken config must not crash diagnostics — return an empty Config
+    that records why parsing failed."""
     config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
     config = cfg.load()
     assert config.path == config_path
     assert config.active_profile == cfg.DEFAULT_PROFILE_NAME
     assert config.profiles == {}
+    assert config.was_load_error
+    assert config.load_error is not None
+    assert "not valid TOML" in config.load_error
+
+
+def test_load_invalid_utf8_records_unicode_error(config_path: Path) -> None:
+    """A config with invalid UTF-8 must not crash diagnostics either; it is
+    recorded on load_error so write commands refuse to clobber it."""
+    config_path.write_bytes(b"active_profile = \xff\xfe\n")
+    config = cfg.load()
+    assert config.profiles == {}
+    assert config.was_load_error
+    assert config.load_error is not None
+    assert "not valid UTF-8" in config.load_error
+
+
+def test_save_refuses_to_overwrite_malformed_config(config_path: Path) -> None:
+    """save() must refuse to overwrite a file that failed to parse on load:
+    a write command would otherwise silently destroy profiles/credentials the
+    user could still repair by hand."""
+    config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
+    config = cfg.load()
+    assert config.was_load_error
+    original = config_path.read_bytes()
+
+    with pytest.raises(PermissionError, match="refusing to overwrite"):
+        cfg.save(config)
+
+    # The corrupt file is left untouched.
+    assert config_path.read_bytes() == original
 
 
 def test_version_succeeds_with_malformed_config(config_path: Path, cli_runner) -> None:
@@ -67,6 +98,16 @@ def test_config_path_succeeds_with_malformed_config(config_path: Path, cli_runne
     config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
     result = cli_runner.invoke(app, ["config", "path"])
     assert result.exit_code == 0, result.output
+    assert str(config_path) in result.output
+
+
+def test_config_path_json_succeeds_with_malformed_config(config_path: Path, cli_runner) -> None:
+    """The `--json config path` branch must keep working when the config TOML
+    is malformed (regression guard for the JSON renderer path)."""
+    config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
+    result = cli_runner.invoke(app, ["--json", "config", "path"])
+    assert result.exit_code == 0, result.output
+    assert "path" in result.output
     assert str(config_path) in result.output
 
 

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 from pathlib import Path
@@ -107,8 +108,8 @@ def test_config_path_json_succeeds_with_malformed_config(config_path: Path, cli_
     config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
     result = cli_runner.invoke(app, ["--json", "config", "path"])
     assert result.exit_code == 0, result.output
-    assert "path" in result.output
-    assert str(config_path) in result.output
+    payload = json.loads(result.output)
+    assert payload["path"] == str(config_path)
 
 
 def test_config_set_preserves_unknown_root_settings(config_path: Path, cli_runner) -> None:

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -45,6 +45,31 @@ def test_load_missing_file_returns_empty_config(config_path: Path) -> None:
     assert config.profiles == {}
 
 
+def test_load_malformed_toml_returns_empty_config(config_path: Path) -> None:
+    """A broken config must not crash diagnostics — return an empty Config."""
+    config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
+    config = cfg.load()
+    assert config.path == config_path
+    assert config.active_profile == cfg.DEFAULT_PROFILE_NAME
+    assert config.profiles == {}
+
+
+def test_version_succeeds_with_malformed_config(config_path: Path, cli_runner) -> None:
+    """`omi version` must keep working when the config TOML is malformed."""
+    config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
+    result = cli_runner.invoke(app, ["version"])
+    assert result.exit_code == 0, result.output
+    assert "omi-cli" in result.output
+
+
+def test_config_path_succeeds_with_malformed_config(config_path: Path, cli_runner) -> None:
+    """`omi config path` must keep working when the config TOML is malformed."""
+    config_path.write_text("active_profile = [\n", encoding="utf-8")  # invalid TOML
+    result = cli_runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0, result.output
+    assert str(config_path) in result.output
+
+
 def test_config_set_preserves_unknown_root_settings(config_path: Path, cli_runner) -> None:
     config_path.write_text(
         'active_profile = "default"\n'


### PR DESCRIPTION
## Summary

Fixes #13161 — with an isolated `OMI_CONFIG` containing invalid TOML (e.g. `active_profile = [`), `omi version`, `omi config path`, and `omi --json config path` all failed with `TOMLDecodeError`. These diagnostics are most useful precisely when the config needs repair and don't require its contents.

## Change

`cfg.load()` now treats malformed TOML and invalid UTF-8 as a recoverable load error for read-only diagnostics, while retaining that state on `Config.load_error`. `save()` refuses to overwrite a config that failed to parse, so write commands cannot silently destroy profiles or credentials that may still be repaired manually.

## Verification

- Regression tests cover malformed TOML, invalid UTF-8, save refusal, `omi version`, human-readable `omi config path`, and parsed JSON `omi --json config path` output
- All new regression tests fail without the fix and pass with it
- `python -m pytest -q sdks/python-cli/tests/test_config.py` — 23 passed, 1 skipped
Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->