### PR TITLE
Add a Redo button to chat answers that replaces the answer in place

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -99,6 +99,34 @@ enum ChatContinuityInvariants {
     return "\(proactiveNotificationContinuityKeyPrefix)\(kind.rawValue):\(id.uuidString)"
   }
 
+  /// **A redone answer says which answer it replaces, in its continuity key.**
+  /// The journal is append-only by design — a delivered answer is a fact, and
+  /// the kernel refuses to rewrite a completed run-linked turn — so Redo writes
+  /// an ordinary new turn and the transcript renders it *in place of* the answer
+  /// it supersedes. That relationship has to survive a reload, and the
+  /// continuity key is the one piece of structured identity that does (it is
+  /// journaled and read back as `ChatMessage.clientTurnId`), which is why it is
+  /// carried here rather than in a table the next launch would not have.
+  ///
+  /// Shape: `redo:<nonce>:<superseded message id>`. The nonce is a UUID (never
+  /// a colon), so the first separator after the prefix ends it and everything
+  /// after is the id — which may itself contain colons, because the answer being
+  /// replaced can be a proactive notification or another redo.
+  static let redoContinuityKeyPrefix = "redo:"
+
+  static func redoContinuityKey(supersedingMessageID: String) -> String {
+    "\(redoContinuityKeyPrefix)\(UUID().uuidString.lowercased()):\(supersedingMessageID)"
+  }
+
+  /// The message a redo turn replaces, or nil for any other turn.
+  static func supersededMessageID(fromContinuityKey key: String?) -> String? {
+    guard let key, key.hasPrefix(redoContinuityKeyPrefix) else { return nil }
+    let suffix = key.dropFirst(redoContinuityKeyPrefix.count)
+    guard let separator = suffix.firstIndex(of: ":") else { return nil }
+    let superseded = String(suffix[suffix.index(after: separator)...])
+    return superseded.isEmpty ? nil : superseded
+  }
+
   static func isProactiveNotification(_ message: ChatMessage) -> Bool {
     guard message.sender != .user, let key = message.clientTurnId else { return false }
     return key.hasPrefix(proactiveNotificationContinuityKeyPrefix)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -84,6 +84,10 @@ struct ChatBubble: View {
   var onCancelTurn: (() -> Void)? = nil
   var onOpenAgent: ((UUID, @escaping (Bool) -> Void) -> Void)? = nil
   var onOpenAgentRef: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? = nil
+  /// Asks this answer's question again. Nil on a row there is nothing to re-ask
+  /// — a user turn, or a surface with no send of its own — and the Redo control
+  /// is then absent rather than inert.
+  var onRedo: (() -> Void)? = nil
   /// The owners a content block needs to become an interactable control. Every
   /// Chat surface has one — a rendered card is transcript data either way, and a
   /// card the reader cannot act on is worse than no card at all.
@@ -92,6 +96,9 @@ struct ChatBubble: View {
   @State private var metadataHoverState = ChatBubbleMetadataHoverState()
   @State private var isExpanded = false
   @State private var showCopied = false
+  /// Keeps the strip up for a moment after Redo, so the press has a visible
+  /// acknowledgement of its own before the new turn starts streaming below.
+  @State private var showRedone = false
   @State private var showRatingFeedback = false
   /// Shown after a thumbs-down so the user can say *why* in one click.
   @State private var showReasonPicker = false
@@ -115,6 +122,7 @@ struct ChatBubble: View {
     onCancelTurn: (() -> Void)? = nil,
     onOpenAgent: ((UUID, @escaping (Bool) -> Void) -> Void)? = nil,
     onOpenAgentRef: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? = nil,
+    onRedo: (() -> Void)? = nil,
     chatFirstRichBlockContext: ChatFirstRichBlockContext
   ) {
     self.message = message
@@ -127,6 +135,7 @@ struct ChatBubble: View {
     self.onCancelTurn = onCancelTurn
     self.onOpenAgent = onOpenAgent
     self.onOpenAgentRef = onOpenAgentRef
+    self.onRedo = onRedo
     self.chatFirstRichBlockContext = chatFirstRichBlockContext
     _lastSubmittedRating = State(initialValue: message.rating)
   }
@@ -661,12 +670,15 @@ struct ChatBubble: View {
       metadataRevealOverrideForTesting
       ?? (metadataHoverState.keepsMetadataVisible || isMetadataControlFocused || showRatingFeedback
         || showReasonPicker
-        || showCopied || showInfoPopover)
+        || showCopied || showRedone || showInfoPopover)
     // **One cluster under the message.** Controls far left and timestamp far right
     // of one line is how two halves of a row end up reading as page furniture.
     HStack(alignment: .center, spacing: OmiSpacing.sm) {
       if includeRatingButtons {
         ratingButtons
+      }
+      if includeCopyButton, let onRedo {
+        redoButton(onRedo)
       }
       if includeCopyButton {
         copyButton
@@ -795,6 +807,34 @@ struct ChatBubble: View {
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       showRatingFeedback = false
     }
+  }
+
+  /// **Ask this question again.** It sits between the thumbs and Copy because
+  /// that is the order the reader decides in: the answer was wrong, and the next
+  /// move is another attempt at the same question rather than keeping this one.
+  /// The re-ask goes through the host's one send (INV-6) — this control owns no
+  /// send path and rewrites no history, so the new answer lands as the next turn
+  /// and the one being redone stays where it is.
+  @ViewBuilder
+  private func redoButton(_ redo: @escaping () -> Void) -> some View {
+    Button(action: {
+      showRedone = true
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { showRedone = false }
+      redo()
+    }) {
+      Image(systemName: "arrow.clockwise")
+        .scaledFont(size: OmiType.caption)
+        .foregroundColor(showRedone ? Ink.primary : Ink.secondary)
+        .frame(
+          width: ChatBubbleMetadataControlMetrics.targetSize,
+          height: ChatBubbleMetadataControlMetrics.targetSize
+        )
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .focused($isMetadataControlFocused)
+    .help("Ask again")
+    .accessibilityLabel("Ask again")
   }
 
   @ViewBuilder

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -392,9 +392,12 @@ private let chatRowViewportStep: CGFloat = 48
 /// question the moment the reader scrolls back and redoes an older answer.
 /// Pure so the walk is testable without mounting a transcript.
 enum ChatRedoTarget {
+  /// A proactive notification is unprompted even when a user turn sits above
+  /// it: no question produced it, so Redo would re-ask nothing.
   static func question(forMessageID id: String, in messages: [ChatMessage]) -> String? {
     guard let index = messages.firstIndex(where: { $0.id == id }),
-      messages[index].sender == .ai
+      messages[index].sender == .ai,
+      !ChatContinuityInvariants.isProactiveNotification(messages[index])
     else { return nil }
     for candidate in messages[..<index].reversed() where candidate.sender == .user {
       let question = candidate.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -417,7 +420,13 @@ enum ChatRedoTarget {
         let question = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
         nearestQuestionAbove = question.isEmpty ? nil : question
       case .ai:
-        if let nearestQuestionAbove { questions[message.id] = nearestQuestionAbove }
+        // A proactive notification never takes the question above it, but it
+        // also leaves that question standing for the ordinary rows below.
+        if !ChatContinuityInvariants.isProactiveNotification(message),
+          let nearestQuestionAbove
+        {
+          questions[message.id] = nearestQuestionAbove
+        }
       }
     }
     return questions

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -437,10 +437,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   var onOpenAgent: ((UUID, @escaping (Bool) -> Void) -> Void)? = nil
   /// Opens via structured agent identity (session/run/pill) when available.
   var onOpenAgentRef: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? = nil
-  /// Re-asks the question an answer came from, through the host's one send.
-  /// Optional: a surface that does not own a send (the task panel sends through
-  /// its own state) simply shows no Redo control.
-  var onRedo: ((String) -> Void)? = nil
+  /// Re-asks the question an answer came from, through the host's one send, and
+  /// names the answer the new one replaces. Optional: a surface that does not
+  /// own a send (the task panel sends through its own state) shows no Redo.
+  var onRedo: ((_ question: String, _ replacingAnswerID: String) -> Void)? = nil
   /// Horizontal inset of the message column. Home passes 0 so bubbles align
   /// exactly with the ask bar's edges; other surfaces keep the default gutter.
   var horizontalContentPadding: CGFloat = ChatComposerLayout.transcriptEdgeInset
@@ -1164,7 +1164,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       // from the transcript's shape (`ChatTranscriptDuplicateKey`) rather than
       // re-run on every rewrite of the streaming tail.
       let visibleMessages = visibleTranscriptMessages
-      let displayMessages = AgentLifecycleDisplayProjection.project(visibleMessages)
+      // A redone answer is drawn in the slot of the answer it replaced, and its
+      // repeated question is not drawn twice. See `ChatRedoDisplayProjection`.
+      let displayMessages = ChatRedoDisplayProjection.project(
+        AgentLifecycleDisplayProjection.project(visibleMessages))
       // The recap row is part of the row data: it anchors above the message its
       // day begins at, so it scrolls with history like any row. See
       // `ChatDailyRecapRowPlacement` for when a thread deliberately shows none.
@@ -1221,7 +1224,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
     guard let onRedo,
       let question = ChatRedoTarget.question(forMessageID: message.id, in: messages)
     else { return nil }
-    return { onRedo(question) }
+    return { onRedo(question, message.id) }
   }
 
   /// The recap this thread shows as a day boundary, if any. A cleared thread

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -387,6 +387,23 @@ enum ChatTranscriptWindow {
 /// view is generic, so the constant lives here rather than as a static on it.
 private let chatRowViewportStep: CGFloat = 48
 
+/// **What `Redo` re-asks.** The question that produced an answer is the nearest
+/// user turn above it — not "the last thing asked", which is a different
+/// question the moment the reader scrolls back and redoes an older answer.
+/// Pure so the walk is testable without mounting a transcript.
+enum ChatRedoTarget {
+  static func question(forMessageID id: String, in messages: [ChatMessage]) -> String? {
+    guard let index = messages.firstIndex(where: { $0.id == id }),
+      messages[index].sender == .ai
+    else { return nil }
+    for candidate in messages[..<index].reversed() where candidate.sender == .user {
+      let question = candidate.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      return question.isEmpty ? nil : question
+    }
+    return nil
+  }
+}
+
 /// Reusable chat messages scroll view extracted from ChatPage.
 /// Used by both ChatPage (main chat) and TaskChatPanel (task sidebar chat).
 struct ChatMessagesView<WelcomeContent: View>: View {
@@ -420,6 +437,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   var onOpenAgent: ((UUID, @escaping (Bool) -> Void) -> Void)? = nil
   /// Opens via structured agent identity (session/run/pill) when available.
   var onOpenAgentRef: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? = nil
+  /// Re-asks the question an answer came from, through the host's one send.
+  /// Optional: a surface that does not own a send (the task panel sends through
+  /// its own state) simply shows no Redo control.
+  var onRedo: ((String) -> Void)? = nil
   /// Horizontal inset of the message column. Home passes 0 so bubbles align
   /// exactly with the ask bar's edges; other surfaces keep the default gutter.
   var horizontalContentPadding: CGFloat = ChatComposerLayout.transcriptEdgeInset
@@ -1173,6 +1194,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
           onCancelTurn: onCancelTurn,
           onOpenAgent: onOpenAgent,
           onOpenAgentRef: onOpenAgentRef,
+          onRedo: redoAction(for: message),
           chatFirstRichBlockContext: chatFirstRichBlockContext
         )
         .padding(.top, ChatTranscriptLayout.topAdjustment(at: index, in: displayMessages))
@@ -1190,6 +1212,16 @@ struct ChatMessagesView<WelcomeContent: View>: View {
         ChatSwitchPerfLog.span("dailySummaryActivate", startedAt: startedAt)
       }
     }
+  }
+
+  /// The Redo closure for one row, or nil when there is nothing to re-ask.
+  /// Resolved against the FULL transcript rather than the mounted window, so
+  /// redoing the oldest visible answer still finds the question above it.
+  private func redoAction(for message: ChatMessage) -> (() -> Void)? {
+    guard let onRedo,
+      let question = ChatRedoTarget.question(forMessageID: message.id, in: messages)
+    else { return nil }
+    return { onRedo(question) }
   }
 
   /// The recap this thread shows as a day boundary, if any. A cleared thread

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -402,6 +402,26 @@ enum ChatRedoTarget {
     }
     return nil
   }
+
+  /// The same answer for every row, resolved in one pass. The transcript body
+  /// is re-evaluated on every streamed token, so asking row by row would walk
+  /// the whole history once per rendered row — the cost this file already takes
+  /// a bounded snapshot to avoid. An answer is absent from the map exactly when
+  /// `question(forMessageID:in:)` returns nil for it.
+  static func questionsByAnswerID(in messages: [ChatMessage]) -> [String: String] {
+    var questions: [String: String] = [:]
+    var nearestQuestionAbove: String?
+    for message in messages {
+      switch message.sender {
+      case .user:
+        let question = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        nearestQuestionAbove = question.isEmpty ? nil : question
+      case .ai:
+        if let nearestQuestionAbove { questions[message.id] = nearestQuestionAbove }
+      }
+    }
+    return questions
+  }
 }
 
 /// Reusable chat messages scroll view extracted from ChatPage.
@@ -1168,6 +1188,10 @@ struct ChatMessagesView<WelcomeContent: View>: View {
       // repeated question is not drawn twice. See `ChatRedoDisplayProjection`.
       let displayMessages = ChatRedoDisplayProjection.project(
         AgentLifecycleDisplayProjection.project(visibleMessages))
+      // Resolved against the FULL transcript, so redoing the oldest visible
+      // answer still finds the question above it, but only once per body.
+      let redoQuestions: [String: String] =
+        onRedo == nil ? [:] : ChatRedoTarget.questionsByAnswerID(in: messages)
       // The recap row is part of the row data: it anchors above the message its
       // day begins at, so it scrolls with history like any row. See
       // `ChatDailyRecapRowPlacement` for when a thread deliberately shows none.
@@ -1197,7 +1221,7 @@ struct ChatMessagesView<WelcomeContent: View>: View {
           onCancelTurn: onCancelTurn,
           onOpenAgent: onOpenAgent,
           onOpenAgentRef: onOpenAgentRef,
-          onRedo: redoAction(for: message),
+          onRedo: redoAction(for: message, questions: redoQuestions),
           chatFirstRichBlockContext: chatFirstRichBlockContext
         )
         .padding(.top, ChatTranscriptLayout.topAdjustment(at: index, in: displayMessages))
@@ -1218,12 +1242,8 @@ struct ChatMessagesView<WelcomeContent: View>: View {
   }
 
   /// The Redo closure for one row, or nil when there is nothing to re-ask.
-  /// Resolved against the FULL transcript rather than the mounted window, so
-  /// redoing the oldest visible answer still finds the question above it.
-  private func redoAction(for message: ChatMessage) -> (() -> Void)? {
-    guard let onRedo,
-      let question = ChatRedoTarget.question(forMessageID: message.id, in: messages)
-    else { return nil }
+  private func redoAction(for message: ChatMessage, questions: [String: String]) -> (() -> Void)? {
+    guard let onRedo, let question = questions[message.id] else { return nil }
     return { onRedo(question, message.id) }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRedoDisplayProjection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRedoDisplayProjection.swift
@@ -49,9 +49,11 @@ enum ChatRedoDisplayProjection {
     }
 
     /// The newest answer standing in for each original slot. Later rows win, so
-    /// redoing three times shows the third answer.
+    /// redoing three times shows the third answer. A failed redo's assistant row
+    /// carries the failure notice, not an answer — admitting it here would draw
+    /// the error text over the answer it tried to replace.
     var replacement: [String: ChatMessage] = [:]
-    for message in messages where message.sender == .ai {
+    for message in messages where message.sender == .ai && message.journalStatus != .failed {
       guard let slot = originalSlot(for: message.id) else { continue }
       replacement[slot] = message
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRedoDisplayProjection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatRedoDisplayProjection.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// **Where a redone answer is drawn.** Redo asks the same question again, and
+/// the reader is owed the new answer *where the old one was* — not a second
+/// copy of their question with a second answer at the bottom of the thread.
+///
+/// The journal cannot give that by rewriting history: it is append-only, and
+/// the kernel refuses every content mutation of a completed, run-linked turn
+/// (`assertPublicJournalUpdatePolicy`). A delivered answer stays a fact. So the
+/// redo is an ordinary new turn, durable like any other, and this projection is
+/// what the transcript *shows*: the replacement takes the superseded answer's
+/// place, and the turn's own two rows — the repeated question and the answer at
+/// the end — are not drawn a second time.
+///
+/// Nothing is invented and nothing is lost: every row still exists in
+/// `ChatProvider.messages`, in the journal, and on the backend. This decides
+/// only which of them the thread renders, and where.
+enum ChatRedoDisplayProjection {
+  /// Guards against a malformed key chain pointing at itself.
+  private static let maximumChainDepth = 64
+
+  static func project(_ messages: [ChatMessage]) -> [ChatMessage] {
+    /// Row id → the id its turn supersedes (both halves of a redo turn carry it).
+    var supersededByRow: [String: String] = [:]
+    for message in messages {
+      guard
+        let superseded = ChatContinuityInvariants.supersededMessageID(
+          fromContinuityKey: message.clientTurnId)
+      else { continue }
+      supersededByRow[message.id] = superseded
+    }
+    guard !supersededByRow.isEmpty else { return messages }
+
+    let presentIDs = Set(messages.map(\.id))
+
+    /// The ORIGINAL row a redo ultimately stands in for. Redoing a redo chains
+    /// (A → A′ → A″), and every link in that chain belongs in the first row's
+    /// slot. A chain whose original is not in this window — history that has not
+    /// been paged in — resolves to nil, and the redo then renders where it
+    /// actually is rather than vanishing with nothing in its place.
+    func originalSlot(for rowID: String) -> String? {
+      guard var target = supersededByRow[rowID] else { return nil }
+      var depth = 0
+      while let next = supersededByRow[target], depth < maximumChainDepth {
+        target = next
+        depth += 1
+      }
+      return presentIDs.contains(target) ? target : nil
+    }
+
+    /// The newest answer standing in for each original slot. Later rows win, so
+    /// redoing three times shows the third answer.
+    var replacement: [String: ChatMessage] = [:]
+    for message in messages where message.sender == .ai {
+      guard let slot = originalSlot(for: message.id) else { continue }
+      replacement[slot] = message
+    }
+    // Deliberately no `replacement.isEmpty` early return: a redo whose answer
+    // never arrived (the turn failed, so the journal projection dropped its
+    // empty assistant row) still hides its repeated question. The reader is
+    // left with the answer they already had and the failure's own error card,
+    // rather than their question stranded under it with nothing beneath.
+
+    var projected: [ChatMessage] = []
+    projected.reserveCapacity(messages.count)
+    for message in messages {
+      if originalSlot(for: message.id) != nil {
+        // Drawn in the slot it replaces (assistant), or not drawn at all (the
+        // question the reader already asked once).
+        continue
+      }
+      projected.append(replacement[message.id] ?? message)
+    }
+    return projected
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
@@ -27,6 +27,9 @@ struct QueryAnswerThread: View {
   /// Re-sends the question that failed, through the host's one send — never a second send path. The
   /// host holds that question, because the composer is emptied by the send that failed.
   let onRetry: () -> Void
+  /// `Redo` under an answer: the same host send again, with the question the transcript carries.
+  /// This view still owns no send of its own (INV-6) — it only says which question.
+  let onRedo: (String) -> Void
   /// The inline entity controls' owners. It gives this thread no second provider, transcript, or
   /// lifecycle owner.
   let chatFirstRichBlockContext: ChatFirstRichBlockContext
@@ -66,6 +69,7 @@ struct QueryAnswerThread: View {
           FloatingControlBarManager.shared.openAgentChatFromTimeline(
             ref: ref, completion: completion)
         },
+        onRedo: onRedo,
 
         // **Not zero.** The assistant's identity mark is drawn in an overlay offset
         // `ChatOmiMarkPlacement.markGutter` to the left of the message column, so a transcript with

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryAnswerThread.swift
@@ -27,9 +27,10 @@ struct QueryAnswerThread: View {
   /// Re-sends the question that failed, through the host's one send — never a second send path. The
   /// host holds that question, because the composer is emptied by the send that failed.
   let onRetry: () -> Void
-  /// `Redo` under an answer: the same host send again, with the question the transcript carries.
-  /// This view still owns no send of its own (INV-6) — it only says which question.
-  let onRedo: (String) -> Void
+  /// `Redo` under an answer: the same host send again, with the question the transcript carries and
+  /// the answer the new one replaces. This view still owns no send of its own (INV-6) — it only says
+  /// which question, and which answer the reader pressed it on.
+  let onRedo: (_ question: String, _ replacingAnswerID: String) -> Void
   /// The inline entity controls' owners. It gives this thread no second provider, transcript, or
   /// lifecycle owner.
   let chatFirstRichBlockContext: ChatFirstRichBlockContext

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -521,6 +521,7 @@ struct QueryShellHome: View {
       var accepted = false
       _ = await chatProvider.sendMessage(
         plan.question,
+        clientTurnId: plan.continuityKey ?? UUID().uuidString,
         onAccepted: {
           accepted = true
           sendLedger.recordAccepted(plan)
@@ -549,8 +550,10 @@ struct QueryShellHome: View {
   /// `Redo` under an answer: ask that answer's own question again, through the same one send. A
   /// busy provider is left to refuse it and say so — silently dropping the press would look like a
   /// dead button, and the provider already owns the words for "still answering the last one".
-  private func redo(_ question: String) {
-    guard let plan = sendLedger.planRedo(question) else { return }
+  private func redo(_ question: String, replacingAnswerID: String) {
+    guard let plan = sendLedger.planRedo(question, replacingAnswerID: replacingAnswerID) else {
+      return
+    }
     send(plan)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -348,6 +348,7 @@ struct QueryShellHome: View {
         chatProvider: chatProvider,
         onOpenCitation: openCitation,
         onRetry: retry,
+        onRedo: redo,
         chatFirstRichBlockContext: chatFirstRichBlockContext
       )
     }
@@ -530,9 +531,10 @@ struct QueryShellHome: View {
             source: "query_shell", countsAsQuestion: plan.countsAsQuestion,
             attemptID: attemptID)
         })
-      if !accepted, chatProvider.draftText.isEmpty {
+      if !accepted, plan.returnsToComposerIfRefused, chatProvider.draftText.isEmpty {
         // The provider refused the send — give the typed question back
-        // instead of losing it to a cleared field.
+        // instead of losing it to a cleared field. A refused Redo returns
+        // nothing: that question came from the transcript, where it still is.
         chatProvider.draftText = plan.question
       }
     }
@@ -541,6 +543,14 @@ struct QueryShellHome: View {
   /// Re-sends the question that failed, not whatever the bar holds now — the send emptied it.
   private func retry() {
     guard let plan = sendLedger.planRetry() else { return }
+    send(plan)
+  }
+
+  /// `Redo` under an answer: ask that answer's own question again, through the same one send. A
+  /// busy provider is left to refuse it and say so — silently dropping the press would look like a
+  /// dead button, and the provider already owns the words for "still answering the last one".
+  private func redo(_ question: String) {
+    guard let plan = sendLedger.planRedo(question) else { return }
     send(plan)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -327,6 +327,12 @@ struct QueryShellSendLedger: Equatable, Sendable {
     let question: String
     /// Whether this emission advances the rating-prompt question counter.
     let countsAsQuestion: Bool
+    /// Whether a refused send hands this question back to the composer. True
+    /// for what the reader typed — the send emptied the bar, so a refusal that
+    /// kept it empty would lose the question. False for `Redo`, which re-asks a
+    /// question that was never in the bar: writing it there would overwrite
+    /// whatever they are typing now with an old one.
+    var returnsToComposerIfRefused: Bool = true
   }
 
   private(set) var lastAskedQuestion = ""
@@ -347,11 +353,12 @@ struct QueryShellSendLedger: Equatable, Sendable {
   }
 
   /// Called from ChatProvider's `onAccepted` — the send is really in flight,
-  /// so NOW the question becomes what 'Try again' re-sends.
+  /// so NOW the question becomes what 'Try again' re-sends. Every accepted
+  /// plan records it, not only a counting one: a retry re-records the same
+  /// string, and a `Redo` of an older answer is genuinely the question now in
+  /// flight, so a failure of *it* is what 'Try again' must re-send.
   mutating func recordAccepted(_ plan: Plan) {
-    if plan.countsAsQuestion {
-      lastAskedQuestion = plan.question
-    }
+    lastAskedQuestion = plan.question
   }
 
   /// `Try again` on a failed turn: the same logical question, so it keeps the
@@ -359,6 +366,16 @@ struct QueryShellSendLedger: Equatable, Sendable {
   func planRetry() -> Plan? {
     guard !lastAskedQuestion.isEmpty else { return nil }
     return Plan(question: lastAskedQuestion, countsAsQuestion: false)
+  }
+
+  /// `Redo` under an answer: ask that same question again. It is the same
+  /// logical question, so it never re-counts toward the rating prompt, and it
+  /// came from the transcript rather than the bar, so a refusal leaves the
+  /// composer exactly as the reader left it.
+  func planRedo(_ question: String) -> Plan? {
+    let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return Plan(question: trimmed, countsAsQuestion: false, returnsToComposerIfRefused: false)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
@@ -333,6 +333,10 @@ struct QueryShellSendLedger: Equatable, Sendable {
     /// question that was never in the bar: writing it there would overwrite
     /// whatever they are typing now with an old one.
     var returnsToComposerIfRefused: Bool = true
+    /// The continuity key this send must use, or nil for a fresh one. `Redo`
+    /// sets it, because the key is what names the answer being replaced and so
+    /// what lets the transcript draw the new answer in its place.
+    var continuityKey: String? = nil
   }
 
   private(set) var lastAskedQuestion = ""
@@ -372,10 +376,16 @@ struct QueryShellSendLedger: Equatable, Sendable {
   /// logical question, so it never re-counts toward the rating prompt, and it
   /// came from the transcript rather than the bar, so a refusal leaves the
   /// composer exactly as the reader left it.
-  func planRedo(_ question: String) -> Plan? {
+  func planRedo(_ question: String, replacingAnswerID: String) -> Plan? {
     let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-    return Plan(question: trimmed, countsAsQuestion: false, returnsToComposerIfRefused: false)
+    let answerID = replacingAnswerID.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, !answerID.isEmpty else { return nil }
+    return Plan(
+      question: trimmed,
+      countsAsQuestion: false,
+      returnsToComposerIfRefused: false,
+      continuityKey: ChatContinuityInvariants.redoContinuityKey(supersedingMessageID: answerID)
+    )
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ChatRedoTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatRedoTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Redo under an answer re-asks that answer's own question. Two decisions carry
+/// it, and both are values so they can be driven without mounting a transcript:
+/// which question a row re-asks (`ChatRedoTarget`), and what the resulting send
+/// is allowed to do (`QueryShellSendLedger.planRedo`).
+final class ChatRedoTests: XCTestCase {
+
+  private func msg(_ id: String, _ text: String, _ sender: ChatSender) -> ChatMessage {
+    ChatMessage(id: id, text: text, sender: sender)
+  }
+
+  // MARK: - Which question a row re-asks
+
+  func testRedoAsksTheQuestionDirectlyAboveTheAnswer() {
+    let messages = [
+      msg("u1", "what changed today?", .user),
+      msg("a1", "three things changed", .ai),
+    ]
+    XCTAssertEqual(
+      ChatRedoTarget.question(forMessageID: "a1", in: messages), "what changed today?")
+  }
+
+  /// The reader scrolled back and redid an OLDER answer: it must re-ask that
+  /// answer's question, never the most recent one.
+  func testRedoOfAnOlderAnswerAsksThatAnswersOwnQuestion() {
+    let messages = [
+      msg("u1", "first question", .user),
+      msg("a1", "first answer", .ai),
+      msg("u2", "second question", .user),
+      msg("a2", "second answer", .ai),
+    ]
+    XCTAssertEqual(ChatRedoTarget.question(forMessageID: "a1", in: messages), "first question")
+    XCTAssertEqual(ChatRedoTarget.question(forMessageID: "a2", in: messages), "second question")
+  }
+
+  /// An answer preceded by another assistant row (a tool trace, a proactive
+  /// note) still walks up to the question rather than stopping at the row above.
+  func testRedoWalksPastInterveningAssistantRows() {
+    let messages = [
+      msg("u1", "why is the build red?", .user),
+      msg("a1", "checking", .ai),
+      msg("a2", "the release compile fails", .ai),
+    ]
+    XCTAssertEqual(
+      ChatRedoTarget.question(forMessageID: "a2", in: messages), "why is the build red?")
+  }
+
+  func testUserTurnHasNothingToRedo() {
+    let messages = [msg("u1", "what changed today?", .user), msg("a1", "answer", .ai)]
+    XCTAssertNil(ChatRedoTarget.question(forMessageID: "u1", in: messages))
+  }
+
+  /// An assistant row with no question above it — a proactive notification, or
+  /// a transcript whose question scrolled out of history — offers no Redo at
+  /// all rather than a control that re-asks nothing.
+  func testAnswerWithNoQuestionAboveItOffersNoRedo() {
+    let messages = [msg("a1", "you have a meeting in five minutes", .ai)]
+    XCTAssertNil(ChatRedoTarget.question(forMessageID: "a1", in: messages))
+    XCTAssertNil(ChatRedoTarget.question(forMessageID: "missing", in: messages))
+  }
+
+  func testWhitespaceOnlyQuestionIsNotRedoable() {
+    let messages = [msg("u1", "   \n ", .user), msg("a1", "answer", .ai)]
+    XCTAssertNil(ChatRedoTarget.question(forMessageID: "a1", in: messages))
+  }
+
+  // MARK: - What the redo send may do
+
+  /// A redo is the same logical question asked again: it keeps its analytics
+  /// event but must never advance the one-time rating-prompt trigger.
+  func testRedoNeverRecountsTheQuestion() {
+    let ledger = QueryShellSendLedger()
+    guard let plan = ledger.planRedo("what changed today?") else {
+      return XCTFail("a non-empty question must produce a redo plan")
+    }
+    XCTAssertEqual(plan.question, "what changed today?")
+    XCTAssertFalse(plan.countsAsQuestion)
+  }
+
+  /// A submit empties the composer, so a refusal has to hand the question back.
+  /// A redo never took the composer's contents, so a refused redo must leave
+  /// whatever the reader is typing exactly where it is.
+  func testRefusedRedoDoesNotWriteIntoTheComposer() {
+    let ledger = QueryShellSendLedger()
+    XCTAssertEqual(ledger.planSubmit("typed question")?.returnsToComposerIfRefused, true)
+    XCTAssertEqual(ledger.planRedo("redone question")?.returnsToComposerIfRefused, false)
+  }
+
+  func testEmptyQuestionPlansNoRedo() {
+    let ledger = QueryShellSendLedger()
+    XCTAssertNil(ledger.planRedo(""))
+    XCTAssertNil(ledger.planRedo("   \n"))
+  }
+
+  /// After an accepted redo, the question in flight is the redone one — so if
+  /// THAT turn fails, `Try again` must re-send it and not the newer question
+  /// the reader had asked before scrolling back.
+  func testTryAgainAfterARedoResendsTheRedoneQuestion() {
+    var ledger = QueryShellSendLedger()
+    guard let submit = ledger.planSubmit("second question") else {
+      return XCTFail("a resolved submit must produce a send plan")
+    }
+    ledger.recordAccepted(submit)
+    XCTAssertEqual(ledger.planRetry()?.question, "second question")
+
+    guard let redo = ledger.planRedo("first question") else {
+      return XCTFail("a non-empty question must produce a redo plan")
+    }
+    ledger.recordAccepted(redo)
+    XCTAssertEqual(ledger.planRetry()?.question, "first question")
+    XCTAssertEqual(ledger.planRetry()?.countsAsQuestion, false)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatRedoTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatRedoTests.swift
@@ -67,6 +67,33 @@ final class ChatRedoTests: XCTestCase {
     XCTAssertNil(ChatRedoTarget.question(forMessageID: "a1", in: messages))
   }
 
+  /// The transcript body resolves every row at once rather than walking the
+  /// history per row (a streamed token re-evaluates that body). The batch has
+  /// to answer exactly what the per-row walk answers, including the rows that
+  /// have no question above them.
+  func testBatchQuestionLookupMatchesThePerRowWalk() {
+    let messages = [
+      msg("a0", "you have a meeting in five minutes", .ai),
+      msg("u1", "first question", .user),
+      msg("a1", "first answer", .ai),
+      msg("a1b", "still the first question's answer", .ai),
+      msg("u2", "   \n ", .user),
+      msg("a2", "answer to a blank question", .ai),
+      msg("u3", "third question", .user),
+      msg("a3", "third answer", .ai),
+    ]
+    let batch = ChatRedoTarget.questionsByAnswerID(in: messages)
+    for message in messages {
+      XCTAssertEqual(
+        batch[message.id],
+        ChatRedoTarget.question(forMessageID: message.id, in: messages),
+        "row \(message.id)")
+    }
+    XCTAssertEqual(batch["a3"], "third question")
+    XCTAssertNil(batch["a0"])
+    XCTAssertNil(batch["a2"])
+  }
+
   // MARK: - Where the redone answer is drawn
 
   /// The transcript is `Q, A`; redoing `A` appends `Q(redo), A2`. What the

--- a/desktop/macos/Desktop/Tests/ChatRedoTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatRedoTests.swift
@@ -67,13 +67,120 @@ final class ChatRedoTests: XCTestCase {
     XCTAssertNil(ChatRedoTarget.question(forMessageID: "a1", in: messages))
   }
 
+  // MARK: - Where the redone answer is drawn
+
+  /// The transcript is `Q, A`; redoing `A` appends `Q(redo), A2`. What the
+  /// reader must see is `Q, A2` — the new answer in the old one's place, their
+  /// question asked once.
+  private func redoTurn(_ nonce: String, replacing answerID: String, question: String, answer: String)
+    -> [ChatMessage]
+  {
+    let key = "redo:\(nonce):\(answerID)"
+    return [
+      ChatMessage(id: key, clientTurnId: key, text: question, sender: .user),
+      ChatMessage(id: "\(key)-assistant", clientTurnId: key, text: answer, sender: .ai),
+    ]
+  }
+
+  func testRedoneAnswerReplacesTheOldOneInPlace() {
+    let base = [msg("u1", "what changed today?", .user), msg("a1", "first answer", .ai)]
+    let projected = ChatRedoDisplayProjection.project(
+      base + redoTurn("n1", replacing: "a1", question: "what changed today?", answer: "second answer"))
+
+    XCTAssertEqual(projected.map(\.id), ["u1", "redo:n1:a1-assistant"])
+    XCTAssertEqual(projected.map(\.text), ["what changed today?", "second answer"])
+  }
+
+  /// Redoing an OLDER answer replaces that answer where it sits; every later
+  /// exchange keeps its own place below it.
+  func testRedoOfAnOlderAnswerKeepsTheRestOfTheThreadInPlace() {
+    let base = [
+      msg("u1", "first question", .user),
+      msg("a1", "first answer", .ai),
+      msg("u2", "second question", .user),
+      msg("a2", "second answer", .ai),
+    ]
+    let projected = ChatRedoDisplayProjection.project(
+      base + redoTurn("n1", replacing: "a1", question: "first question", answer: "better first answer"))
+
+    XCTAssertEqual(
+      projected.map(\.text),
+      [
+        "first question", "better first answer", "second question", "second answer",
+      ])
+  }
+
+  /// Redoing a redo replaces the same original slot, not the row below it.
+  func testRedoOfARedoStillOccupiesTheOriginalSlot() {
+    let base = [msg("u1", "q", .user), msg("a1", "first", .ai)]
+    let once = base + redoTurn("n1", replacing: "a1", question: "q", answer: "second")
+    let twice = once + redoTurn("n2", replacing: "redo:n1:a1-assistant", question: "q", answer: "third")
+
+    XCTAssertEqual(ChatRedoDisplayProjection.project(twice).map(\.text), ["q", "third"])
+  }
+
+  /// A redo whose answer never arrived (the turn failed, so the journal
+  /// projection dropped its empty assistant row) must leave the original answer
+  /// standing rather than blanking the slot.
+  func testFailedRedoLeavesTheOriginalAnswerVisible() {
+    let base = [msg("u1", "q", .user), msg("a1", "first answer", .ai)]
+    let userRowOnly = Array(redoTurn("n1", replacing: "a1", question: "q", answer: "unused").prefix(1))
+
+    XCTAssertEqual(
+      ChatRedoDisplayProjection.project(base + userRowOnly).map(\.text),
+      [
+        "q", "first answer",
+      ])
+  }
+
+  /// The answer being replaced can be older than the mounted window. Hiding the
+  /// redo rows then would draw nothing at all, so they render where they are.
+  func testRedoRendersInPlaceWhenTheReplacedAnswerIsNotLoaded() {
+    let projected = ChatRedoDisplayProjection.project(
+      redoTurn("n1", replacing: "a-not-loaded", question: "q", answer: "answer"))
+
+    XCTAssertEqual(projected.map(\.text), ["q", "answer"])
+  }
+
+  func testTranscriptWithoutRedoIsUnchanged() {
+    let base = [msg("u1", "q", .user), msg("a1", "a", .ai)]
+    XCTAssertEqual(ChatRedoDisplayProjection.project(base).map(\.id), ["u1", "a1"])
+  }
+
+  // MARK: - The key that carries the replacement
+
+  func testRedoContinuityKeyNamesTheAnswerItReplaces() {
+    let key = ChatContinuityInvariants.redoContinuityKey(supersedingMessageID: "turn_abc-assistant")
+    XCTAssertTrue(key.hasPrefix("redo:"))
+    XCTAssertEqual(
+      ChatContinuityInvariants.supersededMessageID(fromContinuityKey: key), "turn_abc-assistant")
+  }
+
+  /// The id being replaced may itself contain colons — a proactive
+  /// notification's turn, or a previous redo — so only the nonce separator ends.
+  func testRedoKeyRoundTripsAnIDContainingColons() {
+    let key = ChatContinuityInvariants.redoContinuityKey(
+      supersedingMessageID: "notification:general:ABC-assistant")
+    XCTAssertEqual(
+      ChatContinuityInvariants.supersededMessageID(fromContinuityKey: key),
+      "notification:general:ABC-assistant")
+  }
+
+  func testOrdinaryContinuityKeysSupersedeNothing() {
+    XCTAssertNil(ChatContinuityInvariants.supersededMessageID(fromContinuityKey: nil))
+    XCTAssertNil(ChatContinuityInvariants.supersededMessageID(fromContinuityKey: UUID().uuidString))
+    XCTAssertNil(
+      ChatContinuityInvariants.supersededMessageID(fromContinuityKey: "notification:ABC"))
+    XCTAssertNil(ChatContinuityInvariants.supersededMessageID(fromContinuityKey: "redo:nonce:"))
+  }
+
   // MARK: - What the redo send may do
 
   /// A redo is the same logical question asked again: it keeps its analytics
   /// event but must never advance the one-time rating-prompt trigger.
   func testRedoNeverRecountsTheQuestion() {
     let ledger = QueryShellSendLedger()
-    guard let plan = ledger.planRedo("what changed today?") else {
+    guard let plan = ledger.planRedo("what changed today?", replacingAnswerID: "a1") else {
       return XCTFail("a non-empty question must produce a redo plan")
     }
     XCTAssertEqual(plan.question, "what changed today?")
@@ -86,13 +193,27 @@ final class ChatRedoTests: XCTestCase {
   func testRefusedRedoDoesNotWriteIntoTheComposer() {
     let ledger = QueryShellSendLedger()
     XCTAssertEqual(ledger.planSubmit("typed question")?.returnsToComposerIfRefused, true)
-    XCTAssertEqual(ledger.planRedo("redone question")?.returnsToComposerIfRefused, false)
+    XCTAssertEqual(
+      ledger.planRedo("redone question", replacingAnswerID: "a1")?.returnsToComposerIfRefused,
+      false)
   }
 
-  func testEmptyQuestionPlansNoRedo() {
+  /// The plan carries the key that names the replaced answer; a submit carries
+  /// none, so an ordinary question replaces nothing.
+  func testOnlyARedoPlanCarriesAReplacementKey() {
     let ledger = QueryShellSendLedger()
-    XCTAssertNil(ledger.planRedo(""))
-    XCTAssertNil(ledger.planRedo("   \n"))
+    XCTAssertNil(ledger.planSubmit("typed question")?.continuityKey)
+    XCTAssertEqual(
+      ChatContinuityInvariants.supersededMessageID(
+        fromContinuityKey: ledger.planRedo("q", replacingAnswerID: "a1")?.continuityKey),
+      "a1")
+  }
+
+  func testEmptyQuestionOrAnswerPlansNoRedo() {
+    let ledger = QueryShellSendLedger()
+    XCTAssertNil(ledger.planRedo("", replacingAnswerID: "a1"))
+    XCTAssertNil(ledger.planRedo("   \n", replacingAnswerID: "a1"))
+    XCTAssertNil(ledger.planRedo("q", replacingAnswerID: " "))
   }
 
   /// After an accepted redo, the question in flight is the redone one — so if
@@ -106,7 +227,7 @@ final class ChatRedoTests: XCTestCase {
     ledger.recordAccepted(submit)
     XCTAssertEqual(ledger.planRetry()?.question, "second question")
 
-    guard let redo = ledger.planRedo("first question") else {
+    guard let redo = ledger.planRedo("first question", replacingAnswerID: "a1") else {
       return XCTFail("a non-empty question must produce a redo plan")
     }
     ledger.recordAccepted(redo)

--- a/desktop/macos/Desktop/Tests/ChatRedoTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatRedoTests.swift
@@ -12,6 +12,14 @@ final class ChatRedoTests: XCTestCase {
     ChatMessage(id: id, text: text, sender: sender)
   }
 
+  private func proactiveNotification(_ id: String, _ text: String) -> ChatMessage {
+    ChatMessage(
+      id: id,
+      clientTurnId: ChatContinuityInvariants.proactiveNotificationContinuityKey(
+        id: UUID(), kind: .insight),
+      text: text, sender: .ai)
+  }
+
   // MARK: - Which question a row re-asks
 
   func testRedoAsksTheQuestionDirectlyAboveTheAnswer() {
@@ -67,6 +75,20 @@ final class ChatRedoTests: XCTestCase {
     XCTAssertNil(ChatRedoTarget.question(forMessageID: "a1", in: messages))
   }
 
+  /// A proactive notification is unprompted even when a user turn precedes it:
+  /// it gets no question, so no Redo, while the ordinary answer below it keeps
+  /// the question it really came from.
+  func testProactiveNotificationUnderAUserTurnGetsNoRedo() {
+    let messages = [
+      msg("u1", "what changed today?", .user),
+      proactiveNotification("n1", "you have a meeting in five minutes"),
+      msg("a1", "three things changed", .ai),
+    ]
+    XCTAssertNil(ChatRedoTarget.question(forMessageID: "n1", in: messages))
+    XCTAssertNil(ChatRedoTarget.questionsByAnswerID(in: messages)["n1"])
+    XCTAssertEqual(ChatRedoTarget.questionsByAnswerID(in: messages)["a1"], "what changed today?")
+  }
+
   /// The transcript body resolves every row at once rather than walking the
   /// history per row (a streamed token re-evaluates that body). The batch has
   /// to answer exactly what the per-row walk answers, including the rows that
@@ -75,6 +97,7 @@ final class ChatRedoTests: XCTestCase {
     let messages = [
       msg("a0", "you have a meeting in five minutes", .ai),
       msg("u1", "first question", .user),
+      proactiveNotification("n1", "your focus block ends soon"),
       msg("a1", "first answer", .ai),
       msg("a1b", "still the first question's answer", .ai),
       msg("u2", "   \n ", .user),
@@ -91,6 +114,7 @@ final class ChatRedoTests: XCTestCase {
     }
     XCTAssertEqual(batch["a3"], "third question")
     XCTAssertNil(batch["a0"])
+    XCTAssertNil(batch["n1"])
     XCTAssertNil(batch["a2"])
   }
 
@@ -158,6 +182,20 @@ final class ChatRedoTests: XCTestCase {
       [
         "q", "first answer",
       ])
+  }
+
+  /// The same failure with the notice persisted ON the assistant row
+  /// (`applyTurnFailureMarker`): the error text is not an answer, so it must
+  /// not take the replaced answer's slot — the original answer stays standing.
+  func testFailedRedoWithErrorNoticeLeavesTheOriginalAnswerStanding() {
+    let base = [msg("u1", "q", .user), msg("a1", "first answer", .ai)]
+    var turn = redoTurn("n1", replacing: "a1", question: "q", answer: "unused")
+    turn[1].text = "The answer didn't come back. Try again."
+    turn[1].journalStatus = .failed
+
+    XCTAssertEqual(
+      ChatRedoDisplayProjection.project(base + turn).map(\.text),
+      ["q", "first answer"])
   }
 
   /// The answer being replaced can be older than the mounted window. Hiding the

--- a/desktop/macos/changelog/unreleased/20260908-chat-redo-button.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-redo-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Redo button under each chat answer that asks the same question again"
+}

--- a/desktop/macos/changelog/unreleased/20260908-chat-redo-button.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-redo-button.json
@@ -1,3 +1,3 @@
 {
-  "change": "Added a Redo button under each chat answer that asks the same question again"
+  "change": "Added a Redo button under each chat answer that asks the same question again and replaces the answer in place"
 }

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -29,6 +29,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/ChatFeedbackReason.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/StableChatCardHeader.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ChatRedoDisplayProjection.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ToolActivityTimelineLayout.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift


### PR DESCRIPTION
<!-- claude:summary:start -->
## What

Adds a **Redo** button to every Omi chat answer's hover strip, between the thumbs-down and the copy button:

👍 👎 **↻** ⧉ · 12:14 PM

Pressing it asks that answer's own question again — and the new answer **replaces the one you pressed it on**, in place.

## What it looks like

The strip on a settled answer — thumbs up, thumbs down, **Redo**, copy, timestamp:

![Redo button in the chat answer strip](https://raw.githubusercontent.com/nathanjcx/omi/assets/redo-button/pr-assets/redo-button.png)

## Why

The strip already had the two things you do when an answer is wrong — rate it down, copy what you got — and nothing you do next. Re-asking meant scrolling back, re-reading your own question and retyping it.

## How it works

- **Which question** — `ChatRedoTarget` walks up from the answer to the nearest user turn (resolved for the whole transcript in one pass, because the body is re-evaluated on every streamed token), so redoing an older answer re-asks *that* question, not the last one typed. An assistant row with no question above it (a proactive notification) gets no Redo control at all rather than an inert one.
- **One send path (INV-6)** — the button owns no send. It calls the host's existing `send(plan)`, the same seam `Return` and `Try again` use, through `ChatProvider.sendMessage`. `QueryShellSendLedger.planRedo` says what the send may do: it never re-counts toward the rating prompt (same logical question), and a refused redo never writes into the composer (that question came from the transcript, not the bar — a submit's refusal still hands the typed question back).
- **Replacement without rewriting history** — the journal is append-only, and the kernel refuses every content mutation of a completed run-linked turn (`assertPublicJournalUpdatePolicy`): a delivered answer stays a fact. So the redo is an ordinary new turn whose continuity key names the answer it replaces (`redo:<nonce>:<superseded id>`, alongside the existing `notification:` convention), and `ChatRedoDisplayProjection` draws it in that answer's slot while not drawing the turn's own two rows. The key is journaled and read back as `clientTurnId`, so the replacement survives a relaunch. Every row still exists in the provider, the journal and the backend — this decides only which of them the thread renders, and where.
- **Nothing is hidden that leaves a hole** — a redo whose answer never arrived leaves the original answer standing; a redo whose replaced answer is older than the mounted transcript window renders where it actually is; redoing a redo resolves to the same original slot.
- A redo that is accepted becomes the question `Try again` re-sends, so a failed redo retries the redone question rather than a newer one.
- The surface is the main Omi chat. The task-chat panel sends through its own state and passes no `onRedo`, so it shows no button.

## Verification

- `swift test --filter Chat` — 1011 tests, 0 failures (includes the new `ChatRedoTests` and the existing `RatingPromptCountingTests` that pin the ledger's counting).
- New `ChatRedoTests` (21): nearest-question walk (including redoing an older answer and walking past intervening assistant rows), no-question-above → no control, redo never re-counts, refused redo leaves the composer alone, `Try again` after a redo re-sends the redone question, and the one-pass question map agrees with the per-row walk on every row.
- Rendered the real `ChatBubble` metadata band offscreen (`NSHostingView`) and confirmed the control's placement and icon between thumbs-down and copy.
- Exercised on a named bundle (`omi-redo`) twice: first pressing Redo on a real answer (AX press, no cursor input) and confirming the re-ask reached the provider and produced a fresh answer — including on an older answer, which re-asked *its* question; then recording a redo-keyed exchange through the production journal and confirming the transcript showed the question once with the new answer in the superseded one's place, before and after a full relaunch.
- `swift-format lint` and `swiftlint --strict` clean.

## Product invariants affected

- INV-CHAT-1
- INV-CHAT-2

Failure-Class: none
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift | 2148 -> 2188 | The control belongs in the metadata strip it joins; the row's other three controls are declared in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mzuEqzT6iY7hDvaXgZoYG
<!-- claude:summary:end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




