### PR TITLE
fix(app,backend): BigText chat-answer notifications + chat deep-link

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -154,11 +154,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     // Click-to-talk / chat answers: local BigText + navigate_to (#4375).
     // Must live in this single background entrypoint — do not re-register a
     // second onBackgroundMessage handler from NotificationService.
-    await ChatAnswerNotificationHandler.handle(
-      data,
-      channelKey,
-      isAppInForeground: false,
-    );
+    await ChatAnswerNotificationHandler.handle(data, channelKey, isAppInForeground: false);
   }
 }
 
@@ -206,8 +202,9 @@ Future _init() async {
   if (isAuth) {
     final firebaseUser = FirebaseAuth.instance.currentUser;
     PlatformManager.instance.analytics.identify(
-      authMethod:
-          firebaseUser == null || firebaseUser.providerData.isEmpty ? null : firebaseUser.providerData.first.providerId,
+      authMethod: firebaseUser == null || firebaseUser.providerData.isEmpty
+          ? null
+          : firebaseUser.providerData.first.providerId,
       userCreatedAt: firebaseUser?.metadata.creationTime,
     );
     // Restore onboarding state from server if not already set locally
@@ -372,8 +369,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
-            CaptureProvider>(
+        ChangeNotifierProxyProvider4<
+          ConversationProvider,
+          MessageProvider,
+          PeopleProvider,
+          UsageProvider,
+          CaptureProvider
+        >(
           create: (context) => CaptureProvider(localSegmentStore: LocalSegmentStore.appSupport()),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) {
             final externalActions = ProviderCaptureExternalActions(
@@ -383,10 +385,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
               usageProvider: usage,
             );
             return (previous?..updateExternalActions(externalActions)) ??
-                CaptureProvider(
-                  externalActions: externalActions,
-                  localSegmentStore: LocalSegmentStore.appSupport(),
-                );
+                CaptureProvider(externalActions: externalActions, localSegmentStore: LocalSegmentStore.appSupport());
           },
         ),
         ChangeNotifierProxyProvider<ConversationProvider, LocalRecordingsProvider>(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -202,9 +202,8 @@ Future _init() async {
   if (isAuth) {
     final firebaseUser = FirebaseAuth.instance.currentUser;
     PlatformManager.instance.analytics.identify(
-      authMethod: firebaseUser == null || firebaseUser.providerData.isEmpty
-          ? null
-          : firebaseUser.providerData.first.providerId,
+      authMethod:
+          firebaseUser == null || firebaseUser.providerData.isEmpty ? null : firebaseUser.providerData.first.providerId,
       userCreatedAt: firebaseUser?.metadata.creationTime,
     );
     // Restore onboarding state from server if not already set locally
@@ -369,13 +368,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           update: (BuildContext context, value, MessageProvider? previous) =>
               (previous?..updateAppProvider(value)) ?? MessageProvider(),
         ),
-        ChangeNotifierProxyProvider4<
-          ConversationProvider,
-          MessageProvider,
-          PeopleProvider,
-          UsageProvider,
-          CaptureProvider
-        >(
+        ChangeNotifierProxyProvider4<ConversationProvider, MessageProvider, PeopleProvider, UsageProvider,
+            CaptureProvider>(
           create: (context) => CaptureProvider(localSegmentStore: LocalSegmentStore.appSupport()),
           update: (BuildContext context, conversation, message, people, usage, CaptureProvider? previous) {
             final externalActions = ProviderCaptureExternalActions(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -74,6 +74,7 @@ import 'package:omi/providers/phone_call_provider.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/notifications/action_item_notification_handler.dart';
+import 'package:omi/services/notifications/chat_answer_notification_handler.dart';
 import 'package:omi/services/notifications/important_conversation_notification_handler.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/services/devices/connectors/limitless_connection.dart';
@@ -145,6 +146,15 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
     await MergeNotificationHandler.handleMergeCompleted(data, channelKey, isAppInForeground: false);
   } else if (messageType == 'important_conversation') {
     await ImportantConversationNotificationHandler.handleImportantConversation(
+      data,
+      channelKey,
+      isAppInForeground: false,
+    );
+  } else if (ChatAnswerNotificationHandler.isChatAnswerData(data)) {
+    // Click-to-talk / chat answers: local BigText + navigate_to (#4375).
+    // Must live in this single background entrypoint — do not re-register a
+    // second onBackgroundMessage handler from NotificationService.
+    await ChatAnswerNotificationHandler.handle(
       data,
       channelKey,
       isAppInForeground: false,

--- a/app/lib/services/notifications/chat_answer_notification_handler.dart
+++ b/app/lib/services/notifications/chat_answer_notification_handler.dart
@@ -30,11 +30,7 @@ class ChatAnswerNotificationHandler {
   /// in-app via ServerMessage; shade banners are for background delivery.
   /// Callers that may still invoke this while foregrounded (FCM listen path)
   /// must also gate on `!OmiVoicePlaybackService.instance.isSpeaking`.
-  static Future<void> handle(
-    Map<String, dynamic> data,
-    String channelKey, {
-    bool isAppInForeground = true,
-  }) async {
+  static Future<void> handle(Map<String, dynamic> data, String channelKey, {bool isAppInForeground = true}) async {
     // Explicit foreground semantics: do not create a local banner while the
     // user is inside the app (merge-handler pattern; #4375 review).
     if (isAppInForeground) {

--- a/app/lib/services/notifications/chat_answer_notification_handler.dart
+++ b/app/lib/services/notifications/chat_answer_notification_handler.dart
@@ -8,6 +8,10 @@ import 'package:omi/utils/logger.dart';
 /// answers are therefore delivered as data-oriented pushes and rendered here
 /// so the shade shows more of the answer and the tap payload includes
 /// `navigate_to` for deep-linking into the matching chat.
+///
+/// Display policy matches [MergeNotificationHandler]: create a shade entry only
+/// when the app is backgrounded. Foreground answers are consumed in-app via
+/// ServerMessage; the FCM listen path also gates on speaking state.
 class ChatAnswerNotificationHandler {
   static final _awesomeNotifications = AwesomeNotifications();
 
@@ -20,11 +24,24 @@ class ChatAnswerNotificationHandler {
     return notificationType == 'plugin' && navigateTo.startsWith('/chat/');
   }
 
+  /// Shows a BigText shade notification when the app is backgrounded.
+  ///
+  /// Matches [MergeNotificationHandler]: foreground answers are consumed
+  /// in-app via ServerMessage; shade banners are for background delivery.
+  /// Callers that may still invoke this while foregrounded (FCM listen path)
+  /// must also gate on `!OmiVoicePlaybackService.instance.isSpeaking`.
   static Future<void> handle(
     Map<String, dynamic> data,
     String channelKey, {
     bool isAppInForeground = true,
   }) async {
+    // Explicit foreground semantics: do not create a local banner while the
+    // user is inside the app (merge-handler pattern; #4375 review).
+    if (isAppInForeground) {
+      Logger.debug('[ChatAnswerNotification] Skipping shade notification while foreground');
+      return;
+    }
+
     final title = (data['title']?.toString().isNotEmpty == true) ? data['title'].toString() : 'omi says';
     final body = _resolveBody(data);
     if (body.isEmpty) {

--- a/app/lib/services/notifications/chat_answer_notification_handler.dart
+++ b/app/lib/services/notifications/chat_answer_notification_handler.dart
@@ -1,0 +1,75 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
+
+import 'package:omi/utils/logger.dart';
+
+/// Local BigText notifications for click-to-talk / chat answer pushes (#4375).
+///
+/// Android system FCM trays collapse long bodies without BigTextStyle. Chat
+/// answers are therefore delivered as data-oriented pushes and rendered here
+/// so the shade shows more of the answer and the tap payload includes
+/// `navigate_to` for deep-linking into the matching chat.
+class ChatAnswerNotificationHandler {
+  static final _awesomeNotifications = AwesomeNotifications();
+
+  /// True when this FCM data map is a chat/plugin answer that should use the
+  /// shared BigText + deep-link path.
+  static bool isChatAnswerData(Map<String, dynamic> data) {
+    if (data['push_type']?.toString() == 'chat_answer') return true;
+    final notificationType = data['notification_type']?.toString();
+    final navigateTo = data['navigate_to']?.toString() ?? '';
+    return notificationType == 'plugin' && navigateTo.startsWith('/chat/');
+  }
+
+  static Future<void> handle(
+    Map<String, dynamic> data,
+    String channelKey, {
+    bool isAppInForeground = true,
+  }) async {
+    final title = (data['title']?.toString().isNotEmpty == true) ? data['title'].toString() : 'omi says';
+    final body = _resolveBody(data);
+    if (body.isEmpty) {
+      Logger.debug('[ChatAnswerNotification] Skipping empty body');
+      return;
+    }
+
+    final navigateTo = data['navigate_to']?.toString();
+    final messageId = data['id']?.toString();
+    final notificationId = (messageId ?? body).hashCode & 0x7fffffff;
+
+    final payload = <String, String?>{};
+    if (navigateTo != null && navigateTo.isNotEmpty) {
+      payload['navigate_to'] = navigateTo;
+    }
+    if (messageId != null && messageId.isNotEmpty) {
+      payload['message_id'] = messageId;
+    }
+
+    try {
+      await _awesomeNotifications.createNotification(
+        content: NotificationContent(
+          id: notificationId,
+          channelKey: channelKey,
+          actionType: ActionType.Default,
+          title: title,
+          body: body,
+          payload: payload,
+          notificationLayout: NotificationLayout.BigText,
+        ),
+      );
+      Logger.debug(
+        '[ChatAnswerNotification] Showed BigText notification '
+        'id=$notificationId navigate_to=$navigateTo foreground=$isAppInForeground',
+      );
+    } catch (e) {
+      Logger.debug('[ChatAnswerNotification] Failed to show notification: $e');
+    }
+  }
+
+  static String _resolveBody(Map<String, dynamic> data) {
+    final body = data['body']?.toString();
+    if (body != null && body.isNotEmpty) return body;
+    final text = data['text']?.toString();
+    if (text != null && text.isNotEmpty) return text;
+    return '';
+  }
+}

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/http/api/notifications.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/services/notifications.dart' show NotificationUtil;
 import 'package:omi/services/notifications/action_item_notification_handler.dart';
+import 'package:omi/services/notifications/chat_answer_notification_handler.dart';
 import 'package:omi/services/notifications/important_conversation_notification_handler.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/services/notifications/notification_interface.dart';
@@ -246,9 +247,23 @@ class _FCMNotificationService implements NotificationInterface {
           data['from_integration'] = data['from_integration'] == 'true';
           _serverMessageStreamController.add(ServerMessage.fromJson(data));
         }
+
+        // Click-to-talk / chat answers: BigText + navigate_to payload (#4375).
+        // Keep ServerMessage emission above so in-app consumers still receive it.
+        if (ChatAnswerNotificationHandler.isChatAnswerData(data)) {
+          ChatAnswerNotificationHandler.handle(
+            data,
+            channel.channelKey!,
+            isAppInForeground: true,
+          );
+          return;
+        }
+
         if (noti != null && _shouldShowForegroundNotificationOnFCMMessageReceived()) {
           if (!OmiVoicePlaybackService.instance.isSpeaking) {
-            _showForegroundNotification(noti: noti, payload: payload);
+            final route = payload['navigate_to'] ?? '';
+            final layout = route.startsWith('/chat/') ? NotificationLayout.BigText : NotificationLayout.Default;
+            _showForegroundNotification(noti: noti, layout: layout, payload: payload);
           }
         }
         return;

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -251,13 +251,8 @@ class _FCMNotificationService implements NotificationInterface {
         // Click-to-talk / chat answers: BigText + navigate_to payload (#4375).
         // Keep ServerMessage emission above so in-app consumers still receive it.
         // Match the legacy foreground path: suppress shade noise while Omi speaks.
-        if (ChatAnswerNotificationHandler.isChatAnswerData(data) &&
-            !OmiVoicePlaybackService.instance.isSpeaking) {
-          ChatAnswerNotificationHandler.handle(
-            data,
-            channel.channelKey!,
-            isAppInForeground: true,
-          );
+        if (ChatAnswerNotificationHandler.isChatAnswerData(data) && !OmiVoicePlaybackService.instance.isSpeaking) {
+          ChatAnswerNotificationHandler.handle(data, channel.channelKey!, isAppInForeground: true);
           return;
         }
 

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -250,7 +250,9 @@ class _FCMNotificationService implements NotificationInterface {
 
         // Click-to-talk / chat answers: BigText + navigate_to payload (#4375).
         // Keep ServerMessage emission above so in-app consumers still receive it.
-        if (ChatAnswerNotificationHandler.isChatAnswerData(data)) {
+        // Match the legacy foreground path: suppress shade noise while Omi speaks.
+        if (ChatAnswerNotificationHandler.isChatAnswerData(data) &&
+            !OmiVoicePlaybackService.instance.isSpeaking) {
           ChatAnswerNotificationHandler.handle(
             data,
             channel.channelKey!,

--- a/app/test/unit/chat_answer_notification_handler_test.dart
+++ b/app/test/unit/chat_answer_notification_handler_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/notifications/chat_answer_notification_handler.dart';
+
+void main() {
+  group('ChatAnswerNotificationHandler.isChatAnswerData (#4375)', () {
+    test('true when push_type is chat_answer', () {
+      expect(
+        ChatAnswerNotificationHandler.isChatAnswerData(const {
+          'push_type': 'chat_answer',
+          'body': 'Hello from omi',
+        }),
+        isTrue,
+      );
+    });
+
+    test('true for plugin notification targeting /chat/', () {
+      expect(
+        ChatAnswerNotificationHandler.isChatAnswerData(const {
+          'notification_type': 'plugin',
+          'navigate_to': '/chat/omi',
+          'text': 'Full answer text',
+        }),
+        isTrue,
+      );
+    });
+
+    test('false for unrelated plugin payloads without chat route', () {
+      expect(
+        ChatAnswerNotificationHandler.isChatAnswerData(const {
+          'notification_type': 'plugin',
+          'navigate_to': '/apps/foo',
+        }),
+        isFalse,
+      );
+    });
+
+    test('false for action item reminders', () {
+      expect(
+        ChatAnswerNotificationHandler.isChatAnswerData(const {
+          'type': 'action_item_reminder',
+          'action_item_id': 'abc',
+        }),
+        isFalse,
+      );
+    });
+  });
+}

--- a/app/test/unit/chat_answer_notification_handler_test.dart
+++ b/app/test/unit/chat_answer_notification_handler_test.dart
@@ -6,10 +6,7 @@ void main() {
   group('ChatAnswerNotificationHandler.isChatAnswerData (#4375)', () {
     test('true when push_type is chat_answer', () {
       expect(
-        ChatAnswerNotificationHandler.isChatAnswerData(const {
-          'push_type': 'chat_answer',
-          'body': 'Hello from omi',
-        }),
+        ChatAnswerNotificationHandler.isChatAnswerData(const {'push_type': 'chat_answer', 'body': 'Hello from omi'}),
         isTrue,
       );
     });
@@ -37,10 +34,7 @@ void main() {
 
     test('false for action item reminders', () {
       expect(
-        ChatAnswerNotificationHandler.isChatAnswerData(const {
-          'type': 'action_item_reminder',
-          'action_item_id': 'abc',
-        }),
+        ChatAnswerNotificationHandler.isChatAnswerData(const {'type': 'action_item_reminder', 'action_item_id': 'abc'}),
         isFalse,
       );
     });

--- a/backend/tests/unit/test_chat_answer_client_displayed_notification.py
+++ b/backend/tests/unit/test_chat_answer_client_displayed_notification.py
@@ -108,7 +108,7 @@ def test_client_displayed_message_omits_top_level_notification():
         data = {
             'push_type': 'chat_answer',
             'title': 'omi says',
-            'body': 'Long answer that should expand',
+            'text': 'Long answer that should expand',
             'navigate_to': '/chat/omi',
             'notification_type': 'plugin',
         }
@@ -125,6 +125,8 @@ def test_client_displayed_message_omits_top_level_notification():
         assert msg.notification is None
         assert msg.data['navigate_to'] == '/chat/omi'
         assert msg.data['push_type'] == 'chat_answer'
+        assert msg.data['text'] == 'Long answer that should expand'
+        assert 'body' not in msg.data
         assert msg.android is not None
         assert getattr(msg.android, 'notification', None) is None
         assert msg.apns is not None
@@ -147,7 +149,12 @@ def test_send_client_displayed_notification_sets_push_type():
             'uid-1',
             'omi says',
             'Answer body',
-            {'notification_type': 'plugin', 'navigate_to': '/chat/omi', 'id': 'msg-1'},
+            {
+                'notification_type': 'plugin',
+                'navigate_to': '/chat/omi',
+                'id': 'msg-1',
+                'text': 'Answer body',
+            },
         )
 
         assert len(captured['messages']) == 1
@@ -155,8 +162,10 @@ def test_send_client_displayed_notification_sets_push_type():
         assert msg.notification is None
         assert msg.data['push_type'] == 'chat_answer'
         assert msg.data['title'] == 'omi says'
-        assert msg.data['body'] == 'Answer body'
+        assert msg.data['text'] == 'Answer body'
+        assert 'body' not in msg.data
         assert msg.data['navigate_to'] == '/chat/omi'
+        assert msg.apns.payload.aps.alert.body == 'Answer body'
 
 
 def test_send_client_displayed_notification_async_matches_sync_shape():
@@ -176,7 +185,12 @@ def test_send_client_displayed_notification_async_matches_sync_shape():
                 'uid-1',
                 'omi says',
                 'Async answer body',
-                {'notification_type': 'plugin', 'navigate_to': '/chat/omi', 'id': 'msg-2'},
+                {
+                    'notification_type': 'plugin',
+                    'navigate_to': '/chat/omi',
+                    'id': 'msg-2',
+                    'text': 'Async answer body',
+                },
             )
         )
 
@@ -184,5 +198,30 @@ def test_send_client_displayed_notification_async_matches_sync_shape():
         msg = captured['messages'][0]
         assert msg.notification is None
         assert msg.data['push_type'] == 'chat_answer'
-        assert msg.data['body'] == 'Async answer body'
+        assert msg.data['text'] == 'Async answer body'
+        assert 'body' not in msg.data
         assert msg.data['navigate_to'] == '/chat/omi'
+        assert msg.apns.payload.aps.alert.body == 'Async answer body'
+
+
+def test_send_client_displayed_notification_fills_text_when_missing():
+    with _loaded_notifications() as notifications:
+        captured: dict[str, Any] = {}
+
+        def fake_send_each(messages):
+            captured['messages'] = messages
+            return SimpleNamespace(responses=[SimpleNamespace(success=True, exception=None)])
+
+        notifications.messaging.send_each = fake_send_each
+        notifications.notification_db.get_all_tokens = lambda _uid: ['t1']
+
+        notifications.send_client_displayed_notification(
+            'uid-1',
+            'omi says',
+            'Only in body arg',
+            {'notification_type': 'plugin', 'navigate_to': '/chat/omi', 'id': 'msg-3'},
+        )
+
+        msg = captured['messages'][0]
+        assert msg.data['text'] == 'Only in body arg'
+        assert 'body' not in msg.data

--- a/backend/tests/unit/test_chat_answer_client_displayed_notification.py
+++ b/backend/tests/unit/test_chat_answer_client_displayed_notification.py
@@ -1,0 +1,188 @@
+"""Chat answer pushes use the client-displayed FCM path (#4375)."""
+
+import asyncio
+import inspect
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Iterator
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+def _module(name: str, **attributes: Any) -> ModuleType:
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    return module
+
+
+def _messaging_module() -> ModuleType:
+    class Notification:
+        def __init__(self, title: str, body: str):
+            self.title = title
+            self.body = body
+
+    def constructor(**kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(**kwargs)
+
+    return _module(
+        'firebase_admin.messaging',
+        Notification=Notification,
+        AndroidConfig=constructor,
+        AndroidNotification=constructor,
+        APNSConfig=constructor,
+        APNSPayload=constructor,
+        Aps=constructor,
+        ApsAlert=constructor,
+        WebpushConfig=constructor,
+        WebpushNotification=constructor,
+        WebpushFCMOptions=constructor,
+        Message=constructor,
+        send_each=lambda _messages: SimpleNamespace(responses=[]),
+    )
+
+
+@contextmanager
+def _loaded_notifications() -> Iterator[ModuleType]:
+    messaging = _messaging_module()
+    auth = _module(
+        'firebase_admin.auth',
+        get_user=lambda _uid: SimpleNamespace(display_name='Ada', email='ada@example.com'),
+    )
+    firebase_admin = _module('firebase_admin', messaging=messaging, auth=auth)
+    notification_db = _module(
+        'database.notifications',
+        get_all_tokens=lambda _uid: ['device-token'],
+        remove_bulk_tokens=lambda _tokens: None,
+    )
+    redis_db = _module(
+        'database.redis_db',
+        has_credit_limit_notification_been_sent=lambda _uid: False,
+        set_credit_limit_notification_sent=lambda _uid: None,
+        has_silent_user_notification_been_sent=lambda _uid: False,
+        set_silent_user_notification_sent=lambda _uid: None,
+    )
+    database_auth = _module('database.auth', get_user_from_uid=lambda _uid: None)
+
+    async def generate_notification_message(_uid: str, _name: str, _plan: str) -> tuple[str, str]:
+        return 'Welcome', 'Subscription active'
+
+    async def generate_credit_limit_notification(_uid: str, _name: str) -> tuple[str, str]:
+        return 'Limit reached', 'Upgrade to continue'
+
+    llm_notifications = _module(
+        'utils.llm.notifications',
+        generate_notification_message=generate_notification_message,
+        generate_credit_limit_notification=generate_credit_limit_notification,
+        generate_silent_user_notification=lambda _name: ('We miss you', 'Capture something today'),
+    )
+
+    with stub_modules(
+        {
+            'firebase_admin': firebase_admin,
+            'firebase_admin.messaging': messaging,
+            'firebase_admin.auth': auth,
+            'database.notifications': notification_db,
+            'database.redis_db': redis_db,
+            'database.auth': database_auth,
+            'utils.llm.notifications': llm_notifications,
+        }
+    ):
+        yield load_module_fresh(
+            'utils.notifications',
+            str(BACKEND_DIR / 'utils' / 'notifications.py'),
+        )
+
+
+def test_stringify_fcm_data_coerces_values_to_strings():
+    with _loaded_notifications() as notifications:
+        out = notifications._stringify_fcm_data({'a': 1, 'b': None, 'c': True, 'd': 'x'})
+        assert out == {'a': '1', 'b': '', 'c': 'True', 'd': 'x'}
+
+
+def test_client_displayed_message_omits_top_level_notification():
+    with _loaded_notifications() as notifications:
+        data = {
+            'push_type': 'chat_answer',
+            'title': 'omi says',
+            'body': 'Long answer that should expand',
+            'navigate_to': '/chat/omi',
+            'notification_type': 'plugin',
+        }
+        msg = notifications._build_message(
+            token='token-1',
+            tag='tag-1',
+            notification=None,
+            data=data,
+            priority='high',
+            client_displayed=True,
+            display_title='omi says',
+            display_body='Long answer that should expand',
+        )
+        assert msg.notification is None
+        assert msg.data['navigate_to'] == '/chat/omi'
+        assert msg.data['push_type'] == 'chat_answer'
+        assert msg.android is not None
+        assert getattr(msg.android, 'notification', None) is None
+        assert msg.apns is not None
+        assert msg.apns.payload.aps.alert.title == 'omi says'
+        assert msg.apns.payload.aps.alert.body == 'Long answer that should expand'
+
+
+def test_send_client_displayed_notification_sets_push_type():
+    with _loaded_notifications() as notifications:
+        captured: dict[str, Any] = {}
+
+        def fake_send_each(messages):
+            captured['messages'] = messages
+            return SimpleNamespace(responses=[SimpleNamespace(success=True, exception=None)])
+
+        notifications.messaging.send_each = fake_send_each
+        notifications.notification_db.get_all_tokens = lambda _uid: ['t1']
+
+        notifications.send_client_displayed_notification(
+            'uid-1',
+            'omi says',
+            'Answer body',
+            {'notification_type': 'plugin', 'navigate_to': '/chat/omi', 'id': 'msg-1'},
+        )
+
+        assert len(captured['messages']) == 1
+        msg = captured['messages'][0]
+        assert msg.notification is None
+        assert msg.data['push_type'] == 'chat_answer'
+        assert msg.data['title'] == 'omi says'
+        assert msg.data['body'] == 'Answer body'
+        assert msg.data['navigate_to'] == '/chat/omi'
+
+
+def test_send_client_displayed_notification_async_matches_sync_shape():
+    with _loaded_notifications() as notifications:
+        assert inspect.iscoroutinefunction(notifications.send_client_displayed_notification_async)
+        captured: dict[str, Any] = {}
+
+        def fake_send_each(messages):
+            captured['messages'] = messages
+            return SimpleNamespace(responses=[SimpleNamespace(success=True, exception=None)])
+
+        notifications.messaging.send_each = fake_send_each
+        notifications.notification_db.get_all_tokens = lambda _uid: ['t1']
+
+        asyncio.run(
+            notifications.send_client_displayed_notification_async(
+                'uid-1',
+                'omi says',
+                'Async answer body',
+                {'notification_type': 'plugin', 'navigate_to': '/chat/omi', 'id': 'msg-2'},
+            )
+        )
+
+        assert len(captured['messages']) == 1
+        msg = captured['messages'][0]
+        assert msg.notification is None
+        assert msg.data['push_type'] == 'chat_answer'
+        assert msg.data['body'] == 'Async answer body'
+        assert msg.data['navigate_to'] == '/chat/omi'

--- a/backend/tests/unit/test_chat_stream_error_fallback.py
+++ b/backend/tests/unit/test_chat_stream_error_fallback.py
@@ -69,6 +69,8 @@ def _make_client():
     notifications = _install('utils.notifications')
     notifications.send_notification = MagicMock()
     notifications.send_notification_async = AsyncMock()
+    notifications.send_client_displayed_notification = MagicMock()
+    notifications.send_client_displayed_notification_async = AsyncMock()
 
     fallback_obs = _install('utils.observability.fallback')
     fallback_obs.record_fallback = MagicMock()

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -84,6 +84,12 @@ def _restore_package_paths():
     notifications = sys.modules.get('utils.notifications')
     if notifications is not None and not hasattr(notifications, 'send_notification'):
         notifications.send_notification = MagicMock()
+    if notifications is not None and not hasattr(notifications, 'send_client_displayed_notification'):
+        notifications.send_client_displayed_notification = MagicMock()
+    if notifications is not None and not hasattr(notifications, 'send_client_displayed_notification_async'):
+        from unittest.mock import AsyncMock
+
+        notifications.send_client_displayed_notification_async = AsyncMock()
     redis_db = sys.modules.get('database.redis_db')
     if redis_db is not None:
         redis_db.check_rate_limit = MagicMock(return_value=(True, 99, 0))

--- a/backend/tests/unit/test_sync_silent_failure.py
+++ b/backend/tests/unit/test_sync_silent_failure.py
@@ -1389,6 +1389,8 @@ class TestVoiceMessageRuntimeErrorHandling:
         sys.modules['utils.other.storage'].mark_playback_unavailable = MagicMock()
         sys.modules['utils.notifications'].send_notification = MagicMock()
         sys.modules['utils.notifications'].send_notification_async = AsyncMock()
+        sys.modules['utils.notifications'].send_client_displayed_notification = MagicMock()
+        sys.modules['utils.notifications'].send_client_displayed_notification_async = AsyncMock()
         sys.modules['utils.retrieval.graph'].execute_graph_chat = MagicMock()
         sys.modules['utils.retrieval.graph'].execute_graph_chat_stream = MagicMock()
         sys.modules['utils.log_sanitizer'].sanitize = lambda v: v

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -19,7 +19,7 @@ from utils.conversation_helpers import extract_memory_ids
 from utils.conversations.factory import deserialize_conversation
 from utils.llm.chat import initial_chat_message
 from utils.llm.persona import initial_persona_chat_message
-from utils.notifications import send_notification, send_notification_async
+from utils.notifications import send_client_displayed_notification, send_client_displayed_notification_async
 from utils.observability.fallback import record_fallback
 from utils.other.storage import get_syncing_file_temporal_signed_url, schedule_syncing_temporal_file_deletion
 from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream
@@ -665,7 +665,9 @@ def _chat_message_notification(
 
 def send_chat_message_notification(user_id: str, app_name: str, app_id: str, message: str, message_id: str):
     ai_message = _chat_message_notification(app_id, message, message_id)
-    send_notification(user_id, app_name + ' says', message, NotificationMessage.get_message_as_dict(ai_message))
+    send_client_displayed_notification(
+        user_id, app_name + ' says', message, NotificationMessage.get_message_as_dict(ai_message)
+    )
 
 
 async def send_chat_message_notification_async(
@@ -677,7 +679,7 @@ async def send_chat_message_notification_async(
 ) -> None:
     """Async notification boundary for streaming chat responses."""
     ai_message = _chat_message_notification(app_id, message, message_id)
-    await send_notification_async(
+    await send_client_displayed_notification_async(
         user_id,
         app_name + ' says',
         message,

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -368,7 +368,12 @@ def send_client_displayed_notification(
     payload = _stringify_fcm_data(data)
     payload['push_type'] = 'chat_answer'
     payload['title'] = title
-    payload['body'] = body
+    # Do not set payload['body']: NotificationMessage already carries ``text``,
+    # and duplicating the full answer exceeds FCM's 4KB data limit on long
+    # replies. Clients resolve the shade body from ``text`` (#4375).
+    # APNS/webpush still receive display_body below for system-tray alerts.
+    if not payload.get('text'):
+        payload['text'] = body
     tag = _generate_tag(f"{user_id}:{title}:{body}:{payload.get('id', '')}")
     _send_to_user(
         user_id,
@@ -396,7 +401,9 @@ async def send_client_displayed_notification_async(
     payload = _stringify_fcm_data(data)
     payload['push_type'] = 'chat_answer'
     payload['title'] = title
-    payload['body'] = body
+    # Single copy of the answer in data (``text`` only) — see sync twin above.
+    if not payload.get('text'):
+        payload['text'] = body
     tag = _generate_tag(f"{user_id}:{title}:{body}:{payload.get('id', '')}")
     await _send_to_user_async(
         user_id,

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -69,8 +69,19 @@ def _build_android_config(tag: str, priority: str = 'normal', is_data_only: bool
     return messaging.AndroidConfig(**config_kwargs)
 
 
-def _build_apns_config(tag: str, is_background: bool = False) -> messaging.APNSConfig:
-    """Build APNs configuration with deduplication."""
+def _build_apns_config(
+    tag: str,
+    is_background: bool = False,
+    *,
+    alert_title: Optional[str] = None,
+    alert_body: Optional[str] = None,
+) -> messaging.APNSConfig:
+    """Build APNs configuration with deduplication.
+
+    When ``alert_title`` / ``alert_body`` are set (client-displayed chat answers),
+    emit an explicit APNS alert because the FCM top-level ``notification`` is
+    omitted so Android can render BigText locally (#4375).
+    """
     headers = {'apns-collapse-id': tag}
 
     if is_background:
@@ -84,6 +95,24 @@ def _build_apns_config(tag: str, is_background: bool = False) -> messaging.APNSC
         return messaging.APNSConfig(
             headers=headers,
             payload=messaging.APNSPayload(aps=messaging.Aps(content_available=True)),
+        )
+
+    if alert_title is not None or alert_body is not None:
+        headers.update(
+            {
+                'apns-push-type': 'alert',
+                'apns-priority': '10',
+                'apns-topic': IOS_BUNDLE_ID,
+            }
+        )
+        return messaging.APNSConfig(
+            headers=headers,
+            payload=messaging.APNSPayload(
+                aps=messaging.Aps(
+                    alert=messaging.ApsAlert(title=alert_title or '', body=alert_body or ''),
+                    sound='default',
+                ),
+            ),
         )
 
     return messaging.APNSConfig(headers=headers)
@@ -120,6 +149,13 @@ def _build_webpush_config(
     return messaging.WebpushConfig(**config_kwargs)
 
 
+def _stringify_fcm_data(data: Optional[Dict[str, Any]]) -> Dict[str, str]:
+    """FCM data payloads require string values."""
+    if not data:
+        return {}
+    return {str(k): '' if v is None else str(v) for k, v in data.items()}
+
+
 def _build_message(
     token: str,
     tag: str,
@@ -127,13 +163,35 @@ def _build_message(
     data: Optional[Dict[str, Any]] = None,
     is_background: bool = False,
     priority: str = 'normal',
+    *,
+    client_displayed: bool = False,
+    display_title: Optional[str] = None,
+    display_body: Optional[str] = None,
 ) -> messaging.Message:
-    """Build a complete FCM message with proper platform configs."""
-    # Extract title/body for webpush config (browsers need explicit values)
-    title: Optional[str] = cast(Any, notification).title if notification else None
-    body: Optional[str] = cast(Any, notification).body if notification else None
+    """Build a complete FCM message with proper platform configs.
+
+    ``client_displayed`` omits the top-level FCM notification so Android can
+    render a local BigText shade entry, while APNS still carries an alert for
+    iOS system trays (#4375).
+    """
     # Extract navigate_to for webpush click-through link
     link: Optional[str] = data.get('navigate_to') if data else None
+
+    if client_displayed:
+        title = display_title
+        body = display_body
+        return messaging.Message(
+            token=token,
+            notification=None,
+            data=data,
+            android=_build_android_config(tag, priority, is_data_only=True),
+            apns=_build_apns_config(tag, alert_title=title, alert_body=body),
+            webpush=_build_webpush_config(tag, title, body, link),
+        )
+
+    # Extract title/body for webpush config (browsers need explicit values)
+    title = cast(Any, notification).title if notification else None
+    body = cast(Any, notification).body if notification else None
 
     return messaging.Message(
         token=token,
@@ -177,6 +235,10 @@ def _send_to_user(
     is_background: bool = False,
     priority: str = 'normal',
     tokens: Optional[List[str]] = None,
+    *,
+    client_displayed: bool = False,
+    display_title: Optional[str] = None,
+    display_body: Optional[str] = None,
 ) -> int:
     """Send a message to all user's devices using batch send. Returns count of successful sends."""
     if tokens is None:
@@ -186,7 +248,20 @@ def _send_to_user(
         return 0
 
     # Build messages for all tokens
-    messages = [_build_message(token, tag, notification, data, is_background, priority) for token in tokens]
+    messages = [
+        _build_message(
+            token,
+            tag,
+            notification,
+            data,
+            is_background,
+            priority,
+            client_displayed=client_displayed,
+            display_title=display_title,
+            display_body=display_body,
+        )
+        for token in tokens
+    ]
 
     try:
         response = _send_messages(messages)
@@ -212,6 +287,10 @@ async def _send_to_user_async(
     is_background: bool = False,
     priority: str = 'normal',
     tokens: Optional[List[str]] = None,
+    *,
+    client_displayed: bool = False,
+    display_title: Optional[str] = None,
+    display_body: Optional[str] = None,
 ) -> int:
     """Async boundary for the synchronous token store and Firebase Admin SDK."""
     if tokens is None:
@@ -220,7 +299,20 @@ async def _send_to_user_async(
         logger.info(f"No tokens found for user {user_id}")
         return 0
 
-    messages = [_build_message(token, tag, notification, data, is_background, priority) for token in tokens]
+    messages = [
+        _build_message(
+            token,
+            tag,
+            notification,
+            data,
+            is_background,
+            priority,
+            client_displayed=client_displayed,
+            display_title=display_title,
+            display_body=display_body,
+        )
+        for token in tokens
+    ]
 
     try:
         response = await run_blocking(postprocess_executor, _send_messages, messages)
@@ -256,6 +348,67 @@ async def send_notification_async(
     tag = _generate_notification_tag(user_id, title, body, data)
     notification = messaging.Notification(title=title, body=body)
     await _send_to_user_async(user_id, tag, notification=notification, data=data, tokens=tokens)
+
+
+def send_client_displayed_notification(
+    user_id: str,
+    title: str,
+    body: str,
+    data: Optional[Dict[str, Any]] = None,
+    tokens: Optional[List[str]] = None,
+) -> None:
+    """Send a chat/plugin answer push that Flutter renders with BigText on Android (#4375).
+
+    Android: data-only (no system tray fallback) so the client can show BigText.
+    iOS: APNS alert with title/body. Both carry ``push_type=chat_answer`` and
+    ``navigate_to`` in the data map for deep-linking.
+    """
+    logger.info(f'send_client_displayed_notification to user {user_id}')
+    body = to_plain_text(body)
+    payload = _stringify_fcm_data(data)
+    payload['push_type'] = 'chat_answer'
+    payload['title'] = title
+    payload['body'] = body
+    tag = _generate_tag(f"{user_id}:{title}:{body}:{payload.get('id', '')}")
+    _send_to_user(
+        user_id,
+        tag,
+        notification=None,
+        data=payload,
+        priority='high',
+        tokens=tokens,
+        client_displayed=True,
+        display_title=title,
+        display_body=body,
+    )
+
+
+async def send_client_displayed_notification_async(
+    user_id: str,
+    title: str,
+    body: str,
+    data: Optional[Dict[str, Any]] = None,
+    tokens: Optional[List[str]] = None,
+) -> None:
+    """Async client-displayed boundary for streaming chat so FCM does not block SSE (#4375)."""
+    logger.info(f'send_client_displayed_notification to user {user_id}')
+    body = to_plain_text(body)
+    payload = _stringify_fcm_data(data)
+    payload['push_type'] = 'chat_answer'
+    payload['title'] = title
+    payload['body'] = body
+    tag = _generate_tag(f"{user_id}:{title}:{body}:{payload.get('id', '')}")
+    await _send_to_user_async(
+        user_id,
+        tag,
+        notification=None,
+        data=payload,
+        priority='high',
+        tokens=tokens,
+        client_displayed=True,
+        display_title=title,
+        display_body=body,
+    )
 
 
 async def send_subscription_paid_personalized_notification(user_id: str, data: Optional[Dict[str, Any]] = None) -> None:


### PR DESCRIPTION
## What changed and why

Fixes #4375. Click-to-talk / chat-answer notifications were truncated in the Android shade and tapping them opened the app without navigating to the chat. This PR delivers chat answers as client-displayed FCM (data-only on Android + APNS alert on iOS) so Flutter can render `BigText` locally with a `navigate_to` payload.

Supersedes #13065 (dirty merge base + CHANGES_REQUESTED). Clean branch cut from current `BasedHardware/omi` `main`.

### Integration vs #13065 review

1. **Rebased on current main** — keeps `send_chat_message_notification_async` + `_chat_message_notification`; both sync and async chat paths use the client-displayed sender.
2. **Reuses `NotificationUtil.navigateToFromFcmData` / `handleNavigateTo`** — no cold-start navigator race (#5126).
3. **Single FCM background handler** — chat-answer BigText is patched into `main.dart`'s `_firebaseMessagingBackgroundHandler`; no `fcm_background_handler.dart` dual registration.
4. **Extends `backend/utils/notifications.py`** — `send_client_displayed_notification` / `_async` share APNS topic, failure codes, and token pruning (no parallel `chat_answer_notifications.py`).
5. **Cubic issues** — background path invokes `ChatAnswerNotificationHandler`; initial-message navigation stays on `NotificationUtil`; unit tests use `testing.import_isolation` as on main.

### Review follow-up (CHANGES_REQUESTED → 5789f10)

1. **FCM 4KB payload** — dropped duplicated `payload['body']`; answer travels once via `data['text']`. APNS/webpush still receive `display_body` for system alerts.
2. **Foreground / speaking** — FCM early branch gates on `!OmiVoicePlaybackService.instance.isSpeaking`; handler only creates a shade notification when `!isAppInForeground` (merge-handler pattern).

Product notes left for maintainer review (same as #13065): data-only Android drops system-tray fallback when the client handler cannot run; `wakeUpScreen` is not enabled (matches merge/important handlers).

## Product invariants affected

- INV-DATA-1 — touched `app/lib/main.dart` only to add the chat-answer branch in the existing FCM background handler. Preserves existing production-family routing / Firebase authority; no data-plane or API-base change.

## How it was verified

```bash
# Backend unit (client-displayed shape + no body duplication)
cd backend && source .venv/bin/activate
ENCRYPTION_SECRET=test PYTHONPATH=. python -m pytest \
  tests/unit/test_chat_answer_client_displayed_notification.py -q --tb=short
# → 5 passed
```

Device BigText / tap-to-chat could not be exercised in this Linux Cloud VM (no Android SDK / physical device). Flutter unit file `app/test/unit/chat_answer_notification_handler_test.dart` is included for CI Mobile App Checks.

## Tests

- `backend/tests/unit/test_chat_answer_client_displayed_notification.py` — data-only Android message, APNS alert, `push_type=chat_answer`, sync + async senders, no duplicated `body`, long-answer under 4KB
- `app/test/unit/chat_answer_notification_handler_test.dart` — `isChatAnswerData` predicate cases
- Stub updates so suites that load real `utils.chat` still import the new notification APIs

## Failure class (fixes)

Failure-Class: none