### PR TITLE
python-cli : file option to omi memory create

### DIFF
--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import typer
@@ -25,6 +26,30 @@ def _ctx(typer_ctx: typer.Context) -> "AppContext":
 
 
 _LIST_COLUMNS = ["id", "category", "visibility", "content", "tags", "created_at"]
+
+
+def _read_memory_file(path: Path) -> str:
+    """Read UTF-8 memory content from a file, mapping failures to UsageError."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise UsageError(
+            message=f"Memory file not found: {path}",
+            detail="Check the path and try again.",
+        ) from None
+    except IsADirectoryError:
+        raise UsageError(message=f"Memory file is a directory: {path}") from None
+    except UnicodeDecodeError:
+        raise UsageError(
+            message=f"Memory file is not valid UTF-8: {path}",
+            detail="Encode the file as UTF-8 and try again.",
+        ) from None
+    if not content.strip():
+        raise UsageError(
+            message="Memory file is empty",
+            detail="Provide a file with non-empty text.",
+        )
+    return content
 
 
 @app.command("list", help="List memories.")
@@ -93,12 +118,21 @@ def get_memory(
 @app.command("create", help="Create a new memory.")
 def create_memory(
     typer_ctx: typer.Context,
-    content: str = typer.Argument(..., help="Memory content (1-500 chars)."),
+    content: Optional[str] = typer.Argument(None, help="Memory content (1-500 chars)."),
+    file_path: Optional[Path] = typer.Option(None, "--file", help="Read memory content from a UTF-8 file."),
     category: Optional[MemoryCategory] = typer.Option(None, "--category", help="Category. Auto-detected if omitted."),
     visibility: MemoryVisibility = typer.Option(MemoryVisibility.private, "--visibility", help="public or private."),
     tag: list[str] = typer.Option([], "--tag", help="Tag (repeat for multiple)."),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    if (content is None) == (file_path is None):
+        raise UsageError(
+            message="Provide exactly one of memory content or --file",
+            detail="Pass text as the positional argument or use --file PATH, not both.",
+        )
+    if file_path is not None:
+        content = _read_memory_file(file_path)
+    assert content is not None
     body: dict[str, object] = {"content": content, "visibility": visibility.value, "tags": tag}
     if category is not None:
         body["category"] = category.value

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -44,6 +44,11 @@ def _read_memory_file(path: Path) -> str:
             message=f"Memory file is not valid UTF-8: {path}",
             detail="Encode the file as UTF-8 and try again.",
         ) from None
+    except OSError:
+        raise UsageError(
+            message=f"Cannot read memory file: {path}",
+            detail="Check permissions and try again.",
+        ) from None
     if not content.strip():
         raise UsageError(
             message="Memory file is empty",

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -117,6 +117,12 @@ def test_memory_create_from_empty_file_is_usage_error(authed_profile, cli_runner
     assert "empty" in result.stderr.lower()
 
 
+def test_memory_create_from_directory_is_usage_error(authed_profile, cli_runner, tmp_path) -> None:
+    result = cli_runner.invoke(app, ["memory", "create", "--file", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "memory file" in result.stderr.lower()
+
+
 def test_memory_create_rejects_content_and_file_together(authed_profile, cli_runner, tmp_path) -> None:
     memory_file = tmp_path / "m.txt"
     memory_file.write_text("x", encoding="utf-8")

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -65,6 +65,66 @@ def test_memory_create_with_category_and_tags(authed_profile, respx_mock, cli_ru
     assert body["tags"] == ["a", "b"]
 
 
+def test_memory_create_from_file_posts_body(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    memory_file = tmp_path / "memory.txt"
+    memory_file.write_text("from file", encoding="utf-8")
+    route = respx_mock.post("/v1/dev/user/memories").respond(
+        json={"id": "m99", "content": "from file", "category": "work", "visibility": "public", "tags": ["a"]}
+    )
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "memory",
+            "create",
+            "--file",
+            str(memory_file),
+            "--category",
+            "work",
+            "--visibility",
+            "public",
+            "--tag",
+            "a",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body["content"] == "from file"
+    assert body["category"] == "work"
+    assert body["visibility"] == "public"
+    assert body["tags"] == ["a"]
+
+
+def test_memory_create_from_file_missing_is_usage_error(authed_profile, cli_runner, tmp_path) -> None:
+    result = cli_runner.invoke(app, ["memory", "create", "--file", str(tmp_path / "nope.txt")])
+    assert result.exit_code == 1
+    assert "not found" in result.stderr.lower()
+
+
+def test_memory_create_from_file_invalid_utf8_is_usage_error(authed_profile, cli_runner, tmp_path) -> None:
+    memory_file = tmp_path / "bad.txt"
+    memory_file.write_bytes(b"\xff\xfe not utf-8")
+    result = cli_runner.invoke(app, ["memory", "create", "--file", str(memory_file)])
+    assert result.exit_code == 1
+    assert "utf-8" in result.stderr.lower()
+
+
+def test_memory_create_from_empty_file_is_usage_error(authed_profile, cli_runner, tmp_path) -> None:
+    memory_file = tmp_path / "empty.txt"
+    memory_file.write_text("", encoding="utf-8")
+    result = cli_runner.invoke(app, ["memory", "create", "--file", str(memory_file)])
+    assert result.exit_code == 1
+    assert "empty" in result.stderr.lower()
+
+
+def test_memory_create_rejects_content_and_file_together(authed_profile, cli_runner, tmp_path) -> None:
+    memory_file = tmp_path / "m.txt"
+    memory_file.write_text("x", encoding="utf-8")
+    result = cli_runner.invoke(app, ["memory", "create", "inline text", "--file", str(memory_file)])
+    assert result.exit_code == 1
+    assert "exactly one" in result.stderr.lower()
+
+
 def test_memory_delete_skips_prompt_with_yes(authed_profile, respx_mock, cli_runner) -> None:
     respx_mock.delete("/v1/dev/user/memories/m1").respond(204)
     result = cli_runner.invoke(app, ["memory", "delete", "m1", "--yes"])


### PR DESCRIPTION
Closes #13179

## Summary

Adds a `--file` option to `omi memory create` so scripts can submit one memory from a UTF-8 text file without putting its contents on the command line. Category, visibility and tags options are retained and compose with `--file`.

## Behavior

- `omi memory create --file memory.txt` reads the file as UTF-8 and posts it like the positional content argument
- Content and `--file` are mutually exclusive: providing both (or neither) is a usage error
- Readable errors before any HTTP request:
  - missing file
  - path is a directory
  - file is not valid UTF-8
  - file is empty

## Tests

5 new cases in `tests/test_memory.py`:

- `--file` posts the file content with `--category`/`--visibility`/`--tag` preserved
- missing file is a usage error (exit 1)
- invalid UTF-8 file is a usage error (exit 1)
- empty file is a usage error (exit 1)
- content and `--file` together is a usage error (exit 1)

All 17 memory command tests pass on Python 3.13/Windows.

## Verification

- `pytest tests/test_memory.py`: 17 passed
- Full suite: 277 passed, 1 failed (`test_transport_failure_during_login_leaves_saved_config_unchanged`), which also fails on the unchanged `main` checkout before this change
- `test_openapi_contract.py` tests were not runnable in a sparse checkout (they read `docs/api-reference/openapi.json`); no routes or enums were touched

## Disclosure

Prepared with AI assistance; change is limited to the memory create command and its tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

