### PR TITLE
fix(app): scope device connection teardown to the device it targets

### DIFF
--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -120,8 +120,8 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> {
     });
   }
 
-  Future<BleAudioCodec> _getAudioCodec() async {
-    var connection = ServiceManager.instance().device.connectionFor(SharedPreferencesUtil().btDevice.id);
+  Future<BleAudioCodec> _getAudioCodec(String deviceId) async {
+    var connection = ServiceManager.instance().device.connectionFor(deviceId);
     if (connection == null) {
       return BleAudioCodec.pcm8;
     }
@@ -323,7 +323,7 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> {
       final currentDevice = provider.device;
       if (currentDevice != null) {
         try {
-          BleAudioCodec codec = await _getAudioCodec();
+          BleAudioCodec codec = await _getAudioCodec(currentDevice.id);
           if (!codec.isOpusSupported()) {
             // Device doesn't support opus, use phone mic
             usePhoneMic = true;

--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -121,7 +121,7 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> {
   }
 
   Future<BleAudioCodec> _getAudioCodec() async {
-    var connection = ServiceManager.instance().device.connection;
+    var connection = ServiceManager.instance().device.connectionFor(SharedPreferencesUtil().btDevice.id);
     if (connection == null) {
       return BleAudioCodec.pcm8;
     }

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -265,7 +265,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   }
 
   Future _bleDisconnectDevice(BtDevice btDevice) async {
-    await ServiceManager.instance().device.disconnectDevice();
+    await ServiceManager.instance().device.disconnectDevice(btDevice.id);
   }
 
   Future<int> _retrieveBatteryLevel(String deviceId) async {

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -199,13 +199,17 @@ class DeviceService {
     // TODO: Start watchdog to discover automatically, re-connect automatically
   }
 
-  void stop() {
+  Future<void> stop() async {
     _status = DeviceServiceStatus.stop;
     onStatusChanged(_status);
 
     // Stop all discoverers to prevent resource leaks and battery drain
     for (final discoverer in _discoverers) {
       discoverer.stop();
+    }
+
+    for (final deviceId in _connections.keys.toList()) {
+      await _teardownConnection(deviceId);
     }
 
     _subscriptions.clear();

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -40,7 +40,14 @@ abstract class IDeviceServiceSubsciption {
   );
 }
 
+typedef DeviceConnectionBuilder = DeviceConnection? Function(BtDevice device);
+
 class DeviceService {
+  DeviceService({DeviceConnectionBuilder? connectionBuilder})
+      : _connectionBuilder = connectionBuilder ?? DeviceConnectionFactory.create;
+
+  final DeviceConnectionBuilder _connectionBuilder;
+
   DeviceServiceStatus _status = DeviceServiceStatus.init;
   List<BtDevice> _devices = [];
   Future<void>? _activeDiscovery;
@@ -54,8 +61,10 @@ class DeviceService {
 
   final Map<Object, IDeviceServiceSubsciption> _subscriptions = {};
 
-  DeviceConnection? _connection;
-  DeviceConnection? get connection => _connection;
+  final Map<String, DeviceConnection> _connections = {};
+
+  DeviceConnection? connectionFor(String deviceId) => _connections[deviceId];
+  List<DeviceConnection> get connections => List.unmodifiable(_connections.values);
   List<BtDevice> get devices => _devices;
 
   DeviceServiceStatus get status => _status;
@@ -131,14 +140,7 @@ class DeviceService {
   }
 
   Future<void> _connectToDevice(String id) async {
-    // Clean up existing connection — disconnect if active, then dispose transport
-    if (_connection != null) {
-      if (_connection!.status == DeviceConnectionState.connected) {
-        await _connection!.disconnect();
-      }
-      await _connection!.transport.dispose();
-    }
-    _connection = null;
+    await _teardownConnection(id);
 
     var device = _devices.firstWhereOrNull((f) => f.id == id);
     Logger.debug(
@@ -165,9 +167,10 @@ class DeviceService {
       }
     }
 
-    _connection = DeviceConnectionFactory.create(device);
-    if (_connection != null) {
-      await _connection!.connect(
+    final connection = _connectionBuilder(device);
+    if (connection != null) {
+      _connections[id] = connection;
+      await connection.connect(
         onConnectionStateChanged: onDeviceConnectionStateChanged,
       );
     } else {
@@ -243,23 +246,24 @@ class DeviceService {
   }) async {
     await _mutex.acquire();
     try {
+      final existing = _connections[deviceId];
       Logger.debug(
-        "ensureConnection ${_connection?.device.id} ${_connection?.status} $force",
+        "ensureConnection $deviceId ${existing?.status} $force",
       );
 
       // Connected to this device — return it
-      if (_connection?.device.id == deviceId && _connection?.status == DeviceConnectionState.connected) {
-        return _connection;
+      if (existing?.status == DeviceConnectionState.connected) {
+        return existing;
       }
 
       // Transport exists for this device but disconnected — native handles reconnection.
       // Don't dispose and recreate the transport; that would cancel native's auto-reconnect.
       // But if force=true (user-initiated), reconnect explicitly.
-      if (!force && _connection?.device.id == deviceId) {
+      if (!force && existing != null) {
         return null;
       }
 
-      // No connection or different device — only connect on force (user-initiated)
+      // No connection for this device — only connect on force (user-initiated)
       if (!force) return null;
 
       try {
@@ -270,7 +274,7 @@ class DeviceService {
       }
 
       _firstConnectedAt ??= DateTime.now();
-      return _connection;
+      return _connections[deviceId];
     } finally {
       _mutex.release();
     }
@@ -283,44 +287,44 @@ class DeviceService {
   // Helper method to get stored device from SharedPreferences
   BtDevice? _getStoredDevice(String id) {
     try {
-      final storedDevice = SharedPreferencesUtil().btDevice;
-      if (storedDevice.id == id && storedDevice.id.isNotEmpty) {
-        return storedDevice;
-      }
+      return SharedPreferencesUtil().btDevices.firstWhereOrNull(
+            (d) => d.id == id && d.id.isNotEmpty,
+          );
     } catch (e) {
       Logger.debug('Error getting stored device: $e');
     }
     return null;
   }
 
-  Future<void> disconnectDevice() async {
-    if (_connection != null) {
-      Logger.debug("DeviceService: Disconnecting device...");
-      await _connection?.disconnect();
-      _connection = null;
+  Future<void> disconnectDevice(String deviceId) async {
+    final connection = _connections[deviceId];
+    if (connection != null) {
+      Logger.debug("DeviceService: Disconnecting device $deviceId...");
+      await connection.disconnect();
+      _connections.remove(deviceId);
+    }
+  }
+
+  Future<void> _teardownConnection(String deviceId) async {
+    final connection = _connections.remove(deviceId);
+    if (connection == null) return;
+    if (connection.status == DeviceConnectionState.connected) {
+      try {
+        await connection.disconnect();
+      } catch (e) {
+        Logger.debug("DeviceService: disconnect for $deviceId failed: $e");
+      }
+    }
+    try {
+      await connection.transport.dispose();
+    } catch (e) {
+      Logger.debug("DeviceService: transport dispose for $deviceId failed: $e");
     }
   }
 
   Future<void> forgetDevice(String deviceId) async {
     Logger.debug("DeviceService: Forgetting device $deviceId");
-    if (_connection != null) {
-      if (_connection!.status == DeviceConnectionState.connected) {
-        try {
-          await _connection!.disconnect();
-        } catch (e) {
-          Logger.debug("DeviceService: disconnect during forget failed: $e");
-        }
-      }
-
-      try {
-        await _connection!.transport.dispose();
-      } catch (e) {
-        Logger.debug(
-          "DeviceService: transport dispose during forget failed: $e",
-        );
-      }
-      _connection = null;
-    }
+    await _teardownConnection(deviceId);
 
     _devices.removeWhere((d) => d.id == deviceId);
   }

--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -84,7 +84,7 @@ class ServiceManager {
     if (!identical(_phoneMic, _mic)) {
       _phoneMic.stop();
     }
-    _device.stop();
+    await _device.stop();
   }
 }
 

--- a/app/test/unit/device_service_connections_test.dart
+++ b/app/test/unit/device_service_connections_test.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/devices.dart';
 import 'package:omi/services/devices/connectors/device_connection.dart';
 import 'package:omi/services/devices/discovery/device_locator.dart';
@@ -63,7 +65,27 @@ void main() {
   late Map<String, _FakeConnection> built;
   late DeviceService service;
 
+  final mockedChannels = <String>{};
+
+  void mockBleHostApi(String method) {
+    final channel = 'dev.flutter.pigeon.omi_pigeon.BleHostApi.$method';
+    mockedChannels.add(channel);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+      channel,
+      (ByteData? message) async => BleHostApi.pigeonChannelCodec.encodeMessage(<Object?>[null]),
+    );
+  }
+
+  tearDown(() {
+    for (final channel in mockedChannels) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(channel, null);
+    }
+    mockedChannels.clear();
+  });
+
   setUp(() async {
+    mockBleHostApi('stopScan');
+    mockBleHostApi('startScan');
     final audio = _device(audioId);
     final glass = _device(glassId, type: DeviceType.openglass);
     SharedPreferences.setMockInitialValues({});
@@ -119,6 +141,17 @@ void main() {
     expect(built[audioId]!.transport.disposed, isTrue);
     expect(service.connectionFor(glassId)?.status, DeviceConnectionState.connected);
     expect(built[glassId]!.transport.disposed, isFalse);
+  });
+
+  test('stopping the service tears down every connection', () async {
+    await service.ensureConnection(audioId, force: true);
+    await service.ensureConnection(glassId, force: true);
+
+    await service.stop();
+
+    expect(service.connections, isEmpty);
+    expect(built[audioId]!.transport.disposed, isTrue);
+    expect(built[glassId]!.transport.disposed, isTrue);
   });
 
   test('without force a device that has never connected is not connected', () async {

--- a/app/test/unit/device_service_connections_test.dart
+++ b/app/test/unit/device_service_connections_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/devices.dart';
+import 'package:omi/services/devices/connectors/device_connection.dart';
+import 'package:omi/services/devices/discovery/device_locator.dart';
+import 'package:omi/services/devices/transports/device_transport.dart';
+
+class _FakeTransport implements DeviceTransport {
+  _FakeTransport(this.deviceId);
+
+  @override
+  final String deviceId;
+  bool disposed = false;
+
+  @override
+  Future<void> dispose() async => disposed = true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConnection implements DeviceConnection {
+  _FakeConnection(this.device) : transport = _FakeTransport(device.id);
+
+  @override
+  final BtDevice device;
+  @override
+  final _FakeTransport transport;
+
+  DeviceConnectionState _state = DeviceConnectionState.disconnected;
+  bool disconnectCalled = false;
+
+  @override
+  DeviceConnectionState get status => _state;
+
+  @override
+  Future<void> connect({void Function(String deviceId, DeviceConnectionState state)? onConnectionStateChanged}) async {
+    _state = DeviceConnectionState.connected;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalled = true;
+    _state = DeviceConnectionState.disconnected;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+BtDevice _device(String id, {DeviceType type = DeviceType.omi}) =>
+    BtDevice(id: id, name: id, type: type, rssi: 0, locator: DeviceLocator.bluetooth(deviceId: id));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const audioId = 'AA:BB:CC:DD:EE:FF';
+  const glassId = '11:22:33:44:55:66';
+
+  late Map<String, _FakeConnection> built;
+  late DeviceService service;
+
+  setUp(() async {
+    final audio = _device(audioId);
+    final glass = _device(glassId, type: DeviceType.openglass);
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    await SharedPreferencesUtil().btDeviceAdd(audio);
+    await SharedPreferencesUtil().btDeviceAdd(glass);
+
+    built = {};
+    service = DeviceService(connectionBuilder: (device) {
+      final connection = _FakeConnection(device);
+      built[device.id] = connection;
+      return connection;
+    });
+  });
+
+  test('connecting a second device leaves the first connected', () async {
+    await service.ensureConnection(audioId, force: true);
+    await service.ensureConnection(glassId, force: true);
+
+    expect(service.connectionFor(audioId)?.status, DeviceConnectionState.connected);
+    expect(service.connectionFor(glassId)?.status, DeviceConnectionState.connected);
+    expect(built[audioId]!.disconnectCalled, isFalse);
+    expect(built[audioId]!.transport.disposed, isFalse);
+    expect(service.connections.length, 2);
+  });
+
+  test('an already connected device is reused rather than reconnected', () async {
+    final first = await service.ensureConnection(audioId, force: true);
+    final second = await service.ensureConnection(audioId, force: true);
+
+    expect(identical(first, second), isTrue);
+    expect(service.connections.length, 1);
+  });
+
+  test('disconnecting one device leaves the other alone', () async {
+    await service.ensureConnection(audioId, force: true);
+    await service.ensureConnection(glassId, force: true);
+
+    await service.disconnectDevice(audioId);
+
+    expect(service.connectionFor(audioId), isNull);
+    expect(service.connectionFor(glassId)?.status, DeviceConnectionState.connected);
+    expect(built[glassId]!.disconnectCalled, isFalse);
+  });
+
+  test('forgetting one device does not tear down another', () async {
+    await service.ensureConnection(audioId, force: true);
+    await service.ensureConnection(glassId, force: true);
+
+    await service.forgetDevice(audioId);
+
+    expect(service.connectionFor(audioId), isNull);
+    expect(built[audioId]!.transport.disposed, isTrue);
+    expect(service.connectionFor(glassId)?.status, DeviceConnectionState.connected);
+    expect(built[glassId]!.transport.disposed, isFalse);
+  });
+
+  test('without force a device that has never connected is not connected', () async {
+    final connection = await service.ensureConnection(audioId);
+
+    expect(connection, isNull);
+    expect(service.connections, isEmpty);
+  });
+}


### PR DESCRIPTION
`forgetDevice(deviceId)` disconnects and disposes whichever connection happens to be open rather than the one it was asked to forget, because `DeviceService` keeps a single connection field and never checks the id against it. Today that is invisible, since there is only ever one connection. It stops being invisible the moment a second device exists.

Fixing it properly means the service has to know which connection belongs to which device, so connections are keyed by device id and teardown is scoped to the device being connected, disconnected, forgotten or stopped. `stop()` now tears down every connection instead of leaving them open, which the single field did too.

`ensureConnection` keeps its signature and all 63 callers already pass a device id, so they did not move. The two places that read the old single-connection field are migrated rather than aliased: `_bleDisconnectDevice` already had the device it was disconnecting, and the speech profile page resolves the codec through the device the page is recording from. Stored-device lookup reads `btDevices` instead of the single `btDevice`, so a device other than the last paired one can still be found on a background reconnect.

I am not claiming #2954 with this. You said there in April that OmiGlass records audio already and the feature was not needed, so this is the connection-ownership bug and its guard, nothing more. Capture still records one device.

Verified by running, from `app/`:

```
$ flutter test test/unit/device_service_connections_test.dart
00:00 +6: All tests passed!

$ bash test.sh
02:18 +1855 ~5: All tests passed!

$ bash scripts/analyze_ratchet.sh
Analyzer ratchet passed.

$ make preflight          (repo root)
PR preflight passed: 14 checks in 12.83s.
```

The six tests drive the registry through an injectable connection builder, the same dependency-injection shape `DeviceProvider` already uses for its loaders: a second device connecting leaves the first connected, an already connected device is reused, and disconnecting, forgetting or stopping tears down only what it should. I have no omi device here, so none of this ran over real BLE.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



