### PR TITLE
python-cli: add memory create-batch from UTF-8 JSON file

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -266,11 +266,12 @@ request. The file can be a JSON array of memory objects, or an object with a
 omi memory create-batch memories.json
 ```
 
-Every entry needs non-empty string `content`. Optional fields: `category`
-(known category), `visibility` (`public` or `private`, defaults to `private`),
-and `tags` (list of strings). Invalid JSON, more than 25 entries, or malformed
-entries fail before any HTTP request; the server still applies its own
-authorization and validation on the single batch call.
+Every entry needs non-empty string `content` (max 500 characters). Optional
+fields: `category` (known category), `visibility` (`public` or `private`,
+defaults to `private`), and `tags` (list of strings). Files may include a UTF-8
+BOM. Invalid JSON, more than 25 entries, or malformed entries fail before any
+HTTP request; the server still applies its own authorization and validation on
+the single batch call.
 
 ## Global flags
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -206,6 +206,7 @@ omi
 │   ├── list [--limit N] [--offset N] [--categories ...]
 │   ├── get <id>
 │   ├── create <content> [--category ...] [--visibility ...] [--tag ...]
+│   ├── create-batch <file.json>
 │   ├── update <id> [--content ...] [--category ...] [--visibility ...] [--tag ...]
 │   └── delete <id> [-y]
 ├── conversation
@@ -247,6 +248,29 @@ omi
 
 `conversation from-segments` reads JSON files as UTF-8 (with or without a BOM),
 UTF-16, or UTF-32, independently of the system's default text encoding.
+
+`memory create-batch` imports up to 25 memories from a UTF-8 JSON file in one
+request. The file can be a JSON array of memory objects, or an object with a
+`memories` array:
+
+```json
+{
+  "memories": [
+    { "content": "Team retro every Friday", "category": "work", "visibility": "private", "tags": ["meetings"] },
+    { "content": "Prefers dark mode" }
+  ]
+}
+```
+
+```bash
+omi memory create-batch memories.json
+```
+
+Every entry needs non-empty string `content`. Optional fields: `category`
+(known category), `visibility` (`public` or `private`, defaults to `private`),
+and `tags` (list of strings). Invalid JSON, more than 25 entries, or malformed
+entries fail before any HTTP request; the server still applies its own
+authorization and validation on the single batch call.
 
 ## Global flags
 

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import typer
@@ -25,6 +27,104 @@ def _ctx(typer_ctx: typer.Context) -> "AppContext":
 
 
 _LIST_COLUMNS = ["id", "category", "visibility", "content", "tags", "created_at"]
+
+
+def _read_utf8_file(path: Path) -> str:
+    """Read UTF-8 text from a file, mapping failures to UsageError."""
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise UsageError(
+            message=f"File not found: {path}",
+            detail="Check the path and try again.",
+        ) from None
+    except IsADirectoryError:
+        raise UsageError(message=f"Path is a directory: {path}") from None
+    except UnicodeDecodeError:
+        raise UsageError(
+            message=f"File is not valid UTF-8: {path}",
+            detail="Encode the file as UTF-8 and try again.",
+        ) from None
+    except OSError:
+        raise UsageError(
+            message=f"Cannot read file: {path}",
+            detail="Check permissions and try again.",
+        ) from None
+    return content
+
+
+def _read_batch_memories(file_path: Path) -> list[dict[str, object]]:
+    """Validate a batch memory JSON file and map it to request entries.
+
+    Accepts a JSON array of memory objects, or an object with a ``memories``
+    array. Each entry must be an object with non-empty ``content``; ``category``
+    and ``visibility`` are validated against the CLI enums, and ``tags`` must be
+    a list of strings.
+    """
+    try:
+        payload = json.loads(_read_utf8_file(file_path))
+    except json.JSONDecodeError as exc:
+        raise UsageError(
+            message=f"Memory file is not valid JSON: {file_path}",
+            detail=f"Parse error at line {exc.lineno} column {exc.colno}.",
+        ) from None
+
+    if isinstance(payload, dict) and isinstance(payload.get("memories"), list):
+        payload = payload["memories"]
+    if not isinstance(payload, list):
+        raise UsageError(
+            message="Memory file must contain a JSON array of memories",
+            detail="Provide an array like [{\"content\": \"...\"}] or {\"memories\": [...]}.",
+        )
+    if not payload:
+        raise UsageError(
+            message="Memory file contains no memories",
+            detail="Provide at least one memory entry.",
+        )
+    if len(payload) > 25:
+        raise UsageError(
+            message=f"Maximum 25 memories per batch request, got {len(payload)}",
+            detail="Split the file into batches of 25 or fewer entries.",
+        )
+
+    entries: list[dict[str, object]] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            raise UsageError(
+                message=f"Memory entry {index} is not an object",
+                detail="Every entry must be a JSON object.",
+            )
+        content = item.get("content")
+        if not isinstance(content, str) or not content.strip():
+            raise UsageError(
+                message=f"Memory entry {index} has empty content",
+                detail="Every entry needs non-empty string content.",
+            )
+        entry: dict[str, object] = {"content": content.strip()}
+        visibility = item.get("visibility", MemoryVisibility.private.value)
+        if not isinstance(visibility, str) or visibility not in MemoryVisibility._value2member_map_:
+            raise UsageError(
+                message=f"Memory entry {index} has invalid visibility: {visibility}",
+                detail="Use 'public' or 'private'.",
+            )
+        entry["visibility"] = visibility
+        tags = item.get("tags", [])
+        if not isinstance(tags, list) or not all(isinstance(t, str) for t in tags):
+            raise UsageError(
+                message=f"Memory entry {index} has invalid tags",
+                detail="'tags' must be a list of strings.",
+            )
+        entry["tags"] = list(tags)
+        category = item.get("category")
+        if category is not None:
+            if not isinstance(category, str) or category not in MemoryCategory._value2member_map_:
+                raise UsageError(
+                    message=f"Memory entry {index} has invalid category: {category}",
+                    detail="Use a known memory category (e.g. work, skills, personal).",
+                )
+            entry["category"] = category
+        entries.append(entry)
+    return entries
 
 
 @app.command("list", help="List memories.")
@@ -106,6 +206,20 @@ def create_memory(
         result = client.post("/v1/dev/user/memories", json_body=body)
     ctx.renderer.success(f"Memory created: [bold]{result.get('id')}[/bold]")
     ctx.renderer.emit(result, title="memory")
+
+
+@app.command("create-batch", help="Create up to 25 memories from a UTF-8 JSON file.")
+def create_memories_batch(
+    typer_ctx: typer.Context,
+    file_path: Path = typer.Argument(..., help="Path to a UTF-8 JSON file with a 'memories' array."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    entries = _read_batch_memories(file_path)
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/memories/batch", json_body={"memories": entries})
+    created_count = result.get("created_count", 0)
+    ctx.renderer.success(f"Created [bold]{created_count}[/bold] memories")
+    ctx.renderer.emit(result, title="memories")
 
 
 @app.command("update", help="Update an existing memory.")

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -30,9 +30,9 @@ _LIST_COLUMNS = ["id", "category", "visibility", "content", "tags", "created_at"
 
 
 def _read_utf8_file(path: Path) -> str:
-    """Read UTF-8 text from a file, mapping failures to UsageError."""
+    """Read UTF-8 (BOM-tolerant) text from a file, mapping failures to UsageError."""
     try:
-        content = path.read_text(encoding="utf-8")
+        content = path.read_text(encoding="utf-8-sig")
     except FileNotFoundError:
         raise UsageError(
             message=f"File not found: {path}",
@@ -99,6 +99,11 @@ def _read_batch_memories(file_path: Path) -> list[dict[str, object]]:
             raise UsageError(
                 message=f"Memory entry {index} has empty content",
                 detail="Every entry needs non-empty string content.",
+            )
+        if len(content.strip()) > 500:
+            raise UsageError(
+                message=f"Memory entry {index} exceeds 500 characters",
+                detail="The batch endpoint rejects content longer than 500 characters.",
             )
         entry: dict[str, object] = {"content": content.strip()}
         visibility = item.get("visibility", MemoryVisibility.private.value)

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -99,6 +99,19 @@ def test_memory_create_batch_posts_body(authed_profile, respx_mock, cli_runner, 
     }
     payload = json.loads(result.stdout)
     assert payload["created_count"] == 2
+    assert payload["memories"] == [{"id": "m1"}, {"id": "m2"}]
+
+
+def test_memory_create_batch_accepts_bom_utf8(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "bom.json"
+    batch_file.write_text(json.dumps([{"content": "bom content"}]), encoding="utf-8-sig")
+    route = respx_mock.post("/v1/dev/user/memories/batch").respond(
+        json={"memories": [{"id": "m1"}], "created_count": 1}
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"memories": [{"content": "bom content", "visibility": "private", "tags": []}]}
 
 
 def test_memory_create_batch_accepts_memories_object(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
@@ -146,6 +159,32 @@ def test_memory_create_batch_auth_failure(authed_profile, respx_mock, cli_runner
     result = cli_runner.invoke(app, ["memory", "create-batch", str(batch_file)])
     assert result.exit_code == 2
     assert "auth" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    ("entries", "message_fragment"),
+    [
+        ('"just a string"', "array"),
+        ("[]", "no memories"),
+        ("[42]", "not an object"),
+        ('[{"content": "   "}]', "empty content"),
+        ('[{"content": "x", "visibility": "weird"}]', "invalid visibility"),
+        ('[{"content": "x", "category": "not-a-category"}]', "invalid category"),
+        ('[{"content": "x", "tags": "not-a-list"}]', "invalid tags"),
+        ('[{"content": "x", "tags": [1, 2]}]', "invalid tags"),
+        (f'[{{"content": "{chr(97) * 501}"}}]', "500 characters"),
+    ],
+)
+def test_memory_create_batch_invalid_entries_send_no_request(
+    authed_profile, respx_mock, cli_runner, tmp_path, entries, message_fragment
+) -> None:
+    batch_file = tmp_path / "invalid.json"
+    batch_file.write_text(entries, encoding="utf-8")
+    respx_mock.post("/v1/dev/user/memories/batch").respond(json={"memories": [], "created_count": 0})
+    result = cli_runner.invoke(app, ["memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert message_fragment in result.stderr.lower()
+    assert not respx_mock.calls
 
 
 def test_memory_update_requires_at_least_one_field(authed_profile, cli_runner) -> None:

--- a/sdks/python-cli/tests/test_memory.py
+++ b/sdks/python-cli/tests/test_memory.py
@@ -71,6 +71,83 @@ def test_memory_delete_skips_prompt_with_yes(authed_profile, respx_mock, cli_run
     assert result.exit_code == 0
 
 
+def test_memory_create_batch_posts_body(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "batch.json"
+    batch_file.write_text(
+        json.dumps(
+            [
+                {"content": "first", "category": "work", "visibility": "public", "tags": ["a"]},
+                {"content": "second"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    route = respx_mock.post("/v1/dev/user/memories/batch").respond(
+        json={
+            "memories": [{"id": "m1"}, {"id": "m2"}],
+            "created_count": 2,
+        }
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body == {
+        "memories": [
+            {"content": "first", "category": "work", "visibility": "public", "tags": ["a"]},
+            {"content": "second", "visibility": "private", "tags": []},
+        ]
+    }
+    payload = json.loads(result.stdout)
+    assert payload["created_count"] == 2
+
+
+def test_memory_create_batch_accepts_memories_object(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "batch.json"
+    batch_file.write_text(json.dumps({"memories": [{"content": "hello"}]}), encoding="utf-8")
+    route = respx_mock.post("/v1/dev/user/memories/batch").respond(
+        json={"memories": [{"id": "m1"}], "created_count": 1}
+    )
+    result = cli_runner.invoke(app, ["--json", "memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"memories": [{"content": "hello", "visibility": "private", "tags": []}]}
+
+
+def test_memory_create_batch_malformed_json_sends_no_request(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "bad.json"
+    batch_file.write_text("{ not json", encoding="utf-8")
+    respx_mock.post("/v1/dev/user/memories/batch").respond(json={"memories": [], "created_count": 0})
+    result = cli_runner.invoke(app, ["memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "not valid json" in result.stderr.lower()
+    assert not respx_mock.calls
+
+
+def test_memory_create_batch_over_25_is_usage_error(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "many.json"
+    batch_file.write_text(json.dumps([{"content": f"m{i}"} for i in range(26)]), encoding="utf-8")
+    respx_mock.post("/v1/dev/user/memories/batch").respond(json={"memories": [], "created_count": 0})
+    result = cli_runner.invoke(app, ["memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "25" in result.stderr
+    assert not respx_mock.calls
+
+
+def test_memory_create_batch_missing_file_is_usage_error(authed_profile, cli_runner, tmp_path) -> None:
+    result = cli_runner.invoke(app, ["memory", "create-batch", str(tmp_path / "nope.json")])
+    assert result.exit_code == 1
+    assert "not found" in result.stderr.lower()
+
+
+def test_memory_create_batch_auth_failure(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "batch.json"
+    batch_file.write_text(json.dumps([{"content": "x"}]), encoding="utf-8")
+    respx_mock.post("/v1/dev/user/memories/batch").respond(401, json={"detail": "nope"})
+    result = cli_runner.invoke(app, ["memory", "create-batch", str(batch_file)])
+    assert result.exit_code == 2
+    assert "auth" in result.stderr.lower()
+
+
 def test_memory_update_requires_at_least_one_field(authed_profile, cli_runner) -> None:
     result = cli_runner.invoke(app, ["memory", "update", "m1"])
     # exit 1 = usage error


### PR DESCRIPTION
Closes #13140

## Summary

Adds `omi memory create-batch <file.json>` to import up to 25 memories from a UTF-8 JSON file in a single authenticated request to the existing `POST /v1/dev/user/memories/batch` endpoint.

## Behavior

- File can be a JSON array of memory objects, or an object with a `memories` array
- Per-entry validation before any HTTP request:
  - non-empty string `content`
  - `visibility` must be `public` or `private` (defaults to `private`)
  - `tags` must be a list of strings
  - `category` must be a known memory category
- More than 25 entries, empty batches, malformed JSON, and unreadable files are usage errors (exit 1) with readable messages
- One API call per invocation; no silent splitting of larger files
- Renders the server response (`memories` + `created_count`)

## Tests

6 new cases in `tests/test_memory.py`:

- request body mapping for a 2-entry file (defaults applied)
- `{"memories": [...]}` object form
- malformed JSON sends no HTTP request
- 26 entries is a usage error and sends no HTTP request
- missing file is a usage error
- 401 from the batch endpoint maps to the documented auth exit code (2)

All 18 memory tests pass on Python 3.13/Windows. `black` and `isort` are clean; the only mypy findings are pre-existing errors in `errors.py`, untouched by this change.

## Docs

README updated: command surface tree, batch file format example, and validation rules.

## Disclosure

Prepared with AI assistance; change is limited to the memory CLI commands, their tests, and the README.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

