### PR TITLE
fix(desktop): chat composer lane + attachment preview continuity

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatResource.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatResource.swift
@@ -166,6 +166,17 @@ struct ChatResource: Identifiable, Equatable {
     attachments.map(ChatResource.attachment) + references.map(ChatResource.conversation)
   }
 
+  /// Re-attach in-memory image bytes, matched by resource id, from rows the
+  /// journal cannot carry them through (see `carryingImageData(from:)`).
+  static func carryingImageData(_ resources: [ChatResource], from local: [ChatResource]) -> [ChatResource] {
+    guard !resources.isEmpty, !local.isEmpty else { return resources }
+    // omi-collection-safety: explicit-non-trapping-merge -- duplicate local ids
+    // (a legacy row echoed twice) keep the first entry; ids are otherwise unique.
+    let localByID = Dictionary(
+      local.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+    return resources.map { $0.carryingImageData(from: localByID[$0.id]) }
+  }
+
   static func artifact(_ artifact: AgentArtifactProjection) -> ChatResource {
     ChatResource(
       id: "artifact:\(artifact.artifactId)",
@@ -254,6 +265,37 @@ struct ChatResource: Identifiable, Equatable {
       return refreshed
     }
     return markingUnavailableOnDisk()
+  }
+
+  /// Returns `self` with in-memory image bytes that this (replayed) resource
+  /// lost at the persistence boundary re-attached from a same-id local row.
+  ///
+  /// The journal and message metadata persist resource metadata only —
+  /// `imageData` is never encoded — so every replayed row arrives with nil
+  /// bytes even when the row it replaces was rendering its thumbnail from
+  /// memory. Without those bytes the tile falls back to the original file path
+  /// (which for a temp export may already be gone) or the server thumbnail,
+  /// and a sent attachment can go blank mid-session. The replay stays the
+  /// authority for every field it does carry; only the bytes come back.
+  func carryingImageData(from local: ChatResource?) -> ChatResource {
+    guard imageData == nil, let local, local.id == id, let bytes = local.imageData else {
+      return self
+    }
+    return ChatResource(
+      id: id,
+      origin: origin,
+      title: title,
+      subtitle: subtitle,
+      mimeType: mimeType,
+      thumbnailURL: thumbnailURL,
+      imageData: bytes,
+      uri: uri,
+      artifactId: artifactId,
+      sessionId: sessionId,
+      runId: runId,
+      state: state,
+      conversationReference: conversationReference
+    )
   }
 
   func markingUnavailableOnDisk() -> ChatResource {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
@@ -392,6 +392,14 @@ struct QueryHeroBar: View {
       maxHeight: maxEditorHeight
     )
     .frame(maxWidth: .infinity)
+    // **The field outranks its neighbours when the lane is contested.** Both rows are one fixed
+    // affordance, this field, and a fixed trailing cluster; the field is the only member with a
+    // reason to flex. A sibling that starts reporting a bloated width (the attach `Menu`'s backing
+    // control was measured at half the lane in a live session) must never be able to take the
+    // field's width with it — the pin on that control's slot is the first guard, and this priority
+    // is the second: whatever else in the row asks for more than it is owed, the reader's typing
+    // surface keeps the space the row owes it.
+    .layoutPriority(1)
     .overlay(alignment: .topLeading) {
       if text.isEmpty && !hasMarkedText {
         Text(placeholder)
@@ -451,6 +459,15 @@ struct QueryHeroBar: View {
     }
     .menuStyle(.borderlessButton)
     .menuIndicator(.hidden)
+    // **The control's slot is one disc wide, whatever its menu machinery reports.** A live session
+    // was measured with this `Menu`'s backing control at 381 pt — half the lane — after which the
+    // HStack split the remaining width evenly between it and the field (the paperclip drawn ~260 pt
+    // into the pill, the caret at the editor's mid-lane leading edge). The label above is already
+    // disc-sized; this pins the *slot*, so the row's one flexible member is always the field and no
+    // state the menu's AppKit side can enter — content rows, a tracking session, a stale fitting
+    // width — can buy lane width. The frame does not clip, so the glyph stays visible wherever the
+    // menu paints it; what it can never again do is move the field.
+    .frame(width: diameter)
     .disabled(attachments.count >= kMaxChatAttachments)
     .help("Attach files or a recent screen frame")
     .accessibilityLabel("Attach files")

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -387,7 +387,12 @@ extension ChatProvider {
       || ChatContentBlockCodec.comparisonData(projected.contentBlocks)
         != ChatContentBlockCodec.comparisonData(existing.contentBlocks)
       || projected.attachments != existing.attachments
-      || projected.resources != existing.resources
+      // Resource `imageData` never comes from the journal, so the comparison
+      // is against what the replace would actually publish: the projection
+      // with local bytes carried back. Otherwise every echo of a row holding
+      // attachment bytes reported a divergence that changed nothing.
+      || ChatResource.carryingImageData(projected.resources, from: existing.resources)
+        != existing.resources
   }
 }
 
@@ -399,13 +404,16 @@ extension ChatProvider {
   /// reconstruct them and a journal projection can never be their authority:
   /// `rating` (user-set), `metadata` (model/token/cost stats attached at
   /// completion, rendered in the message footer), `notificationScreenshot`,
-  /// and in-memory kind-only citation rewrites until the journal catches up.
+  /// per-resource `imageData` (attachment thumbnails the tile renders from
+  /// memory once the picked file — often a temp export — disappears), and
+  /// in-memory kind-only citation rewrites until the journal catches up.
   /// Replacing a row wholesale with the projection would drop them, so carry
   /// them forward from the row being replaced. A field the projection *does*
   /// carry (non-nil) wins, so this stays correct if the journal schema later
   /// starts persisting one of them.
   static func carryingLocalOnlyFields(_ projected: ChatMessage, from existing: ChatMessage) -> ChatMessage {
     var merged = projected
+    merged.resources = ChatResource.carryingImageData(merged.resources, from: existing.resources)
     // A journal echo of a row this client is still streaming is the snapshot
     // it wrote a round trip ago; the live projection has moved on since. Taking
     // the echo's text put the visible answer a few words back on every write

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3838,7 +3838,20 @@ class ChatProvider: ObservableObject {
       .init(message: userMessage, status: .completed),
       .init(message: assistantMessage, status: .streaming),
     ]
-    return await recordCanonicalExchange(turns) != nil
+    guard await recordCanonicalExchange(turns) != nil else { return false }
+    // The journal publishes this user row without the attachment bytes it
+    // never persists, so a first publication renders its tile from the picked
+    // file's path — blank once that path is an app-owned temp export the OS or
+    // a Quick Look purge removes. Put the just-sent bytes back on the row;
+    // later echoes keep them through `carryingLocalOnlyFields`.
+    if let index = messages.firstIndex(where: { $0.id == userMessage.id }) {
+      let carried = ChatResource.carryingImageData(
+        messages[index].resources, from: userMessage.resources)
+      if carried != messages[index].resources {
+        messages[index].resources = carried
+      }
+    }
+    return true
   }
 
   /// Behavioral seam for the journal-first admission contract. Tests inject a

--- a/desktop/macos/Desktop/Tests/ChatAttachmentPreviewContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatAttachmentPreviewContinuityTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The sent attachment tile renders its image from, in order: in-memory bytes,
+/// the original picked file, the server thumbnail (`ChatResourceCard.resourceImage`).
+/// The kernel journal persists resource metadata only, so a journaled user row
+/// arrives without the bytes the pick loaded — and a file picked out of an
+/// app-owned temp export (a Quick Look frame, a pasted screenshot's staging
+/// file) can disappear moments later, collapsing the tile to the gray
+/// placeholder. These tests pin the bytes to the admitted row and its echoes.
+@MainActor
+final class ChatAttachmentPreviewContinuityTests: XCTestCase {
+
+  /// The reported bug: attach a screenshot, send it, and the sent tile goes
+  /// blank once the picked temp file is purged. The admitted turn must keep
+  /// rendering from the bytes the pick already loaded.
+  func testAdmittedAttachmentTurnKeepsImageBytesWhenPickedFileDisappears() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+
+    // A picked screenshot living in a temp export, with the bytes the pick read.
+    let pickedFile = FileManager.default.temporaryDirectory
+      .appendingPathComponent("frame-\(UUID().uuidString).jpg")
+    let imageBytes = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x01])
+    try imageBytes.write(to: pickedFile)
+    // The Quick Look scratch purge removes the export while the chat keeps the row.
+    try FileManager.default.removeItem(at: pickedFile)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: pickedFile.path))
+
+    let attachment = ChatAttachment(
+      id: "local-1",
+      fileName: pickedFile.lastPathComponent,
+      mimeType: "image/jpeg",
+      data: imageBytes,
+      serverId: "file-1",
+      localFileURL: pickedFile,
+      state: .uploaded
+    )
+    let userMessage = ChatMessage(
+      id: "turn-user",
+      clientTurnId: "attempt-1",
+      text: "look at this",
+      sender: .user,
+      attachments: [attachment],
+      resources: ChatResource.userMessageResources(attachments: [attachment], references: [])
+    )
+    let assistantMessage = ChatMessage(
+      id: "turn-assistant",
+      clientTurnId: "attempt-1",
+      text: "",
+      sender: .ai,
+      isStreaming: true
+    )
+
+    // The kernel admits the exchange and publishes the rows back from its
+    // journal — the same encode the write path performs, which drops image bytes.
+    let echoed: [KernelJournalTurn] = [
+      try makeTurn(
+        surface: surface,
+        turnId: userMessage.id,
+        turnSeq: 1,
+        role: "user",
+        content: userMessage.text,
+        status: .completed,
+        resourcesJSON: userMessage.journalWrite(
+          origin: "typed",
+          status: .completed,
+          continuityKey: "attempt-1"
+        ).resourcesJSON),
+      try makeTurn(
+        surface: surface,
+        turnId: assistantMessage.id,
+        turnSeq: 2,
+        role: "assistant",
+        content: assistantMessage.text,
+        status: .streaming,
+        resourcesJSON: "[]"),
+    ]
+    let admitted = await provider.admitStreamingJournalExchange(
+      userMessage: userMessage,
+      assistantMessage: assistantMessage
+    ) { _ in
+      for turn in echoed {
+        provider.projectJournalTurn(turn)
+      }
+      return echoed
+    }
+
+    XCTAssertTrue(admitted, "The exchange must be admitted for the row to exist at all")
+    let userRow = try XCTUnwrap(provider.messages.first { $0.id == "turn-user" })
+    let resource = try XCTUnwrap(userRow.displayResources.first)
+    XCTAssertEqual(
+      resource.imageData, imageBytes,
+      "The sent tile must render from the picked bytes once the temp file is gone")
+  }
+
+  /// A later journal echo still owns every field it persists (a refreshed
+  /// thumbnail wins) while the bytes the journal cannot carry survive the replace.
+  func testJournalEchoRefreshesThumbnailButKeepsCarriedImageBytes() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let pickedFile = FileManager.default.temporaryDirectory
+      .appendingPathComponent("kept-frame-\(UUID().uuidString).jpg")
+    let imageBytes = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x02])
+    try imageBytes.write(to: pickedFile)
+    defer { try? FileManager.default.removeItem(at: pickedFile) }
+
+    let resource = ChatResource(
+      id: "attachment:file-1",
+      origin: .userAttachment,
+      title: "frame-3e8b6ff8-AC51-A8890605A5B5.jpg",
+      subtitle: "image/jpeg",
+      mimeType: "image/jpeg",
+      thumbnailURL: "https://example.com/thumb-1.jpg",
+      imageData: imageBytes,
+      uri: pickedFile.absoluteString,
+      artifactId: nil,
+      sessionId: nil,
+      runId: nil,
+      state: .ready
+    )
+    let userMessage = ChatMessage(
+      id: "turn-user",
+      clientTurnId: "attempt-2",
+      text: "look",
+      sender: .user,
+      resources: [resource]
+    )
+    let assistantMessage = ChatMessage(
+      id: "turn-assistant",
+      clientTurnId: "attempt-2",
+      text: "",
+      sender: .ai,
+      isStreaming: true
+    )
+
+    let echoed: [KernelJournalTurn] = [
+      try makeTurn(
+        surface: surface,
+        turnId: userMessage.id,
+        turnSeq: 1,
+        role: "user",
+        content: userMessage.text,
+        status: .completed,
+        resourcesJSON: ChatResource.encodeResourcesForPersistence(userMessage.displayResources)
+          ?? "[]"),
+      try makeTurn(
+        surface: surface,
+        turnId: assistantMessage.id,
+        turnSeq: 2,
+        role: "assistant",
+        content: assistantMessage.text,
+        status: .streaming,
+        resourcesJSON: "[]"),
+    ]
+    let admitted = await provider.admitStreamingJournalExchange(
+      userMessage: userMessage,
+      assistantMessage: assistantMessage
+    ) { _ in
+      for turn in echoed {
+        provider.projectJournalTurn(turn)
+      }
+      return echoed
+    }
+    XCTAssertTrue(admitted)
+
+    // The kernel later replays the user turn having refreshed the thumbnail.
+    let refreshed = ChatResource(
+      id: resource.id,
+      origin: resource.origin,
+      title: resource.title,
+      subtitle: resource.subtitle,
+      mimeType: resource.mimeType,
+      thumbnailURL: "https://example.com/thumb-2.jpg",
+      imageData: nil,
+      uri: resource.uri,
+      artifactId: nil,
+      sessionId: nil,
+      runId: nil,
+      state: resource.state
+    )
+    provider.projectJournalTurn(
+      try makeTurn(
+        surface: surface,
+        turnId: "turn-user",
+        turnSeq: 3,
+        role: "user",
+        content: "look",
+        status: .completed,
+        resourcesJSON: ChatResource.encodeResourcesForPersistence([refreshed]) ?? "[]"))
+
+    let userRow = try XCTUnwrap(provider.messages.first { $0.id == "turn-user" })
+    let echoedResource = try XCTUnwrap(userRow.displayResources.first)
+    XCTAssertEqual(
+      echoedResource.thumbnailURL, "https://example.com/thumb-2.jpg",
+      "The journal owns the thumbnail and its refreshed value must win")
+    XCTAssertEqual(
+      echoedResource.imageData, imageBytes,
+      "The echo must not strip the bytes the journal never persisted")
+  }
+
+  /// Byte carry is id-matched and never overrides bytes the row already has.
+  func testCarryingImageDataOnlyFillsMissingBytesForMatchingIDs() {
+    let bytes = Data([0xFF, 0xD8, 0xFF])
+    let local = ChatResource(
+      id: "attachment:file-1", origin: .userAttachment, title: "a.jpg", subtitle: nil,
+      mimeType: "image/jpeg", thumbnailURL: nil, imageData: bytes, uri: nil,
+      artifactId: nil, sessionId: nil, runId: nil, state: .ready)
+    let replayed = ChatResource(
+      id: "attachment:file-1", origin: .userAttachment, title: "a.jpg", subtitle: nil,
+      mimeType: "image/jpeg", thumbnailURL: nil, imageData: nil, uri: nil,
+      artifactId: nil, sessionId: nil, runId: nil, state: .ready)
+    let otherID = ChatResource(
+      id: "attachment:file-2", origin: .userAttachment, title: "b.jpg", subtitle: nil,
+      mimeType: "image/jpeg", thumbnailURL: nil, imageData: nil, uri: nil,
+      artifactId: nil, sessionId: nil, runId: nil, state: .ready)
+    let ownBytes = Data([0x89, 0x50])
+    let selfSufficient = ChatResource(
+      id: "attachment:file-1", origin: .userAttachment, title: "a.jpg", subtitle: nil,
+      mimeType: "image/jpeg", thumbnailURL: nil, imageData: ownBytes, uri: nil,
+      artifactId: nil, sessionId: nil, runId: nil, state: .ready)
+
+    let carried = ChatResource.carryingImageData([replayed, otherID, selfSufficient], from: [local])
+
+    XCTAssertEqual(carried[0].imageData, bytes, "A matching id with missing bytes is filled")
+    XCTAssertNil(carried[1].imageData, "A resource the local row never had gains nothing")
+    XCTAssertEqual(carried[2].imageData, ownBytes, "Bytes the row already has are not overridden")
+  }
+
+  // MARK: - Journal turn builder (the dictionary the kernel bridge returns)
+
+  private func makeTurn(
+    surface: AgentSurfaceReference,
+    turnId: String,
+    turnSeq: Int,
+    role: String,
+    content: String,
+    status: KernelJournalTurnStatus,
+    resourcesJSON: String
+  ) throws -> KernelJournalTurn {
+    try XCTUnwrap(
+      KernelJournalTurn(dictionary: [
+        "conversationId": "conversation-1",
+        "turnId": turnId,
+        "turnSeq": turnSeq,
+        "conversationGeneration": 1,
+        "generationBaseTurnSeq": 0,
+        "producerId": "producer:\(turnId):\(turnSeq)",
+        "payloadHash": "sha256:\(turnId):\(turnSeq)",
+        "role": role,
+        "surfaceKind": surface.surfaceKind,
+        "externalRefKind": surface.externalRefKind,
+        "externalRefId": surface.externalRefId,
+        "content": content,
+        "origin": "typed",
+        "status": status.rawValue,
+        "contentBlocks": [],
+        "resources": KernelJournalTurnWrite.jsonArray(resourcesJSON),
+        "metadataJson": "{}",
+        "createdAtMs": 1_700_000_000_000 + turnSeq,
+        "updatedAtMs": 1_700_000_000_000 + turnSeq,
+      ]))
+  }
+}

--- a/desktop/macos/Desktop/Tests/QueryComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryComposerTests.swift
@@ -317,6 +317,74 @@ final class QueryComposerTests: XCTestCase {
     }
   }
 
+  // MARK: - The row's width is the field's
+
+  /// **Nothing the paperclip's menu carries can buy the field's width.**
+  ///
+  /// A live session was measured with the attach `Menu`'s backing control at 381 pt — half the
+  /// lane — so the row split its width evenly between the paperclip and the field, and the caret
+  /// landed mid-lane ("the input chat box UI got messed up"). The control's slot is pinned to one
+  /// disc in `QueryHeroBar.attachButton`; this asserts the observable contract through the editor
+  /// the composer actually puts on screen: the field spans the lane minus the row's fixed controls,
+  /// and what the menu offers — twelve rows, one longer than the lane itself is wide — changes
+  /// nothing. Without the pin this fails even on a fresh mount — the menu's backing chrome alone
+  /// takes a second disc — which is the same mechanism the live session amplified.
+  func testTheFieldKeepsTheLaneWhateverThePaperclipsMenuOffers() throws {
+    let lane: CGFloat = 842
+    let bare = try Composer(width: lane, mode: .answer)
+    defer { bare.tearDown() }
+    let stocked = try Composer(width: lane, mode: .answer, recentScreenFrames: Self.menuRows)
+    defer { stocked.tearDown() }
+
+    let expectedField =
+      lane
+      - QueryShellLayout.panelComposerEdgeInset * 2
+      - QueryShellLayout.panelComposerShellInset * 2
+      - QueryShellLayout.panelComposerControlDiameter * 3
+      - OmiSpacing.sm * 3
+
+    XCTAssertEqual(
+      bare.editorWidth, expectedField, accuracy: 2,
+      "the field does not span the lane the row owes it — some control is taking width it was never given")
+    XCTAssertEqual(
+      stocked.editorWidth, bare.editorWidth, accuracy: 1,
+      "the paperclip's menu content changed the field's width — a menu's rows are picker content, "
+        + "never a claim on the composer's lane")
+  }
+
+  /// The failure was seen as a field squeezed to half its lane. A floor in the field's own terms,
+  /// independent of the row's insets: whatever the controls negotiate, the typing surface keeps at
+  /// least three quarters of the lane it is mounted in.
+  func testTheFieldHoldsMostOfTheLaneEvenWhenTheRowIsContested() throws {
+    let lane: CGFloat = 842
+    let composer = try Composer(width: lane, mode: .answer, recentScreenFrames: Self.menuRows)
+    defer { composer.tearDown() }
+
+    XCTAssertGreaterThan(
+      composer.editorWidth, lane * 0.75,
+      "the field was squeezed below three quarters of the lane — the row's fixed controls are "
+        + "three 28 pt discs; anything larger is a control taking the reader's typing space")
+  }
+
+  /// Rows the paperclip's menu can offer: a full picker — several frames, one with a title wider
+  /// than any disc, and the trailing divider the real menu draws.
+  private static var menuRows: [RecentScreenFrameRow] {
+    (0..<12).compactMap { index in menuRow(index) }
+  }
+
+  private static func menuRow(_ index: Int) -> RecentScreenFrameRow? {
+    let appName: String
+    if index == 0 {
+      appName = "Some Extremely Long Enterprise Application Name With Suffix Edition"
+    } else {
+      appName = "App \(index)"
+    }
+    let timestamp = Date().addingTimeInterval(TimeInterval(-3600 * (index + 1)))
+    return RecentScreenFrameRow(
+      screenshot: Screenshot(
+        id: Int64(index), timestamp: timestamp, appName: appName, windowTitle: nil, imagePath: nil))
+  }
+
   // MARK: - Harness
 
   /// The real `QueryHeroBar` over the real `ChatComposerDraft`, in a window, with the `NSTextView`
@@ -330,9 +398,16 @@ final class QueryComposerTests: XCTestCase {
 
     let surface = Surface()
 
-    init(width: CGFloat = 768, height: CGFloat = 400, mode: QueryShellMode = .results) throws {
+    init(
+      width: CGFloat = 768,
+      height: CGFloat = 400,
+      mode: QueryShellMode = .results,
+      recentScreenFrames: [RecentScreenFrameRow] = []
+    ) throws {
       provider = ChatProvider()
-      host = NSHostingView(rootView: Host(provider: provider, surface: surface, mode: mode))
+      host = NSHostingView(
+        rootView: Host(
+          provider: provider, surface: surface, mode: mode, recentScreenFrames: recentScreenFrames))
       host.frame = NSRect(x: 0, y: 0, width: width, height: height)
       window = NSWindow(
         contentRect: host.frame, styleMask: [.titled], backing: .buffered, defer: false)
@@ -387,6 +462,14 @@ final class QueryComposerTests: XCTestCase {
     var composerHeight: CGFloat {
       settle()
       return textView.enclosingScrollView?.frame.height ?? 0
+    }
+
+    /// The editor's laid-out width in the bar the composer actually mounted — the number the row
+    /// gives the field after every control in it has taken what it claims. Read off the scroll
+    /// view's frame in its own superview, the same surface the reader types into.
+    var editorWidth: CGFloat {
+      settle()
+      return textView.enclosingScrollView?.frame.width ?? 0
     }
 
     /// The bar's own laid-out height in a surface-shaped host, not its `fittingSize` — the failure
@@ -471,6 +554,7 @@ final class QueryComposerTests: XCTestCase {
     @ObservedObject var provider: ChatProvider
     @ObservedObject var surface: Surface
     let mode: QueryShellMode
+    var recentScreenFrames: [RecentScreenFrameRow] = []
     let probe = HeightProbe()
 
     var body: some View {
@@ -491,7 +575,8 @@ final class QueryComposerTests: XCTestCase {
           isWorking: surface.isWorking,
           isStopping: surface.isStopping,
           mode: mode,
-          onAsk: { surface.asks += 1 }
+          onAsk: { surface.asks += 1 },
+          recentScreenFrames: recentScreenFrames
         )
         .background {
           GeometryReader { bar in

--- a/desktop/macos/changelog/unreleased/20260908-chat-attachment-preview.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-attachment-preview.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed sent chat attachments showing a blank placeholder once the picked screenshot's temporary file was removed"
+}

--- a/desktop/macos/changelog/unreleased/20260908-chat-composer-lane.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-composer-lane.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed the Home chat input bar breaking apart when the paperclip menu's backing control grew to half the lane, squeezing the Ask Omi field and pushing the mic and send discs to the window edge"
+  "change": "Fixed the Home chat input bar spreading its controls across the window — the message field, paperclip, microphone, and send button now keep their usual layout"
 }

--- a/desktop/macos/changelog/unreleased/20260908-chat-composer-lane.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-composer-lane.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Home chat input bar breaking apart when the paperclip menu's backing control grew to half the lane, squeezing the Ask Omi field and pushing the mic and send discs to the window edge"
+}


### PR DESCRIPTION
## Chat composer layout fix — the input bar was split in half by the paperclip menu

**Root cause.** In the shipped Beta (v0.12.323) the Home chat input row broke apart: measured with AX on the running app, the paperclip `Menu`'s backing control reported a 381pt width — half the composer lane — so the `HStack` split the remaining width evenly between it and the only other flexible child, the Ask Omi editor. The paperclip drew ~260pt into the pill, the caret and "Ask Omi" placeholder landed mid-lane at the squeezed editor's leading edge, and mic/send pinned against the window edge: "the input chat box UI got messed up" (user screenshot matches: paperclip ~292pt from the window's left edge, placeholder at ~409..489, at a window where the healthy build puts the paperclip at 29 and the editor spanning 62..799).

The row trusted the menu's self-reported width. Even on a fresh mount the menu's backing chrome alone takes a full extra disc beyond its 28pt label (the new test measures the field at 708pt in an 842pt lane without the pin, 736 with it) — the same mechanism a live session amplified to 381pt.

**Fix** (`QueryHeroBar.swift`):
- The attach control's slot is pinned to one control diameter (`.frame(width: diameter)`), so no state the menu's AppKit side can enter — content rows, a tracking session, a stale fitting width — can buy lane width. The frame does not clip, so the glyph stays visible wherever the menu paints it.
- The field takes `.layoutPriority(1)` as the second guard: the row's one flexible member is the field; any sibling that starts reporting a bloated width can never again take the reader's typing surface with it.

**Evidence.** New layout tests in `QueryComposerTests` mount the real `QueryHeroBar` in an 842pt lane and read the editor the composer actually puts on screen: the field spans the lane minus the row's fixed controls, identical whether the paperclip's menu offers nothing or twelve rows (one longer than the lane). Without the pin, the test fails with the field at 708pt. Live verification: the signed-in offline harness instance on this branch lays the row out at attach 25x20 at the panel's leading edge, editor spanning the lane, mic at 807, send at 843 — the healthy pre-regression geometry.

## Attachment preview continuity fix — sent screenshots went blank

**Root cause.** The kernel journal and message metadata persist resource metadata only, never the in-memory `imageData` bytes, so every journal-replayed row arrived with nil bytes even when the row it replaced was rendering its thumbnail from memory. The tile then fell back to the original file path — for a staged screenshot's temp export, already gone — and drew a blank placeholder.

**Fix** (`ChatResource.swift`, `ChatProvider.swift`, `ChatProvider+JournalProjection.swift`): the replay stays the authority for every field it carries; the projection boundary re-attaches the lost bytes from the same-id local row it replaces (`ChatResource.carryingImageData`). Pinned by `ChatAttachmentPreviewContinuityTests` (3 tests) over the real projection path.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — clean.
- `swift test --filter QueryComposerTests` — 20/20 (2 new). `--filter ChatAttachmentPreviewContinuityTests` — 3/3.
- `./scripts/swift-format-wrapper.sh lint` on changed files and `./scripts/swiftlint-wrapper.sh lint` — 0 violations.
- Signed-in offline harness instance on this branch: composer geometry verified healthy via AX (above); no production endpoints contacted.

## Bundle to verify

`/Applications/omi-chat-input-image-preview.app` is rebuilt from this branch against the dev desktop backend + production Firebase auth: sign in with Apple/Google as on Beta, check the Home chat composer (paperclip at the far left, field spanning the row), attach a screenshot and send it — the sent tile keeps its preview.

Failure-Class: none

## Product invariants affected

- INV-AUTH-1 — ChatProvider.swift changed; this fix does not alter session ownership, invalidation, or owner-transition boundaries: it only re-attaches in-memory attachment image bytes at the existing journal projection seam.
- INV-CHAT-1 — the attachment-preview fix reads the kernel journal's replayed rows and re-attaches bytes from the same-id in-memory row; the journal stays the one canonical transcript and no second store is introduced.

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 7318 -> 7331 | attachment-preview continuity fix re-attaches in-memory image bytes at the journal projection boundary (carryingImageData merge at the existing projection seam); splitting the 7.3k-line provider is out of scope for this two-fix change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

