### PR TITLE
feat(python-sdk): add JSON and timeout options to omi-scan

### DIFF
--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -100,8 +100,11 @@ The SDK requires the Opus audio codec library:
     omi-scan --json --timeout 3
     ```
 
-    Each result contains the device `name` and Bluetooth `address`. An empty
-    scan prints `[]`; invalid timeout values are rejected before scanning.
+    Each result contains the device `name` and its Bluetooth `id`. An empty
+    scan prints `[]`; invalid timeout values are rejected before scanning
+    (exit code 2) and a failed scan reports the error on stderr with exit
+    code 1, so `--json` stdout stays parseable. Without `--timeout`, Bleak's
+    own default scan window is used.
   </Step>
   <Step title="Write Your Code">
     ```python
@@ -169,7 +172,7 @@ The SDK requires the Opus audio codec library:
 | Command | Description |
 |---------|-------------|
 | `omi-scan` | Scan for nearby Bluetooth devices |
-| `omi-scan --json --timeout 3` | Print device names and addresses as JSON for scripts |
+| `omi-scan --json --timeout 3` | Print device names and Bluetooth ids as JSON for scripts |
 
 ---
 

--- a/docs/doc/developer/sdk/python.mdx
+++ b/docs/doc/developer/sdk/python.mdx
@@ -93,6 +93,16 @@ The SDK requires the Opus audio codec library:
     0. Omi [7F52EC55-50C9-D1B9-E8D7-19B83217C97D]
     ```
   </Step>
+  <Step title="Use Machine-Readable Output (Optional)">
+    For scripts, request a JSON array and set a finite scan timeout:
+
+    ```bash
+    omi-scan --json --timeout 3
+    ```
+
+    Each result contains the device `name` and Bluetooth `address`. An empty
+    scan prints `[]`; invalid timeout values are rejected before scanning.
+  </Step>
   <Step title="Write Your Code">
     ```python
     import asyncio
@@ -159,6 +169,7 @@ The SDK requires the Opus audio codec library:
 | Command | Description |
 |---------|-------------|
 | `omi-scan` | Scan for nearby Bluetooth devices |
+| `omi-scan --json --timeout 3` | Print device names and addresses as JSON for scripts |
 
 ---
 

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -2,7 +2,8 @@ import argparse
 import asyncio
 import json
 import math
-from typing import Any, Callable
+import sys
+from typing import Any, Callable, Optional
 
 from bleak import BleakClient, BleakScanner
 
@@ -21,19 +22,40 @@ def _positive_timeout(value: str) -> float:
     return timeout
 
 
-def print_devices(json_output: bool = False, timeout: float = 5.0) -> None:
-    """Scan for nearby Bluetooth devices and print them in the requested format."""
-    devices = asyncio.run(BleakScanner.discover(timeout=timeout))
+def _discover(timeout: Optional[float]) -> Any:
+    """Run a discovery, forwarding ``timeout`` only when one was requested.
+
+    ``None`` calls ``BleakScanner.discover()`` exactly as before, keeping the
+    library's own default scan window.
+    """
+    if timeout is None:
+        return asyncio.run(BleakScanner.discover())
+    return asyncio.run(BleakScanner.discover(timeout=timeout))
+
+
+def print_devices(json_output: bool = False, timeout: Optional[float] = None) -> None:
+    """Scan for nearby Bluetooth devices and print them in the requested format.
+
+    The human-readable listing is unchanged. ``json_output`` prints a single
+    JSON array of ``{"name", "id"}`` objects, where ``id`` is the device's
+    Bluetooth address.
+    """
+    devices = _discover(timeout)
     if json_output:
-        print(json.dumps([{"name": d.name, "address": d.address} for d in devices]))
+        print(json.dumps([{"name": d.name, "id": d.address} for d in devices]))
         return
 
     for i, d in enumerate(devices):
         print(f"{i}. {d.name} [{d.address}]")
 
 
-def main() -> None:
-    """Run the ``omi-scan`` command-line interface."""
+def main() -> int:
+    """Run the ``omi-scan`` command-line interface.
+
+    Returns the process status: ``0`` on success, ``1`` when the scan fails,
+    ``2`` on invalid arguments (argparse). Diagnostics go to stderr so the
+    ``--json`` stdout stays parseable.
+    """
     parser = argparse.ArgumentParser(
         description="Scan for nearby Omi Bluetooth devices"
     )
@@ -41,16 +63,22 @@ def main() -> None:
         "--json",
         action="store_true",
         dest="json_output",
-        help="print a JSON array instead of human-readable lines",
+        help='print a JSON array of {"name", "id"} objects',
     )
     parser.add_argument(
         "--timeout",
         type=_positive_timeout,
-        default=5.0,
-        help="scan duration in seconds (default: 5)",
+        default=None,
+        help="scan duration in seconds (default: Bleak's own timeout)",
     )
     args = parser.parse_args()
-    print_devices(json_output=args.json_output, timeout=args.timeout)
+
+    try:
+        print_devices(json_output=args.json_output, timeout=args.timeout)
+    except Exception as exc:  # adapter missing, powered off, or permission denied
+        print(f"omi-scan: error: Bluetooth scan failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 async def listen_to_omi(

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -1,16 +1,56 @@
+import argparse
 import asyncio
-from typing import Callable, Any
-from bleak import BleakScanner, BleakClient
+import json
+import math
+from typing import Any, Callable
+
+from bleak import BleakClient, BleakScanner
 
 # Re-export for callers that want the default Omi audio stream UUID.
 from .constants import AUDIO_DATA_UUID  # noqa: F401
 
 
-def print_devices() -> None:
-    """Scan for and print all nearby Bluetooth devices."""
-    devices = asyncio.run(BleakScanner.discover())
+def _positive_timeout(value: str) -> float:
+    """Parse a finite, positive scan timeout for the command line."""
+    try:
+        timeout = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be a number") from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise argparse.ArgumentTypeError("timeout must be finite and greater than zero")
+    return timeout
+
+
+def print_devices(json_output: bool = False, timeout: float = 5.0) -> None:
+    """Scan for nearby Bluetooth devices and print them in the requested format."""
+    devices = asyncio.run(BleakScanner.discover(timeout=timeout))
+    if json_output:
+        print(json.dumps([{"name": d.name, "address": d.address} for d in devices]))
+        return
+
     for i, d in enumerate(devices):
         print(f"{i}. {d.name} [{d.address}]")
+
+
+def main() -> None:
+    """Run the ``omi-scan`` command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Scan for nearby Omi Bluetooth devices"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="print a JSON array instead of human-readable lines",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_timeout,
+        default=5.0,
+        help="scan duration in seconds (default: 5)",
+    )
+    args = parser.parse_args()
+    print_devices(json_output=args.json_output, timeout=args.timeout)
 
 
 async def listen_to_omi(

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
 ]
 
 [project.scripts]
-omi-scan = "omi.bluetooth:print_devices"
+omi-scan = "omi.bluetooth:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sdks/python/tests/test_bluetooth_scan_cli.py
+++ b/sdks/python/tests/test_bluetooth_scan_cli.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from omi.bluetooth import main, print_devices
+
+
+def test_print_devices_preserves_human_readable_output() -> None:
+    devices = [SimpleNamespace(name="Omi", address="AA:BB")]
+    with (
+        patch("omi.bluetooth.BleakScanner.discover", return_value=devices) as discover,
+        patch("builtins.print") as output,
+    ):
+        print_devices()
+
+    discover.assert_called_once_with(timeout=5.0)
+    output.assert_called_once_with("0. Omi [AA:BB]")
+
+
+def test_cli_json_output_is_a_clean_array_and_forwards_timeout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    devices = [
+        SimpleNamespace(name="Omi", address="AA:BB"),
+        SimpleNamespace(name=None, address="CC:DD"),
+    ]
+    with (
+        patch("omi.bluetooth.BleakScanner.discover", return_value=devices) as discover,
+        patch("sys.argv", ["omi-scan", "--json", "--timeout", "3"]),
+    ):
+        main()
+
+    discover.assert_called_once_with(timeout=3.0)
+    assert json.loads(capsys.readouterr().out) == [
+        {"name": "Omi", "address": "AA:BB"},
+        {"name": None, "address": "CC:DD"},
+    ]
+
+
+def test_cli_json_empty_scan_prints_empty_array(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch("omi.bluetooth.BleakScanner.discover", return_value=[]),
+        patch("sys.argv", ["omi-scan", "--json"]),
+    ):
+        main()
+
+    assert capsys.readouterr().out == "[]\n"
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "-inf"])
+def test_cli_rejects_invalid_timeout(value: str) -> None:
+    with (
+        patch("sys.argv", ["omi-scan", "--timeout", value]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 2
+
+
+def test_cli_propagates_adapter_errors() -> None:
+    with (
+        patch(
+            "omi.bluetooth.BleakScanner.discover",
+            side_effect=RuntimeError("adapter unavailable"),
+        ),
+        patch("sys.argv", ["omi-scan"]),
+        pytest.raises(RuntimeError, match="adapter unavailable"),
+    ):
+        main()

--- a/sdks/python/tests/test_bluetooth_scan_cli.py
+++ b/sdks/python/tests/test_bluetooth_scan_cli.py
@@ -17,8 +17,18 @@ def test_print_devices_preserves_human_readable_output() -> None:
     ):
         print_devices()
 
-    discover.assert_called_once_with(timeout=5.0)
+    discover.assert_called_once_with()
     output.assert_called_once_with("0. Omi [AA:BB]")
+
+
+def test_print_devices_json_output_reports_name_and_id(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    devices = [SimpleNamespace(name="Omi", address="AA:BB")]
+    with patch("omi.bluetooth.BleakScanner.discover", return_value=devices):
+        print_devices(json_output=True)
+
+    assert json.loads(capsys.readouterr().out) == [{"name": "Omi", "id": "AA:BB"}]
 
 
 def test_cli_json_output_is_a_clean_array_and_forwards_timeout(
@@ -32,13 +42,16 @@ def test_cli_json_output_is_a_clean_array_and_forwards_timeout(
         patch("omi.bluetooth.BleakScanner.discover", return_value=devices) as discover,
         patch("sys.argv", ["omi-scan", "--json", "--timeout", "3"]),
     ):
-        main()
+        exit_code = main()
 
     discover.assert_called_once_with(timeout=3.0)
-    assert json.loads(capsys.readouterr().out) == [
-        {"name": "Omi", "address": "AA:BB"},
-        {"name": None, "address": "CC:DD"},
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out) == [
+        {"name": "Omi", "id": "AA:BB"},
+        {"name": None, "id": "CC:DD"},
     ]
+    assert captured.err == ""
 
 
 def test_cli_json_empty_scan_prints_empty_array(
@@ -48,29 +61,52 @@ def test_cli_json_empty_scan_prints_empty_array(
         patch("omi.bluetooth.BleakScanner.discover", return_value=[]),
         patch("sys.argv", ["omi-scan", "--json"]),
     ):
+        exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == "[]\n"
+
+
+def test_cli_without_timeout_defers_to_bleak_default() -> None:
+    with (
+        patch("omi.bluetooth.BleakScanner.discover", return_value=[]) as discover,
+        patch("sys.argv", ["omi-scan"]),
+    ):
         main()
 
-    assert capsys.readouterr().out == "[]\n"
+    discover.assert_called_once_with()
 
 
-@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "-inf"])
-def test_cli_rejects_invalid_timeout(value: str) -> None:
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "-inf", "abc"])
+def test_cli_rejects_invalid_timeout_before_scanning(
+    value: str, capsys: pytest.CaptureFixture[str]
+) -> None:
     with (
+        patch("omi.bluetooth.BleakScanner.discover") as discover,
         patch("sys.argv", ["omi-scan", "--timeout", value]),
         pytest.raises(SystemExit) as exc_info,
     ):
         main()
 
     assert exc_info.value.code == 2
+    discover.assert_not_called()
+    assert capsys.readouterr().out == ""
 
 
-def test_cli_propagates_adapter_errors() -> None:
+def test_cli_reports_adapter_failure_on_stderr_and_exits_nonzero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     with (
         patch(
             "omi.bluetooth.BleakScanner.discover",
             side_effect=RuntimeError("adapter unavailable"),
         ),
-        patch("sys.argv", ["omi-scan"]),
-        pytest.raises(RuntimeError, match="adapter unavailable"),
+        patch("sys.argv", ["omi-scan", "--json"]),
     ):
-        main()
+        exit_code = main()
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "adapter unavailable" in captured.err


### PR DESCRIPTION
## Summary

- add `--json` output to `omi-scan` for automation
- add a finite, positive `--timeout` option while preserving the existing human-readable default
- document the options and cover output, validation, empty scans, invalid values, and adapter errors with tests

## Related issue

Addresses #13131.

## Behavior

The JSON form is an array of objects with `name` and `id` fields, where `id` is the device's Bluetooth address — matching the "names and IDs" interface proposed in #13131. An empty scan emits `[]`.

Exit codes and diagnostics follow the issue's acceptance criteria: invalid, non-finite, or non-positive timeouts are rejected before the Bluetooth adapter is invoked (exit 2), and a failed scan prints a single error line on stderr and exits 1, so the `--json` stdout stays parseable. Without `--timeout`, `print_devices()` calls `BleakScanner.discover()` exactly as it did before this PR, keeping Bleak's own default scan window.

The existing human-readable listing and the importable `print_devices()` signature are unchanged; the only new keyword is optional.

## Validation

- `pip install -e ".[dev]"`; `pytest tests/ -q` → 36 passed
- RED/GREEN: stashing only `sdks/python/omi/bluetooth.py` fails 6 of the 12 tests in `tests/test_bluetooth_scan_cli.py`
- Real run of the installed console script on a machine with no BlueZ adapter:
  - `omi-scan --timeout nan` → exit 2, empty stdout, usage error on stderr
  - `omi-scan --json --timeout 0.01` → exit 1, empty stdout, one-line stderr error
- `black --check` / `isort --check-only` clean on the two touched Python files
- `mypy --strict omi/bluetooth.py` reports the same 7 pre-existing errors as this branch's base commit (none introduced here); the one in this file is the pre-existing `start_notify` signature in `listen_to_omi`
- `make preflight` remains blocked by the base repository's manifest references to missing desktop/web paths unrelated to this SDK change

## Disclosure

This is an AI-assisted contribution under @anakinsuper. I reviewed the change and ran the validation listed above. No secrets or payment details are included.

Failure-Class: none
