### PR TITLE
fix(hacker-news): preserve encoded angle-bracket text

### DIFF
--- a/plugins/omi-hacker-news-app/main.py
+++ b/plugins/omi-hacker-news-app/main.py
@@ -39,12 +39,13 @@ def _clean_text(value: Optional[str]) -> str:
     if not value:
         return ""
 
-    text = unescape(value)
+    text = value
     text = re.sub(r"</?(p|pre|blockquote|ul|ol|li)[^>]*>", "\n", text, flags=re.IGNORECASE)
     text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
     text = re.sub(r"<code[^>]*>", "`", text, flags=re.IGNORECASE)
     text = re.sub(r"</code>", "`", text, flags=re.IGNORECASE)
     text = re.sub(r"<[^>]+>", "", text)
+    text = unescape(text)
     text = re.sub(r"[ \t]+", " ", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()


### PR DESCRIPTION
Fixes #13211.

Strip HTML tags before decoding entities, so encoded literal angle brackets are retained.

Validation: Reviewed the targeted change; no full test suite was run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

