### PR TITLE
fix(arxiv): comply with API request interval

### DIFF
--- a/plugins/omi-arxiv-app/main.py
+++ b/plugins/omi-arxiv-app/main.py
@@ -24,7 +24,8 @@ from pydantic import BaseModel
 ARXIV_API_URL = "https://export.arxiv.org/api/query"
 REQUEST_TIMEOUT_SECONDS = 12
 MAX_LIMIT = 10
-MIN_REQUEST_INTERVAL_SECONDS = 0.35
+# arXiv API Terms of Use require clients to wait at least three seconds between requests.
+MIN_REQUEST_INTERVAL_SECONDS = 3.0
 USER_AGENT = "omi-arxiv-app/1.0 (https://omi.me)"
 ATOM_NS = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
 


### PR DESCRIPTION
Fixes #13209.

Set the request interval to arXiv's required three seconds between requests.

Validation: Reviewed the targeted change; no full test suite was run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

