### PR TITLE
fix(cli): complete configured profile names

### DIFF
--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -105,6 +105,10 @@ def _version_callback(value: bool) -> None:
         typer.echo(f"omi-cli {__version__}")
         raise typer.Exit(code=0)
 
+def _profile_completion(incomplete: str) -> list[str]:
+    """Return configured profile names matching the partially typed value."""
+    return [name for name in cfg.load().list_profiles() if name.startswith(incomplete)]
+
 
 @app.callback()
 def _root(
@@ -115,6 +119,7 @@ def _root(
         "--profile",
         "-p",
         help="Profile to use from ~/.omi/config.toml. Falls back to $OMI_PROFILE then 'default'.",
+        autocompletion=_profile_completion,
     ),
     api_base: Optional[str] = typer.Option(
         None,


### PR DESCRIPTION
Fixes #13206.

Add shell completion for configured names passed to --profile.

Validation: Reviewed the targeted change; no full test suite was run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

