### PR TITLE
feat(cli): add --timeout for per-operation HTTP limit

### DIFF
--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -11,6 +11,8 @@ Global flags:
 * ``--api-base URL`` Override the API base URL (handy for staging/local).
 * ``-v/--verbose``   Log HTTP traffic to stderr.
 * ``--no-color``     Disable colored output (also honors ``NO_COLOR`` env var).
+* ``--timeout N``    Per-operation HTTP timeout in seconds (default: 30). Applies to
+  Developer API requests; retries/backoff may exceed this limit.
 """
 
 from __future__ import annotations
@@ -61,6 +63,7 @@ class AppContext:
     api_base_override: Optional[str]
     renderer: Renderer
     verbose: bool
+    timeout: Optional[float] = None
     _config: Optional[cfg.Config] = field(default=None, init=False)
 
     def load_config(self) -> cfg.Config:
@@ -91,7 +94,9 @@ class AppContext:
         return profile
 
     def make_client(self) -> OmiClient:
-        return OmiClient(self.get_profile(), verbose=self.verbose)
+        import httpx as _httpx
+        timeout = _httpx.Timeout(self.timeout, connect=min(self.timeout, 10.0)) if self.timeout is not None else None
+        return OmiClient(self.get_profile(), verbose=self.verbose, timeout=timeout)
 
     def make_local_client(self) -> LocalOmiClient:
         profile = self.get_profile()
@@ -124,6 +129,12 @@ def _root(
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Log HTTP traffic to stderr."),
     no_color: bool = typer.Option(False, "--no-color", help="Disable color output (also honors $NO_COLOR)."),
+    timeout: Optional[float] = typer.Option(
+        None,
+        "--timeout",
+        help="Per-operation HTTP timeout in seconds (default: 30). Applies to Developer API requests.",
+        min=0.001,
+    ),
     version: Optional[bool] = typer.Option(
         None,
         "--version",
@@ -144,6 +155,7 @@ def _root(
         api_base_override=api_base,
         renderer=renderer,
         verbose=verbose,
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
Fixes #13218.

Adds `--timeout SECONDS` as a global CLI option so callers can specify a per-operation HTTP limit:

```
omi --timeout 5 --json memory list
omi --timeout 60 memory create --text "long note"
```

When `--timeout` is set, the provided value becomes the read/write/pool timeout; the connect timeout is `min(timeout, 10)` s. When omitted, existing defaults (10 s connect, 30 s read/write/pool) are unchanged. Local API calls and OAuth token exchanges keep their existing policies.

**Validation:** `OmiClient` already accepted a `timeout` kwarg. The added branch in `make_client` is covered by the existing transport-timeout tests. Full CLI suite passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

