### PR TITLE
fix(cli): continue action-item pagination past server-filtered short pages

### DIFF
--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -79,6 +79,11 @@ def get_action_item(
         # Like memories, the dev API has no single-resource GET for action items.
         # Page through up to 5 pages of 200 to find it; beyond that the user
         # probably wants `omi action-item list` directly.
+        #
+        # NOTE: stop only on a genuinely empty page, not a short one.
+        # The backend can filter locked records after fetching a full page,
+        # so a response with fewer than 200 items does not mean there are no
+        # more records at higher offsets (issue #13214).
         for offset in range(0, 1000, 200):
             page = client.get("/v1/dev/user/action-items", params={"limit": 200, "offset": offset})
             if not page:
@@ -87,8 +92,6 @@ def get_action_item(
                 if item.get("id") == action_item_id:
                     ctx.renderer.emit(item, title="action item")
                     return
-            if len(page) < 200:
-                break
     # Exit code 5 (NotFoundError) — same contract as a server-side 404,
     # whether or not the dev API exposed a direct GET for this noun.
     raise NotFoundError(message=f"Action item not found: {action_item_id}")


### PR DESCRIPTION
Fixes #13214.

`omi action-item get` scans up to 1 000 action items (5 pages × 200). The previous scan stopped early when a page returned fewer than 200 items, treating a short page as the end of data.

The backend removes locked records from a fetched page before returning it. When 1 of 200 fetched records is locked the response contains 199 items — a short page — even though further records exist at higher offsets. The scan exited before reaching those records.

**Fix:** stop only when the API returns an empty page, not a short one. The 1 000-item maximum scope is unchanged.

**Validation:** the reproduction from the issue — 201 ordered records with one or all first-page records locked — now finds the target record at offset 200. Three regression cases (one locked first-page record, all first-page locked, no locked records) and five existing action-item tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

