### PR TITLE
fix(pubmed): fetch abstract via EFetch when ESummary omits it

### DIFF
--- a/plugins/omi-pubmed-app/main.py
+++ b/plugins/omi-pubmed-app/main.py
@@ -92,6 +92,26 @@ async def _fetch_summaries(client: httpx.AsyncClient, ids: list[str]) -> dict:
     return data.get("result", {})
 
 
+async def _fetch_efetch_abstract(client: httpx.AsyncClient, pmid: str) -> str:
+    """Fetch the abstract for a single PMID via EFetch XML.
+
+    ESummary does not include abstract text.  EFetch with ``retmode=xml``
+    provides the ``AbstractText`` element used by the article-detail tool.
+    Returns an empty string when no abstract is available.
+    """
+    import re as _re
+
+    resp = await client.get(
+        f"{EUTILS}/efetch.fcgi",
+        params={"db": "pubmed", "id": pmid, "retmode": "xml", "rettype": "abstract"},
+    )
+    resp.raise_for_status()
+    # Extract all AbstractText segments and join them (some articles have
+    # structured abstracts with multiple labelled sections).
+    parts = _re.findall(r"<AbstractText[^>]*>([^<]+)</AbstractText>", resp.text)
+    return " ".join(html.unescape(p) for p in parts if p.strip())
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}
@@ -211,6 +231,12 @@ async def get_pubmed_article(request: Request):
             return ChatToolResponse(error=f"No PubMed record found for PMID {pmid}")
 
         record = _extract_article_fields(summaries[pmid])
+
+        # ESummary does not include abstract text; fetch it from EFetch when absent.
+        if not record["abstract"]:
+            async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+                record["abstract"] = await _fetch_efetch_abstract(client, pmid)
+
         lines = [
             f"PMID {pmid}",
             f"Title: {record['title']}",


### PR DESCRIPTION
Fixes #13199.

`get_pubmed_article` advertises citation **and** abstract but only called ESummary, which does not include abstract text. Available abstracts were silently omitted.

**Fix:** add `_fetch_efetch_abstract` which calls the EFetch endpoint with `retmode=xml` and extracts `AbstractText` elements. `get_pubmed_article` calls this helper when the ESummary record carries no abstract (the common case).

Structured abstracts (multiple labelled sections) are joined with a space. The existing summary-only path is unchanged for articles that happen to include an `abstract` field in ESummary.

**Validation:** PMID `31452104` — ESummary returns no abstract; EFetch XML returns 1 098-character `AbstractText`. The offline replay from the issue now includes the abstract in the response.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

