### PR TITLE
fix(auth): signal OAuth completion before writing the callback response

### DIFF
--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -442,8 +442,14 @@ def _make_callback_handler(
                     "<p>Close this tab and run <code>omi auth login --browser</code> again.</p>"
                     "</body></html>"
                 )
-            self.wfile.write(body.encode("utf-8"))
+            # Signal completion before writing the HTTP response so that a
+            # browser disconnect during the write does not prevent the CLI
+            # from proceeding with the captured code/state/error values.
             received_event.set()
+            try:
+                self.wfile.write(body.encode("utf-8"))
+            except OSError:
+                pass  # browser already closed — callback was captured above
 
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 — stdlib signature
             # Silence the default access-log noise. The CLI manages its own UX.


### PR DESCRIPTION
Fixes #13215.

`_make_callback_handler` calls `received_event.set()` after `self.wfile.write(body)`. When the browser disconnects during the confirmation-page write, `wfile.write` raises `OSError` and `received_event.set()` is never reached. The CLI then waits for the full `_BROWSER_TIMEOUT_SECONDS` timeout even though a valid `code` and `state` were already stored in `received`.

**Fix:** set the event before writing the HTTP response body and swallow the `OSError`. The callback fields are captured in `received` before any I/O, so a browser disconnect cannot lose them.

**Validation:** four regression cases — disconnect during write with valid code, disconnect with error callback, write succeeds normally, non-callback path — plus the 25-test OAuth suite pass with the patch. The existing failure is in an API-key transport test unrelated to this change and reproduces on the unchanged base.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

