### PR TITLE
(fix) type insertion point fix for Omi Type feature

### DIFF
--- a/.github/failure-classes/FC-advertised-capability-acknowledges-and-drops.json
+++ b/.github/failure-classes/FC-advertised-capability-acknowledges-and-drops.json
@@ -1,0 +1,15 @@
+{
+    "schema_version": 1,
+    "id": "FC-advertised-capability-acknowledges-and-drops",
+    "violated_contract": "A platform capability that is probed as available and then answers the operation with success may still have done nothing, so a delivery path must confirm the effect on the target rather than trust either answer. Voice typing chose an addressed Accessibility write over Cmd-V wherever AXIsAttributeSettable(kAXSelectedTextAttribute) reported the focused field writable, because only a synchronously verified write can offer Undo last dictation. Measured against a real Chrome textarea, Chromium reports that attribute as settable, answers the write with kAXErrorSuccess, and silently drops it — while setting the selected *range* on the same element takes effect and the native omnibox in the same process accepts both, so the element is reachable and its value is not stale. Every browser- and Electron-backed editor, which is most of where people dictate, therefore took a path that could never land, and its verification failure was classified as a possibly-partial mutation, which must not be retried with a paste. The words were lost and the bar said 'Insertion unconfirmed — check the editor', with a working Cmd-V fallback one branch away and never taken.",
+    "canonical_prevention": "Treat a capability probe and an operation's return code as claims to be checked, not as the outcome. The branch that dispatches the privileged operation reads the target back — over a bounded settling window, because an editor applies a write or a keystroke on its own run loop and the first read is too early even for a paste that lands in 37ms — and only a read-back that shows the intended effect counts as success. Then distinguish the two ways it can fail, because they license different recoveries: a target still holding exactly its captured value, caret and revision after an *acknowledged* operation is proof that no part of it landed, which is the one state where retrying through a different mechanism cannot double-apply; a target that changed into anything else, or an operation whose reply was an error or a timeout, may be half-applied and must never be retried. Record the fallback as a capability mismatch rather than a policy choice, so an API that lies about what it supports is countable per app rather than surfacing as an unexplained user report.",
+    "canonical_prevention_artifact": [
+        "desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift"
+    ],
+    "evidence_prs": [],
+    "scope_hints": [
+        "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift",
+        "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift"
+    ],
+    "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3577,7 +3577,7 @@ class PushToTalkManager: ObservableObject {
       case .pasted(let delivered):
         self.voiceTypingLastOutcome.delivery = "pasted"
         self.voiceTypingLastOutcome.characters = delivered.count
-      case .copied(let delivered):
+      case .copied(let delivered, _):
         self.voiceTypingLastOutcome.delivery = "copied"
         self.voiceTypingLastOutcome.characters = delivered.count
       case .pasteRequested(let delivered):

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3471,7 +3471,7 @@ class PushToTalkManager: ObservableObject {
       return run
     }
     run.text = text
-    run.completion = voiceTypeSession.deliver(text)
+    run.completion = await voiceTypeSession.deliver(text)
     return run
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
@@ -50,8 +50,10 @@ enum DictationTextReplacementResult: Equatable {
 
 enum TextInsertionResult: Equatable {
   case inserted
-  /// Legacy paste dispatch is accepted, but its asynchronous result cannot
-  /// support a verified insertion receipt.
+  /// A paste was dispatched and the editor never showed it landing, so it
+  /// carries no insertion receipt. A paste that *is* read back reports
+  /// `inserted` like any other verified insertion — only its Undo is missing,
+  /// because Cmd-V supplies no inserted range to take back.
   case pastePosted
   case notInserted
   /// Text may already be partly or fully present. Do not copy for a retry.
@@ -69,7 +71,11 @@ protocol DictationTextAccess: AnyObject {
 
 @MainActor
 protocol TextInsertionSink: AnyObject {
-  func paste(_ text: String, into target: TextInsertionTarget) -> TextInsertionResult
+  /// Asynchronous because an editor applies an addressed write or a posted
+  /// paste on its own run loop: the insertion is read back once the editor
+  /// has had a bounded moment to apply it, never on the same turn it was
+  /// dispatched.
+  func paste(_ text: String, into target: TextInsertionTarget) async -> TextInsertionResult
   func copy(_ text: String)
   func focusTarget() -> TextInsertionTarget?
   /// Receipt availability only. The action must separately validate the editor.
@@ -95,6 +101,7 @@ final class PasteboardTextInsertionSink: TextInsertionSink {
   private let clipboardPaste: ((String, TextInsertionTarget) -> Bool)?
   private let clipboardCopy: ((String) -> Void)?
   private let sleepForReceiptExpiry: @MainActor (TimeInterval) async throws -> Void
+  private let sleepForVerification: @MainActor (TimeInterval) async throws -> Void
   private var receiptExpiryTask: Task<Void, Never>?
   var insertionReceiptDidChange: (() -> Void)?
   private struct InsertionReceipt {
@@ -112,6 +119,9 @@ final class PasteboardTextInsertionSink: TextInsertionSink {
     clipboardCopy: ((String) -> Void)? = nil,
     sleepForReceiptExpiry: @escaping @MainActor (TimeInterval) async throws -> Void = { remaining in
       try await Task.sleep(for: .seconds(remaining))
+    },
+    sleepForVerification: @escaping @MainActor (TimeInterval) async throws -> Void = { interval in
+      try await Task.sleep(for: .seconds(interval))
     }
   ) {
     self.access = access
@@ -119,42 +129,104 @@ final class PasteboardTextInsertionSink: TextInsertionSink {
     self.clipboardPaste = clipboardPaste
     self.clipboardCopy = clipboardCopy
     self.sleepForReceiptExpiry = sleepForReceiptExpiry
+    self.sleepForVerification = sleepForVerification
   }
 
   deinit { receiptExpiryTask?.cancel() }
 
   func focusTarget() -> TextInsertionTarget? { access.readFocusedText()?.target }
 
-  func paste(_ text: String, into target: TextInsertionTarget) -> TextInsertionResult {
+  func paste(_ text: String, into target: TextInsertionTarget) async -> TextInsertionResult {
     discardInsertionReceipt()
     guard !text.isEmpty, let before = access.readFocusedText(), before.target == target else { return .notInserted }
+    let expected = (before.value as NSString).replacingCharacters(in: before.selection, with: text)
+    let caretAfterInsertion = NSRange(
+      location: before.selection.location + (text as NSString).length, length: 0)
+    var addressedWriteWasDropped = false
     if before.canReplaceSelection {
       // A reported write failure may be partial. Never retry with Cmd-V or
       // restore the whole document after attempting an addressed mutation.
       let replacement = access.replaceSelection(text, in: target)
       guard replacement != .notAttempted else { return .notInserted }
-      let expected = (before.value as NSString).replacingCharacters(in: before.selection, with: text)
-      guard let after = access.readFocusedText(), after.target.isSameField(as: target),
-        after.value == expected,
-        after.selection == NSRange(location: before.selection.location + (text as NSString).length, length: 0)
-      else { return .uncertain }
-      if before.selection.length == 0 {
+      if let after = await settledField(target, showing: expected) {
+        // The exact expected value in the captured field is the insertion.
+        // Where the editor then left the caret is a separate question, and
+        // only the Undo receipt's: an editor that leaves what it inserted
+        // selected, or that parks the caret at the end of the line, has still
+        // inserted it.
+        guard before.selection.length == 0, after.selection == caretAfterInsertion else { return .inserted }
         installInsertionReceipt(
           InsertionReceipt(
             target: after.target,
             insertedRange: NSRange(location: before.selection.location, length: (text as NSString).length),
             originalDigest: target.valueDigest, expiresAt: now() + 30))
+        return .inserted
       }
-      return .inserted
+      // Chromium answers this write with success and silently drops it.
+      // Measured live against a Chrome textarea: `AXSelectedText` reports as
+      // settable, the write returns `kAXErrorSuccess`, and the value never
+      // changes — while setting the selected *range* on that same element
+      // does take effect, so the element is reachable and the value is not
+      // merely stale. Every browser and Electron editor is on that path, and
+      // the turn ended as an unverified insertion with the dictation lost.
+      //
+      // A field that still holds exactly its captured text, caret and
+      // revision after an *acknowledged* write is proof that no part of it
+      // landed — the one case where falling through to Cmd-V cannot
+      // double-insert. An errored or timed-out reply proves nothing (the
+      // editor may still be processing it) and is never retried.
+      guard replacement == .applied, access.readFocusedText()?.target == target else { return .uncertain }
+      addressedWriteWasDropped = true
+    } else {
+      guard access.readFocusedText()?.target == target else { return .notInserted }
     }
-    guard access.readFocusedText()?.target == target else { return .notInserted }
     let pasted = clipboardPaste?(text, target) ?? pasteViaClipboard(text, into: target)
-    if pasted {
-      DesktopDiagnosticsManager.shared.recordFallback(
-        area: "voice_typing", from: "ax_selected_text", to: "clipboard_paste",
-        reason: "policy", outcome: .degraded)
+    guard pasted else { return .notInserted }
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "voice_typing", from: "ax_selected_text", to: "clipboard_paste",
+      reason: addressedWriteWasDropped ? "capability_mismatch" : "policy", outcome: .degraded)
+    // Readable and writable are separate grants: an editor that refuses an
+    // addressed write still reports its value, so the same read-back that
+    // verifies a write verifies the Cmd-V. Only a paste that is never seen to
+    // land stays merely dispatched. Undo is still not offered — Cmd-V hands
+    // back no inserted range to take away.
+    return await settledField(target, showing: expected) == nil ? .pastePosted : .inserted
+  }
+
+  /// How long an editor gets to show an insertion before it is doubted, and
+  /// how the wait is spent: ten reads 30ms apart, under a hard elapsed cap.
+  /// Both bounds matter — every read is a synchronous Accessibility round
+  /// trip, so an app whose AX server is slow or wedged spends far more than
+  /// the interval per read, and the count alone would not bound the turn. The
+  /// whole window stays inside the pasteboard restore delay.
+  private static let verificationReads = 10
+  private static let verificationInterval: TimeInterval = 0.03
+  private static let verificationWindow: TimeInterval = 0.4
+
+  /// The captured field once it shows `expected`, or nil if it never does.
+  ///
+  /// Both an addressed AX write and a posted Cmd-V reach the editor
+  /// asynchronously. AppKit fields apply them before the next read, but
+  /// web-backed and Electron editors apply them a run-loop turn or two later,
+  /// and a single immediate read reported those correct insertions as
+  /// unverified — the dictation was in the field while the bar said
+  /// "Insertion unconfirmed". The read is repeated, briefly, before the
+  /// insertion is doubted.
+  private func settledField(
+    _ target: TextInsertionTarget, showing expected: String
+  ) async -> FocusedDictationText? {
+    let deadline = now() + Self.verificationWindow
+    for read in 0..<Self.verificationReads {
+      if read > 0 {
+        guard now() < deadline else { break }
+        try? await sleepForVerification(Self.verificationInterval)
+      }
+      guard let field = access.readFocusedText(), field.target.isSameField(as: target),
+        field.value == expected
+      else { continue }
+      return field
     }
-    return pasted ? .pastePosted : .notInserted
+    return nil
   }
 
   /// Opening an Omi menu can temporarily hide the focused text element. A

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -92,6 +92,14 @@ final class VoiceTypeSession: ObservableObject {
   private var latch: Latch = .none
   /// The exact field, selection and value revision captured at release.
   private var releaseFocusTarget: TextInsertionTarget?
+  /// Which turn owns the session, bumped whenever one takes it over.
+  ///
+  /// Delivery spans the editor's settling window, so a push-to-talk turn can
+  /// begin while an earlier delivery is still awaiting its read-back. Without
+  /// this, that older turn's epilogue reset the newer turn's state on its way
+  /// out — `latch = .none` sent the second dictation to chat as a question,
+  /// and `captureOwner = nil` left it delivering nothing.
+  private var generation = 0
 
   /// True once this turn has been recognised as a dictation — whether or not
   /// it can be pasted. A blocked turn still owns the turn: the words are
@@ -116,6 +124,7 @@ final class VoiceTypeSession: ObservableObject {
   }
 
   func begin() {
+    generation &+= 1
     latch = .none
     releaseFocusTarget = nil
     captureOwner = captureAuthorization()
@@ -190,10 +199,17 @@ final class VoiceTypeSession: ObservableObject {
   /// ends the turn. If focus has moved since, the text is copied instead —
   /// the user gets it with one ⌘V rather than finding it in the wrong window.
   func deliver(_ text: String) async -> Completion {
+    let generation = self.generation
+    /// Whether this call still owns the session, or a turn has begun under it
+    /// while the editor was settling.
+    func stillOwnsTheSession() -> Bool { generation == self.generation }
     defer {
-      latch = .none
-      releaseFocusTarget = nil
-      captureOwner = nil
+      // Only ever tear down the turn this call actually delivered.
+      if stillOwnsTheSession() {
+        latch = .none
+        releaseFocusTarget = nil
+        captureOwner = nil
+      }
     }
     let blocked = latch == .blocked
     guard latch == .typing || blocked else { return .none }
@@ -241,7 +257,10 @@ final class VoiceTypeSession: ObservableObject {
       invalidateUndoLastDictation()
       return .insertionUncertain(trimmed)
     }
-    insertionOwner = owner
+    // Undo belongs to the turn that made the insertion, and only while that
+    // turn is still the session's: a newer turn must not offer to take back an
+    // older turn's text.
+    if stillOwnsTheSession() { insertionOwner = owner }
     // Bundle id only — never a field value or Accessibility identifier.
     let target = aimed.bundleIdentifier
     log(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -39,15 +39,26 @@ final class VoiceTypeSession: ObservableObject {
   /// dictation joins the conversation history; a turn that never dictated has
   /// nothing to record.
   enum Completion: Equatable {
+    /// Why a turn ended on the clipboard. The two reasons need different words:
+    /// one is a permission the user can turn on, the other is a race with their
+    /// own focus that nothing needs fixing for.
+    enum CopyReason: Equatable {
+      /// No Accessibility grant, so no insertion was attempted at all.
+      case accessibilityDenied
+      /// Omi was allowed to type, but the destination was not there to type
+      /// into: focus moved, or no insertion could be dispatched. The text is on
+      /// the clipboard rather than in the wrong app.
+      case insertionUnavailable
+    }
+
     case none
     /// The exact insertion was read back from the captured field.
     case pasted(String)
     /// Paste was dispatched to the captured app and the editor never showed it
     /// landing. Clipboard restoration still belongs to the sink.
     case pasteRequested(String)
-    /// Focus moved (or the paste could not be posted), so the text was left on
-    /// the clipboard for the user instead of being pasted into the wrong app.
-    case copied(String)
+    /// The text was left on the clipboard instead of being inserted.
+    case copied(String, CopyReason)
     /// The editor may contain a partial insertion. The clipboard is unchanged;
     /// inspect the destination before deciding whether to retry manually.
     case insertionUncertain(String)
@@ -55,7 +66,8 @@ final class VoiceTypeSession: ObservableObject {
     var statusHint: String? {
       switch self {
       case .none, .pasted: return nil
-      case .copied: return "Copied — press ⌘V to paste"
+      case .copied(_, .accessibilityDenied): return "Copied: turn on Accessibility to paste automatically"
+      case .copied(_, .insertionUnavailable): return "Copied: press ⌘V to paste"
       // Plain enough to act on. "Insertion unconfirmed" read to people as an
       // error the dictation had hit, rather than as the one thing it means:
       // the words were sent and Omi could not watch them arrive.
@@ -68,7 +80,15 @@ final class VoiceTypeSession: ObservableObject {
       case .none: return nil
       case .pasted(let text): return "Typed: \(text)"
       case .pasteRequested(let text): return "Paste requested; check the editor: \(text)"
-      case .copied(let text): return "Copied to clipboard: \(text)"
+      // A dictation that lands on the clipboard because the permission is off
+      // reads as Omi failing. Say what to turn on, in the transcript the user
+      // is already looking at — the status hint is gone a moment later, and
+      // nothing else in the turn mentions Accessibility.
+      case .copied(let text, .accessibilityDenied):
+        return "Copied to clipboard: \(text)\n\nTurn on Accessibility for this Omi app "
+          + "(System Settings → Privacy & Security → Accessibility) to have dictation "
+          + "paste at your cursor automatically."
+      case .copied(let text, .insertionUnavailable): return "Copied to clipboard: \(text)"
       case .insertionUncertain(let text):
         return "Dictation insertion unconfirmed; check the editor: \(text)"
       }
@@ -84,7 +104,8 @@ final class VoiceTypeSession: ObservableObject {
     var text: String? {
       switch self {
       case .none: return nil
-      case .pasted(let text), .pasteRequested(let text), .copied(let text), .insertionUncertain(let text): return text
+      case .pasted(let text), .pasteRequested(let text), .copied(let text, _), .insertionUncertain(let text):
+        return text
       }
     }
   }
@@ -226,12 +247,12 @@ final class VoiceTypeSession: ObservableObject {
     guard !blocked, isAccessibilityTrusted() else {
       log("VoiceTypeSession: Accessibility not granted — copied \(trimmed.count) chars instead of pasting")
       copyFallback(trimmed)
-      return .copied(trimmed)
+      return .copied(trimmed, .accessibilityDenied)
     }
     guard let aimed = releaseFocusTarget, sink.focusTarget() == aimed else {
       log("VoiceTypeSession: dictation target unavailable or changed — copied \(trimmed.count) chars instead")
       copyFallback(trimmed)
-      return .copied(trimmed)
+      return .copied(trimmed, .insertionUnavailable)
     }
     let separator = aimed.needsSeparatingSpace ? " " : ""
     switch await sink.paste(separator + trimmed, into: aimed) {
@@ -248,7 +269,7 @@ final class VoiceTypeSession: ObservableObject {
       // Preserve line continuation only when the destination is still the
       // exact unchanged capture.
       copyFallback(sink.focusTarget() == aimed ? separator + trimmed : trimmed)
-      return .copied(trimmed)
+      return .copied(trimmed, .insertionUnavailable)
     case .uncertain:
       log("VoiceTypeSession: insertion could not be verified for \(trimmed.count) chars")
       DesktopDiagnosticsManager.shared.recordFallback(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
@@ -42,8 +42,8 @@ final class VoiceTypeSession: ObservableObject {
     case none
     /// The exact insertion was read back from the captured field.
     case pasted(String)
-    /// Paste was dispatched to the captured app, but its result is asynchronous
-    /// and has not been verified. Clipboard restoration still belongs to the sink.
+    /// Paste was dispatched to the captured app and the editor never showed it
+    /// landing. Clipboard restoration still belongs to the sink.
     case pasteRequested(String)
     /// Focus moved (or the paste could not be posted), so the text was left on
     /// the clipboard for the user instead of being pasted into the wrong app.
@@ -56,8 +56,10 @@ final class VoiceTypeSession: ObservableObject {
       switch self {
       case .none, .pasted: return nil
       case .copied: return "Copied — press ⌘V to paste"
-      case .pasteRequested: return "Paste requested — check the editor"
-      case .insertionUncertain: return "Insertion unconfirmed — check the editor"
+      // Plain enough to act on. "Insertion unconfirmed" read to people as an
+      // error the dictation had hit, rather than as the one thing it means:
+      // the words were sent and Omi could not watch them arrive.
+      case .pasteRequested, .insertionUncertain: return "Couldn't confirm it landed — check the editor"
       }
     }
 
@@ -187,7 +189,7 @@ final class VoiceTypeSession: ObservableObject {
   /// Pastes the dictated text into the app that had focus at release, and
   /// ends the turn. If focus has moved since, the text is copied instead —
   /// the user gets it with one ⌘V rather than finding it in the wrong window.
-  func deliver(_ text: String) -> Completion {
+  func deliver(_ text: String) async -> Completion {
     defer {
       latch = .none
       releaseFocusTarget = nil
@@ -216,11 +218,14 @@ final class VoiceTypeSession: ObservableObject {
       return .copied(trimmed)
     }
     let separator = aimed.needsSeparatingSpace ? " " : ""
-    switch sink.paste(separator + trimmed, into: aimed) {
+    switch await sink.paste(separator + trimmed, into: aimed) {
     case .inserted:
       break
     case .pastePosted:
-      log("VoiceTypeSession: requested paste of \(trimmed.count) chars into \(aimed.bundleIdentifier)")
+      log("VoiceTypeSession: paste of \(trimmed.count) chars into \(aimed.bundleIdentifier) was not read back")
+      DesktopDiagnosticsManager.shared.recordFallback(
+        area: "voice_typing", from: "clipboard_paste", to: "insertion_unconfirmed",
+        reason: "other", outcome: .degraded)
       return .pasteRequested(trimmed)
     case .notInserted:
       log("VoiceTypeSession: no insertion dispatched — copied \(trimmed.count) chars instead")

--- a/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
@@ -84,6 +84,9 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     /// Wall-clock a verification tick costs, for an app whose Accessibility
     /// server answers slowly enough that ten reads would hold the turn.
     var verificationTickCost: TimeInterval = 0
+    /// Runs on each verification tick, so a test can act while a delivery is
+    /// still awaiting its read-back.
+    var onVerificationTick: (() -> Void)?
     var receiptSleeper: (@MainActor (TimeInterval) async throws -> Void)?
     lazy var sink = makeSink()
 
@@ -102,6 +105,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       // decides when the insertion becomes visible, not the wall clock.
       let noVerificationDelay: @MainActor (TimeInterval) async throws -> Void = { [unowned self] _ in
         clock += verificationTickCost
+        onVerificationTick?()
       }
       if let receiptSleeper {
         return PasteboardTextInsertionSink(
@@ -540,6 +544,37 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     // pre-read and the write's guard), then the 0.4s window admits three
     // verification reads at 0.2s a tick — not the ten the count allows.
     XCTAssertEqual(fixture.editor.reads, 7, "the window, not the read count, ended the wait")
+  }
+
+  func testATurnBegunDuringAnEarlierDeliveryKeepsItsOwnState() async {
+    // Delivery now spans the editor's settling window, so the user can start
+    // the next dictation inside it. The older turn's epilogue must not reset
+    // the newer turn on its way out: it used to clear the latch, which sent
+    // the second dictation to chat as a question, and the capture owner,
+    // which left it delivering nothing.
+    let fixture = Fixture()
+    fixture.begin()
+    fixture.editor.appliesWrite = false
+    fixture.editor.replacementResult = .uncertain
+    var started = false
+    fixture.onVerificationTick = {
+      guard !started else { return }
+      started = true
+      fixture.session.begin()
+      XCTAssertTrue(fixture.session.claim(transcript: "Type the second one"))
+    }
+    let first = await fixture.session.deliver("Hello")
+    XCTAssertEqual(first, .insertionUncertain("Hello"))
+    XCTAssertTrue(fixture.session.claimsTurn, "the turn begun mid-delivery still owns the session")
+    XCTAssertFalse(fixture.session.canUndoLastDictation, "and is not offered the older turn's undo")
+
+    fixture.onVerificationTick = nil
+    fixture.editor.appliesWrite = true
+    fixture.editor.replacementResult = .applied
+    fixture.session.noteRelease()
+    let second = await fixture.session.deliver("Second")
+    XCTAssertEqual(second, .pasted("Second"))
+    XCTAssertEqual(fixture.editor.value, "Original Second")
   }
 
   func testCompletionProjectionsNeverDescribeAnUncertainInsertionAsCopiedOrTyped() {

--- a/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
@@ -141,7 +141,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     fixture.begin()
     fixture.editor.field = "second-field"
     let delivered = await fixture.session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertTrue(fixture.editor.writes.isEmpty)
     XCTAssertTrue(fixture.postedPastes.isEmpty)
     XCTAssertEqual(fixture.clipboard, "Hello")
@@ -153,7 +153,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       fixture.begin()
       if moveCaret { fixture.editor.selection.location = 2 } else { fixture.editor.value = "Changed! " }
       let delivered = await fixture.session.deliver("Hello")
-      XCTAssertEqual(delivered, .copied("Hello"))
+      XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
       XCTAssertTrue(fixture.editor.writes.isEmpty)
       XCTAssertTrue(fixture.postedPastes.isEmpty)
     }
@@ -166,7 +166,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       fixture.begin()
       if denied { fixture.trusted = false }
       let delivered = await fixture.session.deliver("Hello")
-      XCTAssertEqual(delivered, .copied("Hello"))
+      XCTAssertEqual(delivered, .copied("Hello", denied ? .accessibilityDenied : .insertionUnavailable))
       XCTAssertTrue(fixture.editor.writes.isEmpty)
       XCTAssertTrue(fixture.postedPastes.isEmpty)
       XCTAssertFalse(fixture.session.canUndoLastDictation)
@@ -298,7 +298,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     fixture.begin()
     fixture.editor.writeSucceeds = false
     let delivered = await fixture.session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertTrue(fixture.postedPastes.isEmpty)
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
@@ -310,7 +310,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     fixture.begin()
     fixture.editor.writeSucceeds = false
     let delivered = await fixture.session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertEqual(fixture.clipboard, " Hello")
     XCTAssertEqual(fixture.editor.value, "Original")
     XCTAssertTrue(fixture.postedPastes.isEmpty)
@@ -590,10 +590,22 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     XCTAssertEqual(requested.text, "Hello")
     XCTAssertFalse(requested.isConfirmedDelivery)
 
-    let copied = VoiceTypeSession.Completion.copied("Hello")
-    XCTAssertEqual(copied.statusHint, "Copied — press ⌘V to paste")
+    let copied = VoiceTypeSession.Completion.copied("Hello", .insertionUnavailable)
+    XCTAssertEqual(copied.statusHint, "Copied: press ⌘V to paste")
     XCTAssertEqual(copied.journalAcknowledgement, "Copied to clipboard: Hello")
     XCTAssertTrue(copied.isConfirmedDelivery)
+
+    // The permission is the one thing here the user can act on, and the status
+    // hint is gone a moment later — so the transcript has to carry it.
+    let blocked = VoiceTypeSession.Completion.copied("Hello", .accessibilityDenied)
+    XCTAssertEqual(blocked.statusHint, "Copied: turn on Accessibility to paste automatically")
+    XCTAssertEqual(
+      blocked.journalAcknowledgement,
+      "Copied to clipboard: Hello\n\nTurn on Accessibility for this Omi app "
+        + "(System Settings → Privacy & Security → Accessibility) to have dictation "
+        + "paste at your cursor automatically.")
+    XCTAssertEqual(blocked.text, "Hello")
+    XCTAssertTrue(blocked.isConfirmedDelivery)
 
     let pasted = VoiceTypeSession.Completion.pasted("Hello")
     XCTAssertNil(pasted.statusHint)

--- a/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypeTargetSafetyTests.swift
@@ -14,12 +14,30 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     var writeSucceeds = true
     var appliesWrite = true
     var replacementResult: DictationTextReplacementResult = .applied
+    /// Reads that must pass before an applied write becomes visible, the way a
+    /// web-backed editor applies one on a later run-loop turn.
+    var readsBeforeWriteIsVisible = 0
+    /// Where the editor parks the caret once it has applied the write, for
+    /// editors that do not collapse it after the inserted text.
+    var caretAfterWrite: NSRange?
+    private var pendingWrite: (value: String, selection: NSRange)?
+    private(set) var reads = 0
     var writes: [String] = []
     var didSelect: (() -> Void)?
     var didWrite: (() -> Void)?
 
     func readFocusedText() -> FocusedDictationText? {
+      reads += 1
       guard readable else { return nil }
+      if let pendingWrite {
+        if readsBeforeWriteIsVisible > 0 {
+          readsBeforeWriteIsVisible -= 1
+        } else {
+          value = pendingWrite.value
+          selection = pendingWrite.selection
+          self.pendingWrite = nil
+        }
+      }
       return FocusedDictationText(
         elementID: AnyHashable(field), processID: 42, bundleIdentifier: "test.editor",
         value: value, selection: selection, canReplaceSelection: writable)
@@ -29,8 +47,15 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       guard writeSucceeds, readFocusedText()?.target == target else { return .notAttempted }
       writes.append(text)
       if appliesWrite {
-        value = (value as NSString).replacingCharacters(in: selection, with: text)
-        selection = NSRange(location: selection.location + (text as NSString).length, length: 0)
+        let written = (value as NSString).replacingCharacters(in: selection, with: text)
+        let caret =
+          caretAfterWrite ?? NSRange(location: selection.location + (text as NSString).length, length: 0)
+        if readsBeforeWriteIsVisible > 0 {
+          pendingWrite = (written, caret)
+        } else {
+          value = written
+          selection = caret
+        }
       }
       didWrite?()
       return replacementResult
@@ -53,24 +78,41 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     var clock: TimeInterval = 100
     var clipboard = "User clipboard"
     var postedPastes: [String] = []
+    /// Whether a dispatched Cmd-V reaches the editor, as it does in an app
+    /// that reads the pasteboard but exposes no writable selected text.
+    var pasteLands = false
+    /// Wall-clock a verification tick costs, for an app whose Accessibility
+    /// server answers slowly enough that ten reads would hold the turn.
+    var verificationTickCost: TimeInterval = 0
     var receiptSleeper: (@MainActor (TimeInterval) async throws -> Void)?
     lazy var sink = makeSink()
 
     private func makeSink() -> PasteboardTextInsertionSink {
       let paste: (String, TextInsertionTarget) -> Bool = { [unowned self] text, _ in
         postedPastes.append(text)
+        if pasteLands {
+          editor.value = (editor.value as NSString).replacingCharacters(in: editor.selection, with: text)
+          editor.selection = NSRange(
+            location: editor.selection.location + (text as NSString).length, length: 0)
+        }
         return true
       }
       let copy: (String) -> Void = { [unowned self] in clipboard = $0 }
+      // Verification polling runs its reads back to back: the editor fake
+      // decides when the insertion becomes visible, not the wall clock.
+      let noVerificationDelay: @MainActor (TimeInterval) async throws -> Void = { [unowned self] _ in
+        clock += verificationTickCost
+      }
       if let receiptSleeper {
         return PasteboardTextInsertionSink(
           access: editor, now: { [unowned self] in clock },
           clipboardPaste: paste, clipboardCopy: copy,
-          sleepForReceiptExpiry: receiptSleeper)
+          sleepForReceiptExpiry: receiptSleeper, sleepForVerification: noVerificationDelay)
       }
       return PasteboardTextInsertionSink(
         access: editor, now: { [unowned self] in clock },
-        clipboardPaste: paste, clipboardCopy: copy)
+        clipboardPaste: paste, clipboardCopy: copy,
+        sleepForVerification: noVerificationDelay)
     }
 
     lazy var session = VoiceTypeSession(
@@ -84,53 +126,57 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       XCTAssertTrue(session.claim(transcript: "Type hello"))
     }
 
-    func deliver(_ text: String = "Hello") {
-      XCTAssertEqual(session.deliver(text), .pasted(text))
+    func deliver(_ text: String = "Hello") async {
+      let delivered = await session.deliver(text)
+      XCTAssertEqual(delivered, .pasted(text))
     }
   }
 
-  func testSwitchingFieldsInTheSameAppCopiesInsteadOfWriting() {
+  func testSwitchingFieldsInTheSameAppCopiesInsteadOfWriting() async {
     let fixture = Fixture()
     fixture.begin()
     fixture.editor.field = "second-field"
-    XCTAssertEqual(fixture.session.deliver("Hello"), .copied("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertTrue(fixture.editor.writes.isEmpty)
     XCTAssertTrue(fixture.postedPastes.isEmpty)
     XCTAssertEqual(fixture.clipboard, "Hello")
   }
 
-  func testMovingCaretOrEditingTheSameFieldInvalidatesCapture() {
+  func testMovingCaretOrEditingTheSameFieldInvalidatesCapture() async {
     for moveCaret in [true, false] {
       let fixture = Fixture()
       fixture.begin()
       if moveCaret { fixture.editor.selection.location = 2 } else { fixture.editor.value = "Changed! " }
-      XCTAssertEqual(fixture.session.deliver("Hello"), .copied("Hello"))
+      let delivered = await fixture.session.deliver("Hello")
+      XCTAssertEqual(delivered, .copied("Hello"))
       XCTAssertTrue(fixture.editor.writes.isEmpty)
       XCTAssertTrue(fixture.postedPastes.isEmpty)
     }
   }
 
-  func testUnreadableTargetAndRevokedAccessibilityCopySafely() {
+  func testUnreadableTargetAndRevokedAccessibilityCopySafely() async {
     for denied in [true, false] {
       let fixture = Fixture()
       if !denied { fixture.editor.readable = false }
       fixture.begin()
       if denied { fixture.trusted = false }
-      XCTAssertEqual(fixture.session.deliver("Hello"), .copied("Hello"))
+      let delivered = await fixture.session.deliver("Hello")
+      XCTAssertEqual(delivered, .copied("Hello"))
       XCTAssertTrue(fixture.editor.writes.isEmpty)
       XCTAssertTrue(fixture.postedPastes.isEmpty)
       XCTAssertFalse(fixture.session.canUndoLastDictation)
     }
   }
 
-  func testReadableEditorWithoutWritableAXRequestsPasteWithoutClaimingDelivery() {
+  func testReadableEditorWithoutWritableAXRequestsPasteWithoutClaimingDelivery() async {
     let fixture = Fixture()
     fixture.editor.writable = false
     fixture.begin()
-    let completion = fixture.session.deliver("Hello")
+    let completion = await fixture.session.deliver("Hello")
     XCTAssertEqual(completion, .pasteRequested("Hello"))
     XCTAssertFalse(completion.isConfirmedDelivery)
-    XCTAssertEqual(completion.statusHint, "Paste requested — check the editor")
+    XCTAssertEqual(completion.statusHint, "Couldn't confirm it landed — check the editor")
     XCTAssertEqual(fixture.postedPastes, ["Hello"])
     XCTAssertEqual(fixture.clipboard, "User clipboard", "no copy-for-retry fallback follows a dispatched paste")
     XCTAssertFalse(fixture.session.canUndoLastDictation)
@@ -138,22 +184,23 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     XCTAssertTrue(fixture.editor.writes.isEmpty)
   }
 
-  func testSinkReportsPasteDispatchSeparatelyFromVerifiedInsertion() throws {
+  func testSinkReportsPasteDispatchSeparatelyFromVerifiedInsertion() async throws {
     let fixture = Fixture()
     fixture.editor.writable = false
     let target = try XCTUnwrap(fixture.sink.focusTarget())
-    XCTAssertEqual(fixture.sink.paste("Hello", into: target), .pastePosted)
+    let result = await fixture.sink.paste("Hello", into: target)
+    XCTAssertEqual(result, .pastePosted)
     XCTAssertEqual(fixture.postedPastes, ["Hello"])
     XCTAssertFalse(fixture.sink.canUndoInsertion)
     XCTAssertEqual(fixture.editor.value, "Original ", "dispatch alone supplies no insertion evidence")
   }
 
-  func testVerifiedInsertionUndoDeletesOnlyDictationAndPreservesClipboard() {
+  func testVerifiedInsertionUndoDeletesOnlyDictationAndPreservesClipboard() async {
     let fixture = Fixture()
     fixture.editor.value = "Original"
     fixture.editor.selection.location = 8
     fixture.begin()
-    fixture.deliver("Hello 🌍")
+    await fixture.deliver("Hello 🌍")
     XCTAssertEqual(fixture.editor.value, "Original Hello 🌍")
     // Successful manager terminal cleanup must not revoke the receipt.
     fixture.session.abandon()
@@ -166,20 +213,20 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     XCTAssertFalse(fixture.session.undoLastDictation())
   }
 
-  func testReplacingSelectedContentDoesNotOfferDestructiveUndo() {
+  func testReplacingSelectedContentDoesNotOfferDestructiveUndo() async {
     let fixture = Fixture()
     fixture.editor.selection = NSRange(location: 0, length: 8)
     fixture.begin()
-    fixture.deliver()
+    await fixture.deliver()
     XCTAssertEqual(fixture.editor.value, "Hello ")
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
 
-  func testUserEditOrCaretMoveRevokesUndoWithoutTouchingTheirWork() {
+  func testUserEditOrCaretMoveRevokesUndoWithoutTouchingTheirWork() async {
     for moveCaret in [true, false] {
       let fixture = Fixture()
       fixture.begin()
-      fixture.deliver()
+      await fixture.deliver()
       if moveCaret { fixture.editor.selection.location = 1 } else { fixture.editor.value += " My next edit" }
       let expected = fixture.editor.value
       XCTAssertFalse(fixture.session.undoLastDictation())
@@ -188,39 +235,40 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     }
   }
 
-  func testUndoRevalidatesContentAfterSelectingTheInsertedRange() {
+  func testUndoRevalidatesContentAfterSelectingTheInsertedRange() async {
     let fixture = Fixture()
     fixture.begin()
-    fixture.deliver()
+    await fixture.deliver()
     fixture.editor.didSelect = { fixture.editor.value += " Concurrent user edit" }
     XCTAssertFalse(fixture.session.undoLastDictation())
     XCTAssertEqual(fixture.editor.value, "Original Hello Concurrent user edit")
     XCTAssertEqual(fixture.editor.writes, ["Hello"])
   }
 
-  func testNewTurnAndExpiryRevokeUndo() {
+  func testNewTurnAndExpiryRevokeUndo() async {
     for newTurn in [true, false] {
       let fixture = Fixture()
       fixture.begin()
-      fixture.deliver()
+      await fixture.deliver()
       if newTurn { fixture.session.begin() } else { fixture.clock += 30 }
       XCTAssertFalse(fixture.session.undoLastDictation())
       XCTAssertEqual(fixture.editor.value, "Original Hello")
     }
   }
 
-  func testOwnerChangeAndSameOwnerReauthenticationRevokeUndoAndDelivery() {
+  func testOwnerChangeAndSameOwnerReauthenticationRevokeUndoAndDelivery() async {
     for sameOwner in [true, false] {
       for delivered in [true, false] {
         let fixture = Fixture()
         fixture.begin()
-        if delivered { fixture.deliver() }
+        if delivered { await fixture.deliver() }
         fixture.authority.beginTransition()
         if !sameOwner { fixture.owner = "owner-B" }
         fixture.authority.endTransition(ownerID: fixture.owner)
         XCTAssertFalse(fixture.session.undoLastDictation())
         if !delivered {
-          XCTAssertEqual(fixture.session.deliver("Hello"), .none)
+          let delivered = await fixture.session.deliver("Hello")
+          XCTAssertEqual(delivered, .none)
           XCTAssertTrue(fixture.editor.writes.isEmpty)
         }
         XCTAssertEqual(fixture.clipboard, "User clipboard")
@@ -228,11 +276,12 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     }
   }
 
-  func testSuccessfulAXReplyWithoutVerifiedTextReportsUncertaintyWithoutCopying() {
+  func testSuccessfulAXReplyWithoutVerifiedTextReportsUncertaintyWithoutCopying() async {
     let fixture = Fixture()
     fixture.begin()
     fixture.editor.didWrite = { fixture.editor.value = "Unexpected editor contents" }
-    XCTAssertEqual(fixture.session.deliver("Hello"), .insertionUncertain("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .insertionUncertain("Hello"))
     XCTAssertEqual(fixture.editor.writes, ["Hello"])
     XCTAssertEqual(fixture.editor.value, "Unexpected editor contents")
     XCTAssertEqual(fixture.clipboard, "User clipboard")
@@ -240,32 +289,34 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
 
-  func testFailedAddressedWriteDoesNotRetryAnUncertainMutationWithPaste() {
+  func testFailedAddressedWriteDoesNotRetryAnUncertainMutationWithPaste() async {
     let fixture = Fixture()
     fixture.begin()
     fixture.editor.writeSucceeds = false
-    XCTAssertEqual(fixture.session.deliver("Hello"), .copied("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertTrue(fixture.postedPastes.isEmpty)
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
 
-  func testFailedWriteKeepsSeparatorForManualPasteIntoUnchangedTarget() {
+  func testFailedWriteKeepsSeparatorForManualPasteIntoUnchangedTarget() async {
     let fixture = Fixture()
     fixture.editor.value = "Original"
     fixture.editor.selection = NSRange(location: 8, length: 0)
     fixture.begin()
     fixture.editor.writeSucceeds = false
-    XCTAssertEqual(fixture.session.deliver("Hello"), .copied("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertEqual(fixture.clipboard, " Hello")
     XCTAssertEqual(fixture.editor.value, "Original")
     XCTAssertTrue(fixture.postedPastes.isEmpty)
   }
 
-  func testMenuFocusAvailabilityReadsPreserveReceiptUntilTheAction() {
+  func testMenuFocusAvailabilityReadsPreserveReceiptUntilTheAction() async {
     for menuHasReadableElement in [true, false] {
       let fixture = Fixture()
       fixture.begin()
-      fixture.deliver()
+      await fixture.deliver()
       fixture.editor.readable = menuHasReadableElement
       fixture.editor.field = "menu"
       XCTAssertTrue(fixture.session.canUndoLastDictation)
@@ -279,11 +330,11 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     }
   }
 
-  func testAvailabilityDoesNotAuthorizeUndoIntoAMenuOrAnotherField() {
+  func testAvailabilityDoesNotAuthorizeUndoIntoAMenuOrAnotherField() async {
     for readable in [true, false] {
       let fixture = Fixture()
       fixture.begin()
-      fixture.deliver()
+      await fixture.deliver()
       fixture.editor.readable = readable
       fixture.editor.field = "second-field"
       XCTAssertTrue(fixture.session.canUndoLastDictation)
@@ -310,7 +361,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       }
     }
     fixture.begin()
-    fixture.deliver()
+    await fixture.deliver()
     await fulfillment(of: [sleeperStarted], timeout: 1)
     let expired = expectation(description: "receipt expiry published")
     var publications = 0
@@ -332,11 +383,11 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     subscription.cancel()
   }
 
-  func testOwnerRevocationAndExpiryStillOverrideMenuAvailability() {
+  func testOwnerRevocationAndExpiryStillOverrideMenuAvailability() async {
     for expire in [true, false] {
       let fixture = Fixture()
       fixture.begin()
-      fixture.deliver()
+      await fixture.deliver()
       fixture.editor.readable = false
       XCTAssertTrue(fixture.session.canUndoLastDictation)
       if expire { fixture.clock += 30 } else { fixture.authority.beginTransition() }
@@ -347,7 +398,7 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     }
   }
 
-  func testPartialMutationWithFailedAXReplyIsUncertainAndNeverCopiedForRetry() {
+  func testPartialMutationWithFailedAXReplyIsUncertainAndNeverCopiedForRetry() async {
     let fixture = Fixture()
     fixture.begin()
     // Models AXUIElementSetAttributeValue returning a failure after only part
@@ -357,7 +408,8 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
       fixture.editor.value = "Original Hel"
       fixture.editor.selection = NSRange(location: 12, length: 0)
     }
-    XCTAssertEqual(fixture.session.deliver("Hello"), .insertionUncertain("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .insertionUncertain("Hello"))
     XCTAssertEqual(fixture.editor.value, "Original Hel")
     XCTAssertEqual(fixture.editor.writes, ["Hello"])
     XCTAssertEqual(fixture.clipboard, "User clipboard")
@@ -365,38 +417,140 @@ final class VoiceTypeTargetSafetyTests: XCTestCase {
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
 
-  func testFailedDispatchedAXRequestWithUnchangedRereadRemainsUncertain() {
+  func testFailedDispatchedAXRequestWithUnchangedRereadRemainsUncertain() async {
     let fixture = Fixture()
     fixture.begin()
     fixture.editor.appliesWrite = false
     fixture.editor.replacementResult = .uncertain
-    XCTAssertEqual(fixture.session.deliver("Hello"), .insertionUncertain("Hello"))
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .insertionUncertain("Hello"))
     XCTAssertEqual(fixture.editor.value, "Original ")
     XCTAssertEqual(fixture.clipboard, "User clipboard")
     XCTAssertTrue(fixture.postedPastes.isEmpty)
     XCTAssertFalse(fixture.session.canUndoLastDictation)
   }
 
-  func testFailedAXReplyWithExactVerifiedResultIsAConfirmedInsertion() {
+  func testFailedAXReplyWithExactVerifiedResultIsAConfirmedInsertion() async {
     let fixture = Fixture()
     fixture.begin()
     fixture.editor.replacementResult = .uncertain
-    fixture.deliver()
+    await fixture.deliver()
     XCTAssertEqual(fixture.editor.value, "Original Hello")
     XCTAssertTrue(fixture.session.undoLastDictation())
     XCTAssertEqual(fixture.editor.value, "Original ")
     XCTAssertEqual(fixture.clipboard, "User clipboard")
   }
 
+  func testAnEditorThatAppliesTheWriteOnALaterReadIsAConfirmedInsertion() async {
+    // Web-backed and Electron editors apply an addressed write a run-loop turn
+    // or two after the request. A single immediate read called those correct
+    // insertions unverified, and the bar sent the user off to check an editor
+    // that already had the dictation in it.
+    let fixture = Fixture()
+    fixture.begin()
+    fixture.editor.readsBeforeWriteIsVisible = 3
+    await fixture.deliver()
+    XCTAssertEqual(fixture.editor.value, "Original Hello")
+    XCTAssertTrue(fixture.session.canUndoLastDictation)
+  }
+
+  func testAnEditorThatParksTheCaretElsewhereStillConfirmsTheInsertion() async {
+    // The exact expected value is in the captured field, so the text landed.
+    // Where the editor then left the caret is the receipt's business.
+    let fixture = Fixture()
+    fixture.begin()
+    fixture.editor.caretAfterWrite = NSRange(location: 0, length: 0)
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .pasted("Hello"))
+    XCTAssertEqual(fixture.editor.value, "Original Hello")
+    XCTAssertEqual(fixture.clipboard, "User clipboard")
+    XCTAssertFalse(fixture.session.canUndoLastDictation, "no verified caret, no range to take back")
+  }
+
+  func testAPasteReadBackFromTheEditorIsAConfirmedInsertion() async {
+    let fixture = Fixture()
+    fixture.editor.writable = false
+    fixture.pasteLands = true
+    fixture.begin()
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .pasted("Hello"))
+    XCTAssertEqual(fixture.postedPastes, ["Hello"])
+    XCTAssertEqual(fixture.editor.value, "Original Hello")
+    XCTAssertEqual(fixture.clipboard, "User clipboard", "a landed paste is never copied for retry")
+    XCTAssertFalse(fixture.session.canUndoLastDictation, "Cmd-V hands back no inserted range")
+  }
+
+  func testAnAcknowledgedWriteThatChangedNothingFallsBackToPaste() async {
+    // The Chromium shape, measured live: AXSelectedText reports settable, the
+    // write is answered with success, and the field is untouched. Before this
+    // the turn ended as an unverified insertion and the dictation was lost.
+    let fixture = Fixture()
+    fixture.editor.appliesWrite = false
+    fixture.pasteLands = true
+    fixture.begin()
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .pasted("Hello"))
+    XCTAssertEqual(fixture.editor.writes, ["Hello"], "the addressed write is still tried first")
+    XCTAssertEqual(fixture.postedPastes, ["Hello"])
+    XCTAssertEqual(fixture.editor.value, "Original Hello")
+    XCTAssertEqual(fixture.clipboard, "User clipboard")
+    XCTAssertFalse(fixture.session.canUndoLastDictation, "Cmd-V hands back no inserted range")
+  }
+
+  func testADroppedWriteThatCannotBePastedEitherIsReportedNotTyped() async {
+    let fixture = Fixture()
+    fixture.editor.appliesWrite = false
+    fixture.begin()
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .pasteRequested("Hello"))
+    XCTAssertEqual(fixture.postedPastes, ["Hello"])
+    XCTAssertEqual(fixture.editor.value, "Original ")
+    XCTAssertEqual(fixture.clipboard, "User clipboard", "a dispatched paste is never copied for retry")
+  }
+
+  func testAnEditorThatMovedUnderAnAcknowledgedWriteIsNeverRetriedWithPaste() async {
+    // Anything other than the captured field, caret and revision may hold a
+    // half-applied write. Only an untouched field earns the Cmd-V retry.
+    let fixture = Fixture()
+    fixture.begin()
+    fixture.editor.didWrite = {
+      fixture.editor.value = "Original Hel"
+      fixture.editor.selection = NSRange(location: 12, length: 0)
+    }
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .insertionUncertain("Hello"))
+    XCTAssertTrue(fixture.postedPastes.isEmpty)
+    XCTAssertEqual(fixture.clipboard, "User clipboard")
+  }
+
+  func testASlowAccessibilityServerCannotStretchVerificationPastItsWindow() async {
+    // Every read is a synchronous AX round trip. Against an app whose AX
+    // server answers slowly, the read count alone would let verification hold
+    // the turn for seconds, so the elapsed window ends it first.
+    let fixture = Fixture()
+    fixture.begin()
+    // An errored reply keeps the turn on the single verification pass: an
+    // acknowledged write that changed nothing goes on to Cmd-V instead.
+    fixture.editor.appliesWrite = false
+    fixture.editor.replacementResult = .uncertain
+    fixture.verificationTickCost = 0.2
+    let delivered = await fixture.session.deliver("Hello")
+    XCTAssertEqual(delivered, .insertionUncertain("Hello"))
+    // Two capture reads (release, delivery) and two inside the paste (its own
+    // pre-read and the write's guard), then the 0.4s window admits three
+    // verification reads at 0.2s a tick — not the ten the count allows.
+    XCTAssertEqual(fixture.editor.reads, 7, "the window, not the read count, ended the wait")
+  }
+
   func testCompletionProjectionsNeverDescribeAnUncertainInsertionAsCopiedOrTyped() {
     let uncertain = VoiceTypeSession.Completion.insertionUncertain("Hello")
-    XCTAssertEqual(uncertain.statusHint, "Insertion unconfirmed — check the editor")
+    XCTAssertEqual(uncertain.statusHint, "Couldn't confirm it landed — check the editor")
     XCTAssertEqual(uncertain.journalAcknowledgement, "Dictation insertion unconfirmed; check the editor: Hello")
     XCTAssertEqual(uncertain.text, "Hello")
     XCTAssertFalse(uncertain.isConfirmedDelivery)
 
     let requested = VoiceTypeSession.Completion.pasteRequested("Hello")
-    XCTAssertEqual(requested.statusHint, "Paste requested — check the editor")
+    XCTAssertEqual(requested.statusHint, "Couldn't confirm it landed — check the editor")
     XCTAssertEqual(requested.journalAcknowledgement, "Paste requested; check the editor: Hello")
     XCTAssertEqual(requested.text, "Hello")
     XCTAssertFalse(requested.isConfirmedDelivery)

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -121,7 +121,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     var caretAfterWord = false
     var focus: String? = "1:com.example.editor"
 
-    func paste(_ text: String, into target: TextInsertionTarget) -> TextInsertionResult {
+    func paste(_ text: String, into target: TextInsertionTarget) async -> TextInsertionResult {
       guard pasteSucceeds, focusTarget() == target else { return .notInserted }
       pasted.append(text)
       return .inserted
@@ -152,33 +152,36 @@ final class VoiceTypeSessionTests: XCTestCase {
     return (session, sink)
   }
 
-  func testAClosingTranscriptThatOpensWithTheWakeWordIsPastedWhole() {
+  func testAClosingTranscriptThatOpensWithTheWakeWordIsPastedWhole() async {
     let (session, sink) = makeSession()
     XCTAssertEqual(session.payload(from: "Type hello world."), "Hello world.")
     XCTAssertTrue(session.claimsTurn)
-    XCTAssertEqual(session.deliver("Hello world."), .pasted("Hello world."))
+    let delivered = await session.deliver("Hello world.")
+    XCTAssertEqual(delivered, .pasted("Hello world."))
     XCTAssertEqual(sink.pasted, ["Hello world."])
     XCTAssertTrue(sink.copied.isEmpty)
     XCTAssertFalse(session.claimsTurn, "delivery ends the turn")
   }
 
-  func testAQuestionIsLeftToChatAndNothingIsPasted() {
+  func testAQuestionIsLeftToChatAndNothingIsPasted() async {
     let (session, sink) = makeSession()
     XCTAssertNil(session.payload(from: "what's on my calendar tomorrow"))
     XCTAssertFalse(session.claimsTurn)
-    XCTAssertEqual(session.deliver("what's on my calendar tomorrow"), .none)
+    let delivered = await session.deliver("what's on my calendar tomorrow")
+    XCTAssertEqual(delivered, .none)
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertTrue(sink.copied.isEmpty)
   }
 
-  func testAProbeClaimLatchesAndTheClosingTranscriptIsReadLeniently() {
+  func testAProbeClaimLatchesAndTheClosingTranscriptIsReadLeniently() async {
     // The mid-hold probe heard the wake word; the closing transcript, from the
     // backend, spelled it differently. The turn stays a dictation and the
     // stray word is dropped rather than pasted.
     let (session, sink) = makeSession()
     XCTAssertTrue(session.claim(transcript: "Type hello wor"))
     XCTAssertEqual(session.payload(from: "Tie, hello world, how are you?"), "Hello world, how are you?")
-    XCTAssertEqual(session.deliver("Hello world, how are you?"), .pasted("Hello world, how are you?"))
+    let delivered = await session.deliver("Hello world, how are you?")
+    XCTAssertEqual(delivered, .pasted("Hello world, how are you?"))
     XCTAssertEqual(sink.pasted, ["Hello world, how are you?"])
   }
 
@@ -201,7 +204,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertEqual(session.payload(from: "Type hello"), "Hello")
   }
 
-  func testWithoutAccessibilityTheTurnStillDictatesButCopiesInsteadOfPasting() {
+  func testWithoutAccessibilityTheTurnStillDictatesButCopiesInsteadOfPasting() async {
     // Regression for #12877: a "type …" turn with no Accessibility grant used
     // to release itself to the realtime model once blocked, which then acted
     // on the words as an instruction (spawned an agent) instead of dictating
@@ -211,18 +214,20 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertTrue(session.claim(transcript: "Type hello"), "a blocked turn still claims itself")
     XCTAssertEqual(session.payload(from: "Type hello again"), "Hello again", "one denied turn stays denied")
     XCTAssertTrue(session.claimsTurn)
-    XCTAssertEqual(session.deliver("Hello again"), .copied("Hello again"))
+    let delivered = await session.deliver("Hello again")
+    XCTAssertEqual(delivered, .copied("Hello again"))
     XCTAssertTrue(sink.pasted.isEmpty, "no Accessibility grant means no paste is even attempted")
     XCTAssertEqual(sink.copied, ["Hello again"])
   }
 
-  func testADictationThatContinuesALineOpensWithASpace() {
+  func testADictationThatContinuesALineOpensWithASpace() async {
     let (session, sink) = makeSession()
     sink.caretAfterWord = true
     session.noteRelease()
     XCTAssertNotNil(session.payload(from: "Type I think so"))
     // The space is on screen but not part of what the turn dictated.
-    XCTAssertEqual(session.deliver("I think so"), .pasted("I think so"))
+    let delivered = await session.deliver("I think so")
+    XCTAssertEqual(delivered, .pasted("I think so"))
     XCTAssertEqual(sink.pasted, [" I think so"])
   }
 
@@ -238,89 +243,97 @@ final class VoiceTypeSessionTests: XCTestCase {
     }
   }
 
-  func testADictationAtALineStartAddsNoSpace() {
+  func testADictationAtALineStartAddsNoSpace() async {
     let (session, sink) = makeSession()
     sink.caretAfterWord = false
     XCTAssertNotNil(session.payload(from: "Type hello"))
-    _ = session.deliver("Hello")
+    _ = await session.deliver("Hello")
     XCTAssertEqual(sink.pasted, ["Hello"])
   }
 
-  func testFocusThatMovedAfterReleaseCopiesInsteadOfPasting() {
+  func testFocusThatMovedAfterReleaseCopiesInsteadOfPasting() async {
     // Observed live before this existed: a dock click brought Omi's own window
     // forward and the dictation landed in it instead of the document.
     let (session, sink) = makeSession()
     XCTAssertNotNil(session.payload(from: "Type hello world"))
     sink.focus = "2:com.omi.desktop-dev"
-    XCTAssertEqual(session.deliver("Hello world"), .copied("Hello world"))
+    let delivered = await session.deliver("Hello world")
+    XCTAssertEqual(delivered, .copied("Hello world"))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello world"])
   }
 
-  func testAnUnreadableFocusAtReleaseCopiesInsteadOfGuessing() {
+  func testAnUnreadableFocusAtReleaseCopiesInsteadOfGuessing() async {
     let sink = RecordingSink()
     sink.focus = nil
     let session = authorizedSession(sink: sink)
     session.begin()
     session.noteRelease()
     XCTAssertNotNil(session.payload(from: "Type hello"))
-    XCTAssertEqual(session.deliver("Hello"), .copied("Hello"))
+    let delivered = await session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello"])
   }
 
-  func testFocusThatBecameUnreadableAfterReleaseCopies() {
+  func testFocusThatBecameUnreadableAfterReleaseCopies() async {
     let (session, sink) = makeSession()
     XCTAssertNotNil(session.payload(from: "Type hello"))
     sink.focus = nil
-    XCTAssertEqual(session.deliver("Hello"), .copied("Hello"))
+    let delivered = await session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello"])
   }
 
-  func testAFailedPasteFallsBackToTheClipboard() {
+  func testAFailedPasteFallsBackToTheClipboard() async {
     let (session, sink) = makeSession()
     sink.pasteSucceeds = false
     XCTAssertNotNil(session.payload(from: "Type hello"))
-    XCTAssertEqual(session.deliver("Hello"), .copied("Hello"))
+    let delivered = await session.deliver("Hello")
+    XCTAssertEqual(delivered, .copied("Hello"))
     XCTAssertEqual(sink.copied, ["Hello"])
   }
 
-  func testEmptyTextDeliversNothing() {
+  func testEmptyTextDeliversNothing() async {
     let (session, sink) = makeSession()
     XCTAssertEqual(session.payload(from: "Type."), "")
-    XCTAssertEqual(session.deliver("   "), .none)
+    let delivered = await session.deliver("   ")
+    XCTAssertEqual(delivered, .none)
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertTrue(sink.copied.isEmpty)
   }
 
-  func testTextWithNothingInItDeliversNothing() {
+  func testTextWithNothingInItDeliversNothing() async {
     // A breath decoded as "." or "…" is not a dictation: nothing is pasted
     // and nothing is left on the clipboard.
     for text in [".", "…", ", ,", "?!"] {
       let (session, sink) = makeSession()
       XCTAssertNotNil(session.payload(from: "Type hello"))
-      XCTAssertEqual(session.deliver(text), .none, text)
+      let delivered = await session.deliver(text)
+      XCTAssertEqual(delivered, .none, text)
       XCTAssertTrue(sink.pasted.isEmpty)
       XCTAssertTrue(sink.copied.isEmpty)
     }
   }
 
-  func testANewTurnForgetsThePreviousClaim() {
+  func testANewTurnForgetsThePreviousClaim() async {
     let (session, sink) = makeSession()
     XCTAssertTrue(session.claim(transcript: "Type hello"))
     session.begin()
     XCTAssertFalse(session.claimsTurn)
-    XCTAssertEqual(session.deliver("Hello"), .none)
+    let delivered = await session.deliver("Hello")
+    XCTAssertEqual(delivered, .none)
     XCTAssertTrue(sink.pasted.isEmpty)
   }
 
-  func testAbandonEndsTheTurnWithoutDelivering() {
+  func testAbandonEndsTheTurnWithoutDelivering() async {
     let (session, sink) = makeSession()
     XCTAssertTrue(session.claim(transcript: "Type hello"))
     session.abandon()
     XCTAssertFalse(session.claimsTurn)
-    XCTAssertEqual(session.deliver("Hello"), .none)
+    let delivered = await session.deliver("Hello")
+    XCTAssertEqual(delivered, .none)
     XCTAssertTrue(sink.pasted.isEmpty)
   }
 }

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -215,8 +215,11 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertEqual(session.payload(from: "Type hello again"), "Hello again", "one denied turn stays denied")
     XCTAssertTrue(session.claimsTurn)
     let delivered = await session.deliver("Hello again")
-    XCTAssertEqual(delivered, .copied("Hello again"))
+    XCTAssertEqual(delivered, .copied("Hello again", .accessibilityDenied))
     XCTAssertTrue(sink.pasted.isEmpty, "no Accessibility grant means no paste is even attempted")
+    XCTAssertEqual(
+      delivered.journalAcknowledgement?.contains("Turn on Accessibility"), true,
+      "the transcript is where the user finds out why their dictation did not land at the cursor")
     XCTAssertEqual(sink.copied, ["Hello again"])
   }
 
@@ -258,7 +261,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertNotNil(session.payload(from: "Type hello world"))
     sink.focus = "2:com.omi.desktop-dev"
     let delivered = await session.deliver("Hello world")
-    XCTAssertEqual(delivered, .copied("Hello world"))
+    XCTAssertEqual(delivered, .copied("Hello world", .insertionUnavailable))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello world"])
   }
@@ -271,7 +274,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     session.noteRelease()
     XCTAssertNotNil(session.payload(from: "Type hello"))
     let delivered = await session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello"])
   }
@@ -281,7 +284,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     XCTAssertNotNil(session.payload(from: "Type hello"))
     sink.focus = nil
     let delivered = await session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertTrue(sink.pasted.isEmpty)
     XCTAssertEqual(sink.copied, ["Hello"])
   }
@@ -291,7 +294,7 @@ final class VoiceTypeSessionTests: XCTestCase {
     sink.pasteSucceeds = false
     XCTAssertNotNil(session.payload(from: "Type hello"))
     let delivered = await session.deliver("Hello")
-    XCTAssertEqual(delivered, .copied("Hello"))
+    XCTAssertEqual(delivered, .copied("Hello", .insertionUnavailable))
     XCTAssertEqual(sink.copied, ["Hello"])
   }
 

--- a/desktop/macos/changelog/unreleased/20260908-voice-typing-insertion-confirmed.json
+++ b/desktop/macos/changelog/unreleased/20260908-voice-typing-insertion-confirmed.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed voice typing losing a dictation in browsers and Electron apps, where it reported \"Insertion unconfirmed\" instead of typing the text"
+}


### PR DESCRIPTION
## What broke

Saying **"type …"** into Chrome, Slack, VS Code — any browser- or Electron-backed
editor — lost the dictation and left `Insertion unconfirmed — check the editor`
in the notch.

Voice typing prefers an addressed Accessibility write (`AXSelectedText` on the
captured field) over `⌘V`, because only a synchronously verified write can offer
*Undo last dictation*. It takes that path whenever
`AXIsAttributeSettable(kAXSelectedTextAttribute)` says the field is writable.

## Measured, not inferred

An AX probe making exactly the calls the sink makes, against a real Chrome
textarea (throwaway instance, own profile, background window):

```
AXSelectedText settable        -> true
set AXSelectedText             -> kAXErrorSuccess, value unchanged after 2s
set AXSelectedTextRange (same element) -> kAXErrorSuccess, selection actually moved
Cmd-V, window focused          -> landed after 37ms, visible on read 2
```

Chromium advertises the attribute as settable, acknowledges the write with
success, and silently drops it. The value is not stale: the selected *range*
set on that same element takes effect, and the native omnibox in the same
process accepts both. So every browser and Electron editor took the addressed
path, the read-back never matched, and the turn ended `.uncertain` — which
deliberately does **not** copy for retry, so the words were simply gone.

## The fix

1. **A provably dropped write falls through to `⌘V`.** A field still holding
   exactly its captured text, caret and revision after an *acknowledged* write
   is proof that no part of it landed — the one case where `⌘V` cannot
   double-insert. An errored or timed-out reply still proves nothing and is
   still never retried. The fallback records `capability_mismatch` rather than
   `policy`.

   That precondition is measured, not assumed: replaying the production
   sequence against Chrome, the field after the dropped write is byte-identical
   — `value="Original "`, `selection={9, 0}`, `digest=9feb5fc02300` before and
   after — so the fallback does fire. Had Chromium's no-op nudged the caret,
   this fix would have sat there doing nothing.
2. **Verification settles instead of reading once.** The old code re-read the
   field on the same turn it dispatched the write; the measurement above shows
   even a 37ms paste is invisible to that first read. Now: ten reads 30ms apart
   under a hard 400ms elapsed cap, so a slow or wedged AX server cannot stretch
   the turn either.
3. **The value is the insertion; the caret is only the receipt's business.** A
   verified value was being called uncertain when the editor left the caret
   anywhere but collapsed after the insertion. A caret mismatch now costs the
   turn its Undo, not its confirmation.
4. **The `⌘V` path is verified by the same read-back**, so a paste that is seen
   to land is a confirmed insertion instead of `Paste requested — check the
   editor` on every dictation into such an app. Undo is still not offered
   there: `⌘V` hands back no inserted range to take away.
5. What stays genuinely unverifiable says so in plainer words
   (`Couldn't confirm it landed — check the editor`), and a paste that is never
   read back records a fallback, so the next occurrence is countable.

Delivery safety is unchanged: a possibly-partial mutation is never retried with
a paste, a dispatched paste is never copied for retry, and Undo still requires
an exactly verified field, value and caret.

## Two follow-ups in this PR

**A regression this PR introduced, caught in review.** Awaiting the read-back
gives delivery a window in which the *next* push-to-talk turn can begin, and
`deliver`'s epilogue reset the session unconditionally on its way out. The older
turn cleared the newer one: `latch = .none` dropped the claim, sending the
second dictation to chat as a question, and `captureOwner = nil` left it
delivering nothing. Pressing again promptly after a dictation was enough. The
session now carries a generation bumped by `begin()`; a delivery only tears down
the turn it delivered, and only that turn may take the Undo receipt.

**Saying which clipboard fallback happened.** A dictation reaching the clipboard
has two quite different causes, and one line served both. A missing
Accessibility grant now says so, and the journal entry — which outlives the
status hint — names the pane to turn it on in. Everything else keeps the plain
⌘V line.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Both are path-matched. Neither changes: the dictation is still journaled once
per turn through the same exchange (INV-CHAT-1), and the voice-turn lifecycle
owner and its terminal reasons are untouched — only the sink's insertion
verdict and the hint text it produces (INV-VOICE-1).

## Failure class (fixes)

Failure-Class: new

New class `FC-advertised-capability-acknowledges-and-drops`, defined in this PR:
a platform capability probe answered `true`, the operation it gated answered
`success`, and nothing happened. The delivery path trusted both answers, had a
working fallback one branch away, and never took it. The guard that
generalises: confirm the effect by reading the target back over a bounded
settling window, and treat a *provably untouched* target — the one state that
cannot be half-applied — as licence to fall back.

## Verification

- `xcrun swift test --filter VoiceType` in `desktop/macos/Desktop` — **74 tests,
  0 failures**.
- Seven new tests. **Negative controls, each run:** with the old single read,
  the caret requirement and no fallback restored, the insertion tests fail —
  the Chromium-shaped one reporting exactly the `insertionUncertain` completion
  users saw; with the turn-ownership test forced to always pass, the
  concurrency test fails on all three of its claims.
- `make preflight` — **24/24 checks pass**.
- The live AX probe above. The focused `⌘V` check restored the frontmost
  application and the pasteboard; the throwaway Chrome instance and its profile
  were deleted afterwards. Nothing in the user's own browser was touched.
- `python3 scripts/check_desktop_test_quality.py` — at or below baseline.
- Pre-existing and unrelated: a full `xcrun swift test` of the package crashes
  the xctest process (signal 5, AddressBook CoreData XPC) and leaves 2
  `JITProactivityRuntime` failures. Both reproduce with these files reverted to
  `origin/main`; the crashing suite passes in isolation.
- **Not** exercised as a live Omi dictation: that needs a held hotkey and speech
  at the machine's keyboard, plus an Accessibility grant a fresh named bundle
  does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YAvWj7NGZqFRw6AensUhy
