### PR TITLE
fix(desktop): defer native PTT evidence attach until its journal row exists

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -36,9 +36,16 @@ extension RealtimeHubController {
       createdAt: capturedAt)
   }
 
-  /// Resolves one native OCR result. The journal update is queued through the
-  /// same streaming write tail when available and otherwise targets the exact
-  /// stable user turn ID; no active-turn lookup can redirect it to a later PTT.
+  /// Resolves one native OCR result. When the streaming write tail already
+  /// contains this continuity key, the journal update is queued behind the
+  /// record task. When the producing user row is already known
+  /// (`journalUserTurnID`) and streaming has not begun — or has already
+  /// finalized — the update attaches directly to that row. When no producing
+  /// row is known yet, the resolved evidence stays on the ledger so the
+  /// projection constructor, `persistNativeEvidenceAfterJournalAdmission`, or
+  /// `bindNativeTurnEvidenceToProducingRow` can attach it after admission.
+  /// Never synthesize a stable user turn ID for an UPDATE against a row that
+  /// does not exist yet.
   func resolveNativeTurnEvidence(
     turnID: VoiceTurnID,
     ownerID: String,
@@ -67,20 +74,21 @@ extension RealtimeHubController {
       ? .unavailable
       : (evidence.extractionCompleteness == .partial ? .partial : .complete)
     guard turnEvidenceLedger.resolve(key: key, evidence: evidence, state: state) else { return }
-    guard let surface = entry.surface else { return }
-    let userTurnID =
-      entry.journalUserTurnID
-      ?? KernelTurnProjection.stableTurnID(continuityKey: continuityKey, role: "user")
     if streamingJournalWriteLedger.contains(continuityKey: continuityKey) {
       enqueueNativeEvidenceUpdate(continuityKey: continuityKey, evidence: evidence)
       return
     }
+    guard let surface = entry.surface, let userTurnID = entry.journalUserTurnID else { return }
     Task { @MainActor [weak self] in
       guard let self,
         RuntimeOwnerIdentity.currentOwnerId() == ownerID,
         let current = self.turnEvidenceLedger.evidence(for: key)
       else { return }
-      let accepted = await FloatingControlBarManager.shared.attachRealtimeUserEvidence(
+      if self.streamingJournalWriteLedger.contains(continuityKey: continuityKey) {
+        self.enqueueNativeEvidenceUpdate(continuityKey: continuityKey, evidence: current)
+        return
+      }
+      let accepted = await self.attachResolvedNativeUserEvidence(
         surface: surface,
         ownerID: ownerID,
         userTurnID: userTurnID,
@@ -92,6 +100,25 @@ extension RealtimeHubController {
       _ = self.turnEvidenceLedger.markEvidencePersisted(key: key)
       _ = self.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: userTurnID)
     }
+  }
+
+  /// Single attach seam so tests can observe the UPDATE without a kernel journal.
+  func attachResolvedNativeUserEvidence(
+    surface: AgentSurfaceReference,
+    ownerID: String,
+    userTurnID: String,
+    evidence: ConversationEvidence
+  ) async -> Bool {
+    #if DEBUG
+      if let hook = turnEvidenceLedger.testingAttachRealtimeUserEvidence {
+        return await hook(surface, ownerID, userTurnID, evidence)
+      }
+    #endif
+    return await FloatingControlBarManager.shared.attachRealtimeUserEvidence(
+      surface: surface,
+      ownerID: ownerID,
+      userTurnID: userTurnID,
+      evidence: evidence)
   }
 
   /// Terminal OCR already bound to this exact owner/turn reservation, if any.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift
@@ -373,6 +373,10 @@ extension RealtimeHubController {
             // Cancel any streaming projection that may have started before the
             // spawn receipt arrived; the spawn owns the canonical exchange now.
             self.cancelStreamingJournalWrites(forContinuityKey: receipt.continuityKey)
+            self.bindNativeTurnEvidenceToProducingRow(
+              turnID: turnID,
+              journalUserTurnID: KernelTurnProjection.stableTurnID(
+                continuityKey: receipt.continuityKey, role: "user"))
             self.lastTurnDiagnostics = [
               "provider": self.providerTag,
               "provider_transcript": self.turnTranscript,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+StreamingJournal.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+StreamingJournal.swift
@@ -88,26 +88,22 @@ extension RealtimeHubController {
   ) {
     guard streamingJournalWriteLedger.contains(continuityKey: continuityKey) else { return }
     streamingJournalWriteLedger.enqueueUpdate(continuityKey: continuityKey) { [weak self] projection in
-      let accepted = await FloatingControlBarManager.shared.attachRealtimeUserEvidence(
+      guard let self else { return false }
+      let accepted = await self.attachResolvedNativeUserEvidence(
         surface: projection.admissionSurface,
         ownerID: projection.ownerID,
         userTurnID: projection.userTurnID,
         evidence: evidence)
-      if accepted, let self,
-        let turnID = Self.turnID(forVoiceContinuityKey: projection.continuityKey)
-      {
-        let key = RealtimeTurnEvidenceLedger.Key(
-          ownerID: projection.ownerID,
-          turnID: turnID,
-          continuityKey: projection.continuityKey)
+      guard let turnID = Self.turnID(forVoiceContinuityKey: projection.continuityKey) else {
+        return accepted
+      }
+      let key = RealtimeTurnEvidenceLedger.Key(
+        ownerID: projection.ownerID,
+        turnID: turnID,
+        continuityKey: projection.continuityKey)
+      if accepted {
         _ = self.turnEvidenceLedger.markEvidencePersisted(key: key)
-      } else if !accepted, let self,
-        let turnID = Self.turnID(forVoiceContinuityKey: projection.continuityKey)
-      {
-        let key = RealtimeTurnEvidenceLedger.Key(
-          ownerID: projection.ownerID,
-          turnID: turnID,
-          continuityKey: projection.continuityKey)
+      } else {
         _ = self.turnEvidenceLedger.markPersistenceFailed(key: key)
       }
       return accepted
@@ -128,13 +124,14 @@ extension RealtimeHubController {
     let key = RealtimeTurnEvidenceLedger.Key(
       ownerID: ownerID, turnID: turnID, continuityKey: continuityKey)
     guard let entry = turnEvidenceLedger.entry(for: key) else { return true }
-    guard entry.state != .pending else { return true }
-    if entry.evidencePersisted { return true }
-    guard let evidence = entry.evidence else { return true }
     let userTurnID =
       entry.journalUserTurnID
       ?? KernelTurnProjection.stableTurnID(continuityKey: continuityKey, role: "user")
-    let accepted = await FloatingControlBarManager.shared.attachRealtimeUserEvidence(
+    _ = turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: userTurnID)
+    guard entry.state != .pending else { return true }
+    if entry.evidencePersisted { return true }
+    guard let evidence = entry.evidence else { return true }
+    let accepted = await attachResolvedNativeUserEvidence(
       surface: entry.surface ?? FloatingControlBarManager.shared.mainChatSurfaceReference(),
       ownerID: ownerID,
       userTurnID: userTurnID,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeTurnEvidence.swift
@@ -43,6 +43,14 @@ final class RealtimeTurnEvidenceLedger {
 
   var count: Int { entries.count }
 
+  #if DEBUG
+    /// Hermetic observation seam for native-evidence attach tests. Production
+    /// attaches through `FloatingControlBarManager`; tests inject this to count
+    /// and order writes without a live kernel journal.
+    var testingAttachRealtimeUserEvidence:
+      (@MainActor (AgentSurfaceReference, String, String, ConversationEvidence) async -> Bool)?
+  #endif
+
   func begin(
     ownerID: String,
     turnID: VoiceTurnID,

--- a/desktop/macos/Desktop/Tests/RealtimeTurnEvidenceTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeTurnEvidenceTests.swift
@@ -511,6 +511,157 @@ final class RealtimeTurnEvidenceTests: XCTestCase {
     XCTAssertTrue(ledger.resolve(key: key, evidence: evidence, state: .complete))
     XCTAssertEqual(ledger.evidence(for: key), evidence)
   }
+
+  func testOCRBeforeJournalRowDoesNotAttachAndLaterAdmissionCarriesEvidence() async throws {
+    try await withNativeEvidenceTestOwner { ownerID in
+      let controller = RealtimeHubController()
+      let turnID = VoiceTurnID()
+      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+      let key = try XCTUnwrap(
+        controller.turnEvidenceLedger.begin(
+          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+      var attachCount = 0
+      controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, _, _ in
+        attachCount += 1
+        return true
+      }
+
+      controller.resolveNativeTurnEvidence(
+        turnID: turnID,
+        ownerID: ownerID,
+        capturedAt: Date(timeIntervalSince1970: 11),
+        text: "form instructions")
+
+      XCTAssertEqual(attachCount, 0)
+      let resolved = try XCTUnwrap(controller.turnEvidenceLedger.evidence(for: key))
+      XCTAssertEqual(resolved.bodyText, "form instructions")
+      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+      XCTAssertNil(controller.turnEvidenceLedger.entry(for: key)?.journalUserTurnID)
+
+      let projection = RealtimeStreamingJournalProjection(
+        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface,
+        evidence: [resolved])
+      XCTAssertEqual(projection.userMessage(text: "which form?").metadata?.evidence, [resolved])
+
+      XCTAssertTrue(
+        controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: projection.userTurnID))
+      let persisted = await controller.persistNativeEvidenceAfterJournalAdmission(
+        ownerID: ownerID, continuityKey: continuityKey)
+      XCTAssertTrue(persisted)
+      XCTAssertEqual(attachCount, 1)
+      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+    }
+  }
+
+  func testOCRAfterBoundUserRowAndFinalizedStreamingAttachesOnce() async throws {
+    try await withNativeEvidenceTestOwner { ownerID in
+      let controller = RealtimeHubController()
+      let turnID = VoiceTurnID()
+      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+      let producingRow = KernelTurnProjection.stableTurnID(continuityKey: continuityKey, role: "user")
+      let key = try XCTUnwrap(
+        controller.turnEvidenceLedger.begin(
+          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+      XCTAssertTrue(controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: producingRow))
+
+      let projection = RealtimeStreamingJournalProjection(
+        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+      XCTAssertTrue(
+        controller.streamingJournalWriteLedger.begin(projection: projection) { _ in true })
+      let finalized = await controller.streamingJournalWriteLedger.finalize(
+        continuityKey: continuityKey
+      ) { _ in true }
+      XCTAssertEqual(finalized, .completed(true))
+      XCTAssertFalse(controller.streamingJournalWriteLedger.contains(continuityKey: continuityKey))
+
+      var attachedTurnIDs: [String] = []
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, userTurnID, _ in
+          attachedTurnIDs.append(userTurnID)
+          continuation.resume()
+          return true
+        }
+        controller.resolveNativeTurnEvidence(
+          turnID: turnID,
+          ownerID: ownerID,
+          capturedAt: Date(timeIntervalSince1970: 12),
+          text: "visible form")
+      }
+
+      XCTAssertEqual(attachedTurnIDs, [producingRow])
+      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+    }
+  }
+
+  func testOCRWhileStreamingLedgerContainsKeyWaitsForRecordTask() async throws {
+    try await withNativeEvidenceTestOwner { ownerID in
+      let controller = RealtimeHubController()
+      let turnID = VoiceTurnID()
+      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+      let key = try XCTUnwrap(
+        controller.turnEvidenceLedger.begin(
+          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+      let projection = RealtimeStreamingJournalProjection(
+        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+      let recordLatch = MainActorLatch()
+      var events: [String] = []
+      XCTAssertTrue(
+        controller.streamingJournalWriteLedger.begin(projection: projection) { _ in
+          await recordLatch.wait()
+          events.append("record")
+          return true
+        })
+      await Task.yield()
+
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, _, _ in
+          events.append("attach")
+          continuation.resume()
+          return true
+        }
+        controller.resolveNativeTurnEvidence(
+          turnID: turnID,
+          ownerID: ownerID,
+          capturedAt: Date(timeIntervalSince1970: 13),
+          text: "streaming screen")
+        XCTAssertEqual(events, [])
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+        recordLatch.release()
+      }
+
+      XCTAssertEqual(events, ["record", "attach"])
+      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+    }
+  }
+}
+
+@MainActor
+private func withNativeEvidenceTestOwner(
+  _ body: (String) async throws -> Void
+) async throws {
+  if let ownerID = RuntimeOwnerIdentity.currentOwnerId() {
+    try await body(ownerID)
+    return
+  }
+  let defaults = UserDefaults.standard
+  let previous = defaults.string(forKey: .authUserId)
+  let ownerID = "evidence-attach-\(UUID().uuidString.lowercased())"
+  defaults.set(ownerID, forKey: .authUserId)
+  defer {
+    if let previous {
+      defaults.set(previous, forKey: .authUserId)
+    } else {
+      defaults.removeObject(forKey: .authUserId)
+    }
+  }
+  guard RuntimeOwnerIdentity.currentOwnerId() == ownerID else {
+    throw XCTSkip("could not install a test owner identity")
+  }
+  try await body(ownerID)
 }
 
 @MainActor

--- a/desktop/macos/changelog/unreleased/20260908-ptt-native-evidence-attach-admission.json
+++ b/desktop/macos/changelog/unreleased/20260908-ptt-native-evidence-attach-admission.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed voice turns dropping the on-screen context captured when you pressed the talk button"
+}


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Fixes #13205. Native PTT OCR could finish before the streaming journal inserted the user row; `resolveNativeTurnEvidence` then synthesized a stable turn ID and ran an UPDATE-only attach, which failed with a missing-row RPC, logged `journal_evidence_append_failed`, and marked the ledger `persistenceFailed`. Direct attach now runs only when `journalUserTurnID` is already bound; otherwise the resolved evidence stays on the ledger for the projection constructor / post-admission persist / producing-row bind. If streaming starts while the deferred attach is in flight, the write joins the ordered tail. Accepted `spawn_agent` receipts now bind the producing user row immediately, because that path creates the kernel row without the streaming constructor.

## Product invariants affected

- INV-CHAT-1

## How it was verified

Swift unit tests only. Installed binaries were **not** rebuilt or live-tested (restored authenticated QA sessions took precedence). Pre-fix live evidence is in issue #13205.

```
cd desktop/macos && xcrun swift test --package-path Desktop --filter 'RealtimeTurnEvidenceTests|RealtimeHubBargeInContinuityTests'
```
93 tests, 0 failures (RealtimeTurnEvidenceTests 26/26 including 3 new admission tests; RealtimeHubBargeInContinuityTests 67/67).

```
cd desktop/macos && ./scripts/agent-logic-harness.sh --swift-only
```
Passed (focused Swift lifecycle/state tests, 33s).

```
python3 desktop/macos/scripts/check_desktop_test_quality.py
```
OK.

## Tests

`RealtimeTurnEvidenceTests` now drives `resolveNativeTurnEvidence` through an injectable attach seam:

1. OCR before any journal row / streaming ledger → no attach, ledger keeps evidence with `persistenceFailed == false`, later `persistNativeEvidenceAfterJournalAdmission` carries it.
2. OCR after `journalUserTurnID` is bound and streaming has finalized → direct attach exactly once.
3. OCR while the streaming ledger contains the key → attach is enqueued behind the record task.

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

Caller audit of `voice:<uuid>` user-row creation:

- Streaming constructor includes ledger evidence and `attachJournalUserTurn`.
- Non-streaming `recordExchange` includes evidence, binds the row, then `persistNativeEvidenceAfterJournalAdmission`.
- Dictation / typed fallback call `bindNativeTurnEvidenceToProducingRow`.
- Spawn-accepted receipts created the kernel row without any of those; this PR adds `bindNativeTurnEvidenceToProducingRow` there. `persistNativeEvidenceAfterJournalAdmission` also binds `journalUserTurnID` while OCR is still pending so a later resolve can attach.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionDelegate.swift | 1588 -> 1592 | Bind native PTT evidence to the spawn-admitted user row.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

