### PR TITLE
feat(desktop): add Silent Type to keep dictation out of the chat context

### DIFF
--- a/.github/failure-classes/FC-suppression-latched-after-recovery-window.json
+++ b/.github/failure-classes/FC-suppression-latched-after-recovery-window.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-suppression-latched-after-recovery-window",
+  "violated_contract": "A suppression that must keep interrupted-turn recovery from re-journaling a deliberately unwritten turn has to be standing before any failure path can read it, not only once the protected lifecycle completes. Silent Type armed `journalSuppressedContinuityKey` solely in the dictation delivery close path, so a realtime provider failure or a barge-in while the dictation was still finalizing reached `captureInterruptedTurnPayloadIfNeeded` with no receipt to stand down on: recovery awaited the language-identifier verdict and journaled the exact text the toggle exists to keep out of the chat.",
+  "canonical_prevention": "Arm the receipt at the boundary that opens the protected lifecycle — turn start — and derive every later decision in that lifecycle from the value read at that boundary, so a mid-flight flip cannot split the turn. End the suppression where the turn provably changes kind (a hub commit is a question, whose provider-failure continuity depends on recovery), not where the protected content first appears. Regression coverage drives the real recovery seam with the receipt armed at turn start and fails when the arm is removed.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift",
+    "desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift",
+    "desktop/macos/Desktop/Tests/VoiceTypingSilentModeTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/FloatingControlBar/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -128,6 +128,9 @@ enum DefaultsKey: String {
   /// One-shot marker: the PTT-only microphone choice has been folded into the shared
   /// `preferredMicrophoneDeviceUID`, so it is never carried over twice.
   case shortcutPTTMicrophoneMergedIntoPreferred = "shortcut_pttMicrophoneMergedIntoPreferred"
+  /// Silent Type: a dictation still types into the focused app, but the turn is
+  /// never written to the chat transcript. Absent means off.
+  case shortcutSilentTypeEnabled = "shortcut_silentTypeEnabled"
   case floatingBarNotificationPreviewsEnabled = "shortcut_floatingBarNotificationPreviewsEnabled"
   case floatingBarCachedPlan = "floatingBar_cachedPlan"
   case floatingBarCachedDesktopGrandfatherUntil = "floatingBar_cachedDesktopGrandfatherUntil"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -791,6 +791,7 @@ class PushToTalkManager: ObservableObject {
     seenFinalSegmentIDs.removeAll()
     lastInterimText = ""
     voiceTypeSession.begin()
+    latchSilentTypeForTurnStart(turnID: currentVoiceTurnID)
     resetVoiceTypingSources()
     voiceTypingLastOutcome = VoiceTypingOutcome()
     currentContextSnapshot = nil
@@ -863,6 +864,7 @@ class PushToTalkManager: ObservableObject {
       seenFinalSegmentIDs.removeAll()
       lastInterimText = ""
       voiceTypeSession.begin()
+      latchSilentTypeForTurnStart(turnID: currentVoiceTurnID)
       resetVoiceTypingSources()
       voiceTypingLastOutcome = VoiceTypingOutcome()
       currentContextSnapshot = nil
@@ -3172,6 +3174,29 @@ class PushToTalkManager: ObservableObject {
   }
   private var voiceTypingLastOutcome = VoiceTypingOutcome()
 
+  /// Silent Type for the current turn, read once at turn start. A mid-turn flip
+  /// must not split a turn: the delivery close path decides with the value the
+  /// turn started under, not whatever the toggle reads seconds later.
+  private var voiceTypingSilentTypeEnabled = false
+
+  /// Latches Silent Type at turn start, before anything can fail mid-turn.
+  ///
+  /// The delivery close path used to be the only place that named the turn as
+  /// suppressed — but a realtime provider failure while the dictation is still
+  /// finalizing reaches interrupted-turn recovery earlier, and recovery with no
+  /// receipt to stand down on journals the very text the toggle keeps out of
+  /// the chat. Arming at turn start means every recovery path mid-turn sees the
+  /// receipt. The toggle is read once per turn, so a mid-turn flip cannot
+  /// produce half-suppressed behavior. A turn that reaches the hub's commit is
+  /// a question, and `RealtimeHubController.commitTurn` ends the suppression
+  /// there; until then a question that dies mid-hold also stands recovery down
+  /// — the fail-closed direction for a privacy toggle.
+  func latchSilentTypeForTurnStart(turnID: VoiceTurnID?) {
+    voiceTypingSilentTypeEnabled = ShortcutSettings.shared.silentTypeEnabled
+    guard voiceTypingSilentTypeEnabled, let turnID else { return }
+    RealtimeHubController.shared.suppressJournalRecoveryAtTurnStart(turnID: turnID)
+  }
+
   private func resetVoiceTypingSources() {
     voiceTypingProbeSchedule.reset()
     voiceTypingOpeningDecoder.reset()
@@ -3596,8 +3621,10 @@ class PushToTalkManager: ObservableObject {
         transcriptLength: self.voiceTypingLastOutcome.characters)
       self.terminateVoiceTypingLifecycle(
         disposition: run.completion.isConfirmedDelivery ? .committed : .cancelled, totalSec: totalSec)
+      // The turn-start latch, not a fresh read: a mid-turn flip must not split
+      // a turn between suppressed and journaled behavior.
       let record = VoiceTypingChatRecordPolicy.decide(
-        silentTypeEnabled: ShortcutSettings.shared.silentTypeEnabled)
+        silentTypeEnabled: voiceTypingSilentTypeEnabled)
       if !record.journalsExchange {
         // Both consequences of not writing: the reserved native source has no
         // producing row to attach to, and recovery must not resurrect the

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -3596,25 +3596,37 @@ class PushToTalkManager: ObservableObject {
         transcriptLength: self.voiceTypingLastOutcome.characters)
       self.terminateVoiceTypingLifecycle(
         disposition: run.completion.isConfirmedDelivery ? .committed : .cancelled, totalSec: totalSec)
-      // The journal write is awaited before the turn ends, so a lifecycle
-      // change at turn end cannot drop it; the wait is bounded so a slow
-      // bridge cannot hold the bar, and the write itself is not cancelled
-      // at the bound — it finishes in the background.
-      let utterance = run.transcript ?? ""
-      let completion = run.completion
-      // Register the write under the native `voice:<uuid>` identity before the
-      // bounded wait so a timeout+cancel still sees persistPending.
-      let journal = RealtimeHubController.shared.enqueueTurnPersistence(
-        idempotencyKey: RealtimeHubController.voiceContinuityKey(for: turnID)
-      ) {
-        await self.recordVoiceTypingExchange(
-          utterance: utterance, completion: completion, turnID: turnID)
-      }
-      let journaled =
-        (try? await DeadlinedOperation.run(seconds: Self.voiceTypingJournalWaitSeconds) { await journal.value })
-        ?? false
-      if !journaled {
-        log("PushToTalkManager: voice typing exchange not confirmed journaled before the turn ended")
+      let record = VoiceTypingChatRecordPolicy.decide(
+        silentTypeEnabled: ShortcutSettings.shared.silentTypeEnabled)
+      if !record.journalsExchange {
+        // Both consequences of not writing: the reserved native source has no
+        // producing row to attach to, and recovery must not resurrect the
+        // transcript on a later provider failure.
+        if record.suppressesJournalRecovery, record.retiresReservedEvidence {
+          RealtimeHubController.shared.suppressJournalRecoveryForUnwrittenTurn(turnID: turnID)
+        }
+        log("PushToTalkManager: silent type — dictation kept out of the chat transcript")
+      } else {
+        // The journal write is awaited before the turn ends, so a lifecycle
+        // change at turn end cannot drop it; the wait is bounded so a slow
+        // bridge cannot hold the bar, and the write itself is not cancelled
+        // at the bound — it finishes in the background.
+        let utterance = run.transcript ?? ""
+        let completion = run.completion
+        // Register the write under the native `voice:<uuid>` identity before the
+        // bounded wait so a timeout+cancel still sees persistPending.
+        let journal = RealtimeHubController.shared.enqueueTurnPersistence(
+          idempotencyKey: RealtimeHubController.voiceContinuityKey(for: turnID)
+        ) {
+          await self.recordVoiceTypingExchange(
+            utterance: utterance, completion: completion, turnID: turnID)
+        }
+        let journaled =
+          (try? await DeadlinedOperation.run(seconds: Self.voiceTypingJournalWaitSeconds) { await journal.value })
+          ?? false
+        if !journaled {
+          log("PushToTalkManager: voice typing exchange not confirmed journaled before the turn ended")
+        }
       }
       guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
       if let hint = run.completion.statusHint {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -197,6 +197,7 @@ extension RealtimeHubController {
     lastExternalToolName = ""
     lastExternalToolErrorCode = ""
     turnIdempotencyKey = Self.voiceContinuityKey(for: turnID)
+    if journalSuppressedContinuityKey != turnIdempotencyKey { journalSuppressedContinuityKey = nil }
     turnPublicWebEvidence = nil
     resetScreenGrounding(for: turnID)
     if let interruptedTurnTask, !supersedesPendingReplacement {
@@ -348,7 +349,27 @@ extension RealtimeHubController {
     return .accepted
   }
 
+  /// Whether a turn's just-spoken text may still be recovered into the journal.
+  /// A deliberately unwritten turn (Silent Type) has no accepted receipt to stand
+  /// recovery down, so it names itself here instead.
+  static func recoversInterruptedTurn(continuityKey: String, suppressedKey: String?) -> Bool {
+    continuityKey.isEmpty || suppressedKey != continuityKey
+  }
+
+  /// Never journal this turn's transcript, on any path: no producing row, and no
+  /// interrupted-turn recovery. Used by a Silent Type dictation, which delivered
+  /// its text to the focused app and must leave the chat untouched.
+  func suppressJournalRecoveryForUnwrittenTurn(turnID: VoiceTurnID) {
+    journalSuppressedContinuityKey = Self.voiceContinuityKey(for: turnID)
+    retireNativeTurnEvidenceAfterRejectedWrite(turnID: turnID)
+  }
+
   func captureInterruptedTurnPayloadIfNeeded() -> Task<InterruptedTurnPayload?, Never>? {
+    if !Self.recoversInterruptedTurn(
+      continuityKey: turnIdempotencyKey, suppressedKey: journalSuppressedContinuityKey)
+    {
+      return nil
+    }
     if turnPersistenceLedger.pendingContinuityKeys.contains(turnIdempotencyKey)
       || turnPersistenceLedger.receipt(for: turnIdempotencyKey)?.accepted == true
       || !prefetchedVoiceContextTurnIDs.isDisjoint(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -356,6 +356,17 @@ extension RealtimeHubController {
     continuityKey.isEmpty || suppressedKey != continuityKey
   }
 
+  /// Arms the suppression at the start of a turn while Silent Type is on. The
+  /// delivery close path would only name the turn after it has finished
+  /// delivering, but a provider failure during finalization reaches
+  /// `captureInterruptedTurnPayloadIfNeeded` earlier — and recovery must find
+  /// the receipt already standing, not journal the dictation into the chat.
+  /// `commitTurn` ends the suppression for a turn that commits as a question,
+  /// whose provider-failure continuity depends on recovery.
+  func suppressJournalRecoveryAtTurnStart(turnID: VoiceTurnID) {
+    journalSuppressedContinuityKey = Self.voiceContinuityKey(for: turnID)
+  }
+
   /// Never journal this turn's transcript, on any path: no producing row, and no
   /// interrupted-turn recovery. Used by a Silent Type dictation, which delivered
   /// its text to the focused app and must leave the chat untouched.
@@ -560,6 +571,11 @@ extension RealtimeHubController {
       log("RealtimeHub: rejected duplicate/stale physical commit before provider side effects")
       return .rejectedNoSession
     }
+    // A commit is by definition not a dictation — dictations are routed to the
+    // typing pipeline before any hub commit — so a Silent Type suppression
+    // armed at this turn's start ends here, and the question keeps the
+    // provider-failure continuity that recovery provides.
+    journalSuppressedContinuityKey = nil
 
     if let pending = replacementAudioBuffer {
       VoiceTurnCoordinator.shared.publish(.hubCommitDeferredForReplacement(turnID: turnID))

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -93,9 +93,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   /// Stable per-turn key for kernel idempotent voice-turn persistence.
   var turnIdempotencyKey = ""
   /// The one continuity key whose transcript must never reach the journal, even
-  /// through interrupted-turn recovery. Holds at most the most recent such turn:
-  /// only `turnIdempotencyKey` is ever compared against it, and minting a
-  /// different key clears it.
+  /// through interrupted-turn recovery. Armed at the start of a turn while
+  /// Silent Type is on, and re-asserted when the dictation is delivered. Holds
+  /// at most the most recent such turn: only `turnIdempotencyKey` is ever
+  /// compared against it, and minting a different key clears it — as does
+  /// committing a turn as a question, whose continuity depends on recovery.
   var journalSuppressedContinuityKey: String?
   /// (a) Pure cache of the typed kernel voice-context snapshot. Rebuild via
   /// `refreshVoiceContextSnapshot` / `fetchVoiceContextSnapshot` on relaunch.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -92,6 +92,11 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   var audioReceivedThisTurn = false
   /// Stable per-turn key for kernel idempotent voice-turn persistence.
   var turnIdempotencyKey = ""
+  /// The one continuity key whose transcript must never reach the journal, even
+  /// through interrupted-turn recovery. Holds at most the most recent such turn:
+  /// only `turnIdempotencyKey` is ever compared against it, and minting a
+  /// different key clears it.
+  var journalSuppressedContinuityKey: String?
   /// (a) Pure cache of the typed kernel voice-context snapshot. Rebuild via
   /// `refreshVoiceContextSnapshot` / `fetchVoiceContextSnapshot` on relaunch.
   var prefetchedVoiceContext = ""
@@ -489,6 +494,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
     lastExternalToolName = ""
     lastExternalToolErrorCode = ""
     turnIdempotencyKey = ""
+    journalSuppressedContinuityKey = nil
     turnAudio16k.removeAll()
     turnEarlyVerdictCode = nil
     lastTurnDiagnostics.removeAll()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -379,6 +379,15 @@ class ShortcutSettings: ObservableObject {
     didSet { UserDefaults.standard.set(silentTypeEnabled, forKey: .shortcutSilentTypeEnabled) }
   }
 
+  /// The persisted read behind `silentTypeEnabled`'s initial value — what a
+  /// fresh process restores at launch. Split out of `private init` so a test
+  /// can exercise the decode itself: a same-process write followed by a read
+  /// only exercises the `didSet` writer, never this restore path. Absent key
+  /// reads false — Silent Type ships off.
+  static func persistedSilentTypeEnabled(from defaults: UserDefaults = .standard) -> Bool {
+    defaults.object(forKey: .shortcutSilentTypeEnabled) as? Bool ?? false
+  }
+
   /// Empty means Automatic. A non-empty value is a stable CoreAudio device UID
   /// selected specifically for push-to-talk, independent of the macOS default input.
   /// The one microphone choice, shared by transcription and push-to-talk.
@@ -643,8 +652,7 @@ class ShortcutSettings: ObservableObject {
     self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
     self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
     self.pttMuteSystemAudio = UserDefaults.standard.object(forKey: "shortcut_pttMuteSystemAudio") as? Bool ?? true
-    self.silentTypeEnabled =
-      UserDefaults.standard.object(forKey: .shortcutSilentTypeEnabled) as? Bool ?? false
+    self.silentTypeEnabled = Self.persistedSilentTypeEnabled()
     self.pttInputDeviceUID = UserDefaults.standard.string(forKey: .shortcutPTTInputDeviceUID) ?? ""
     self.selectedModel = ModelQoS.Claude.sanitizedSelection(
       UserDefaults.standard.string(forKey: "shortcut_selectedModel")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -372,6 +372,13 @@ class ShortcutSettings: ObservableObject {
     didSet { UserDefaults.standard.set(pttMuteSystemAudio, forKey: "shortcut_pttMuteSystemAudio") }
   }
 
+  /// Silent Type: dictation still types into the focused app, but the turn is
+  /// never written to the chat transcript, so what you type by voice stays out
+  /// of Omi's chat context. Off by default — dictations are journaled as usual.
+  @Published var silentTypeEnabled: Bool {
+    didSet { UserDefaults.standard.set(silentTypeEnabled, forKey: .shortcutSilentTypeEnabled) }
+  }
+
   /// Empty means Automatic. A non-empty value is a stable CoreAudio device UID
   /// selected specifically for push-to-talk, independent of the macOS default input.
   /// The one microphone choice, shared by transcription and push-to-talk.
@@ -636,6 +643,8 @@ class ShortcutSettings: ObservableObject {
     self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
     self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
     self.pttMuteSystemAudio = UserDefaults.standard.object(forKey: "shortcut_pttMuteSystemAudio") as? Bool ?? true
+    self.silentTypeEnabled =
+      UserDefaults.standard.object(forKey: .shortcutSilentTypeEnabled) as? Bool ?? false
     self.pttInputDeviceUID = UserDefaults.standard.string(forKey: .shortcutPTTInputDeviceUID) ?? ""
     self.selectedModel = ModelQoS.Claude.sanitizedSelection(
       UserDefaults.standard.string(forKey: "shortcut_selectedModel")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypingChatRecordPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypingChatRecordPolicy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Whether a delivered dictation also enters Omi's chat context.
+///
+/// By the time this is asked the text has already been typed into the focused
+/// app, so the only remaining question is what the turn does to the chat
+/// transcript. Silent Type answers "nothing": dictation stays a typing tool and
+/// never becomes chat history.
+///
+/// The two consequences travel together deliberately. A native source (terminal
+/// OCR) is reserved under `voice:<uuid>` at turn start and is bound to the
+/// journal row that records the turn; when there is no such row, the
+/// reservation must be fenced instead, or a late extraction callback can invent
+/// an admission for a turn that was never written.
+enum VoiceTypingChatRecordPolicy {
+  struct Decision: Equatable {
+    /// Write the dictation to the chat transcript as a `realtime_voice` exchange.
+    let journalsExchange: Bool
+    /// Retire the native source reserved for this turn, because no producing
+    /// journal row will ever exist for it to attach to.
+    let retiresReservedEvidence: Bool
+    /// Bar interrupted-turn recovery from resurrecting this turn's transcript.
+    /// Recovery normally stands down because the turn already has an accepted
+    /// persistence receipt; a turn that was never written has none, so without
+    /// this a later provider failure would journal the very text the user asked
+    /// to keep out of the chat.
+    let suppressesJournalRecovery: Bool
+  }
+
+  static func decide(silentTypeEnabled: Bool) -> Decision {
+    silentTypeEnabled
+      ? Decision(
+        journalsExchange: false, retiresReservedEvidence: true, suppressesJournalRecovery: true)
+      : Decision(
+        journalsExchange: true, retiresReservedEvidence: false, suppressesJournalRecovery: false)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Transcription.swift
@@ -296,6 +296,33 @@ extension SettingsContentView {
         }
       }
 
+      // Silent Type
+      settingsCard(settingId: "transcription.silenttype") {
+        VStack(alignment: .leading, spacing: OmiSpacing.md) {
+          HStack {
+            Image(systemName: "keyboard.badge.eye")
+              .scaledFont(size: OmiType.subheading)
+              .foregroundColor(Ink.secondary)
+
+            VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+              Text("Silent Type")
+                .scaledFont(size: OmiType.subheading, weight: .medium)
+                .foregroundColor(Ink.primary)
+
+              Text("Keeps what you dictate with Omi Type out of the chat.")
+                .scaledFont(size: OmiType.body)
+                .foregroundColor(Ink.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $shortcutSettings.silentTypeEnabled)
+              .toggleStyle(OmiToggleStyle())
+          }
+        }
+      }
+
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -105,6 +105,11 @@ struct SettingsSearchItem: Identifiable {
       name: "Local VAD Gate", subtitle: "Skip silence to reduce transcription cost",
       keywords: ["vad", "silence", "gate", "cost", "deepgram"], section: .transcription,
       icon: "waveform", settingId: "transcription.vadgate"),
+    SettingsSearchItem(
+      name: "Silent Type", subtitle: "Keeps what you dictate with Omi Type out of the chat",
+      keywords: ["silent", "type", "dictation", "voice typing", "private", "chat context"],
+      section: .transcription,
+      icon: "keyboard", settingId: "transcription.silenttype"),
 
     // Notifications
     SettingsSearchItem(

--- a/desktop/macos/Desktop/Tests/VoiceTypingSilentModeTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingSilentModeTests.swift
@@ -1,3 +1,4 @@
+import VoiceTurnDomain
 import XCTest
 
 @testable import Omi_Computer
@@ -8,6 +9,7 @@ import XCTest
 @MainActor
 final class VoiceTypingSilentModeTests: XCTestCase {
   private static let defaultsKey = DefaultsKey.shortcutSilentTypeEnabled.rawValue
+  private static let managerSourceName = "PushToTalkManager.swift"
   private var savedSetting: Bool?
   private var hadSavedSetting = false
 
@@ -90,7 +92,7 @@ final class VoiceTypingSilentModeTests: XCTestCase {
       ).journalsExchange)
   }
 
-  func testTogglingSilentTypePersistsAcrossLaunches() {
+  func testTogglingSilentTypePersistsAcrossLaunches() throws {
     ShortcutSettings.shared.silentTypeEnabled = true
     XCTAssertTrue(
       UserDefaults.standard.bool(forKey: Self.defaultsKey),
@@ -102,6 +104,147 @@ final class VoiceTypingSilentModeTests: XCTestCase {
 
     ShortcutSettings.shared.silentTypeEnabled = false
     XCTAssertFalse(UserDefaults.standard.bool(forKey: Self.defaultsKey))
+
+    // The writes above only exercise the `didSet` writer in this process. A
+    // relaunch restores the toggle through the launch read, so prove that read
+    // against a fresh defaults domain, the way a fresh settings instance sees it.
+    let launchDomain = "omi-silent-type-relaunch-\(UUID().uuidString)"
+    let launchDefaults = try XCTUnwrap(UserDefaults(suiteName: launchDomain))
+    defer { launchDefaults.removePersistentDomain(forName: launchDomain) }
+    XCTAssertFalse(
+      ShortcutSettings.persistedSilentTypeEnabled(from: launchDefaults),
+      "an absent key reads false — Silent Type ships off for a fresh install")
+    launchDefaults.set(true, forKey: Self.defaultsKey)
+    let restored = ShortcutSettings.persistedSilentTypeEnabled(from: launchDefaults)
+    XCTAssertTrue(
+      restored,
+      "the launch read must restore exactly what the toggle persisted")
+    XCTAssertFalse(
+      VoiceTypingChatRecordPolicy.decide(silentTypeEnabled: restored).journalsExchange,
+      "the restored toggle keeps the dictation out of the chat transcript")
+  }
+
+  /// The race this closes. Suppression used to latch only in the delivery
+  /// close path, so a realtime provider failure while the dictation was still
+  /// finalizing reached `captureInterruptedTurnPayloadIfNeeded` with no
+  /// suppression receipt — and recovery journaled the very text the user asked
+  /// to keep out of the chat. The turn now names itself as suppressed at its
+  /// start, before anything can fail mid-turn.
+  func testProviderFailureDuringFinalizationKeepsASilentTypeDictationOutOfRecovery() {
+    ShortcutSettings.shared.silentTypeEnabled = true
+    let hub = RealtimeHubController.shared
+    let coordinator = VoiceTurnCoordinator.shared
+    PushToTalkManager.shared.cleanup()
+    let turnID = coordinator.begin(intent: .hold, ownerID: "silent-type-race-owner")
+    defer {
+      hub.turnTranscript = ""
+      hub.turnIdempotencyKey = ""
+      hub.journalSuppressedContinuityKey = nil
+      coordinator.reset()
+    }
+    coordinator.publish(.selectRoute(turnID: turnID, route: .hub(sessionID: nil)))
+
+    // Mid-finalization: the provider has already streamed the dictation back
+    // as this turn's transcript, nothing has been delivered yet, and no
+    // persistence receipt exists — then the socket fails.
+    hub.turnIdempotencyKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+    hub.turnTranscript = "type hello from the privacy race"
+    hub.journalSuppressedContinuityKey = nil
+
+    // Turn start, not delivery, latches the suppression.
+    PushToTalkManager.shared.latchSilentTypeForTurnStart(turnID: turnID)
+
+    XCTAssertNil(
+      hub.captureInterruptedTurnPayloadIfNeeded(),
+      "a provider failure during finalization must not hand a Silent Type "
+        + "dictation's transcript to interrupted-turn recovery")
+    XCTAssertEqual(
+      hub.journalSuppressedContinuityKey,
+      RealtimeHubController.voiceContinuityKey(for: turnID),
+      "the suppression receipt must stay standing for the whole turn")
+  }
+
+  /// With the toggle off the latch is inert: the turn keeps the recovery that
+  /// provider-failure continuity depends on, byte-identical to the journaled
+  /// behavior Silent Type opted out of.
+  func testTurnStartLatchIsInertWhileSilentTypeIsOff() {
+    ShortcutSettings.shared.silentTypeEnabled = false
+    let hub = RealtimeHubController.shared
+    let coordinator = VoiceTurnCoordinator.shared
+    PushToTalkManager.shared.cleanup()
+    let turnID = coordinator.begin(intent: .hold, ownerID: "journaled-turn-owner")
+    defer {
+      hub.turnTranscript = ""
+      hub.turnIdempotencyKey = ""
+      hub.journalSuppressedContinuityKey = nil
+      coordinator.reset()
+    }
+    coordinator.publish(.selectRoute(turnID: turnID, route: .hub(sessionID: nil)))
+    hub.turnIdempotencyKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+    hub.turnTranscript = "what is on my calendar tomorrow"
+    hub.journalSuppressedContinuityKey = nil
+
+    PushToTalkManager.shared.latchSilentTypeForTurnStart(turnID: turnID)
+
+    XCTAssertNil(
+      hub.journalSuppressedContinuityKey,
+      "a journaled turn must not carry a suppression receipt")
+    XCTAssertNotNil(
+      hub.captureInterruptedTurnPayloadIfNeeded(),
+      "with Silent Type off a failed turn keeps its provider-failure recovery")
+  }
+
+  /// The toggle is read once, at turn start. A flip mid-turn must not split the
+  /// turn: one that began with Silent Type off keeps journaling semantics, and
+  /// one that began with it on stays suppressed.
+  func testMidTurnToggleFlipDoesNotSplitTheTurn() {
+    let hub = RealtimeHubController.shared
+    let coordinator = VoiceTurnCoordinator.shared
+    PushToTalkManager.shared.cleanup()
+    let offThenOnTurn = coordinator.begin(intent: .hold, ownerID: "mid-turn-flip-owner")
+    defer {
+      hub.turnTranscript = ""
+      hub.turnIdempotencyKey = ""
+      hub.journalSuppressedContinuityKey = nil
+      coordinator.reset()
+    }
+    coordinator.publish(.selectRoute(turnID: offThenOnTurn, route: .hub(sessionID: nil)))
+    hub.turnIdempotencyKey = RealtimeHubController.voiceContinuityKey(for: offThenOnTurn)
+    hub.turnTranscript = "type a note about the flip"
+    hub.journalSuppressedContinuityKey = nil
+
+    ShortcutSettings.shared.silentTypeEnabled = false
+    PushToTalkManager.shared.latchSilentTypeForTurnStart(turnID: offThenOnTurn)
+    ShortcutSettings.shared.silentTypeEnabled = true
+
+    XCTAssertNil(
+      hub.journalSuppressedContinuityKey,
+      "a turn that started with Silent Type off is not suppressed by a mid-turn flip on")
+  }
+
+  /// The latch is only as good as its wiring: both physical turn starts must
+  /// arm it, and the delivery close path must decide with the latched value
+  /// rather than a fresh read.
+  func testTurnStartsLatchTheSuppressionAndDeliveryDecidesWithTheLatch() throws {
+    let testFile = URL(fileURLWithPath: #filePath)
+    // omi-test-quality: source-inspection -- static contract: both turn starts must arm the Silent Type latch, delivery decides with the latched value
+    let source = try String(
+      contentsOf:
+        testFile
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appendingPathComponent("Sources/FloatingControlBar")
+        .appendingPathComponent(Self.managerSourceName),
+      encoding: .utf8)
+    XCTAssertEqual(
+      source.components(
+        separatedBy: "latchSilentTypeForTurnStart(turnID: currentVoiceTurnID)"
+      ).count - 1,
+      2,
+      "hold and locked turn starts must both latch Silent Type at the turn's start")
+    XCTAssertTrue(
+      source.contains("silentTypeEnabled: voiceTypingSilentTypeEnabled"),
+      "the delivery close path must decide with the turn-start latch, not a fresh read")
   }
 
   func testSilentTypeIsSearchableFromTheTranscriptionTab() {

--- a/desktop/macos/Desktop/Tests/VoiceTypingSilentModeTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingSilentModeTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Silent Type: dictation still types into the focused app, but the turn never
+/// reaches the chat transcript, so voice-typed text stays out of Omi's chat
+/// context. Off by default — dictations are journaled as they always were.
+@MainActor
+final class VoiceTypingSilentModeTests: XCTestCase {
+  private static let defaultsKey = DefaultsKey.shortcutSilentTypeEnabled.rawValue
+  private var savedSetting: Bool?
+  private var hadSavedSetting = false
+
+  override func setUp() async throws {
+    hadSavedSetting = UserDefaults.standard.object(forKey: Self.defaultsKey) != nil
+    savedSetting = hadSavedSetting ? UserDefaults.standard.bool(forKey: Self.defaultsKey) : nil
+  }
+
+  override func tearDown() async throws {
+    if let savedSetting {
+      UserDefaults.standard.set(savedSetting, forKey: Self.defaultsKey)
+    } else {
+      UserDefaults.standard.removeObject(forKey: Self.defaultsKey)
+    }
+    ShortcutSettings.shared.silentTypeEnabled = savedSetting ?? false
+    savedSetting = nil
+    hadSavedSetting = false
+  }
+
+  func testDictationIsJournaledWhenSilentTypeIsOff() {
+    let decision = VoiceTypingChatRecordPolicy.decide(silentTypeEnabled: false)
+    XCTAssertTrue(
+      decision.journalsExchange,
+      "with Silent Type off a delivered dictation must still enter the chat transcript")
+    XCTAssertFalse(
+      decision.retiresReservedEvidence,
+      "the journal path binds its own reserved source; retiring it here would drop late OCR")
+    XCTAssertFalse(
+      decision.suppressesJournalRecovery,
+      "a journaled turn stands recovery down with its accepted receipt, not a suppression")
+  }
+
+  func testSilentTypeKeepsDictationOutOfChatAndFencesReservedEvidence() {
+    let decision = VoiceTypingChatRecordPolicy.decide(silentTypeEnabled: true)
+    XCTAssertFalse(
+      decision.journalsExchange,
+      "Silent Type must not write the dictation to the chat transcript")
+    XCTAssertTrue(
+      decision.retiresReservedEvidence,
+      "no producing row will exist, so the reserved native source must be fenced "
+        + "or a late extraction can invent an admission for an unwritten turn")
+    XCTAssertTrue(
+      decision.suppressesJournalRecovery,
+      "an unwritten turn has no accepted receipt, so recovery must be barred explicitly")
+  }
+
+  /// The gap this closes: interrupted-turn recovery normally stands down because
+  /// the turn already has an accepted persistence receipt. A Silent Type turn is
+  /// never written, so it has none — without an explicit suppression a later
+  /// provider failure would journal the very text the user kept out of the chat.
+  func testSuppressedTurnIsNeverRecoveredIntoTheJournal() {
+    XCTAssertFalse(
+      RealtimeHubController.recoversInterruptedTurn(
+        continuityKey: "voice:A", suppressedKey: "voice:A"),
+      "a Silent Type turn's transcript must not be resurrected by recovery")
+  }
+
+  func testRecoveryStillRunsForOtherTurns() {
+    XCTAssertTrue(
+      RealtimeHubController.recoversInterruptedTurn(
+        continuityKey: "voice:B", suppressedKey: "voice:A"),
+      "suppressing one dictation must not disable recovery for every later turn")
+    XCTAssertTrue(
+      RealtimeHubController.recoversInterruptedTurn(
+        continuityKey: "voice:B", suppressedKey: nil),
+      "an ordinary turn keeps provider-failure continuity")
+    XCTAssertTrue(
+      RealtimeHubController.recoversInterruptedTurn(continuityKey: "", suppressedKey: nil),
+      "an unkeyed turn is not treated as suppressed")
+  }
+
+  func testSilentTypeIsOffForAUserWhoNeverChoseIt() {
+    UserDefaults.standard.removeObject(forKey: Self.defaultsKey)
+    XCTAssertFalse(
+      UserDefaults.standard.object(forKey: Self.defaultsKey) as? Bool ?? false,
+      "Silent Type ships off: dictation keeps its existing chat-transcript behavior")
+    XCTAssertTrue(
+      VoiceTypingChatRecordPolicy.decide(
+        silentTypeEnabled: UserDefaults.standard.object(forKey: Self.defaultsKey) as? Bool ?? false
+      ).journalsExchange)
+  }
+
+  func testTogglingSilentTypePersistsAcrossLaunches() {
+    ShortcutSettings.shared.silentTypeEnabled = true
+    XCTAssertTrue(
+      UserDefaults.standard.bool(forKey: Self.defaultsKey),
+      "the toggle must survive a relaunch, like every other push-to-talk preference")
+    XCTAssertFalse(
+      VoiceTypingChatRecordPolicy.decide(
+        silentTypeEnabled: UserDefaults.standard.bool(forKey: Self.defaultsKey)
+      ).journalsExchange)
+
+    ShortcutSettings.shared.silentTypeEnabled = false
+    XCTAssertFalse(UserDefaults.standard.bool(forKey: Self.defaultsKey))
+  }
+
+  func testSilentTypeIsSearchableFromTheTranscriptionTab() {
+    let item = SettingsSearchItem.allSearchableItems.first { $0.settingId == "transcription.silenttype" }
+    XCTAssertNotNil(item, "the Silent Type card must be reachable from settings search")
+    XCTAssertEqual(item?.section, .transcription)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260908-silent-type-mode.json
+++ b/desktop/macos/changelog/unreleased/20260908-silent-type-mode.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added Silent Type in Transcription settings — dictation still types into the app you are in, but the text is kept out of Omi's chat context"
+}

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -35,6 +35,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/PTTRoutePolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeAudioTrim.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypingChatRecordPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeCommandParser.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeWakeWordProbeSchedule.swift

--- a/desktop/macos/e2e/flows/ptt-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/ptt-lifecycle.yaml
@@ -35,7 +35,9 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/PTTRoutePolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeAudioTrim.swift
-  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypingChatRecordPolicy.swift
+  # VoiceTypingChatRecordPolicy.swift is deliberately not claimed here: this
+  # flow's too-short turn never reaches the dictation delivery close path where
+  # its decide(...) runs. That policy is covered by VoiceTypingSilentModeTests.
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeCommandParser.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeWakeWordProbeSchedule.swift

--- a/desktop/macos/e2e/flows/ptt-natural-dictation.yaml
+++ b/desktop/macos/e2e/flows/ptt-natural-dictation.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/TextInsertionSink.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeSession.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationPolisher.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypingChatRecordPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/NotchVoiceMorphMark.swift
 preconditions:
   - auth_ready
@@ -27,6 +28,10 @@ steps:
   - id: S2b
     name: Clean acknowledgement skips polish
     do: "In the same disposable editor, hold PTT and say 'type Thanks', then release. On a capture whose acknowledgement payload is already clean and matches the locally formatted text, with no on-screen spelling hints, verify unchanged insertion and the llm_polish-to-local_format policy diagnostic with no remote polish request. If recognition changed casing or formatting, record that as ineligible rather than claiming a skip. Repeat with 'type Meet at three, no, four' and verify the normal polish path still runs."
+    verify: true
+  - id: S2c
+    name: Silent Type dictation stays out of the chat
+    do: "In Settings → Transcription turn Silent Type on. In the disposable editor hold PTT, say 'type Silent check', then release. Verify the text is still typed into the editor and the chat transcript gains no dictation turn for it. Toggle Silent Type back off and repeat once, verifying the chat records the dictation again as before."
     verify: true
   - id: S3
     name: Changed target copies instead of writing

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -72,6 +72,7 @@ KEYS = [
     "shortcut_solidBackground",
     "shortcut_pttSoundsEnabled",
     "shortcut_pttMuteSystemAudio",
+    "shortcut_silentTypeEnabled",
     "shortcut_selectedModel",
     "shortcut_pttTranscriptionMode",
     "shortcut_draggableBarEnabled",


### PR DESCRIPTION
## Summary

Adds **Silent Type**, a toggle at the end of Settings → Transcription that keeps voice-typed text out of Omi's chat context.

Voice typing has always written the turn to the chat transcript as `Typed: <text>` — the dictation types into the focused app *and* becomes chat history. With Silent Type on, delivery is unchanged (still transcribed, formatted, polished, pasted into the focused app) and only the journal write is skipped. **Off by default**, so nothing changes unless a user turns it on.

## Not writing the turn has three consequences, not one

`VoiceTypingChatRecordPolicy` returns all three as one decision so they cannot drift apart:

1. **Skip the exchange write** — the visible behavior.
2. **Fence the reserved native source.** Terminal OCR is reserved under `voice:<uuid>` at turn start and binds to the journal row that records the turn. With no such row it must be retired, or a late extraction callback can invent an admission for a turn that was never written.
3. **Bar interrupted-turn recovery.** This one is easy to miss and is the reason the policy is a type rather than an `if`. `captureInterruptedTurnPayloadIfNeeded` normally stands down for a completed dictation because the turn has an *accepted persistence receipt*. A turn that was never written has no receipt, and `cancelTurn` clears `turnTranscript` but not `fullLIDTask` — so on a later provider failure the recovery path would have awaited the language-identifier verdict and journaled the very text the user asked to keep out of the chat. The turn now names itself in `journalSuppressedContinuityKey`, which `beginTurn` and the hub reset both clear, so at most one key is ever held.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Neither invariant's contract changes. The dictation write path, its continuity key (`voice-typing-<turnID>`), its single `recordExchange` writer, and its idempotency are untouched; Silent Type only decides whether that one write is issued, and closes the two ways an unwritten turn could otherwise still reach the journal.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 4090 -> 4129 | the dictation close path gains one branch (skip the write, suppress recovery) plus the re-indent of the existing journal block, and the race fix latches the suppression at turn start (one per-turn property, one latch method, two call sites); splitting the file is a far larger change than this toggle warrants
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift | 1583 -> 1591 | one stored property (`journalSuppressedContinuityKey`) with its contract comment, clearing it in the existing turn reset, and the commit-clears-suppression note added to that comment
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift | 780 -> 817 | the recovery gate belongs next to the recovery decision it guards: one pure predicate, one suppression entry point, its check in `captureInterruptedTurnPayloadIfNeeded`, plus the race fix's turn-start arm and commit-time clear

## Verification

Named bundle `omi-silent-type`, live PTT harness injecting the same 2.1 s "type hello from the silent type check" hold through `ptt_manager_turn` (production chunk path and closing turn, not a reducer stub). Re-run against the final tree after the recovery fix:

| Silent Type | `main_chat_snapshot` | Log | Delivery |
|---|---|---|---|
| off | 14 → 16 messages (`Type hello from the silent type check.` + `Copied to clipboard: …`) | journal write posted | clipboard set |
| on | stayed at 16 | `silent type — dictation kept out of the chat transcript` | clipboard still `Hello from the silent type check.` |

The toggle was flipped by AX-pressing the real switch in Settings → Transcription (no cursor movement, no synthetic clicks); `defaults read com.omi.omi-silent-type shortcut_silentTypeEnabled` then returned `1`. Delivery reads "copied" rather than "pasted" only because the throwaway bundle has no Accessibility grant; the same path runs either way.

Also green:
- `xcrun swift build -c debug --package-path Desktop`
- `desktop/macos/test.sh` (full component suite)
- `./scripts/agent-logic-harness.sh` (PTT/realtime focus — 787 Swift tests)
- `make preflight` — 24/24 checks
- 7 new `VoiceTypingSilentModeTests`, covering the default-off contract, persistence, all three policy consequences, and that suppressing one dictation does not disable provider-failure continuity for any other turn

## Failure class (fixes)

Failure-Class: new

The race fix (`fix(desktop): latch Silent Type suppression at turn start`) adds `.github/failure-classes/FC-suppression-latched-after-recovery-window.json`: a suppression that must keep recovery from re-journaling an unwritten turn has to stand from the boundary that opens the protected lifecycle, not from its completion — and ends where the turn provably changes kind (a hub commit is a question). Its regression test drives the real `captureInterruptedTurnPayloadIfNeeded` seam and fails with the turn-start arm removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qhxvneaRH5QSxv7yiFUov


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


