### PR TITLE
Voice typing: leave an opening "this" to the dictation, not the wake phrase

### DIFF
--- a/.github/failure-classes/FC-command-prefix-absorbs-content-token.json
+++ b/.github/failure-classes/FC-command-prefix-absorbs-content-token.json
@@ -1,0 +1,14 @@
+{
+    "schema_version": 1,
+    "id": "FC-command-prefix-absorbs-content-token",
+    "violated_contract": "A command vocabulary matched longest-first against free user content must not take a token that is also an ordinary opening of that content, unless the user marked the token as part of the command. Voice typing matched the wake phrases \"type out\", \"type this\" and \"type\" longest-first, so \"type this is a test\" parsed as the phrase \"type this\" plus the dictation \"is a test\" and typed \"Is a test\". The speaker's own first word was deleted, silently, inside their text — \"this\" being about the commonest word an English sentence opens with — and nothing downstream could recover it, because by then the word was simply not in the payload. The greedy match was right for \"type out an email\", which people do speak straight through, and wrong for the phrase nobody speaks straight through: the instruction is said as \"type this: buy milk\", with the pause that a recognizer renders as punctuation.",
+    "canonical_prevention": "Split the command vocabulary by whether its extra token can also open real content. A phrase whose last token is ordinary content may only claim that token when the user marked the phrase as an instruction — punctuation from the speaker's pause, or the end of the utterance — and on a plain separator it must fall through to the shorter command, leaving the token to the payload. Resolve the remaining ambiguity toward keeping the user's words: an extra word the user has to delete is visible and costs a keystroke, while a word the parser ate is invisible and unrecoverable. Cover both readings of the same opening in one test, so the phrase that must keep its token and the phrase that must give it back cannot drift apart.",
+    "canonical_prevention_artifact": [
+        "desktop/macos/Desktop/Tests/VoiceTypingTests.swift"
+    ],
+    "evidence_prs": [],
+    "scope_hints": [
+        "desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeCommandParser.swift"
+    ],
+    "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeCommandParser.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/VoiceTypeCommandParser.swift
@@ -25,12 +25,40 @@ enum VoiceTypeCommandParser {
 
   /// Spoken openings that start a typing turn. `"type"` is the documented one;
   /// the others are what ASR reliably returns for the same intent, and they are
-  /// matched longest-first so "type out hello" dictates "hello", not "out hello".
+  /// matched longest-first so "type out hello" dictates "hello", not "out hello"
+  /// — except where `phrasesNeedingInstructionBoundary` says the last word may
+  /// belong to the speaker instead.
   static let wakeWords = ["type out", "type this", "type"]
+
+  /// Wake phrases whose last word is also an ordinary first word of dictated
+  /// text, so the phrase may only take that word when punctuation — or the end
+  /// of the utterance — marks it as the instruction it is.
+  ///
+  /// "this" is about the commonest word an English sentence opens with, and
+  /// nobody speaks the instruction as "type this hello there": they say "type
+  /// this: hello there", or just "type hello there". Taking it on a plain
+  /// space turned "type this is a test" into "Is a test" — the speaker's own
+  /// first word deleted, silently, inside their text. "type out" is not in
+  /// this set because it *is* spoken straight through ("type out an email"),
+  /// and dictation rarely opens on "out".
+  private static let phrasesNeedingInstructionBoundary: Set<String> = ["type this"]
 
   /// Punctuation ASR attaches to the wake word ("Type, hello") or that opens the
   /// dictated text. Stripped from the front of the payload, never from its body.
   private static let separators = CharacterSet(charactersIn: " \t\n,:;.-–—")
+
+  /// The subset of `separators` that marks the end of a spoken instruction
+  /// rather than an ordinary gap between words: the pause or colon a speaker
+  /// puts after "type this". A space is not one.
+  private static let instructionBoundary = CharacterSet(charactersIn: ",:;.-–—")
+
+  /// Whether what follows a wake phrase marks the phrase as an instruction:
+  /// punctuation, once any spaces are skipped, or nothing left to dictate.
+  private static func opensAnInstruction(_ rest: Substring) -> Bool {
+    let afterSpaces = rest.drop(while: { $0 == " " || $0 == "\t" })
+    guard let first = afterSpaces.unicodeScalars.first else { return true }
+    return instructionBoundary.contains(first)
+  }
 
   static func decide(_ transcript: String) -> Decision {
     let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -53,6 +81,11 @@ enum VoiceTypeCommandParser {
         // longer word, so this was never a command.
         continue
       }
+      // A phrase that would swallow an ordinary opening word needs the speaker
+      // to have marked it as an instruction. Falling through leaves the word to
+      // the shorter wake word's payload: "type this is a test" is "type" plus
+      // "this is a test", not "type this" plus "is a test".
+      if phrasesNeedingInstructionBoundary.contains(wake), !opensAnInstruction(rest[...]) { continue }
       let payload = String(
         rest.drop(while: { $0.unicodeScalars.allSatisfy(separators.contains) })
       )
@@ -128,7 +161,11 @@ enum VoiceTypeCommandParser {
     if case .typing(let payload) = decide(transcript) { return payload }
     let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
     let separatorClass = "[\\s,:;.\\-–—]*"
-    let alternatives = (wakeWords + wakeWordMishearings).map(NSRegularExpression.escapedPattern(for:))
+    // Boundary-requiring phrases are deliberately absent: `decide` has already
+    // settled them, and this looser pass must not take back the opening word it
+    // decided to keep.
+    let openings = wakeWords.filter { !phrasesNeedingInstructionBoundary.contains($0) } + wakeWordMishearings
+    let alternatives = openings.map(NSRegularExpression.escapedPattern(for:))
     let pattern = "^(?i)(?:" + alternatives.joined(separator: "|") + ")\\b" + separatorClass
     if let range = trimmed.range(of: pattern, options: .regularExpression) {
       return capitalizingFirstWord(String(trimmed[range.upperBound...]))

--- a/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceTypingTests.swift
@@ -52,6 +52,42 @@ final class VoiceTypeCommandParserTests: XCTestCase {
       .typing(payload: "Buy milk"))
   }
 
+  func testAnOpeningThisBelongsToTheSpeakerNotTheWakePhrase() {
+    // Reported live: "type this is a test" came out as "Is a test". The
+    // longest-match wake phrase "type this" ate the speaker's own first word,
+    // and "this" is about the commonest word an English sentence opens with.
+    XCTAssertEqual(
+      VoiceTypeCommandParser.decide("type this is a test"),
+      .typing(payload: "This is a test"))
+    XCTAssertEqual(
+      VoiceTypeCommandParser.decide("Type this looks wrong to me"),
+      .typing(payload: "This looks wrong to me"))
+    XCTAssertEqual(
+      VoiceTypeCommandParser.payloadAssumingDictation("Type this is a test"), "This is a test")
+    // The same word is still the speaker's after a misheard wake word.
+    XCTAssertEqual(
+      VoiceTypeCommandParser.payloadAssumingDictation("Typed this is a test"), "This is a test")
+    XCTAssertEqual(
+      VoiceTypeCommandParser.payloadAssumingDictation("Tie, this is a test"), "This is a test")
+  }
+
+  func testAPauseOrColonStillMarksTypeThisAsTheInstruction() {
+    // Spoken as an instruction, the phrase keeps its word: what tells the two
+    // apart is the punctuation a speaker's pause leaves behind.
+    for opening in ["type this: buy milk", "Type this, buy milk", "Type this. Buy milk"] {
+      XCTAssertEqual(
+        VoiceTypeCommandParser.decide(opening), .typing(payload: "Buy milk"), opening)
+    }
+    // Straight-through phrasings are untouched: nobody dictates text opening
+    // on "out", and "type out an email" is how people speak the instruction.
+    XCTAssertEqual(
+      VoiceTypeCommandParser.decide("type out the address"), .typing(payload: "The address"))
+    // And the turn is still claimed either way.
+    for opening in ["type this is a test", "type this: buy milk"] {
+      XCTAssertTrue(VoiceTypeCommandParser.opensLikeDictation(opening), opening)
+    }
+  }
+
   func testAClaimedTurnReadsAMisheardWakeWordLeniently() {
     // The closing transcript comes from a stronger recognizer than the probe
     // that claimed the turn, and it may spell the wake word its own way.

--- a/desktop/macos/changelog/unreleased/20260908-voice-typing-this-wake-phrase.json
+++ b/desktop/macos/changelog/unreleased/20260908-voice-typing-this-wake-phrase.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed voice typing dropping the first word when a dictation starts with \"this\" — \"type this is a test\" now types \"This is a test\", not \"Is a test\""
+}


### PR DESCRIPTION
## What broke

Saying **"type this is a test"** typed **"Is a test"**. The speaker's own first
word was deleted, silently, inside their text.

`VoiceTypeCommandParser` matches its wake phrases longest-first —
`["type out", "type this", "type"]` — so the transcript parsed as the phrase
*"type this"* plus the dictation *"is a test"*, and `capitalizingFirstWord`
turned the fragment into `Is a test`. Nothing downstream could recover it: by
then the word was simply not in the payload. "this" is about the commonest word
an English sentence opens with, so this fired constantly.

## The fix

The greedy match is right for `"type out an email"` — people do speak that
straight through — and wrong for the phrase nobody speaks straight through. The
instruction is said as *"type this: buy milk"*, with a pause the recognizer
renders as punctuation.

So a wake phrase whose last token is also an ordinary opening word may only
claim that token when the speaker marked the phrase as an instruction:
punctuation (`, : ; . - – —`) or the end of the utterance. On a plain space it
falls through to the shorter wake word, and the token stays with the dictation.

| said | before | after |
|---|---|---|
| type this is a test | `Is a test` | `This is a test` |
| Type this looks wrong to me | `Looks wrong to me` | `This looks wrong to me` |
| type this: buy milk | `Buy milk` | `Buy milk` |
| Type this, buy milk | `Buy milk` | `Buy milk` |
| type out the address | `The address` | `The address` |

`"type out"` is deliberately not in the boundary-requiring set: dictation rarely
opens on "out", and `"type out an email"` is how people speak the instruction.
The looser `payloadAssumingDictation` pass (which strips misheard wake words
like "Tie" and "Typed") no longer offers the boundary-requiring phrases either,
so it cannot take back the opening word `decide` just decided to keep.

## Product invariants affected

- INV-CHAT-1

Path-matched and unchanged. A dictation is still journaled exactly once per
turn through the same exchange; only the payload extracted from an
already-claimed turn changes, so the transcript records the words the speaker
actually said rather than a fragment of them.

## Failure class (fixes)

Failure-Class: new

New class `FC-command-prefix-absorbs-content-token`, defined in this PR: a
command vocabulary matched longest-first against free user content took a token
that was also an ordinary opening of that content. The rule that generalises is
the asymmetry in the damage — an extra word the user has to delete is visible
and costs a keystroke; a word the parser ate is invisible and unrecoverable — so
ambiguity resolves toward keeping the user's words unless they marked the token
as part of the command.

## Verification

- `xcrun swift test --filter VoiceTypeCommandParserTests` — **12 tests, 0
  failures**.
- Two new tests. **Negative control:** with the boundary set emptied, they fail
  with exactly the reported output — `typing(payload: "Is a test")`.
- **Live, end to end in the real app.** Built as the named bundle
  `omi-type-this`, drove a real push-to-talk turn through the production chunk
  path with `ptt_manager_turn` on synthesized speech for *"Type this is a test
  of the insertion fix."*:

  ```
  PushToTalkManager: closing dictation — 2.4s of audio, transcript pending
  TranscriptionService: Batch transcription result provider=parakeet transcriptCharacters=41
  PushToTalkManager: dictation copied — 36 chars via backend_batch_stt in 671ms
  $ pbpaste
  This as a test of the insertion fix.
  ```

  It opens on **This**, not *Is*. (Delivery is `copied` rather than `pasted`
  only because a fresh named bundle holds no Accessibility grant; "as" for "is"
  mid-sentence is Parakeet on synthetic speech, and the polisher was skipped —
  that bundle has no active plan or BYOK key.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YAvWj7NGZqFRw6AensUhy


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

