### PR TITLE
feat(macos): classify PTT terminals as dictation vs question

### DIFF
--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -1702,7 +1702,10 @@ class AnalyticsManager {
     if let audioSecondsBucket = PTTAttemptLifecycleRecorder.AudioSecondsBucket.bucket(fromSeconds: audioSeconds) {
       props["audio_seconds_bucket"] = audioSecondsBucket.rawValue
     }
-    if let dictationTranscriber {
+    if turnKind == .dictation,
+      let dictationTranscriber,
+      ["route", "backend_batch_stt", "on_device_asr"].contains(dictationTranscriber)
+    {
       props["dictation_transcriber"] = dictationTranscriber
     }
     floatingBarPTTTelemetryCaptureForTests?("floating_bar_ptt_ended", props)

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -167,6 +167,9 @@ class AnalyticsManager {
   var questionTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
   /// Test seam for search events; emitters live in `Analytics/AnalyticsManager+Search.swift`.
   var searchTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
+  /// Scoped observation of floating-bar PTT terminal telemetry. Nil in
+  /// production; tests install a capture at the same boundary as PostHog.
+  private var floatingBarPTTTelemetryCaptureForTests: (@MainActor (String, [String: Any]) -> Void)?
 
   func setFloatingBarQueryTelemetryCaptureForTests(
     _ capture: (@MainActor (String, [String: Any]) -> Void)?
@@ -178,6 +181,12 @@ class AnalyticsManager {
     _ capture: (@MainActor (String, [String: Any]) -> Void)?
   ) {
     searchTelemetryCaptureForTests = capture
+  }
+
+  func setFloatingBarPTTTelemetryCaptureForTests(
+    _ capture: (@MainActor (String, [String: Any]) -> Void)?
+  ) {
+    floatingBarPTTTelemetryCaptureForTests = capture
   }
 
   // MARK: - Initialization
@@ -1662,14 +1671,41 @@ class AnalyticsManager {
   ///
   /// The wire property names are deliberately unchanged: existing dashboards and
   /// the PTT quality baseline join on them.
-  func floatingBarPTTEnded(mode: String, committed: Bool, transcriptLength: Int?) {
+  ///
+  /// `turn_kind` classifies the terminal by user intent, not route mechanics:
+  /// `dictation` (the voice-typing pipeline ran, paste succeeded or not),
+  /// `question` (committed or attempted agent answer), or `unknown`
+  /// (cancelled / too-short / silent discard before intent was knowable).
+  /// Deliberately absent from `floating_bar_ptt_started`: a dictation is only
+  /// recognized mid-hold. Optional bounded extras follow the same rule —
+  /// `audioSeconds` collapses into the closed `audio_seconds_bucket` when the
+  /// site already knows the length, and `dictationTranscriber` is the dictation
+  /// pipeline's bounded transcriber id (`route` when the STT route already
+  /// produced the transcript; otherwise `backend_batch_stt` / `on_device_asr`
+  /// from `DictationTranscriber.Source`). No deeper provider split here.
+  func floatingBarPTTEnded(
+    mode: String,
+    committed: Bool,
+    transcriptLength: Int?,
+    turnKind: PTTAttemptLifecycleRecorder.TurnKind = .unknown,
+    audioSeconds: Double? = nil,
+    dictationTranscriber: String? = nil
+  ) {
     var props: [String: Any] = [
       "mode": mode,
       "had_transcript": committed,
+      "turn_kind": turnKind.rawValue,
     ]
     if let transcriptLength {
       props["transcript_length"] = transcriptLength
     }
+    if let audioSecondsBucket = PTTAttemptLifecycleRecorder.AudioSecondsBucket.bucket(fromSeconds: audioSeconds) {
+      props["audio_seconds_bucket"] = audioSecondsBucket.rawValue
+    }
+    if let dictationTranscriber {
+      props["dictation_transcriber"] = dictationTranscriber
+    }
+    floatingBarPTTTelemetryCaptureForTests?("floating_bar_ptt_ended", props)
     PostHogManager.shared.track("floating_bar_ptt_ended", properties: props)
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -900,6 +900,7 @@ final class DesktopDiagnosticsManager {
     "attempt_id", "capture_start_outcome", "capture_start_status_class",
     "ms_to_first_audio_bucket", "ms_to_first_usable_frame_bucket",
     "first_chunks_energy_bucket", "turn_disposition",
+    "turn_kind",
     "input_route_class", "input_route_source", "route_changed_during_attempt",
     "recovery_triggered", "recovery_attempt_id", "recovery_outcome_of_next_turn",
     "judgeable", "telemetry_schema_version",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -525,7 +525,7 @@ final class PTTAttemptLifecycleRecorder {
       rms: rms,
       isNearZero: isNearZero,
       judgeable: judgeable,
-      telemetrySchemaVersion: 2)
+      telemetrySchemaVersion: 3)
 
     emit(snapshot)
     return snapshot

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTAttemptLifecycleRecorder.swift
@@ -45,6 +45,30 @@ final class PTTAttemptLifecycleRecorder {
     }
   }
 
+  /// What a bounded turn-audio duration collapses into for remote querying on
+  /// the product event (`floating_bar_ptt_ended`); the lifecycle event keeps
+  /// its rounded seconds and does not use this bucket.
+  enum AudioSecondsBucket: String {
+    case lt2 = "lt_2"
+    case lt5 = "lt_5"
+    case lt10 = "lt_10"
+    case lt20 = "lt_20"
+    case lt60 = "lt_60"
+    case ge60 = "ge_60"
+
+    /// Nil when the site genuinely does not know the turn's audio length, so
+    /// the property is omitted rather than reporting a fake bucket.
+    static func bucket(fromSeconds seconds: Double?) -> AudioSecondsBucket? {
+      guard let seconds else { return nil }
+      if seconds < 2 { return .lt2 }
+      if seconds < 5 { return .lt5 }
+      if seconds < 10 { return .lt10 }
+      if seconds < 20 { return .lt20 }
+      if seconds < 60 { return .lt60 }
+      return .ge60
+    }
+  }
+
   /// Energy class of the first received audio chunks — distinguishes a capture
   /// that delivers real samples from one that delivers only zeros.
   enum FirstChunksEnergyBucket: String {
@@ -124,6 +148,18 @@ final class PTTAttemptLifecycleRecorder {
     case cancelled
   }
 
+  /// What the user used the PTT turn for, classified when the turn terminates.
+  /// Intent is only knowable once a route resolved it — a dictation is claimed
+  /// mid-hold (or by the closing decode) and closes through the voice-typing
+  /// pipeline; a question commits to an answer path. Cancels, too-short taps,
+  /// and silent discards happen before any intent exists and stay `unknown`
+  /// rather than being forced into a bucket they cannot support.
+  enum TurnKind: String {
+    case dictation
+    case question
+    case unknown
+  }
+
   enum RecoveryAction: String {
     case none
     case captureRebuild = "capture_rebuild"
@@ -164,6 +200,10 @@ final class PTTAttemptLifecycleRecorder {
     var msToFirstUsableFrameBucket: MillisecondsBucket
     var firstChunksEnergyBucket: FirstChunksEnergyBucket
     var turnDisposition: TurnDisposition
+    /// Intent classification at termination (dictation / question / unknown).
+    /// Defaulted so legacy direct `Snapshot` constructions — tests — keep
+    /// compiling while every production terminate site passes it explicitly.
+    var turnKind: TurnKind = .unknown
     var inputRouteClass: InputRouteClass
     var inputRouteSource: InputRouteSource
     var routeChangedDuringAttempt: Bool
@@ -203,6 +243,7 @@ final class PTTAttemptLifecycleRecorder {
         "ms_to_first_usable_frame_bucket": msToFirstUsableFrameBucket.rawValue,
         "first_chunks_energy_bucket": firstChunksEnergyBucket.rawValue,
         "turn_disposition": turnDisposition.rawValue,
+        "turn_kind": turnKind.rawValue,
         "input_route_class": inputRouteClass.rawValue,
         "input_route_source": inputRouteSource.rawValue,
         "route_changed_during_attempt": routeChangedDuringAttempt,
@@ -408,6 +449,7 @@ final class PTTAttemptLifecycleRecorder {
   @discardableResult
   func terminate(
     disposition: TurnDisposition,
+    turnKind: TurnKind = .unknown,
     source: String,
     peak: Int?,
     rms: Int?,
@@ -465,6 +507,7 @@ final class PTTAttemptLifecycleRecorder {
       msToFirstUsableFrameBucket: MillisecondsBucket.bucket(fromMs: msToFirstUsable),
       firstChunksEnergyBucket: firstEnergy,
       turnDisposition: disposition,
+      turnKind: turnKind,
       inputRouteClass: inputRouteClass,
       inputRouteSource: inputRouteSource,
       routeChangedDuringAttempt: routeChangedDuringAttempt,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1649,6 +1649,12 @@ class PushToTalkManager: ObservableObject {
             turnAudioSeconds: Double(audioData.count / 2) / 16000.0,
             voicedAudioSeconds: nil,
             judgeable: true)
+          AnalyticsManager.shared.floatingBarPTTEnded(
+            mode: self.finalizedMode,
+            committed: false,
+            transcriptLength: nil,
+            turnKind: .question,
+            audioSeconds: Double(audioData.count / 2) / 16000.0)
           self.voiceTurnCoordinator.publish(
             .transcriptionFailed(turnID: turnID, message: error.localizedDescription))
           return
@@ -3596,12 +3602,13 @@ class PushToTalkManager: ObservableObject {
         if let recoveryAuthorization, let transcript = run.transcript {
           OfflinePTTQuestionRecovery.shared.capture(transcript, authorization: recoveryAuthorization)
         }
-        // Offline question kept for review — still closed by the dictation
-        // pipeline, so it stays a dictation terminal.
+        // Closing decode said this was not dictation. Offline cannot answer,
+        // but the intent is a question (kept for review/copy).
         AnalyticsManager.shared.floatingBarPTTEnded(
           mode: self.finalizedMode, committed: false, transcriptLength: nil,
-          turnKind: .dictation, audioSeconds: totalSec, dictationTranscriber: run.transcriber)
-        self.terminateVoiceTypingLifecycle(disposition: .cancelled, totalSec: totalSec)
+          turnKind: .question, audioSeconds: totalSec)
+        self.terminateVoiceTypingLifecycle(
+          disposition: .cancelled, totalSec: totalSec, turnKind: .question)
         self.voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .noNetwork))
         return
       }
@@ -3671,11 +3678,13 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func terminateVoiceTypingLifecycle(
-    disposition: PTTAttemptLifecycleRecorder.TurnDisposition, totalSec: Double
+    disposition: PTTAttemptLifecycleRecorder.TurnDisposition,
+    totalSec: Double,
+    turnKind: PTTAttemptLifecycleRecorder.TurnKind = .dictation
   ) {
     pttLifecycle.terminate(
       disposition: disposition,
-      turnKind: .dictation,
+      turnKind: turnKind,
       source: "voice_typing",
       peak: nil,
       rms: nil,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1422,6 +1422,7 @@ class PushToTalkManager: ObservableObject {
         }
         pttLifecycle.terminate(
           disposition: resolution.disposition,
+          turnKind: .unknown,
           source: "hub",
           peak: peak,
           rms: rms,
@@ -1439,8 +1440,11 @@ class PushToTalkManager: ObservableObject {
             reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false, recoveryAlreadyTriggered: true)
         }
         _ = RealtimeHubController.shared.cancelTurn(turnID: turnID)
+        // Discarded before any intent existed: the hub turn never carried
+        // speech, so dictation-vs-question was never determined.
         AnalyticsManager.shared.floatingBarPTTEnded(
-          mode: finalizedMode, committed: false, transcriptLength: nil)
+          mode: finalizedMode, committed: false, transcriptLength: nil,
+          turnKind: .unknown, audioSeconds: totalSec)
         // Too short to have captured anything (fast tap / capture not ready) — hint
         // the user to hold longer instead of clearing silently. A longer hub turn
         // that simply had no speech keeps the quiet reset.
@@ -1499,6 +1503,7 @@ class PushToTalkManager: ObservableObject {
           recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
         pttLifecycle.terminate(
           disposition: resolution.disposition,
+          turnKind: .unknown,
           source: isOmniSTT ? "omni_stt" : "batch_stt",
           peak: peak,
           rms: rms,
@@ -1509,8 +1514,10 @@ class PushToTalkManager: ObservableObject {
         log(
           "PushToTalkManager: discarding silent turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s) — not transcribing"
         )
+        // Silent discard — intent (type vs ask) never materialized.
         AnalyticsManager.shared.floatingBarPTTEnded(
-          mode: finalizedMode, committed: false, transcriptLength: nil)
+          mode: finalizedMode, committed: false, transcriptLength: nil,
+          turnKind: .unknown, audioSeconds: totalSec)
         if recoveryDecision.shouldRebuildCapture {
           requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: isBatch)
         }
@@ -1633,6 +1640,9 @@ class PushToTalkManager: ObservableObject {
           let (batchPeak, batchRMS) = Self.audioEnergy(pcm16k: audioData)
           self.pttLifecycle.terminate(
             disposition: .committed,
+            // Voiced speech reached the batch question route; the STT error
+            // ended it there. An attempted question, not an unknown discard.
+            turnKind: .question,
             source: "batch_stt",
             peak: batchPeak,
             rms: batchRMS,
@@ -1805,11 +1815,14 @@ class PushToTalkManager: ObservableObject {
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: finalizedMode,
         committed: true,
-        transcriptLength: query.count
-      )
+        transcriptLength: query.count,
+        // Transcript exists and the dictation claim already said no: this is a
+        // dispatched agent question.
+        turnKind: .question)
       DesktopDiagnosticsManager.shared.recordPTTCommitted(mode: finalizedMode, hubActive: false)
       pttLifecycle.terminate(
         disposition: .committed,
+        turnKind: .question,
         source: isOmniSTT ? "omni_stt" : "batch_stt",
         // The turn's PCM was consumed before finalization reached this point, so
         // these are genuinely unknown here rather than zero.
@@ -1819,13 +1832,17 @@ class PushToTalkManager: ObservableObject {
         voicedAudioSeconds: nil,
         judgeable: true)
     } else {
-      AnalyticsManager.shared.floatingBarPTTEnded(mode: finalizedMode, committed: false, transcriptLength: 0)
+      // No transcript materialized, so dictation-vs-question was never
+      // determined (live turns that return empty are usually silence).
+      AnalyticsManager.shared.floatingBarPTTEnded(
+        mode: finalizedMode, committed: false, transcriptLength: 0, turnKind: .unknown)
       // Empty transcript after the turn reached finalization (e.g. a live-Deepgram
       // turn that returned nothing). The recorder's tracked capture state
       // (first-audio / first-usable-frame) classifies it; this resolves any pending
       // recovery exactly once instead of skipping the lifecycle emit.
       pttLifecycle.terminate(
         disposition: .committed,
+        turnKind: .unknown,
         source: isOmniSTT ? "omni_stt" : "batch_stt",
         // The turn's PCM was consumed before finalization reached this point, so
         // these are genuinely unknown here rather than zero.
@@ -2042,9 +2059,12 @@ class PushToTalkManager: ObservableObject {
       // report an empty transcript and drag the transcript-length distribution
       // down with attempts that never reached STT; `floatingBarPTTEnded` omits the
       // property entirely when this is nil.
-      transcriptLength: nil)
+      transcriptLength: nil,
+      // Denied before capture: intent never had a chance to exist.
+      turnKind: .unknown)
     pttLifecycle.terminate(
       disposition: .permissionDenied,
+      turnKind: .unknown,
       source: "permission_gate",
       peak: nil,
       rms: nil,
@@ -2252,6 +2272,7 @@ class PushToTalkManager: ObservableObject {
         recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
       pttLifecycle.terminate(
         disposition: resolution.disposition,
+        turnKind: .unknown,
         source: "buffered_hub",
         peak: peak,
         rms: rms,
@@ -2268,8 +2289,10 @@ class PushToTalkManager: ObservableObject {
       if recoveryDecision.shouldRebuildCapture {
         requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: false)
       }
+      // Speech gate discarded the buffered turn before intent was knowable.
       AnalyticsManager.shared.floatingBarPTTEnded(
-        mode: finalizedMode, committed: false, transcriptLength: nil)
+        mode: finalizedMode, committed: false, transcriptLength: nil,
+        turnKind: .unknown, audioSeconds: totalSec)
       if resolution.captureStartedLate {
         finishCaptureNotReadyPTTTurn(reason: "buffered hub, \(String(format: "%.2f", totalSec))s")
       } else if let turnID = currentVoiceTurnID {
@@ -2310,6 +2333,7 @@ class PushToTalkManager: ObservableObject {
     let (committedPeak, committedRMS) = Self.audioEnergy(pcm16k: turnAudio)
     pttLifecycle.terminate(
       disposition: .committed,
+      turnKind: .question,
       source: "buffered_hub",
       peak: committedPeak,
       rms: committedRMS,
@@ -2317,7 +2341,8 @@ class PushToTalkManager: ObservableObject {
       voicedAudioSeconds: nil,
       judgeable: true)
     AnalyticsManager.shared.floatingBarPTTEnded(
-      mode: finalizedMode, committed: true, transcriptLength: nil)
+      mode: finalizedMode, committed: true, transcriptLength: nil,
+      turnKind: .question, audioSeconds: totalSec)
     log(
       "PushToTalkManager: buffered hub turn "
         + "\(commitResult == .accepted ? "committed" : "deferred until its realtime session is ready") after warm wait")
@@ -2350,6 +2375,7 @@ class PushToTalkManager: ObservableObject {
         recoveryResult: recoveryDecision.shouldRebuildCapture ? "attempted" : "not_attempted")
       pttLifecycle.terminate(
         disposition: resolution.disposition,
+        turnKind: .unknown,
         source: "warm_wait_fallback",
         peak: peak,
         rms: rms,
@@ -2361,7 +2387,8 @@ class PushToTalkManager: ObservableObject {
         "PushToTalkManager: discarding warm-wait fallback turn (audio \(String(format: "%.2f", totalSec))s, voiced \(String(format: "%.2f", voicedSec))s)"
       )
       AnalyticsManager.shared.floatingBarPTTEnded(
-        mode: finalizedMode, committed: false, transcriptLength: nil)
+        mode: finalizedMode, committed: false, transcriptLength: nil,
+        turnKind: .unknown, audioSeconds: totalSec)
       if recoveryDecision.shouldRebuildCapture {
         requestCoreAudioCaptureRecovery(reason: "repeated dead-mic PTT turns", restartPTT: false, batchMode: true)
       }
@@ -2988,6 +3015,7 @@ class PushToTalkManager: ObservableObject {
         // PR exists to diagnose never produces a lifecycle event.
         self.pttLifecycle.terminate(
           disposition: .silentRejected,
+          turnKind: .unknown,
           source: "capture_start",
           // Capture never started, so zero samples is a measured fact here, not a
           // placeholder: it is what distinguishes a failed start from an unknown.
@@ -3325,14 +3353,18 @@ class PushToTalkManager: ObservableObject {
     let (committedPeak, committedRMS) = Self.audioEnergy(pcm16k: turnAudio)
     pttLifecycle.terminate(
       disposition: .committed,
+      turnKind: .question,
       source: "hub",
       peak: committedPeak,
       rms: committedRMS,
       turnAudioSeconds: totalSec,
       voicedAudioSeconds: nil,
       judgeable: true)
+    // The closing dictation check already said no: this hub turn is an agent
+    // question committed for an answer.
     AnalyticsManager.shared.floatingBarPTTEnded(
-      mode: finalizedMode, committed: true, transcriptLength: nil)
+      mode: finalizedMode, committed: true, transcriptLength: nil,
+      turnKind: .question, audioSeconds: totalSec)
     log(
       "PushToTalkManager: hub turn "
         + "\(commitResult == .accepted ? "committed" : "deferred until its realtime session is ready")")
@@ -3545,7 +3577,11 @@ class PushToTalkManager: ObservableObject {
       guard run.transcript != nil else {
         log("PushToTalkManager: dictation produced no transcript from any recognizer")
         self.voiceTypeSession.abandon()
-        AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
+        // The voice-typing pipeline ran, so the terminal is a dictation even
+        // though no recognizer produced text.
+        AnalyticsManager.shared.floatingBarPTTEnded(
+          mode: self.finalizedMode, committed: false, transcriptLength: nil,
+          turnKind: .dictation, audioSeconds: totalSec)
         self.terminateVoiceTypingLifecycle(disposition: .silentRejected, totalSec: totalSec)
         let reason: VoiceTurnTerminalReason =
           wasClaimed ? .transcriptionFailed : (offlineRoute ? .noNetwork : .silentRejected)
@@ -3560,7 +3596,11 @@ class PushToTalkManager: ObservableObject {
         if let recoveryAuthorization, let transcript = run.transcript {
           OfflinePTTQuestionRecovery.shared.capture(transcript, authorization: recoveryAuthorization)
         }
-        AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
+        // Offline question kept for review — still closed by the dictation
+        // pipeline, so it stays a dictation terminal.
+        AnalyticsManager.shared.floatingBarPTTEnded(
+          mode: self.finalizedMode, committed: false, transcriptLength: nil,
+          turnKind: .dictation, audioSeconds: totalSec, dictationTranscriber: run.transcriber)
         self.terminateVoiceTypingLifecycle(disposition: .cancelled, totalSec: totalSec)
         self.voiceTurnCoordinator.publish(.finish(turnID: turnID, reason: .noNetwork))
         return
@@ -3570,7 +3610,10 @@ class PushToTalkManager: ObservableObject {
       switch run.completion {
       case .none:
         log("PushToTalkManager: dictation had nothing to paste (\(elapsed)ms)")
-        AnalyticsManager.shared.floatingBarPTTEnded(mode: self.finalizedMode, committed: false, transcriptLength: nil)
+        // Dictation recognized, delivered nothing: still a dictation terminal.
+        AnalyticsManager.shared.floatingBarPTTEnded(
+          mode: self.finalizedMode, committed: false, transcriptLength: nil,
+          turnKind: .dictation, audioSeconds: totalSec, dictationTranscriber: run.transcriber)
         self.terminateVoiceTypingLifecycle(disposition: .cancelled, totalSec: totalSec)
         self.voiceTurnCoordinator.publish(.cancel(turnID: turnID, reason: .cancelled))
         return
@@ -3593,7 +3636,8 @@ class PushToTalkManager: ObservableObject {
           + "\(run.polished ? ", polished" : "") in \(elapsed)ms")
       AnalyticsManager.shared.floatingBarPTTEnded(
         mode: self.finalizedMode, committed: run.completion.isConfirmedDelivery,
-        transcriptLength: self.voiceTypingLastOutcome.characters)
+        transcriptLength: self.voiceTypingLastOutcome.characters,
+        turnKind: .dictation, audioSeconds: totalSec, dictationTranscriber: run.transcriber)
       self.terminateVoiceTypingLifecycle(
         disposition: run.completion.isConfirmedDelivery ? .committed : .cancelled, totalSec: totalSec)
       // The journal write is awaited before the turn ends, so a lifecycle
@@ -3631,6 +3675,7 @@ class PushToTalkManager: ObservableObject {
   ) {
     pttLifecycle.terminate(
       disposition: disposition,
+      turnKind: .dictation,
       source: "voice_typing",
       peak: nil,
       rms: nil,

--- a/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDiagnosticsManagerTests.swift
@@ -564,6 +564,7 @@ import XCTest
       recorder.noteInputRoute(class: .bluetooth, source: .override)
       recorder.terminate(
         disposition: .silentRejected,
+        turnKind: .unknown,
         source: "hub",
         peak: 0,
         rms: 0,
@@ -587,6 +588,8 @@ import XCTest
       XCTAssertEqual(snapshot["input_route_class"] as? String, "bluetooth")
       XCTAssertEqual(snapshot["input_route_source"] as? String, "override")
       XCTAssertEqual(snapshot["turn_disposition"] as? String, "silent_rejected")
+      // The funnel split key rides the same bounded snapshot.
+      XCTAssertEqual(snapshot["turn_kind"] as? String, "unknown")
       XCTAssertNotNil(snapshot["attempt_id"])
       // Privacy: no raw device identity, hardware id, or error string leaks.
       XCTAssertFalse(json.contains("engineStartFailed") || json.contains("OSStatus"))

--- a/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private final class Box<T>: @unchecked Sendable {
+  var value: T
+  init(_ value: T) { self.value = value }
+}
+
+/// Contract tests for the `floating_bar_ptt_ended` terminal classification
+/// (`turn_kind`): dictation vs question vs unknown. The capture seam lives on
+/// `AnalyticsManager`'s main-actor boundary so tests observe the real event
+/// name and payload without initializing PostHog.
+@MainActor
+final class FloatingBarPTTAnalyticsTests: XCTestCase {
+  private let capturedBox = Box<[(String, [String: Any])]>([])
+
+  private func startCapturing() {
+    let box = capturedBox
+    box.value = []
+    AnalyticsManager.shared.setFloatingBarPTTTelemetryCaptureForTests { event, properties in
+      box.value.append((event, properties))
+    }
+    addTeardownBlock {
+      await MainActor.run {
+        AnalyticsManager.shared.setFloatingBarPTTTelemetryCaptureForTests(nil)
+      }
+    }
+  }
+
+  // MARK: - turn_kind closed set
+
+  func testEndedPayloadCarriesEveryTurnKindRawValue() {
+    startCapturing()
+
+    for (kind, raw) in [
+      (PTTAttemptLifecycleRecorder.TurnKind.dictation, "dictation"),
+      (.question, "question"),
+      (.unknown, "unknown"),
+    ] {
+      AnalyticsManager.shared.floatingBarPTTEnded(
+        mode: "hold", committed: false, transcriptLength: nil, turnKind: kind)
+      XCTAssertEqual(capturedBox.value.last?.1["turn_kind"] as? String, raw)
+    }
+    let kinds = capturedBox.value.map { $0.1["turn_kind"] as? String }
+    XCTAssertEqual(kinds, ["dictation", "question", "unknown"])
+    for captured in capturedBox.value {
+      XCTAssertEqual(captured.0, "floating_bar_ptt_ended")
+      XCTAssertEqual(captured.1["mode"] as? String, "hold")
+      XCTAssertEqual(captured.1["had_transcript"] as? Bool, false)
+    }
+  }
+
+  func testTurnKindDefaultsToUnknownWhenSiteCannotKnowIntent() {
+    startCapturing()
+
+    AnalyticsManager.shared.floatingBarPTTEnded(mode: "hold", committed: false, transcriptLength: nil)
+
+    XCTAssertEqual(capturedBox.value.single?.1["turn_kind"] as? String, "unknown")
+  }
+
+  func testExistingWirePropertiesAreUnchanged() {
+    startCapturing()
+
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "toggle", committed: true, transcriptLength: 42, turnKind: .question)
+
+    let props = capturedBox.value.single?.1
+    XCTAssertEqual(props?["mode"] as? String, "toggle")
+    XCTAssertEqual(props?["had_transcript"] as? Bool, true)
+    XCTAssertEqual(props?["transcript_length"] as? Int, 42)
+  }
+
+  // MARK: - optional bounded extras
+
+  func testAudioSecondsCollapseIntoClosedBuckets() {
+    startCapturing()
+
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: nil, turnKind: .question, audioSeconds: 19.5)
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: nil, turnKind: .question, audioSeconds: 61)
+    // A site that genuinely does not know the length omits the property.
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: nil, turnKind: .question)
+
+    let buckets = capturedBox.value.map { $0.1["audio_seconds_bucket"] as? String }
+    XCTAssertEqual(buckets, ["lt_20", "ge_60", nil])
+  }
+
+  func testDictationTranscriberRidesOnlyDictationTerminals() {
+    startCapturing()
+
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: 3, turnKind: .dictation,
+      dictationTranscriber: "backend_batch_stt")
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: nil, turnKind: .question)
+
+    XCTAssertEqual(capturedBox.value[0].1["dictation_transcriber"] as? String, "backend_batch_stt")
+    XCTAssertNil(capturedBox.value[1].1["dictation_transcriber"])
+  }
+
+  // MARK: - privacy boundary
+
+  /// PostHog receives bounded dimensions only: the payload's key set is closed
+  /// and contains no transcript, prompt, or free-text key.
+  func testPayloadKeysStayBoundedAndContentFree() {
+    startCapturing()
+
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: 12, turnKind: .dictation,
+      audioSeconds: 3, dictationTranscriber: "on_device_asr")
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: false, transcriptLength: nil, turnKind: .unknown)
+
+    let allowed: Set<String> = [
+      "mode", "had_transcript", "transcript_length", "turn_kind", "audio_seconds_bucket",
+      "dictation_transcriber",
+    ]
+    for (_, props) in capturedBox.value {
+      assertKeysWithin(Set(props.keys), allowed)
+    }
+    // No key may carry content, even by another name.
+    let contentBearing: Set<String> = [
+      "transcript", "transcript_text", "text", "prompt", "message", "query", "response",
+    ]
+    for (_, props) in capturedBox.value {
+      XCTAssertTrue(Set(props.keys).isDisjoint(with: contentBearing))
+    }
+  }
+
+  // MARK: - call-site wiring (source inspection)
+
+  /// Every terminal in `PushToTalkManager` must classify its `turn_kind`
+  /// explicitly — the payload contract above is worthless if a site forgets
+  /// the argument and silently reports `unknown`.
+  func testEveryPTTTerminalCallSiteClassifiesTurnKindExplicitly() throws {
+    // omi-test-quality: source-inspection -- static contract: every floatingBarPTTEnded and pttLifecycle.terminate call site in PushToTalkManager passes an explicit turnKind; driving the full CoreAudio/key-event stack behaviorally is not possible in a unit test, and the payload contract is covered behaviorally above.
+    let source = try pushToTalkManagerSource()
+
+    for (_, call) in balancedCalls(of: "floatingBarPTTEnded(", in: source)
+      + balancedCalls(of: "pttLifecycle.terminate(", in: source)
+    {
+      XCTAssertTrue(
+        call.contains("turnKind:"), "terminal call site must pass turnKind:\n\(call.prefix(200))")
+    }
+
+    // The dictation close funnels through finishVoiceTypingTurn; every product
+    // event inside it is a dictation terminal.
+    let body = try functionBody(named: "finishVoiceTypingTurn", in: source)
+    for (lineNumber, call) in balancedCalls(of: "floatingBarPTTEnded(", in: body) {
+      XCTAssertTrue(
+        call.contains("turnKind: .dictation"),
+        "dictation close must classify as .dictation (body line \(lineNumber))")
+    }
+  }
+
+  /// The lifecycle terminate inside the dictation close is the one place a
+  /// `voice_typing` snapshot is emitted — it must be `dictation`, not the
+  /// `unknown` default.
+  func testVoiceTypingLifecycleTerminateIsDictation() throws {
+    // omi-test-quality: source-inspection -- static contract: terminateVoiceTypingLifecycle is the single voice_typing lifecycle emit and must pass .dictation; the recorder field itself is covered behaviorally in PTTAttemptLifecycleRecorderTests.
+    let source = try pushToTalkManagerSource()
+    let body = try functionBody(named: "terminateVoiceTypingLifecycle", in: source)
+    XCTAssertTrue(body.contains("turnKind: .dictation"))
+  }
+
+  // MARK: - helpers
+  private func pushToTalkManagerSource() throws -> String {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/FloatingControlBar/PushToTalkManager.swift")
+    // omi-test-quality: source-inspection -- static contract: reads PushToTalkManager.swift for the annotated turn_kind call-site tripwires above; payload behavior is covered behaviorally in this file.
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  /// Extracts a `func <name>(...) { ... }` body by brace matching.
+  private func functionBody(named name: String, in source: String) throws -> String {
+    let signature = try XCTUnwrap(
+      source.range(of: "func \(name)("), "function \(name) not found")
+    let opening = try XCTUnwrap(source[signature.lowerBound...].firstIndex(of: "{"))
+    var depth = 1
+    var index = source.index(after: opening)
+    while index < source.endIndex, depth > 0 {
+      if source[index] == "{" { depth += 1 }
+      if source[index] == "}" { depth -= 1 }
+      index = source.index(after: index)
+    }
+    return String(source[opening..<index])
+  }
+
+  /// Returns `(lineNumber, fullBalancedCall)` for every occurrence of `needle`
+  /// in `source`, where the call text spans from the needle through its
+  /// matching close parenthesis.
+  private func balancedCalls(of needle: String, in source: String) -> [(Int, String)] {
+    var calls: [(Int, String)] = []
+    var searchRange = source.startIndex..<source.endIndex
+    while let found = source.range(of: needle, range: searchRange) {
+      var depth = 1
+      var index = found.upperBound
+      while index < source.endIndex, depth > 0 {
+        if source[index] == "(" { depth += 1 }
+        if source[index] == ")" { depth -= 1 }
+        index = source.index(after: index)
+      }
+      calls.append(
+        (
+          source[..<(found.lowerBound)].components(separatedBy: "\n").count,
+          String(source[found.lowerBound..<index])
+        ))
+      searchRange = index..<source.endIndex
+    }
+    return calls
+  }
+}
+
+extension Array {
+  fileprivate var single: Element? { count == 1 ? first : nil }
+}
+
+private func assertKeysWithin(
+  _ keys: Set<String>, _ allowed: Set<String>, file: StaticString = #filePath, line: UInt = #line
+) {
+  XCTAssertTrue(
+    keys.subtracting(allowed).isEmpty, "unexpected payload keys: \(keys.subtracting(allowed))",
+    file: file, line: line)
+}

--- a/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
@@ -178,8 +178,9 @@ final class FloatingBarPTTAnalyticsTests: XCTestCase {
   func testVoiceTypingLifecycleTerminateIsDictation() throws {
     // omi-test-quality: source-inspection -- static contract: terminateVoiceTypingLifecycle is the single voice_typing lifecycle emit and defaults to .dictation; the recorder field itself is covered behaviorally in PTTAttemptLifecycleRecorderTests.
     let source = try pushToTalkManagerSource()
+    // Default lives on the signature, which `functionBody` strips at `{`.
+    XCTAssertTrue(source.contains("TurnKind = .dictation"))
     let body = try functionBody(named: "terminateVoiceTypingLifecycle", in: source)
-    XCTAssertTrue(body.contains("= .dictation"))
     XCTAssertTrue(body.contains("turnKind: turnKind"))
   }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarPTTAnalyticsTests.swift
@@ -99,6 +99,15 @@ final class FloatingBarPTTAnalyticsTests: XCTestCase {
 
     XCTAssertEqual(capturedBox.value[0].1["dictation_transcriber"] as? String, "backend_batch_stt")
     XCTAssertNil(capturedBox.value[1].1["dictation_transcriber"])
+
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: 3, turnKind: .question,
+      dictationTranscriber: "backend_batch_stt")
+    AnalyticsManager.shared.floatingBarPTTEnded(
+      mode: "hold", committed: true, transcriptLength: 3, turnKind: .dictation,
+      dictationTranscriber: "not-a-real-source")
+    XCTAssertNil(capturedBox.value[2].1["dictation_transcriber"])
+    XCTAssertNil(capturedBox.value[3].1["dictation_transcriber"])
   }
 
   // MARK: - privacy boundary
@@ -146,24 +155,32 @@ final class FloatingBarPTTAnalyticsTests: XCTestCase {
         call.contains("turnKind:"), "terminal call site must pass turnKind:\n\(call.prefix(200))")
     }
 
-    // The dictation close funnels through finishVoiceTypingTurn; every product
-    // event inside it is a dictation terminal.
+    // The dictation close funnels through finishVoiceTypingTurn. Offline
+    // `notADictation` is an attempted question, not a dictation terminal.
     let body = try functionBody(named: "finishVoiceTypingTurn", in: source)
     for (lineNumber, call) in balancedCalls(of: "floatingBarPTTEnded(", in: body) {
+      let isQuestion = call.contains("turnKind: .question")
+      let isDictation = call.contains("turnKind: .dictation")
       XCTAssertTrue(
-        call.contains("turnKind: .dictation"),
-        "dictation close must classify as .dictation (body line \(lineNumber))")
+        isQuestion || isDictation,
+        "dictation close must classify turnKind (body line \(lineNumber))")
+      if isQuestion {
+        XCTAssertTrue(
+          body.contains("if run.notADictation"),
+          "question classification in finishVoiceTypingTurn is only for notADictation")
+      }
     }
   }
 
   /// The lifecycle terminate inside the dictation close is the one place a
-  /// `voice_typing` snapshot is emitted — it must be `dictation`, not the
-  /// `unknown` default.
+  /// `voice_typing` snapshot is emitted — default dictation, overridable for
+  /// the offline notADictation question path.
   func testVoiceTypingLifecycleTerminateIsDictation() throws {
-    // omi-test-quality: source-inspection -- static contract: terminateVoiceTypingLifecycle is the single voice_typing lifecycle emit and must pass .dictation; the recorder field itself is covered behaviorally in PTTAttemptLifecycleRecorderTests.
+    // omi-test-quality: source-inspection -- static contract: terminateVoiceTypingLifecycle is the single voice_typing lifecycle emit and defaults to .dictation; the recorder field itself is covered behaviorally in PTTAttemptLifecycleRecorderTests.
     let source = try pushToTalkManagerSource()
     let body = try functionBody(named: "terminateVoiceTypingLifecycle", in: source)
-    XCTAssertTrue(body.contains("turnKind: .dictation"))
+    XCTAssertTrue(body.contains("= .dictation"))
+    XCTAssertTrue(body.contains("turnKind: turnKind"))
   }
 
   // MARK: - helpers

--- a/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
+++ b/desktop/macos/Desktop/Tests/PTTAttemptLifecycleRecorderTests.swift
@@ -504,6 +504,79 @@ import XCTest
       XCTAssertEqual(recorder.holdSeconds ?? 0, 0.947, accuracy: 0.001)
     }
 
+    // MARK: - Turn kind classification
+
+    /// `turn_kind` rides the same snapshot as the capture funnel so a
+    /// release-health query splits dictation vs question without using the
+    /// product event as its denominator.
+    func testTerminateCarriesTheExplicitTurnKind() {
+      for (kind, raw) in [
+        (PTTAttemptLifecycleRecorder.TurnKind.dictation, "dictation"),
+        (.question, "question"),
+        (.unknown, "unknown"),
+      ] {
+        let recorder = makeRecorder()
+        begin(recorder)
+        captureAccepted(recorder)
+        let snapshot = recorder.terminate(
+          disposition: .committed,
+          turnKind: kind,
+          source: "hub",
+          peak: 1200,
+          rms: 300,
+          turnAudioSeconds: 2,
+          voicedAudioSeconds: 1,
+          judgeable: true)
+        XCTAssertEqual(snapshot.properties["turn_kind"] as? String, raw)
+        XCTAssertEqual(snapshot.turnKind, kind)
+      }
+    }
+
+    /// A site that terminates before intent is knowable (cancel, too-short,
+    /// silent discard) omits the argument rather than guessing.
+    func testTerminateWithoutTurnKindStaysUnknown() {
+      let recorder = makeRecorder()
+      begin(recorder)
+      let snapshot = terminate(recorder, disposition: .tooShort, peak: 0, rms: 0, seconds: 0.2, judgeable: false)
+      XCTAssertEqual(snapshot.properties["turn_kind"] as? String, "unknown")
+    }
+
+    /// A directly-constructed snapshot (the success-denominator path in
+    /// `DesktopDiagnosticsManagerTests`) defaults to `unknown` so the closed
+    /// set always has a value on the wire.
+    func testSnapshotTurnKindDefaultsToUnknown() {
+      let snapshot = PTTAttemptLifecycleRecorder.Snapshot(
+        attemptId: "1", failureClass: .committed, captureStartOutcome: .accepted,
+        captureStartStatusClass: .ok, msToFirstAudioBucket: .lt100,
+        msToFirstUsableFrameBucket: .lt200, firstChunksEnergyBucket: .audible,
+        turnDisposition: .committed, inputRouteClass: .builtIn, inputRouteSource: .default,
+        routeChangedDuringAttempt: false, recoveryTriggered: false, recoveryAction: .none,
+        recoveryAttemptId: nil, recoveryOutcomeOfNextTurn: .none, mode: "hold", source: "hub",
+        hubActive: true, micPermissionGranted: true, turnAudioSeconds: 2.0,
+        voicedAudioSeconds: 1.5, peak: 1200, rms: 300, isNearZero: false, judgeable: true,
+        telemetrySchemaVersion: 2)
+      XCTAssertEqual(snapshot.properties["turn_kind"] as? String, "unknown")
+    }
+
+    /// The product event's closed audio buckets — boundaries are exclusive
+    /// lower edges (`lt_2` is [0,2), `ge_60` is [60,∞)).
+    func testAudioSecondsBucketBoundaries() {
+      typealias Bucket = PTTAttemptLifecycleRecorder.AudioSecondsBucket
+      XCTAssertNil(Bucket.bucket(fromSeconds: nil))
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 0), .lt2)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 1.99), .lt2)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 2), .lt5)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 4.99), .lt5)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 5), .lt10)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 9.99), .lt10)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 10), .lt20)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 19.99), .lt20)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 20), .lt60)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 59.99), .lt60)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 60), .ge60)
+      XCTAssertEqual(Bucket.bucket(fromSeconds: 600), .ge60)
+    }
+
     private func terminate(
       _ recorder: PTTAttemptLifecycleRecorder,
       disposition: PTTAttemptLifecycleRecorder.TurnDisposition,

--- a/desktop/macos/changelog/unreleased/20260908-ptt-turn-kind-metrics.json
+++ b/desktop/macos/changelog/unreleased/20260908-ptt-turn-kind-metrics.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "note": "Internal analytics: turn_kind (dictation/question/unknown) on floating_bar_ptt_ended and ptt_audio_capture_lifecycle, plus bounded audio_seconds_bucket and dictation_transcriber dimensions. No user-facing behavior change."
+}

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -51,7 +51,7 @@ the release-evidence layer (`#9523`) will consume.
 ### PTT terminal-outcome funnel — `ptt_audio_capture_lifecycle`
 
 - **Source event:** `desktop_health_event` with `event = ptt_audio_capture_lifecycle`
-  (`telemetry_schema_version >= 2`).
+  (`telemetry_schema_version >= 2`; `turn_kind` from version 3).
 - **Denominator (attempts):** all `ptt_audio_capture_lifecycle` events in the window,
   grouped by `failure_class`. Every terminal disposition — including success — is
   emitted remotely, so the denominator is queryable.


### PR DESCRIPTION
## Summary

Product question: we cannot tell when users use hold-to-talk for **voice typing / dictation** ("say type") vs **regular agent PTT** (ask Omi). `floating_bar_ptt_ended.mode` only carries hold/toggle, and `had_transcript` is already deprecated as a success/quality dimension.

This adds a closed `turn_kind` (`dictation` | `question` | `unknown`) to every terminal PTT product event, classified at terminate time:

- **`floating_bar_ptt_ended`**: `turn_kind` on every terminal, plus optional bounded extras where the call site already knows them — `audio_seconds_bucket` (closed buckets `lt_2`/`lt_5`/`lt_10`/`lt_20`/`lt_60`/`ge_60`) and, for dictation only, `dictation_transcriber` (`route` | `backend_batch_stt` | `on_device_asr`; no deeper provider split). Existing wire properties (`mode`, `had_transcript`, `transcript_length`) unchanged.
- **`ptt_audio_capture_lifecycle`**: the same `turn_kind` closed set on the `PTTAttemptLifecycleRecorder` snapshot, so release-health funnels split dictation vs question without using the product event as a denominator. `turn_kind` added to the diagnostics cloud-incident key allowlist.

Classification rules (each terminal site passes its value explicitly):

- `dictation` — the voice-typing pipeline ran (`finishVoiceTypingTurn`), including failed/empty paste and no-transcript outcomes.
- `question` — committed or attempted agent answer: hub commit (primary + buffered), STT-cascade dispatch with transcript, and the batch-STT failure terminal (voiced speech reached the question route).
- `unknown` — cancelled / too-short / silent discard / permission-denied / capture-start-failure before intent was knowable. Not forced into either bucket.

`floating_bar_ptt_started` stays unclassified — dictation is recognized mid-hold, so intent does not exist at press time.

## Product invariants affected

- **INV-VOICE-1** — no lifecycle ownership changes: terminals keep firing exactly once per attempt on the same sites; `turn_kind` is a payload dimension on existing events. The doubled-terminal guard (`finishMicrophonePermissionDeniedAttempt`) is untouched.
- **INV-CHAT-1** — no transcript routing changes; no transcript content is added to telemetry (bounded dimensions only, per `desktop/macos/AGENTS.md` product analytics integrity).

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/AnalyticsManager.swift | 1710 -> 1749 | turn_kind/audio_seconds_bucket/dictation_transcriber payload + test seam on the existing PTT product-event helper; gate transcriber to dictation+known sources
Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift | 1524 -> 1525 | one allowlist key (turn_kind) so the lifecycle incident snapshot keeps its funnel split dimension
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 4090 -> 4144 | explicit turnKind at terminals; batch STT fail emits floating_bar_ptt_ended; offline notADictation classified as question

## PostHog query contract

```
dictation users = uniq person_id where event=floating_bar_ptt_ended and turn_kind=dictation
question users  = uniq person_id where event=floating_bar_ptt_ended and turn_kind=question
```

Terminal-attempt split (capture funnel): group `ptt_audio_capture_lifecycle` by `turn_kind`.

## Tests

- `FloatingBarPTTAnalyticsTests` (new): behavioral payload contract via a PostHog-boundary capture seam — closed-set raw values, default-`unknown`, unchanged legacy keys, bucket boundaries, transcriber-only-on-dictation, bounded content-free key set; plus annotated source-inspection tripwires pinning an explicit `turnKind:` at every `floatingBarPTTEnded`/`pttLifecycle.terminate` call site and `.dictation` at the dictation close.
- `PTTAttemptLifecycleRecorderTests`: `turn_kind` passthrough for all three kinds, default `unknown` at terminate, direct-`Snapshot` default, `AudioSecondsBucket` boundary table.
- `DesktopDiagnosticsManagerTests`: `turn_kind` rides the diagnostics attachment lifecycle event.
- Sabotage-verified: removing `turn_kind` from either payload made the new assertions fail (6 failures), then restored.

Verification (worktree `ptt-turn-kind` on `origin/main` @ `f42089f53c`):

- `xcrun swift build -c debug --package-path Desktop` — clean.
- `xcrun swift test --package-path Desktop --filter 'FloatingBarPTTAnalyticsTests|PTTAttemptLifecycleRecorderTests|DesktopDiagnosticsManagerTests'` — 69 tests, 0 failures.
- `./scripts/swift-format-wrapper.sh lint -r <changed files>` — clean; `python3 scripts/check_desktop_test_quality.py` — at baseline.

## Changelog

`kind: none` — internal analytics only (`desktop/macos/changelog/unreleased/20260908-ptt-turn-kind-metrics.json`).

## Out of scope

STT provider split (Parakeet vs Velma), chat-quota metering, backend changes, PostHog saved insights (events only).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


