### PR TITLE
fix(desktop): a settled chat answer never restarts on a stale journal echo, and journal refreshes stop scanning the whole transcript

### DIFF
--- a/.github/failure-classes/FC-stale-streaming-echo-regresses-settled-row.json
+++ b/.github/failure-classes/FC-stale-streaming-echo-regresses-settled-row.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-stale-streaming-echo-regresses-settled-row",
+  "violated_contract": "A durable store's echo of a write is a snapshot from the moment the write was queued. When the in-memory row has since crossed a monotonic state boundary (a streaming transcript row that settled on its terminal answer), an echo still carrying the earlier state must not be projected over it: the row would regress to the earlier state and content, and the terminal replay would then flip it forward a second time, so the reader sees the change happen twice.",
+  "canonical_prevention": "Row projection compares the echo's lifecycle state against the row's before merging: a projected row still marked streaming never replaces an assistant row that has already settled, while a terminal projection always lands. A behavioural test settles a row, projects a streaming echo behind it, and asserts the row keeps its terminal text, stays settled, and publishes nothing; a second test asserts the terminal replay that follows still replaces the row.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ChatStreamingJournalCoalescingTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift",
+    "desktop/macos/Desktop/Sources/Chat/KernelTurnProjection.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
@@ -209,10 +209,27 @@ enum ChatCitationMarkup {
   static let kindOnlyMarkerPattern =
     #"\[(memory|task|goal|conversation|screenshot|web|source|capture|rewind)\](?![\s:]*\d)"#
 
+  /// Compiled once per pattern. Every marker scan used to compile its
+  /// expression on the call, and the citation-inheritance pass runs one scan
+  /// per text of every settled assistant row on every journal projection —
+  /// hundreds of compiles per streaming write on a long transcript, all on
+  /// the main thread. `NSRegularExpression` is immutable and thread-safe.
+  private static let expressionLock = NSLock()
+  private nonisolated(unsafe) static var expressions: [String: NSRegularExpression] = [:]
+
+  static func expression(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression? {
+    let key = "\(options.rawValue):\(pattern)"
+    expressionLock.lock()
+    defer { expressionLock.unlock() }
+    if let cached = expressions[key] { return cached }
+    guard let compiled = try? NSRegularExpression(pattern: pattern, options: options) else { return nil }
+    expressions[key] = compiled
+    return compiled
+  }
+
   static func explicitlyRequestsSources(_ text: String) -> Bool {
     guard
-      let expression = try? NSRegularExpression(
-        pattern: #"\b(?:citations?|cite|sources)\b"#, options: [.caseInsensitive])
+      let expression = expression(#"\b(?:citations?|cite|sources)\b"#, options: [.caseInsensitive])
     else { return false }
     return expression.firstMatch(
       in: text,
@@ -222,18 +239,38 @@ enum ChatCitationMarkup {
   /// Numeric citations outside inline-code spans, in reading order. Incomplete streaming markers
   /// and bracketed prose are left alone. Kind-prefixed copies such as `[memory 5023]` still count.
   static func ordinals(in text: String) -> [Int] {
-    markerMatches(in: text, pattern: numericMarkerPattern).map(\.ordinal)
+    ordinalsLock.lock()
+    if let cached = ordinalsByText[text] {
+      ordinalsLock.unlock()
+      return cached
+    }
+    ordinalsLock.unlock()
+    let ordinals = markerMatches(in: text, pattern: numericMarkerPattern).map(\.ordinal)
+    ordinalsLock.lock()
+    // Bounded, not LRU: settled answers repeat verbatim on every projection
+    // and a streaming row's changing text is never asked here, so the set
+    // that matters is the transcript's settled rows, which fit many times over.
+    if ordinalsByText.count >= 4_096 { ordinalsByText.removeAll(keepingCapacity: true) }
+    ordinalsByText[text] = ordinals
+    ordinalsLock.unlock()
+    return ordinals
   }
+
+  /// `ordinals(in:)` memoized by text. The citation-inheritance pass asks it
+  /// for every text of every settled assistant row on every journal
+  /// projection — one per coalesced streaming write — and a regex scan per
+  /// row made that pass cost the transcript's length in milliseconds.
+  private static let ordinalsLock = NSLock()
+  private nonisolated(unsafe) static var ordinalsByText: [String: [Int]] = [:]
 
   static func markerMatches(
     in text: String,
     pattern: String
   ) -> [(range: Range<String.Index>, ordinal: Int)] {
+    // Every marker opens with a bracket; a text without one has nothing to scan.
+    guard text.utf8.contains(UInt8(ascii: "[")) else { return [] }
     let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
-    guard
-      let expression = try? NSRegularExpression(
-        pattern: pattern, options: [.caseInsensitive])
-    else { return [] }
+    guard let expression = expression(pattern, options: [.caseInsensitive]) else { return [] }
     let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
     return expression.matches(in: text, range: nsRange).compactMap { match in
       guard let full = Range(match.range(at: 0), in: text),
@@ -265,7 +302,7 @@ enum ChatCitationMarkup {
   static func inheritedReferences(
     citedIn message: ChatMessage,
     resolved: [ChatCitationReference],
-    earlierTurns: [ChatMessage],
+    earlierTurns: some BidirectionalCollection<ChatMessage>,
     lookback: Int = 8
   ) -> [ChatCitationReference] {
     var unresolved = message.citedCitationOrdinals.subtracting(resolved.map(\.ordinal))
@@ -330,11 +367,9 @@ enum ChatCitationMarkup {
   private static func kindOnlyMatches(
     in text: String
   ) -> [(range: Range<String.Index>, label: String)] {
+    guard text.utf8.contains(UInt8(ascii: "[")) else { return [] }
     let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
-    guard
-      let expression = try? NSRegularExpression(
-        pattern: kindOnlyMarkerPattern, options: [.caseInsensitive])
-    else { return [] }
+    guard let expression = expression(kindOnlyMarkerPattern, options: [.caseInsensitive]) else { return [] }
     let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
     return expression.matches(in: text, range: nsRange).compactMap { match in
       guard let full = Range(match.range(at: 0), in: text),
@@ -426,7 +461,7 @@ enum ChatCitationMarkup {
   }
 
   private static func firstBoldPhrase(in claim: String) -> String? {
-    guard let expression = try? NSRegularExpression(pattern: #"\*\*(.+?)\*\*"#),
+    guard let expression = expression(#"\*\*(.+?)\*\*"#),
       let match = expression.firstMatch(
         in: claim, range: NSRange(claim.startIndex..<claim.endIndex, in: claim)),
       let range = Range(match.range(at: 1), in: claim)
@@ -523,9 +558,8 @@ enum ChatCitationMarkup {
   }
 
   private static func webReferences(in text: String) -> [ChatCitationReference] {
-    guard
-      let expression = try? NSRegularExpression(
-        pattern: #"\[(\d{1,4})\]\((https?://[^\s)]+)\)"#)
+    guard text.utf8.contains(UInt8(ascii: "[")),
+      let expression = expression(#"\[(\d{1,4})\]\((https?://[^\s)]+)\)"#)
     else { return [] }
     let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
     var seen = Set<Int>()

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -72,6 +72,15 @@ extension ChatProvider {
         && projected.contentBlocks.isEmpty
         && projected.resources.isEmpty
       func replace(at index: Int) {
+        // A streaming echo is the snapshot a write carried a round trip ago. A
+        // row that has already settled — the terminal answer landed and
+        // `isStreaming` flipped, the frame the transcript folds its tool chips
+        // and commentary away on — is newer than any such snapshot by
+        // construction. Taking the echo whole put the shorter text and the
+        // chips back on screen until the terminal replay flipped them away a
+        // second time: the answer visibly started over. The terminal replay
+        // is not streaming and still lands below.
+        if Self.isStaleStreamingEcho(projected, for: updatedMessages[index]) { return }
         let merged = Self.carryingLocalOnlyFields(projected, from: updatedMessages[index])
         guard !merged.isProjectionEquivalent(to: updatedMessages[index]) else { return }
         updatedMessages[index] = merged
@@ -100,7 +109,9 @@ extension ChatProvider {
     // it read unchanged and still owe a restored follow-up the chips it
     // borrows from an earlier turn. The publication gate therefore sits
     // behind the citation projection, and what inheritance bound counts as a
-    // change worth publishing.
+    // change worth publishing. This pass runs on every journal refresh — one
+    // per coalesced streaming write — so it must cost the transcript's
+    // length in lookups, not in regex scans (`ChatCitationMarkup.ordinals`).
     let orderBeforeCanonicalSort = updatedMessages.map(\.id)
     updatedMessages.sort {
       if $0.createdAt == $1.createdAt { return $0.id < $1.id }
@@ -148,7 +159,7 @@ extension ChatProvider {
       let inherited = ChatCitationMarkup.inheritedReferences(
         citedIn: messages[index],
         resolved: messages[index].inlineCitationReferences,
-        earlierTurns: Array(messages[..<index]))
+        earlierTurns: messages[..<index])
       guard !inherited.isEmpty else { continue }
       messages[index].persistCitedReferences(from: inherited)
     }
@@ -229,7 +240,7 @@ extension ChatProvider {
     let inheritedReferences = ChatCitationMarkup.inheritedReferences(
       citedIn: messages[index],
       resolved: turnReferences,
-      earlierTurns: Array(messages[..<index]))
+      earlierTurns: messages[..<index])
     let bindableReferences = turnReferences + inheritedReferences
     let bindBase: [ChatCitationReference]
     if messages[index].hasKindOnlyCitationMarkers {
@@ -397,6 +408,14 @@ extension ChatProvider {
 }
 
 extension ChatProvider {
+  /// A journal row still marked streaming, arriving for an assistant row this
+  /// client has already settled. The write it echoes was queued before the
+  /// terminal mutation (`supersededByTerminalization` gates the ones queued
+  /// after), so its content is older than the row on screen.
+  static func isStaleStreamingEcho(_ projected: ChatMessage, for existing: ChatMessage) -> Bool {
+    projected.isStreaming && !existing.isStreaming && existing.sender == .ai
+  }
+
   /// Upsert by canonical turn ID only. Text equality is deliberately ignored:
   /// two identical messages with distinct turn IDs are distinct journal rows.
   /// Some `ChatMessage` fields live only in the in-memory row and are never

--- a/desktop/macos/Desktop/Tests/ChatJournalProjectionCostTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatJournalProjectionCostTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// What one journal echo costs on the main thread as the transcript grows.
+///
+/// Every coalesced streaming write refreshes the journal and projects the
+/// echo through `projectJournalTurns`, which runs whole-transcript work
+/// (canonical sort, citation inheritance, citation-identifier diff) before it
+/// can decide that nothing visible changed. This pins that cost as a
+/// function of transcript length so it is measured rather than guessed.
+@MainActor
+final class ChatJournalProjectionCostTests: XCTestCase {
+
+  func testStreamingEchoProjectionCostAcrossTranscriptSizes() throws {
+    for rows in [50, 300, 800] {
+      let provider = ChatProvider()
+      let surface = provider.mainChatSurfaceReference()
+      provider.messages = Self.transcript(rows: rows)
+      let live = try XCTUnwrap(provider.messages.last)
+      let liveID = live.id
+      let liveText = live.text
+      let echo = try Self.makeTurn(
+        surface: surface, turnID: liveID, status: .streaming,
+        content: String(liveText.prefix(liveText.count / 2)),
+        contentBlocks: [["type": "text", "id": "\(liveID):text", "text": String(liveText.prefix(liveText.count / 2))]],
+        turnSeq: rows + 1)
+      // Warm once, then time.
+      provider.projectJournalTurns([echo])
+      let iterations = 10
+      let start = ContinuousClock.now
+      for _ in 0..<iterations {
+        provider.projectJournalTurns([echo])
+      }
+      let elapsed = ContinuousClock.now - start
+      let perCallMs =
+        Double(elapsed.components.attoseconds) / 1e15 / Double(iterations)
+        + Double(elapsed.components.seconds) * 1000 / Double(iterations)
+      // Attribute the pass: the canonical sort and the citation inheritance
+      // are the two whole-transcript steps a no-op echo still runs.
+      var sorted = provider.messages
+      let sortStart = ContinuousClock.now
+      for _ in 0..<iterations {
+        sorted = provider.messages
+        sorted.sort {
+          if $0.createdAt == $1.createdAt { return $0.id < $1.id }
+          return $0.createdAt < $1.createdAt
+        }
+      }
+      let sortMs = Self.milliseconds(ContinuousClock.now - sortStart) / Double(iterations)
+      var inherited = provider.messages
+      let inheritStart = ContinuousClock.now
+      for _ in 0..<iterations {
+        inherited = provider.messages
+        ChatProvider.inheritCitationsAcrossTurns(&inherited)
+      }
+      let inheritMs = Self.milliseconds(ContinuousClock.now - inheritStart) / Double(iterations)
+      print(
+        "PROJECTION_COST rows=\(rows) per_echo_ms=\(String(format: "%.2f", perCallMs)) "
+          + "sort_ms=\(String(format: "%.2f", sortMs)) inherit_ms=\(String(format: "%.2f", inheritMs))")
+      XCTAssertEqual(provider.messages.last?.text, liveText, "the echo behind the live row must not move the text back")
+    }
+  }
+
+  private static func milliseconds(_ duration: Duration) -> Double {
+    Double(duration.components.seconds) * 1000 + Double(duration.components.attoseconds) / 1e15
+  }
+
+  private static func transcript(rows: Int) -> [ChatMessage] {
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    var messages: [ChatMessage] = []
+    let prose = String(repeating: "A sentence about what was discussed, with a marker [1] and another [2]. ", count: 6)
+    for index in 0..<rows {
+      let createdAt = base.addingTimeInterval(TimeInterval(index))
+      if index % 2 == 0 {
+        messages.append(
+          ChatMessage(id: "user-\(index)", text: "Question \(index)?", createdAt: createdAt, sender: .user))
+      } else {
+        let id = "assistant-\(index)"
+        let isLast = index == rows - 1
+        messages.append(
+          ChatMessage(
+            id: id,
+            text: prose,
+            createdAt: createdAt,
+            sender: .ai,
+            isStreaming: isLast,
+            contentBlocks: [
+              .text(id: "\(id):text", text: prose),
+              .citation(
+                id: "\(id):c1",
+                reference: ChatCitationReference(
+                  ordinal: 1, kind: .conversation, sourceID: "conv-\(index)", title: "Conversation \(index)")),
+              .citation(
+                id: "\(id):c2",
+                reference: ChatCitationReference(
+                  ordinal: 2, kind: .memory, sourceID: "mem-\(index)", title: "Memory \(index)")),
+            ],
+            turnOwner: .mainChat,
+            journalStatus: isLast ? .streaming : .completed))
+      }
+    }
+    return messages
+  }
+
+  private static func makeTurn(
+    surface: AgentSurfaceReference,
+    turnID: String,
+    status: KernelJournalTurnStatus,
+    content: String,
+    contentBlocks: [[String: Any]],
+    turnSeq: Int
+  ) throws -> KernelJournalTurn {
+    try XCTUnwrap(
+      KernelJournalTurn(dictionary: [
+        "conversationId": "conversation-1",
+        "turnId": turnID,
+        "turnSeq": turnSeq,
+        "conversationGeneration": 1,
+        "generationBaseTurnSeq": 0,
+        "producerId": "producer:\(turnID)",
+        "payloadHash": "sha256:\(turnID):\(turnSeq)",
+        "role": "assistant",
+        "surfaceKind": surface.surfaceKind,
+        "externalRefKind": surface.externalRefKind,
+        "externalRefId": surface.externalRefId,
+        "content": content,
+        "origin": "test",
+        "status": status.rawValue,
+        "contentBlocks": contentBlocks,
+        "resources": [],
+        "metadataJson": "{}",
+        "createdAtMs": 1_700_000_000_000 + Int64(turnSeq) * 1000,
+        "updatedAtMs": 1_700_000_000_000 + Int64(turnSeq) * 1000,
+      ]))
+  }
+}

--- a/desktop/macos/Desktop/Tests/ChatStreamingJournalCoalescingTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatStreamingJournalCoalescingTests.swift
@@ -163,6 +163,96 @@ final class ChatStreamingJournalCoalescingTests: XCTestCase {
     XCTAssertEqual(publishes, 1)
   }
 
+  func testAStreamingEchoNeverRegressesARowThatAlreadySettled() throws {
+    // The turn settled: the terminal answer replaced the streamed projection
+    // and `isStreaming` flipped, which is the frame the transcript folds its
+    // tool chips and commentary away on. A `.streaming` journal echo that was
+    // still on the wire is a snapshot from *before* that frame; taking it
+    // whole puts the shorter text and the tool chips back on screen, then the
+    // terminal replay flips them away again — the answer visibly starts over.
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let turnID = "assistant-turn-3"
+    let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let finalText = "Here is the complete answer after the tool ran."
+    let settledBlocks: [ChatContentBlock] = [
+      .text(id: "\(turnID):commentary", text: "Let me look that up."),
+      .toolCall(id: "\(turnID):tool", name: "get_conversations", status: .completed, toolUseId: "t1"),
+      .text(id: "\(turnID):answer", text: finalText),
+    ]
+    provider.messages = [
+      ChatMessage(id: "user-turn-3", text: "Question?", createdAt: createdAt.addingTimeInterval(-1), sender: .user),
+      ChatMessage(
+        id: turnID,
+        text: finalText,
+        createdAt: createdAt,
+        sender: .ai,
+        isStreaming: false,
+        contentBlocks: settledBlocks,
+        turnOwner: .mainChat,
+        journalStatus: .streaming),
+    ]
+    var publishes = 0
+    let subscription = provider.$messages.dropFirst().sink { _ in publishes += 1 }
+    defer { subscription.cancel() }
+
+    let echoText = "Here is the comp"
+    provider.projectJournalTurns([
+      try Self.makeTurn(
+        surface: surface,
+        turnID: turnID,
+        role: "assistant",
+        status: .streaming,
+        content: echoText,
+        contentBlocks: [
+          ["type": "text", "id": "\(turnID):commentary", "text": "Let me look that up."],
+          [
+            "type": "toolCall", "id": "\(turnID):tool", "name": "get_conversations", "status": "running",
+            "toolUseId": "t1",
+          ],
+          ["type": "text", "id": "\(turnID):answer", "text": echoText],
+        ],
+        turnSeq: 9)
+    ])
+
+    XCTAssertFalse(provider.messages[1].isStreaming, "a settled row never goes back to streaming on an echo")
+    XCTAssertEqual(provider.messages[1].text, finalText, "the settled answer outranks any streaming snapshot")
+    XCTAssertEqual(provider.messages[1].visibleAnswerText, finalText)
+    XCTAssertEqual(publishes, 0, "a stale streaming echo must not republish the transcript")
+  }
+
+  func testATerminalReplayStillLandsAfterAStreamingEchoWasIgnored() throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let turnID = "assistant-turn-4"
+    provider.messages = [
+      ChatMessage(
+        id: turnID,
+        text: "Settled locally.",
+        sender: .ai,
+        isStreaming: false,
+        contentBlocks: [.text(id: "\(turnID):answer", text: "Settled locally.")],
+        journalStatus: .streaming)
+    ]
+    provider.projectJournalTurns([
+      try Self.makeTurn(
+        surface: surface, turnID: turnID, role: "assistant", status: .streaming,
+        content: "Settled", contentBlocks: [["type": "text", "id": "\(turnID):answer", "text": "Settled"]],
+        turnSeq: 10)
+    ])
+    XCTAssertEqual(provider.messages[0].text, "Settled locally.")
+    provider.projectJournalTurns([
+      try Self.makeTurn(
+        surface: surface, turnID: turnID, role: "assistant", status: .completed,
+        content: "Settled by the journal.",
+        contentBlocks: [["type": "text", "id": "\(turnID):terminal", "text": "Settled by the journal."]],
+        turnSeq: 11)
+    ])
+    XCTAssertEqual(
+      provider.messages[0].text, "Settled by the journal.", "the terminal row is still the durable authority")
+    XCTAssertFalse(provider.messages[0].isStreaming)
+  }
+
   // MARK: - Plumbing
 
   private static func makeTurn(

--- a/desktop/macos/changelog/unreleased/20260908-chat-answer-no-restart-on-settle.json
+++ b/desktop/macos/changelog/unreleased/20260908-chat-answer-no-restart-on-settle.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a finished chat answer briefly jumping back to an older, shorter version with its tool chips while it settled, and made long transcripts stay responsive while an answer streams"
+}


### PR DESCRIPTION
## What changed and why

Two things David sees in the macOS chat when an answer uses tools: the finished answer appears to stream twice ("it starts to stream while the tool calls are still showing, then starts over again with no tool calls"), and the whole app lags while the answer is being produced.

**The restart.** A streaming turn journals its row on every coalesced flush, and each write's refresh echoes that row back through `projectJournalTurns`. `carryingLocalOnlyFields` protects a row that is *still streaming* from an echo behind it (#13053), but the moment the turn settles — `finalizeAssistantMessageCitations` lands the terminal answer and flips `isStreaming` — that protection no longer applies, and an echo still on the wire (`status: streaming`, queued before terminalization, so `supersededByTerminalization` cannot gate it) was taken whole. The row went back to the shorter streamed text with its tool-call blocks marked running, so the transcript re-showed the chips and the partial answer, until the terminal replay flipped it forward again. `isStreaming` is exactly the frame the transcript folds its tool chips and pre-tool commentary away on (`ChatBubble.visibleChatGroups`), which is why the second pass reads as "starts over, with no tool calls".

**The lag.** Every one of those refreshes ran a whole-transcript pass before it could decide it had nothing to publish: a canonical sort, then `inheritCitationsAcrossTurns`, which for every settled assistant row copied the transcript prefix into a fresh array and compiled a new `NSRegularExpression` per text to find `[n]` markers. Measured in the new `ChatJournalProjectionCostTests` (debug build), one no-op echo cost 1.6 ms at 50 rows, 10.7 ms at 300 and 33.4 ms at 800 rows, on the main thread, at the streaming write cadence — and none of it is on the render path #13053 measured, so a long main-chat transcript stayed laggy after that fix.

## Fixes

- `ChatProvider+JournalProjection.swift` — `projectJournalTurns` ignores a streaming echo for an assistant row that has already settled (`isStaleStreamingEcho`); the terminal replay is not streaming and still replaces the row. `inheritCitationsAcrossTurns` and `finalizeAssistantMessageCitations` pass the transcript prefix as a slice instead of copying it per row.
- `ChatCitation.swift` — `ChatCitationMarkup` compiles each marker expression once (`expression(_:options:)`), skips texts with no `[`, and memoizes `ordinals(in:)` by text, so the per-refresh inheritance pass costs the transcript's length in dictionary lookups rather than regex compiles and scans. `inheritedReferences` takes any bidirectional collection.

Per-echo projection cost after the change (same test, same debug build): 0.47 ms at 50 rows, 2.8 ms at 300, 7.3 ms at 800 — sort 0.26 ms, inheritance 5.6 ms of that.

## Product invariants affected

- INV-CHAT-1 — the journal stays the sole mutation owner and the durable authority. This change only refuses to project a *stale* streaming revision over a row the same journal has already terminalized locally; the terminal revision still replaces the row (`testATerminalReplayStillLandsAfterAStreamingEchoWasIgnored`). No second store, no per-surface reconciliation.

## How it was verified

- Live, baseline: polled `main_chat_snapshot` every ~40 ms on E2E pool slot `omi-e2e-2` during a tool-using turn (`get_conversations`). The visible answer streamed to 415 characters, then at t=6.00 s stepped back to 124 characters (raw text 526 → 235, identical to the snapshot written 0.7 s earlier) and re-grew to 442 before settling — the restart, machine-readable. That slot's binary predates #13053; the settled-row window this PR closes is the part #13053 left open and is reproduced hermetically below. Probe script and raw samples are in the run record.
- Hermetic: `xcrun swift test --package-path Desktop --filter 'Chat'` — 983 tests, 0 failures. `testAStreamingEchoNeverRegressesARowThatAlreadySettled` fails on `origin/main` (the echo replaced the settled row and republished; 3 assertions) and passes with the fix.
- Live, fix build: the same probe on `omi-e2e-1` running this branch (75caa863e5). Commentary streamed to 61 chars and blanked at tool start (by design), the answer grew 43 → 432 chars with no step-back, settled at t=6.4 s and folded its chips once; blocks went `text:2, tool, citations` → `text:1, tool, citations` on the terminal replay with the text unchanged. Bridge `/state` latency while streaming: p50 3 ms, p95 16 ms, max 43 ms.

## Tests

- `Desktop/Tests/ChatStreamingJournalCoalescingTests.swift` — `testAStreamingEchoNeverRegressesARowThatAlreadySettled` (the regression test for the restart) and `testATerminalReplayStillLandsAfterAStreamingEchoWasIgnored` (the terminal replay still wins).
- `Desktop/Tests/ChatJournalProjectionCostTests.swift` — measures the per-echo projection cost at 50/300/800 rows and prints the sort/inheritance split, so the cost is a number in CI output rather than a guess.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

New definition `FC-stale-streaming-echo-regresses-settled-row`. Violated contract: a store's echo of a write is a snapshot from when the write was queued, and must not be projected over an in-memory row that has since crossed a monotonic lifecycle boundary. Canonical guard: row projection compares the echo's lifecycle state with the row's and refuses a streaming echo for a settled assistant row, with a behavioural test that settles a row, projects a streaming echo behind it, and asserts nothing regresses or republishes. Evidence: this PR (the pre-fix test failure above); the streaming-row half of the same class was fixed in #13053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
