### PR TITLE
feat(type): cloud Parakeet for dictation, metered a tenth as before for their plan

### DIFF
--- a/backend/config/voice_budget_policy.py
+++ b/backend/config/voice_budget_policy.py
@@ -30,15 +30,28 @@ class VoiceBudgetSurface(str, Enum):
 # Dictation is metered at a tenth of the audio it sends. It replaces typing, so
 # a user runs it in minutes-long stretches across a working day where a spoken
 # question lasts seconds; charged alike, voice typing alone would spend the
-# whole two-hour allowance and leave a user none of it for anything else. The
-# provider cost this defers is the cheapest on the platform — the typing surface
-# is served by the self-hosted Parakeet deployment first (see
-# ``config.stt_provider_policy``), not by a per-minute vendor.
+# whole two-hour allowance and leave a user none of it for anything else.
 #
 # This is a cost guard, not an authorization boundary: the surface is whatever
-# the client declares, and the ceilings that do exist to stop abuse (the
-# per-request body cap, MAX_SESSION_DURATION_S, and fair_use's daily audio
-# ceiling) are all unaffected by it.
+# the client declares, and any client can declare it. Be precise about what
+# still bounds a request once it does, because on the voice-message endpoints
+# it is less than the names elsewhere in the codebase suggest:
+#
+# - The per-request body cap (``_MAX_PCM_BODY_BYTES``, 200 MB — roughly 104
+#   minutes of 16 kHz mono) is the only per-request ceiling. It is unaffected.
+# - ``MAX_SESSION_DURATION_S`` bounds a *streaming* PTT session's reservation.
+#   On the batch route it is only the worst case charged when a file's duration
+#   cannot be read; it rejects nothing, so it does not bound this discount.
+# - ``fair_use``'s daily audio ceiling meters the listen and sync speech
+#   pipelines. It is never consulted here.
+#
+# So the rolling 24 h ``DAILY_BUDGET_MS`` is effectively the only daily ceiling
+# on this endpoint, and dividing what a request spends against it raises the
+# audio one account can push through in a day by the same factor — from ~2 h to
+# ~20 h at the divisor below. That is the intended product trade (dictation is
+# served by the self-hosted Parakeet deployment first — see
+# ``config.stt_provider_policy`` — not by a per-minute vendor), but it is the
+# cost this rate is really buying, and it should be re-priced deliberately.
 BUDGET_DIVISOR_BY_SURFACE: Final[Mapping[VoiceBudgetSurface, int]] = {
     VoiceBudgetSurface.PTT: 1,
     VoiceBudgetSurface.VOICE_TYPING: 10,

--- a/backend/config/voice_budget_policy.py
+++ b/backend/config/voice_budget_policy.py
@@ -1,0 +1,66 @@
+"""How much of the shared voice allowance one request spends.
+
+Deliberately dependency-free — no Redis, no `av`, no environment. The rate a
+surface is charged at is a product decision, and keeping it here lets the
+router, the limiter, and their tests read the same policy without standing up
+the infrastructure the limiter needs to enforce it.
+
+Who may spend the allowance, and how much of it is left, stays in
+``utils.voice_duration_limiter``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from math import ceil
+from typing import Final, Mapping, Optional
+
+
+class VoiceBudgetSurface(str, Enum):
+    """What a request spent its audio on, for metering purposes only.
+
+    The allowance is one pool shared by every voice-message endpoint. The
+    surface never changes who may spend it — only the rate.
+    """
+
+    PTT = 'ptt'
+    VOICE_TYPING = 'voice_typing'
+
+
+# Dictation is metered at a tenth of the audio it sends. It replaces typing, so
+# a user runs it in minutes-long stretches across a working day where a spoken
+# question lasts seconds; charged alike, voice typing alone would spend the
+# whole two-hour allowance and leave a user none of it for anything else. The
+# provider cost this defers is the cheapest on the platform — the typing surface
+# is served by the self-hosted Parakeet deployment first (see
+# ``config.stt_provider_policy``), not by a per-minute vendor.
+#
+# This is a cost guard, not an authorization boundary: the surface is whatever
+# the client declares, and the ceilings that do exist to stop abuse (the
+# per-request body cap, MAX_SESSION_DURATION_S, and fair_use's daily audio
+# ceiling) are all unaffected by it.
+BUDGET_DIVISOR_BY_SURFACE: Final[Mapping[VoiceBudgetSurface, int]] = {
+    VoiceBudgetSurface.PTT: 1,
+    VoiceBudgetSurface.VOICE_TYPING: 10,
+}
+
+
+def resolve_budget_surface(raw: Optional[str]) -> VoiceBudgetSurface:
+    """Read a client-declared surface, defaulting to the undiscounted rate."""
+    try:
+        return VoiceBudgetSurface((raw or '').strip().lower())
+    except ValueError:
+        return VoiceBudgetSurface.PTT
+
+
+def budget_cost_ms(duration_ms: int, surface: VoiceBudgetSurface = VoiceBudgetSurface.PTT) -> int:
+    """What ``duration_ms`` of audio on ``surface`` costs from the allowance.
+
+    A probe (``0``) stays free, and audio carrying any duration always costs at
+    least a millisecond: rounding real turns down to nothing would make the
+    budget unenforceable one short turn at a time.
+    """
+    divisor = BUDGET_DIVISOR_BY_SURFACE.get(surface, 1)
+    if duration_ms <= 0 or divisor <= 1:
+        return duration_ms
+    return max(1, ceil(duration_ms / divisor))

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -91,6 +91,7 @@ from utils.observability import submit_langsmith_feedback
 from utils.observability.fallback import record_fallback
 from utils.journey_metrics_contract import resolve_client_kind, resolve_client_kind_from_headers
 from utils.observability.journeys import ClientJourneyAttempt, JourneyAttempt
+from config.voice_budget_policy import budget_cost_ms, resolve_budget_surface
 from utils.voice_duration_limiter import (
     MAX_SESSION_DURATION_S,
     compute_pcm_duration_ms,
@@ -1019,6 +1020,7 @@ async def transcribe_voice_message(
         stt_provider, _, stt_model = get_prerecorded_service(resolved_language)
         context_keywords = _parse_context_keywords(request.query_params.get("keywords"))
         encoding = request.query_params.get("encoding", "linear16")
+        budget_surface = resolve_budget_surface(request.query_params.get("surface"))
         try:
             sample_rate = int(request.query_params.get("sample_rate", "16000"))
             channels = int(request.query_params.get("channels", "1"))
@@ -1054,7 +1056,7 @@ async def transcribe_voice_message(
         parity_capture = SurfaceParityCapture.from_environ(
             principal_id=uid,
             session_id=str(uuid.uuid4()),
-            surface="ptt",
+            surface=budget_surface.value,
             source="desktop_ptt_http",
             provider_lane="stt",
             route_or_model=stt_model or stt_provider or "prerecorded",
@@ -1068,9 +1070,11 @@ async def transcribe_voice_message(
         )
         parity_capture.observe_audio("client", audio_bytes)
 
-        # Daily budget check
+        # Daily budget check. Voice typing is metered at a tenth of its audio
+        # (budget_cost_ms) — the turn still runs at full length, it just costs a
+        # dictation-shaped fraction of the shared allowance.
         duration_ms = compute_pcm_duration_ms(len(audio_bytes), sample_rate, channels)
-        allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, budget_cost_ms(duration_ms, budget_surface))
         if not allowed:
             del audio_bytes
             raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
@@ -1085,7 +1089,7 @@ async def transcribe_voice_message(
             audio_seconds=duration_ms / 1000 if encoding == 'linear16' else None,
         )
         try:
-            transcript, detected_language = await run_blocking(
+            transcription = await run_blocking(
                 sync_executor,
                 transcribe_pcm_bytes,
                 audio_bytes,
@@ -1096,6 +1100,11 @@ async def transcribe_voice_message(
                 channels=channels,
                 keywords=context_keywords,
             )
+            transcript, detected_language = transcription.text, transcription.language
+            # Report the provider that produced these words, not the one selection
+            # started on: the chain may have failed over to Velma behind Parakeet.
+            stt_provider = transcription.provider or stt_provider
+            stt_model = transcription.model or stt_model
             outcome = TranscriptionOutcome.SUCCESS if transcript else TranscriptionOutcome.EXPECTED_SILENCE
             parity_capture.observe(
                 "inbound",

--- a/backend/tests/unit/_chat_router_test_harness.py
+++ b/backend/tests/unit/_chat_router_test_harness.py
@@ -265,6 +265,7 @@ def wire_common_stubs(install) -> SimpleNamespace:
     prerecorded = install('utils.stt.pre_recorded', ModuleType('utils.stt.pre_recorded'))
     prerecorded.PrerecordedSTTConfigurationError = type('PrerecordedSTTConfigurationError', (Exception,), {})
     prerecorded.get_prerecorded_service = MagicMock(return_value=('parakeet', 'en', 'parakeet'))
+    prerecorded.get_prerecorded_service_chain = MagicMock(return_value=(('parakeet', 'en', 'parakeet'),))
 
     usage_tracker = install('utils.llm.usage_tracker', ModuleType('utils.llm.usage_tracker'))
     usage_tracker.set_usage_context = MagicMock(return_value='usage-token')

--- a/backend/tests/unit/test_chat_stream_error_fallback.py
+++ b/backend/tests/unit/test_chat_stream_error_fallback.py
@@ -89,6 +89,7 @@ def _make_client():
     pre_recorded.prerecorded = MagicMock(return_value=[{'word': 'hello'}])
     pre_recorded.prerecorded_from_bytes = MagicMock(return_value=[{'word': 'hello'}])
     pre_recorded.get_prerecorded_service = MagicMock(return_value=('parakeet', 'en', 'parakeet'))
+    pre_recorded.get_prerecorded_service_chain = MagicMock(return_value=(('parakeet', 'en', 'parakeet'),))
     pre_recorded.PrerecordedSTTConfigurationError = type('PrerecordedSTTConfigurationError', (Exception,), {})
 
     common.usage_tracker.track_usage = MagicMock()

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -584,6 +584,13 @@ class TestDeepgramPrerecordedFromBytesPCM:
         assert detected_lang == 'es'  # normalized from es-ES
 
 
+def _pcm_transcription(text, language, provider='parakeet', model='parakeet'):
+    """Build the ``transcribe_pcm_bytes`` return shape for a router-level stub."""
+    from utils.chat import PcmTranscription
+
+    return PcmTranscription(text, language, provider, model)
+
+
 # ---------------------------------------------------------------------------
 # transcribe_pcm_bytes: language selection and error propagation
 # ---------------------------------------------------------------------------
@@ -599,18 +606,18 @@ class TestTranscribePcmBytes:
 
     @patch('utils.chat.postprocess_words')
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_language_model_forwarded(self, mock_get_model, mock_dg, mock_postprocess):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_language_model_forwarded(self, mock_chain, mock_dg, mock_postprocess):
         """stt_language and stt_model should be passed to deepgram_prerecorded_from_bytes."""
         from utils.chat import transcribe_pcm_bytes
 
-        mock_get_model.return_value = ('parakeet', 'es', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'es', 'parakeet'),)
         mock_dg.return_value = [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'Hola'}]
         mock_seg = MagicMock()
         mock_seg.text = 'Hola'
         mock_postprocess.return_value = [mock_seg]
 
-        text, lang = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='es')
+        text, lang, _provider, _model = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='es')
 
         mock_dg.assert_called_once()
         call_kwargs = mock_dg.call_args[1]
@@ -620,13 +627,13 @@ class TestTranscribePcmBytes:
         assert text == 'Hola'
 
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_runtime_error_propagates(self, mock_get_model, mock_dg):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_runtime_error_propagates(self, mock_chain, mock_dg):
         """Provider failures should become safe typed upstream failures."""
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         mock_dg.side_effect = RuntimeError('Deepgram failed')
 
         with pytest.raises(TranscriptionFailure) as exc_info:
@@ -635,13 +642,13 @@ class TestTranscribePcmBytes:
         assert 'Deepgram failed' not in str(exc_info.value)
 
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_empty_words_after_audio_is_unexpected(self, mock_get_model, mock_dg):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_empty_words_after_audio_is_unexpected(self, mock_chain, mock_dg):
         """Non-silent audio with an empty provider result is retryable failure."""
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         mock_dg.return_value = []
 
         with pytest.raises(TranscriptionFailure) as exc_info:
@@ -651,24 +658,24 @@ class TestTranscribePcmBytes:
 
     @patch('utils.chat.linear16_pcm_is_silent', return_value=True)
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_linear16_vad_silence_is_expected_silence(self, mock_get_model, mock_dg, mock_vad):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_linear16_vad_silence_is_expected_silence(self, mock_chain, mock_dg, mock_vad):
         """Only a successful local VAD silence decision gets the 200 empty path."""
         from utils.chat import transcribe_pcm_bytes
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
-        assert transcribe_pcm_bytes(b'\x00' * 100, 'test-uid', language='en') == (None, 'en')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
+        assert transcribe_pcm_bytes(b'\x00' * 100, 'test-uid', language='en') == (None, 'en', 'parakeet', 'parakeet')
         mock_dg.assert_not_called()
         mock_vad.assert_called_once_with(b'\x00' * 100, sample_rate=16000, channels=1)
 
     @patch('utils.chat.prerecorded_from_bytes', side_effect=RuntimeError('encoded provider rejected input'))
-    @patch('utils.chat.get_prerecorded_service')
-    def test_non_linear16_zero_bytes_are_not_claimed_as_silence(self, mock_get_model, mock_dg):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_non_linear16_zero_bytes_are_not_claimed_as_silence(self, mock_chain, mock_dg):
         """Encoded bytes need provider validation; zero bytes are not PCM silence."""
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         with pytest.raises(TranscriptionFailure) as exc_info:
             transcribe_pcm_bytes(b'\x00' * 100, 'test-uid', language='en', encoding='opus')
 
@@ -676,13 +683,13 @@ class TestTranscribePcmBytes:
         mock_dg.assert_called_once()
 
     @patch('utils.chat.linear16_pcm_is_silent')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_linear16_vad_decode_failure_is_invalid_input(self, mock_get_model, mock_vad):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_linear16_vad_decode_failure_is_invalid_input(self, mock_chain, mock_vad):
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
         from utils.stt.vad import VADAudioDecodeError
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         mock_vad.side_effect = VADAudioDecodeError('bad PCM')
 
         with pytest.raises(TranscriptionFailure) as exc_info:
@@ -692,19 +699,19 @@ class TestTranscribePcmBytes:
 
     @patch('utils.chat.postprocess_words')
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_multi_language_returns_detected_language(self, mock_get_model, mock_dg, mock_postprocess):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_multi_language_returns_detected_language(self, mock_chain, mock_dg, mock_postprocess):
         """Multi-language mode should return the Deepgram-detected language, not hardcoded 'en'."""
         from utils.chat import transcribe_pcm_bytes
 
-        mock_get_model.return_value = ('parakeet', 'multi', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'multi', 'parakeet'),)
         # return_language=True path returns (words, detected_lang)
         mock_dg.return_value = ([{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'Bonjour'}], 'fr')
         mock_seg = MagicMock()
         mock_seg.text = 'Bonjour'
         mock_postprocess.return_value = [mock_seg]
 
-        text, lang = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='multi')
+        text, lang, _provider, _model = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='multi')
 
         assert text == 'Bonjour'
         assert lang == 'fr'
@@ -714,18 +721,18 @@ class TestTranscribePcmBytes:
 
     @patch('utils.chat.postprocess_words')
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_chinese_language_uses_nova3(self, mock_get_model, mock_dg, mock_postprocess):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_chinese_language_uses_nova3(self, mock_chain, mock_dg, mock_postprocess):
         """Chinese should use nova-3 model."""
         from utils.chat import transcribe_pcm_bytes
 
-        mock_get_model.return_value = ('parakeet', 'zh', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'zh', 'parakeet'),)
         mock_dg.return_value = [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': '你好'}]
         mock_seg = MagicMock()
         mock_seg.text = '你好'
         mock_postprocess.return_value = [mock_seg]
 
-        text, lang = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='zh')
+        text, lang, _provider, _model = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='zh')
 
         call_kwargs = mock_dg.call_args[1]
         assert call_kwargs['model'] == 'parakeet'
@@ -733,13 +740,13 @@ class TestTranscribePcmBytes:
 
     @patch('utils.chat.postprocess_words')
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_whitespace_only_transcript_is_unexpected_empty(self, mock_get_model, mock_dg, mock_postprocess):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_whitespace_only_transcript_is_unexpected_empty(self, mock_chain, mock_dg, mock_postprocess):
         """Whitespace-only provider output is not reclassified as silence."""
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         mock_dg.return_value = [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': ' '}]
         mock_seg = MagicMock()
         mock_seg.text = '   '
@@ -750,19 +757,132 @@ class TestTranscribePcmBytes:
         assert exc_info.value.outcome == TranscriptionOutcome.EMPTY_UNEXPECTED
 
     @patch('utils.chat.prerecorded_from_bytes')
-    @patch('utils.chat.get_prerecorded_service')
-    def test_postprocess_empty_is_unexpected(self, mock_get_model, mock_dg):
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_postprocess_empty_is_unexpected(self, mock_chain, mock_dg):
         """An empty postprocessed result stays a retryable provider failure."""
         from utils.chat import transcribe_pcm_bytes
         from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
 
-        mock_get_model.return_value = ('parakeet', 'en', 'parakeet')
+        mock_chain.return_value = (('parakeet', 'en', 'parakeet'),)
         mock_dg.return_value = [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'hello'}]
         # postprocess_words is imported at module level; mock it
         with patch('utils.chat.postprocess_words', return_value=[]):
             with pytest.raises(TranscriptionFailure) as exc_info:
                 transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
         assert exc_info.value.outcome == TranscriptionOutcome.EMPTY_UNEXPECTED
+
+    # -----------------------------------------------------------------
+    # Chain failover: cloud Parakeet, then Velma-2, then (in the client)
+    # the on-device model.
+    # -----------------------------------------------------------------
+
+    _CHAIN = (('parakeet', 'en', 'parakeet'), ('modulate', 'en', 'velma-2'))
+
+    @patch('utils.chat.postprocess_words')
+    @patch('utils.chat.prerecorded_from_bytes')
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_upstream_error_fails_over_to_the_next_provider(self, mock_chain, mock_stt, mock_postprocess):
+        """A provider that errors hands the audio on instead of ending the turn."""
+        from utils.chat import transcribe_pcm_bytes
+
+        mock_chain.return_value = self._CHAIN
+        mock_stt.side_effect = [
+            RuntimeError('parakeet unreachable'),
+            [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'Hello'}],
+        ]
+        mock_seg = MagicMock()
+        mock_seg.text = 'Hello'
+        mock_postprocess.return_value = [mock_seg]
+
+        result = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
+
+        assert result.text == 'Hello'
+        # The response must name the provider whose words these are.
+        assert result.provider == 'modulate'
+        assert result.model == 'velma-2'
+        assert [call[1]['service'] for call in mock_stt.call_args_list] == ['parakeet', 'modulate']
+
+    @patch('utils.chat.postprocess_words')
+    @patch('utils.chat.prerecorded_from_bytes')
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_empty_result_on_speech_fails_over(self, mock_chain, mock_stt, mock_postprocess):
+        """Speech-positive audio the first provider heard nothing in still gets a second ear."""
+        from utils.chat import transcribe_pcm_bytes
+
+        mock_chain.return_value = self._CHAIN
+        mock_stt.side_effect = [[], [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'Hello'}]]
+        mock_seg = MagicMock()
+        mock_seg.text = 'Hello'
+        mock_postprocess.return_value = [mock_seg]
+
+        result = transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
+
+        assert (result.text, result.provider) == ('Hello', 'modulate')
+
+    @patch('utils.chat.prerecorded_from_bytes')
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_invalid_input_does_not_spend_a_second_provider(self, mock_chain, mock_stt):
+        """Audio no provider could transcribe ends the request on the first attempt."""
+        from utils.chat import transcribe_pcm_bytes
+        from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
+
+        mock_chain.return_value = self._CHAIN
+        mock_stt.side_effect = ValueError('not decodable audio')
+
+        with pytest.raises(TranscriptionFailure) as exc_info:
+            transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
+
+        assert exc_info.value.outcome == TranscriptionOutcome.INVALID_INPUT
+        assert mock_stt.call_count == 1
+
+    @patch('utils.chat.prerecorded_from_bytes')
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_the_last_providers_failure_is_the_one_raised(self, mock_chain, mock_stt):
+        """With the chain exhausted the client is told, and falls back on-device."""
+        from utils.chat import transcribe_pcm_bytes
+        from utils.stt.outcomes import TranscriptionFailure, TranscriptionOutcome
+
+        mock_chain.return_value = self._CHAIN
+        mock_stt.side_effect = [RuntimeError('parakeet unreachable'), RuntimeError('velma unreachable')]
+
+        with pytest.raises(TranscriptionFailure) as exc_info:
+            transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
+
+        assert exc_info.value.outcome == TranscriptionOutcome.UPSTREAM_ERROR
+        assert exc_info.value.provider == 'modulate'
+        assert mock_stt.call_count == 2
+
+    @patch('utils.chat.record_fallback')
+    @patch('utils.chat.postprocess_words')
+    @patch('utils.chat.prerecorded_from_bytes')
+    @patch('utils.chat.get_prerecorded_service_chain')
+    def test_a_failover_is_recorded(self, mock_chain, mock_stt, mock_postprocess, mock_record):
+        """The switch is observable; a silent failover hides a provider outage."""
+        from utils.chat import transcribe_pcm_bytes
+
+        mock_chain.return_value = self._CHAIN
+        mock_stt.side_effect = [
+            RuntimeError('parakeet unreachable'),
+            [{'timestamp': [0.0, 0.5], 'speaker': 'SPEAKER_00', 'text': 'Hello'}],
+        ]
+        mock_seg = MagicMock()
+        mock_seg.text = 'Hello'
+        mock_postprocess.return_value = [mock_seg]
+
+        transcribe_pcm_bytes(b'\x01' * 100, 'test-uid', language='en')
+
+        mock_record.assert_called_once()
+        recorded = mock_record.call_args[1]
+        assert recorded['from_mode'] == 'parakeet'
+        assert recorded['to_mode'] == 'modulate'
+        assert recorded['outcome'] == 'degraded'
+        # Bounded vocabulary: an unlisted component or reason is silently
+        # bucketed to 'other', which would make the switch unreadable.
+        from utils.observability.fallback import ALLOWED_COMPONENTS, ALLOWED_REASONS
+
+        assert recorded['component'] in ALLOWED_COMPONENTS
+        assert recorded['reason'] in ALLOWED_REASONS
+        assert recorded['reason'] == 'provider_5xx'
 
 
 # ---------------------------------------------------------------------------
@@ -971,7 +1091,7 @@ class TestVoiceMessageTranscribeEndpoint:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_returns_transcript(self, mock_transcribe):
         """application/octet-stream should dispatch to PCM path and return JSON."""
-        mock_transcribe.return_value = ('Hello world', 'en')
+        mock_transcribe.return_value = _pcm_transcription('Hello world', 'en')
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
@@ -1063,7 +1183,7 @@ class TestVoiceMessageTranscribeEndpoint:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_no_speech_empty_transcript(self, mock_transcribe):
         """No speech detected should return 200 with empty transcript (not 422)."""
-        mock_transcribe.return_value = (None, 'en')
+        mock_transcribe.return_value = _pcm_transcription(None, 'en')
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
@@ -1813,7 +1933,7 @@ class TestVoiceMessageTranscribeBoundary:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_accepts_boundary_sample_rate_8000(self, mock_transcribe):
         """sample_rate=8000 (lower bound) should be accepted."""
-        mock_transcribe.return_value = ('hello', 'en')
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
@@ -1828,7 +1948,7 @@ class TestVoiceMessageTranscribeBoundary:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_accepts_boundary_sample_rate_48000(self, mock_transcribe):
         """sample_rate=48000 (upper bound) should be accepted."""
-        mock_transcribe.return_value = ('hello', 'en')
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
@@ -1843,7 +1963,7 @@ class TestVoiceMessageTranscribeBoundary:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_accepts_channels_2(self, mock_transcribe):
         """channels=2 (upper bound) should be accepted."""
-        mock_transcribe.return_value = ('hello', 'en')
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
         client, module, saved = _make_chat_client()
         try:
             resp = client.post(
@@ -1882,7 +2002,7 @@ class TestDurationBudgetEnforcement:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_budget_consumed_with_correct_duration(self, mock_transcribe):
         """Successful octet-stream request should consume budget with correct duration_ms."""
-        mock_transcribe.return_value = ('hello', 'en')
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
         client, module, saved = _make_chat_client()
         try:
             with patch.object(module, 'try_consume_budget', return_value=(True, 1000, 7199000)) as mock_budget:
@@ -1897,6 +2017,43 @@ class TestDurationBudgetEnforcement:
                 call_args = mock_budget.call_args[0]
                 assert call_args[0] == 'test-uid'
                 assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+        finally:
+            _cleanup_chat_client(saved)
+
+    @patch('utils.chat.transcribe_pcm_bytes')
+    def test_voice_typing_is_charged_a_tenth_of_its_audio(self, mock_transcribe):
+        """The dictation surface spends the shared allowance ten times slower."""
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'try_consume_budget', return_value=(True, 100, 7199900)) as mock_budget:
+                resp = client.post(
+                    '/v2/voice-message/transcribe?surface=voice_typing',
+                    # One second of 16 kHz mono audio, as above.
+                    content=b'\x00' * 32000,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 200
+                # The turn still transcribes the whole second; only the charge shrinks.
+                assert mock_transcribe.call_args[0][0] == b'\x00' * 32000
+                assert mock_budget.call_args[0][1] == 100
+        finally:
+            _cleanup_chat_client(saved)
+
+    @patch('utils.chat.transcribe_pcm_bytes')
+    def test_an_unknown_surface_pays_the_full_rate(self, mock_transcribe):
+        """A client cannot invent a cheaper surface; only the known one discounts."""
+        mock_transcribe.return_value = _pcm_transcription('hello', 'en')
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'try_consume_budget', return_value=(True, 1000, 7199000)) as mock_budget:
+                resp = client.post(
+                    '/v2/voice-message/transcribe?surface=free',
+                    content=b'\x00' * 32000,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 200
+                assert mock_budget.call_args[0][1] == 1000
         finally:
             _cleanup_chat_client(saved)
 
@@ -2018,7 +2175,7 @@ class TestNoPerSessionCap:
     @patch('utils.chat.transcribe_pcm_bytes')
     def test_octet_stream_over_120s_accepted(self, mock_transcribe):
         """Octet-stream with >120s audio should be accepted if budget allows."""
-        mock_transcribe.return_value = ('long message', 'en')
+        mock_transcribe.return_value = _pcm_transcription('long message', 'en')
         client, module, saved = _make_chat_client()
         try:
             # 300s at 16kHz mono = 9,600,000 bytes → well over 120s

--- a/backend/tests/unit/test_prerecorded_language_coverage.py
+++ b/backend/tests/unit/test_prerecorded_language_coverage.py
@@ -4,7 +4,11 @@ import pytest
 
 from config.prerecorded_stt import TranscriptionOutcome
 from utils.stt.outcomes import TranscriptionFailure, failure_from_exception
-from utils.stt.pre_recorded import PrerecordedSTTService, get_prerecorded_service
+from utils.stt.pre_recorded import (
+    PrerecordedSTTService,
+    get_prerecorded_service,
+    get_prerecorded_service_chain,
+)
 
 # Every base language the mobile picker offers (app/lib/providers/home_provider.dart).
 CLIENT_OFFERED_LANGUAGES = (
@@ -153,6 +157,39 @@ def test_parakeet_only_deployment_still_reaches_velma_for_a_language_it_cannot_s
     service, resolved_language, _model = get_prerecorded_service('hi')
     assert service == PrerecordedSTTService.MODULATE
     assert resolved_language == 'multi'
+
+
+def test_the_chain_orders_every_provider_the_deployment_declared(monkeypatch):
+    """The failover tail is the deployment's own ordering, not a second guess."""
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet,modulate-velma-2')
+
+    assert get_prerecorded_service_chain('en') == (
+        (PrerecordedSTTService.PARAKEET, 'en', 'parakeet'),
+        (PrerecordedSTTService.MODULATE, 'en', 'velma-2'),
+    )
+
+
+def test_the_chain_head_is_what_selection_returns(monkeypatch):
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet,modulate-velma-2')
+
+    assert get_prerecorded_service('en') == get_prerecorded_service_chain('en')[0]
+
+
+def test_a_language_only_one_provider_serves_has_no_failover(monkeypatch):
+    """Velma cannot be a fallback for a language it will not take a code for."""
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet,modulate-velma-2')
+
+    assert get_prerecorded_service_chain('ru') == ((PrerecordedSTTService.PARAKEET, 'ru', 'parakeet'),)
+
+
+def test_a_repeated_model_token_does_not_repeat_a_provider(monkeypatch):
+    """A duplicated token must not spend two attempts on the same provider."""
+    monkeypatch.setenv('STT_PRERECORDED_MODEL', 'parakeet,parakeet,modulate-velma-2')
+
+    assert get_prerecorded_service_chain('en') == (
+        (PrerecordedSTTService.PARAKEET, 'en', 'parakeet'),
+        (PrerecordedSTTService.MODULATE, 'en', 'velma-2'),
+    )
 
 
 def test_no_enabled_provider_raises_a_non_retryable_config_failure(monkeypatch):

--- a/backend/tests/unit/test_sync_silent_failure.py
+++ b/backend/tests/unit/test_sync_silent_failure.py
@@ -822,6 +822,9 @@ class TestProcessSegmentReal:
         sys.modules['utils.stt.pre_recorded'].get_prerecorded_service = MagicMock(
             return_value=('deepgram', 'multi', 'nova-3')
         )
+        sys.modules['utils.stt.pre_recorded'].get_prerecorded_service_chain = MagicMock(
+            return_value=(('deepgram', 'multi', 'nova-3'),)
+        )
         sys.modules['utils.stt.vad'].vad_is_empty = MagicMock()
         sys.modules['utils.speaker_assignment'].process_speaker_assigned_segments = MagicMock()
         sys.modules['utils.speaker_identification'].detect_speaker_from_text = MagicMock(return_value=None)
@@ -1428,6 +1431,9 @@ class TestVoiceMessageRuntimeErrorHandling:
         sys.modules['utils.stt.pre_recorded'].get_deepgram_model_for_language = MagicMock(return_value=('en', 'nova-3'))
         sys.modules['utils.stt.pre_recorded'].get_prerecorded_service = MagicMock(
             return_value=('deepgram', 'en', 'nova-3')
+        )
+        sys.modules['utils.stt.pre_recorded'].get_prerecorded_service_chain = MagicMock(
+            return_value=(('deepgram', 'en', 'nova-3'),)
         )
         sys.modules['utils.stt.vad'].VADAudioDecodeError = type('VADAudioDecodeError', (RuntimeError,), {})
         sys.modules['utils.stt.vad'].VADProcessingError = type('VADProcessingError', (RuntimeError,), {})

--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1413,6 +1413,9 @@ class TestAsyncCoordinatorBehavioral:
         sys.modules['utils.stt.pre_recorded'].get_prerecorded_service = MagicMock(
             return_value=('deepgram', 'multi', 'nova-3')
         )
+        sys.modules['utils.stt.pre_recorded'].get_prerecorded_service_chain = MagicMock(
+            return_value=(('deepgram', 'multi', 'nova-3'),)
+        )
         sys.modules['utils.client_device'].resolve_client_device = MagicMock(
             return_value=MagicMock(client_device_id=None, platform=None)
         )
@@ -3160,6 +3163,9 @@ class TestV2EndpointExecution:
         sys.modules['utils.log_sanitizer'].sanitize = lambda value: value
         sys.modules['utils.stt.pre_recorded'].get_prerecorded_service = MagicMock(
             return_value=('deepgram', 'multi', 'nova-3')
+        )
+        sys.modules['utils.stt.pre_recorded'].get_prerecorded_service_chain = MagicMock(
+            return_value=(('deepgram', 'multi', 'nova-3'),)
         )
         sys.modules['utils.client_device'].resolve_client_device = MagicMock(
             return_value=MagicMock(client_device_id=None, platform=None)

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -482,6 +482,76 @@ class TestConstants:
 
 
 # ===========================================================================
+# Metering rate by surface
+# ===========================================================================
+
+
+class TestBudgetCostBySurface:
+    """Voice typing spends the shared allowance a tenth as fast as PTT does."""
+
+    def test_ptt_pays_the_full_duration(self):
+        from utils.voice_duration_limiter import VoiceBudgetSurface, budget_cost_ms
+
+        assert budget_cost_ms(30_000, VoiceBudgetSurface.PTT) == 30_000
+
+    def test_the_default_surface_is_undiscounted(self):
+        """An un-declared caller must not silently get the dictation rate."""
+        from utils.voice_duration_limiter import budget_cost_ms
+
+        assert budget_cost_ms(30_000) == 30_000
+
+    def test_voice_typing_pays_a_tenth(self):
+        from utils.voice_duration_limiter import VoiceBudgetSurface, budget_cost_ms
+
+        assert budget_cost_ms(30_000, VoiceBudgetSurface.VOICE_TYPING) == 3_000
+
+    def test_a_short_dictation_still_costs_something(self):
+        """Rounding a real turn down to free would make the budget unenforceable."""
+        from utils.voice_duration_limiter import VoiceBudgetSurface, budget_cost_ms
+
+        assert budget_cost_ms(5, VoiceBudgetSurface.VOICE_TYPING) == 1
+        assert budget_cost_ms(1, VoiceBudgetSurface.VOICE_TYPING) == 1
+
+    def test_a_probe_stays_free(self):
+        from utils.voice_duration_limiter import VoiceBudgetSurface, budget_cost_ms
+
+        assert budget_cost_ms(0, VoiceBudgetSurface.VOICE_TYPING) == 0
+
+    def test_the_dictation_rate_is_ten_times_cheaper(self):
+        """The number the product decision names, asserted directly."""
+        from utils.voice_duration_limiter import VoiceBudgetSurface, budget_cost_ms
+
+        duration_ms = 600_000  # ten minutes of dictation
+        ptt = budget_cost_ms(duration_ms, VoiceBudgetSurface.PTT)
+        typing = budget_cost_ms(duration_ms, VoiceBudgetSurface.VOICE_TYPING)
+        assert ptt == typing * 10
+
+    def test_a_full_allowance_of_dictation_is_twenty_hours(self):
+        from utils.voice_duration_limiter import DAILY_BUDGET_MS, VoiceBudgetSurface, budget_cost_ms
+
+        one_hour_ms = 3_600_000
+        spent = budget_cost_ms(20 * one_hour_ms, VoiceBudgetSurface.VOICE_TYPING)
+        assert spent == DAILY_BUDGET_MS
+
+
+class TestResolveBudgetSurface:
+    """The surface is client-declared, so every unknown value must read as PTT."""
+
+    def test_known_surfaces_resolve(self):
+        from utils.voice_duration_limiter import VoiceBudgetSurface, resolve_budget_surface
+
+        assert resolve_budget_surface('voice_typing') == VoiceBudgetSurface.VOICE_TYPING
+        assert resolve_budget_surface('VOICE_TYPING') == VoiceBudgetSurface.VOICE_TYPING
+        assert resolve_budget_surface(' ptt ') == VoiceBudgetSurface.PTT
+
+    @pytest.mark.parametrize('raw', [None, '', 'typing', 'dictation', 'free', '10'])
+    def test_anything_else_pays_full_rate(self, raw):
+        from utils.voice_duration_limiter import VoiceBudgetSurface, resolve_budget_surface
+
+        assert resolve_budget_surface(raw) == VoiceBudgetSurface.PTT
+
+
+# ===========================================================================
 # Concurrent WS admission (real Lua via fakeredis)
 # ===========================================================================
 

--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -1,7 +1,7 @@
 import base64
 import uuid
 from datetime import datetime, timezone
-from typing import AsyncGenerator, List, Optional, Tuple
+from typing import AsyncGenerator, List, NamedTuple, Optional, Tuple
 
 from fastapi import HTTPException
 
@@ -28,6 +28,7 @@ from utils.stt.pre_recorded import (
     prerecorded,
     prerecorded_from_bytes,
     get_prerecorded_service,
+    get_prerecorded_service_chain,
 )
 from utils.stt.outcomes import (
     TranscriptionFailure,
@@ -209,39 +210,33 @@ def transcribe_voice_message_segment(
     return _transcribe_voice_message_url(url, path, language)
 
 
-def transcribe_pcm_bytes(
-    audio_bytes: bytes,
-    uid: str,
-    language: str = 'multi',
-    encoding: str = 'linear16',
-    sample_rate: int = 16000,
-    channels: int = 1,
-    keywords: Optional[List[str]] = None,
-) -> Tuple[Optional[str], Optional[str]]:
-    """Transcribe raw PCM audio bytes through the selected pre-recorded STT provider.
+class PcmTranscription(NamedTuple):
+    """One PCM transcription and the provider that actually produced it.
 
-    Skips GCS upload and WAV conversion for maximum speed.
-    Used by desktop PTT batch mode.
+    The provider is reported rather than inferred from selection: the chain can
+    fail over mid-request, and the response has to name the provider whose words
+    the user is about to read.
     """
-    if not language:
-        language = resolve_voice_message_language(uid, None)
 
-    provider, stt_language, stt_model = get_prerecorded_service(language)
+    text: Optional[str]
+    language: Optional[str]
+    provider: Optional[str]
+    model: Optional[str]
+
+
+def _transcribe_pcm_once(
+    audio_bytes: bytes,
+    *,
+    provider: str,
+    stt_language: Optional[str],
+    stt_model: str,
+    encoding: str,
+    sample_rate: int,
+    channels: int,
+    keywords: Optional[List[str]],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Transcribe through one pinned provider, raising a typed terminal failure."""
     is_multi = stt_language == 'multi'
-
-    if encoding == 'linear16':
-        try:
-            if linear16_pcm_is_silent(audio_bytes, sample_rate=sample_rate, channels=channels):
-                return None, stt_language if not is_multi else None
-        except VADAudioDecodeError as error:
-            raise TranscriptionFailure(
-                TranscriptionOutcome.INVALID_INPUT,
-                provider=provider,
-                retryable=False,
-            ) from error
-        except VADProcessingError as error:
-            raise TranscriptionFailure(TranscriptionOutcome.UPSTREAM_ERROR, provider=provider) from error
-
     try:
         if is_multi:
             result = prerecorded_from_bytes(
@@ -254,6 +249,7 @@ def transcribe_pcm_bytes(
                 model=stt_model,
                 return_language=True,
                 keywords=keywords,
+                service=provider,
             )
             words, detected_language = result
         else:
@@ -266,6 +262,7 @@ def transcribe_pcm_bytes(
                 language=stt_language,
                 model=stt_model,
                 keywords=keywords,
+                service=provider,
             )
             detected_language = stt_language
     except Exception as error:
@@ -288,6 +285,102 @@ def transcribe_pcm_bytes(
         raise empty_unexpected_failure(provider)
 
     return text, detected_language
+
+
+_PCM_FAILOVER_REASONS = {
+    TranscriptionOutcome.TIMEOUT: 'timeout',
+    TranscriptionOutcome.UPSTREAM_ERROR: 'provider_5xx',
+    TranscriptionOutcome.EMPTY_UNEXPECTED: 'empty_result',
+    TranscriptionOutcome.CONFIG_ERROR: 'config_incomplete',
+}
+
+
+def transcribe_pcm_bytes(
+    audio_bytes: bytes,
+    uid: str,
+    language: str = 'multi',
+    encoding: str = 'linear16',
+    sample_rate: int = 16000,
+    channels: int = 1,
+    keywords: Optional[List[str]] = None,
+) -> PcmTranscription:
+    """Transcribe raw PCM audio bytes through the pre-recorded STT chain.
+
+    Skips GCS upload and WAV conversion for maximum speed. Used by desktop PTT
+    batch mode — the route behind voice typing.
+
+    The whole chain is walked, not only its head. A recoverable failure — an
+    upstream error, a timeout, or an empty result on audio the VAD called
+    speech-positive — hands the same bytes to the next configured provider
+    (cloud Parakeet, then Velma-2), so the client reaches for its on-device
+    model only once every cloud provider has had its turn. Failures no other
+    provider would survive (invalid input, a misconfigured runtime) end the
+    request where they happen rather than spending a second provider call on
+    audio that cannot be transcribed.
+
+    A provider that hangs instead of failing is not failed over here: the
+    client's own deadline ends that turn on its on-device model, which is the
+    tier below this chain either way.
+    """
+    if not language:
+        language = resolve_voice_message_language(uid, None)
+
+    chain = get_prerecorded_service_chain(language)
+    head_provider, head_language, head_model = chain[0]
+
+    if encoding == 'linear16':
+        try:
+            if linear16_pcm_is_silent(audio_bytes, sample_rate=sample_rate, channels=channels):
+                return PcmTranscription(
+                    None,
+                    head_language if head_language != 'multi' else None,
+                    head_provider,
+                    head_model,
+                )
+        except VADAudioDecodeError as error:
+            raise TranscriptionFailure(
+                TranscriptionOutcome.INVALID_INPUT,
+                provider=head_provider,
+                retryable=False,
+            ) from error
+        except VADProcessingError as error:
+            raise TranscriptionFailure(TranscriptionOutcome.UPSTREAM_ERROR, provider=head_provider) from error
+
+    for index, (provider, stt_language, stt_model) in enumerate(chain):
+        try:
+            text, detected_language = _transcribe_pcm_once(
+                audio_bytes,
+                provider=provider,
+                stt_language=stt_language,
+                stt_model=stt_model,
+                encoding=encoding,
+                sample_rate=sample_rate,
+                channels=channels,
+                keywords=keywords,
+            )
+        except TranscriptionFailure as failure:
+            remaining = chain[index + 1 :]
+            if not failure.retryable or not remaining:
+                raise
+            next_provider = remaining[0][0]
+            record_fallback(
+                component='stt_selection',
+                from_mode=provider,
+                to_mode=next_provider,
+                reason=_PCM_FAILOVER_REASONS.get(failure.outcome, 'other'),
+                outcome='degraded',
+            )
+            logger.warning(
+                'PCM transcription failing over: outcome=%s from=%s to=%s',
+                failure.outcome.value,
+                failure.provider,
+                next_provider,
+            )
+            continue
+        return PcmTranscription(text, detected_language, provider, stt_model)
+
+    # Unreachable: the last hop has no remaining provider, so it re-raises above.
+    raise TranscriptionFailure(TranscriptionOutcome.CONFIG_ERROR, retryable=False)
 
 
 def process_voice_message_segment(

--- a/backend/utils/observability/fallback.py
+++ b/backend/utils/observability/fallback.py
@@ -42,6 +42,10 @@ ALLOWED_REASONS = frozenset(
         'byok',
         'malformed_doc',
         'capacity_full',
+        # A provider answered but returned no words for audio the VAD called
+        # speech-positive — distinct from a 5xx, and the reason the pre-recorded
+        # chain hands the same audio to the next provider.
+        'empty_result',
         'allocation_rejected',
         'private_tool_output_in_context',
         'not_authorized',

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -79,46 +79,80 @@ class PrerecordedSTTProvider(ABC):
     ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], str]]: ...
 
 
-def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Optional[str], str]:
-    """Route pre-recorded STT based on STT_PRERECORDED_MODEL env var.
+# Velma's batch API accepts a language code only for the languages it claims;
+# everything else has to go through its own detection (the 'multi' selection at
+# the bottom of the chain).
+_MODULATE_PRERECORDED_LANGUAGES = frozenset({'en', 'es', 'fr', 'de', 'it', 'pt', 'nl', 'ja', 'ko', 'zh'})
 
-    Iterates comma-separated models (same pattern as STT_SERVICE_MODELS for streaming).
-    First model allowed by the central serving policy that supports the language
-    wins. Disabled-provider tokens are ignored, then policy-owned defaults provide
-    the serving fallback. A language no capability map claims falls through to Velma
-    rather than failing selection.
+
+def _prerecorded_candidates(models: Sequence[str], base_lang: str) -> List[Tuple[str, Optional[str], str]]:
+    """Every provider one model preference can serve this language with, in order."""
+    candidates: List[Tuple[str, Optional[str], str]] = []
+    seen: set[str] = set()
+
+    def admit(candidate: Tuple[str, Optional[str], str]) -> None:
+        if candidate[0] in seen:
+            return
+        seen.add(candidate[0])
+        candidates.append(candidate)
+
+    for m in models:
+        m = m.strip()
+        if m == 'modulate-velma-2' and provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.PRERECORDED):
+            if base_lang in _MODULATE_PRERECORDED_LANGUAGES:
+                admit((PrerecordedSTTService.MODULATE, base_lang, 'velma-2'))
+            continue
+        if m == 'parakeet' and provider_is_enabled(PARAKEET_PROVIDER, STTServingSurface.PRERECORDED):
+            if parakeet_supports_language(STTServingSurface.PRERECORDED, base_lang):
+                admit((PrerecordedSTTService.PARAKEET, base_lang, 'parakeet'))
+    return candidates
+
+
+def get_prerecorded_service_chain(language: Optional[str] = 'en') -> Tuple[Tuple[str, Optional[str], str], ...]:
+    """Order every pre-recorded provider that can serve one request's language.
+
+    Selection and failover read the same list so they cannot disagree. The head
+    is the provider a request starts on — what ``get_prerecorded_service``
+    returns and what every existing caller uses. The tail is what a caller able
+    to spend a second attempt hands the audio to when the head fails
+    recoverably (``transcribe_pcm_bytes``, the route behind voice typing):
+    the deployment already declares an order (``parakeet,modulate-velma-2``),
+    and honoring only its first entry turned a recoverable provider error into a
+    user-visible failure while a configured, capable provider sat unused.
+
+    Same routing rules as before: comma-separated ``STT_PRERECORDED_MODEL``
+    tokens (the pattern ``STT_SERVICE_MODELS`` uses for streaming), filtered by
+    the central serving policy and by language capability. Disabled-provider
+    tokens are ignored, then policy-owned defaults provide the serving fallback.
+    A language no capability map claims falls through to Velma rather than
+    failing selection.
     """
     base_lang = normalized_stt_language(language) or 'en'
 
-    def select(models: Sequence[str]) -> Optional[Tuple[str, Optional[str], str]]:
-        for m in models:
-            m = m.strip()
-            if m == 'modulate-velma-2' and provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.PRERECORDED):
-                if base_lang in {'en', 'es', 'fr', 'de', 'it', 'pt', 'nl', 'ja', 'ko', 'zh'}:
-                    return PrerecordedSTTService.MODULATE, base_lang, 'velma-2'
-                continue
-            if m == 'parakeet' and provider_is_enabled(PARAKEET_PROVIDER, STTServingSurface.PRERECORDED):
-                if parakeet_supports_language(STTServingSurface.PRERECORDED, base_lang):
-                    return PrerecordedSTTService.PARAKEET, base_lang, 'parakeet'
-        return None
-
-    selected = select(get_prerecorded_models())
-    if selected is not None:
-        return selected
-
     # A disabled/unknown preference must not become a provider call. Use the
     # deployment-validated, policy-owned defaults instead.
-    selected = select(default_models_for_surface(STTServingSurface.PRERECORDED))
-    if selected is not None:
-        return selected
+    for models in (get_prerecorded_models(), default_models_for_surface(STTServingSurface.PRERECORDED)):
+        chain = _prerecorded_candidates(models, base_lang)
+        if chain:
+            return tuple(chain)
 
     # Velma's batch API detects the language itself — we never send a code — so it can
     # serve languages the capability maps omit, and values that are not codes at all.
     if provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.PRERECORDED):
-        return PrerecordedSTTService.MODULATE, 'multi', 'velma-2'
+        return ((PrerecordedSTTService.MODULATE, 'multi', 'velma-2'),)
 
     # Only reachable with every pre-recorded provider disabled, which no retry resolves.
     raise TranscriptionFailure(TranscriptionOutcome.CONFIG_ERROR, retryable=False)
+
+
+def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Optional[str], str]:
+    """Route pre-recorded STT based on STT_PRERECORDED_MODEL env var.
+
+    The provider a request starts on: the head of
+    ``get_prerecorded_service_chain``. A caller that can afford a second attempt
+    walks the whole chain instead of calling this.
+    """
+    return get_prerecorded_service_chain(language)[0]
 
 
 # Lazily initialized because constructing the SDK client at import makes every
@@ -1020,9 +1054,19 @@ class ParakeetPrerecordedProvider(PrerecordedSTTProvider):
         )
 
 
-def get_prerecorded_provider(language: Optional[str] = 'en') -> PrerecordedSTTProvider:
-    """Construct exactly the language-aware provider selected for telemetry."""
-    service, _provider_language, model = get_prerecorded_service(language)
+def get_prerecorded_provider(
+    language: Optional[str] = 'en', *, service: Optional[str] = None
+) -> PrerecordedSTTProvider:
+    """Construct exactly the language-aware provider selected for telemetry.
+
+    ``service`` pins the provider to one the caller already took from
+    ``get_prerecorded_service_chain``, so a failover attempt reaches the provider
+    that attempt is for rather than re-selecting the chain head and retrying the
+    provider that just failed.
+    """
+    model: Optional[str] = None
+    if service is None:
+        service, _provider_language, model = get_prerecorded_service(language)
     if service == PrerecordedSTTService.MODULATE:
         return ModulatePrerecordedProvider()
     if service == PrerecordedSTTService.PARAKEET:
@@ -1069,9 +1113,13 @@ def prerecorded_from_bytes(
     model: str = "nova-3",
     return_language: bool = False,
     keywords: Optional[Sequence[str]] = None,
+    service: Optional[str] = None,
 ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], str]]:
-    """Route pre-recorded bytes transcription through STT_PRERECORDED_MODEL."""
-    provider = get_prerecorded_provider(language)
+    """Route pre-recorded bytes transcription through STT_PRERECORDED_MODEL.
+
+    ``service`` pins one already-selected provider for a failover attempt.
+    """
+    provider = get_prerecorded_provider(language, service=service)
     return provider.transcribe_bytes(
         audio_bytes,
         sample_rate=sample_rate,

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -17,6 +17,13 @@ Design:
 Constants:
 - MAX_SESSION_DURATION_S: 120 seconds per request/session.
 - DAILY_BUDGET_MS: 7,200,000 ms (2 hours) per rolling 24h window.
+
+Metering rate:
+- The allowance is one shared pool, but surfaces do not spend it at the same
+  rate. Voice typing is charged a tenth of its audio, so a dictation-heavy day
+  cannot consume a user's whole voice-message allowance. The rate itself lives
+  in config.voice_budget_policy (budget_cost_ms), which has no dependencies and
+  is therefore readable by callers and tests that never stand up Redis.
 """
 
 import logging
@@ -25,6 +32,11 @@ from typing import Any, Dict, Optional
 
 import av
 
+from config.voice_budget_policy import (  # re-exported so callers may read the rate off the limiter
+    VoiceBudgetSurface as VoiceBudgetSurface,
+    budget_cost_ms as budget_cost_ms,
+    resolve_budget_surface as resolve_budget_surface,
+)
 from database.redis_db import r
 
 logger = logging.getLogger(__name__)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ARCHITECTURE.md
@@ -61,9 +61,11 @@ The fuller recovery, insertion, and notch contract lives in
   in `.finalizing` (the bar shows it thinking) until delivery lands, exactly as
   it does for a batch-transcribed question, and every path ends the turn.
   1. **Transcribe** (`DictationTranscriber`): the backend's pre-recorded
-     recognizer (`/v2/voice-message/transcribe`, `velma-2` first) with the
-     on-screen keywords as vocabulary, bounded to 12 s; on failure, timeout,
-     or an empty result, the on-device model. With no network only the
+     recognizer (`/v2/voice-message/transcribe`) with the on-screen keywords as
+     vocabulary, bounded to 12 s; on failure, timeout, or an empty result, the
+     on-device model. The backend answers that one call from its own chain —
+     cloud Parakeet, then Velma-2 on a recoverable failure — so the on-device
+     model is reached only once both cloud providers have been tried. With no network only the
      on-device model runs, and a route that latched offline at key-down stays
      offline even if a path comes back mid-hold. A route that already
      produced a backend transcript (omni STT, batch STT after a warm-wait)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1641,7 +1641,8 @@ class PushToTalkManager: ObservableObject {
             try await TranscriptionService.batchTranscribe(
               audioData: audioData,
               language: language,
-              contextKeywords: self.currentContextSnapshot?.keywords ?? []
+              contextKeywords: self.currentContextSnapshot?.keywords ?? [],
+              surface: self.batchBudgetSurface
             )
           }
           guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
@@ -1653,7 +1654,8 @@ class PushToTalkManager: ObservableObject {
             batchResult = try await TranscriptionService.batchTranscribe(
               audioData: audioData,
               language: "en",
-              contextKeywords: self.currentContextSnapshot?.keywords ?? []
+              contextKeywords: self.currentContextSnapshot?.keywords ?? [],
+              surface: self.batchBudgetSurface
             )
             guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
           }
@@ -2467,7 +2469,8 @@ class PushToTalkManager: ObservableObject {
         let batchResult = try await TranscriptionService.batchTranscribe(
           audioData: audio,
           language: language,
-          contextKeywords: self.currentContextSnapshot?.keywords ?? []
+          contextKeywords: self.currentContextSnapshot?.keywords ?? [],
+          surface: self.batchBudgetSurface
         )
         guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
         self.activeTracer?.end("batch_transcribe")
@@ -3429,14 +3432,29 @@ class PushToTalkManager: ObservableObject {
   /// pre-recorded model with the on-screen vocabulary, then the on-device
   /// model. Each switch is recorded, so a backend that keeps losing turns to
   /// the fallback is visible.
+  /// How a batch turn should be metered against the shared voice allowance.
+  ///
+  /// A turn that has already latched as typing is a dictation whatever route
+  /// ends up transcribing it — the warm-wait and omni fallbacks reuse their
+  /// transcript for the paste rather than transcribing twice, so they are the
+  /// dictation's only backend call. The latch moves one way and only from a
+  /// probe the user has already spoken into, so a turn that has not claimed yet
+  /// pays the full rate: this under-claims the discount, never over-claims it.
+  private var batchBudgetSurface: TranscriptionService.BudgetSurface {
+    voiceTypeSession.claimsTurn ? .voiceTyping : .ptt
+  }
+
   private func makeDictationTranscriber(
     keywords: [String], language: String, allowNetwork: Bool
   ) -> DictationTranscriber {
     DictationTranscriber(
       isOnline: allowNetwork && NetworkReachability.shared.isOnline,
       backend: { audio in
+        // Declared as typing so the backend meters this turn at the dictation
+        // rate: a paragraph spoken into a text field must not cost the same
+        // slice of the allowance as a paragraph asked of the assistant.
         try await TranscriptionService.batchTranscribe(
-          audioData: audio, language: language, contextKeywords: keywords
+          audioData: audio, language: language, contextKeywords: keywords, surface: .voiceTyping
         ).transcript
       },
       onDevice: { audio in
@@ -4091,7 +4109,8 @@ extension PushToTalkManager {
         let language = AssistantSettings.shared.effectiveTranscriptionLanguage
         let batchResult = try await TranscriptionService.batchTranscribe(
           audioData: audio, language: language,
-          contextKeywords: self.currentContextSnapshot?.keywords ?? [])
+          contextKeywords: self.currentContextSnapshot?.keywords ?? [],
+          surface: self.batchBudgetSurface)
         guard self.voiceTurnCoordinator.activeTurnID == turnID else { return }
         let provider = batchResult.provider ?? "unknown"
         let model = batchResult.model ?? "unknown"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationTranscriber.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTyping/DictationTranscriber.swift
@@ -3,12 +3,14 @@ import Foundation
 /// Turns a finished turn's audio into its best available transcript.
 ///
 /// Accuracy first, then availability: the backend's pre-recorded recognizer
-/// (`/v2/voice-message/transcribe`, `velma-2` first) hears the whole utterance
-/// with the on-screen vocabulary as context, and it is what a dictation is
-/// transcribed with whenever it can be reached. The on-device Parakeet model —
-/// already loaded for language identification — is the fallback, and with no
-/// network it is the only recognizer there is. A turn never ends with nothing
-/// while either can still answer.
+/// (`/v2/voice-message/transcribe`) hears the whole utterance with the
+/// on-screen vocabulary as context, and it is what a dictation is transcribed
+/// with whenever it can be reached. Behind that one call the backend runs its
+/// own chain — cloud Parakeet, then Velma-2 if Parakeet fails recoverably — so
+/// a single cloud provider being down does not cost the dictation its accuracy.
+/// The on-device Parakeet model — already loaded for language identification —
+/// is the last tier, and with no network it is the only recognizer there is. A
+/// turn never ends with nothing while either can still answer.
 ///
 /// The recognizers are injected so the order can be exercised without a
 /// network or a model.

--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -742,13 +742,27 @@ enum WebSocketConnectionAttempt {
 // MARK: - Batch (Pre-Recorded) Transcription (PTT only)
 
 extension TranscriptionService {
+  /// Which surface a batch turn came from.
+  ///
+  /// The backend meters the shared voice-message allowance by surface: a
+  /// dictation is charged a tenth of its audio, a spoken question the whole of
+  /// it. Typing runs in minutes-long stretches where a question runs in
+  /// seconds, so charging them alike would spend a user's day of allowance on
+  /// dictation alone. Declaring it wrong only mis-bills the allowance — it
+  /// grants no capability, and every abuse ceiling is enforced regardless.
+  enum BudgetSurface: String {
+    case ptt
+    case voiceTyping = "voice_typing"
+  }
+
   /// Transcribe a complete audio buffer using the Python backend `/v2/voice-message/transcribe`.
   /// Returns the transcript plus the provider/model selected by the backend.
   static func batchTranscribe(
     audioData: Data,
     language: String = "en",
     apiKey: String? = nil,
-    contextKeywords: [String] = []
+    contextKeywords: [String] = [],
+    surface: BudgetSurface = .ptt
   ) async throws -> BatchTranscriptionResult {
     // Always use Firebase auth + Python backend
     let authService = await MainActor.run { AuthService.shared }
@@ -764,6 +778,7 @@ extension TranscriptionService {
       URLQueryItem(name: "sample_rate", value: "16000"),
       URLQueryItem(name: "encoding", value: "linear16"),
       URLQueryItem(name: "channels", value: "1"),
+      URLQueryItem(name: "surface", value: surface.rawValue),
     ]
     if !sanitizedKeywords.isEmpty {
       queryItems.append(URLQueryItem(name: "keywords", value: sanitizedKeywords.joined(separator: ",")))
@@ -793,7 +808,8 @@ extension TranscriptionService {
     request.httpBody = audioData
 
     log(
-      "TranscriptionService: Batch transcribing \(audioData.count) bytes via Python backend, contextKeywords=\(sanitizedKeywords.count)"
+      "TranscriptionService: Batch transcribing \(audioData.count) bytes via Python backend, "
+        + "surface=\(surface.rawValue), contextKeywords=\(sanitizedKeywords.count)"
     )
 
     let (data, response) = try await URLSession.shared.data(for: request)

--- a/desktop/macos/changelog/unreleased/20260908-omi-type-cheaper-and-steadier.json
+++ b/desktop/macos/changelog/unreleased/20260908-omi-type-cheaper-and-steadier.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi Type now uses far less of your daily voice allowance, and keeps its accuracy when a transcription provider is having a bad day."
+}


### PR DESCRIPTION
<!-- claude:summary:start -->
## Summary

- **Omi Type is served by cloud Parakeet, and stays served when it fails.** `get_prerecorded_service` returned only the head of the deployment's declared order (`parakeet,modulate-velma-2`) and nothing iterated it, so a recoverable Parakeet failure ended the request `502` while a configured, capable Velma sat unused — and the desktop dropped straight to its on-device model. Selection and failover now read one list, so the chain is **cloud Parakeet → Velma-2 → on-device**.
- **Only recoverable failures spend a second provider.** An upstream error, a timeout, or an empty result on speech-positive audio hands the same bytes on; invalid input and misconfiguration stop where they happen. A provider that hangs is left to the client's own 12 s deadline, which ends that turn on-device — the tier below this chain either way.
- **The response tells the truth about who answered.** `stt_provider`/`stt_model` now name the provider whose words the user is reading, not the one selection started on, and every switch is recorded through `record_fallback` (`component=stt_selection`, with one new bounded reason, `empty_result`).
- **Voice typing costs a tenth of the shared voice allowance.** Dictation replaces typing, so it runs in minutes-long stretches where a spoken question lasts seconds; charged alike it would spend a user's whole two-hour allowance on dictation alone. A full allowance is now ~20 hours of dictation instead of 2. The turn still transcribes at full length — only the charge shrinks.
- **The rate is policy, not plumbing.** `config/voice_budget_policy.py` is dependency-free (no Redis, no `av`, no env) so the router, the limiter and their tests read the same numbers without standing up infrastructure.

### Why cloud Parakeet leads the chain

The ordering itself is not new — the deployment has declared `parakeet,modulate-velma-2` for the `PRERECORDED` surface for a while. What was new is that nothing walked past the head, so the declared preference only ever held on the happy path. This PR makes the deployment's stated order the order that actually runs.

**Cost.** Parakeet is ours: `backend/parakeet/` runs `nvidia/parakeet-tdt-0.6b-v3` on a GKE GPU node pool behind an internal load balancer, with dynamic batching (`PARAKEET_MAX_BATCH_SIZE=32`, 2 ms flush) and an HPA on `parakeet_request_latency_p99`. A dictation turn served there spends GPU capacity we are already paying for and already scaling. Velma-2 is an external vendor billed per minute of audio. Dictation is the highest-volume, lowest-value-per-second speech on the platform — minutes-long stretches of ordinary typing — so it is exactly the traffic that should land on the fixed-cost provider and not on the metered one.

**Quality.** The batch path is the strong Parakeet configuration, not the streaming one: TDT 0.6b with full punctuation, capitalization, and timestamps, rather than the RNNT streaming model that emits lowercase and unpunctuated text. The remaining gap to Velma-2 is small, and dictation is the surface most tolerant of it — utterances are short, the user is watching the words appear and corrects inline, and anything Parakeet genuinely cannot serve now falls through to Velma-2 instead of dropping to the client's on-device model, which is the weakest tier of the three. Net of that fallback, this raises the floor: before this change a single recoverable Parakeet error sent the turn to on-device.

**So the trade is:** the large majority of dictation minutes move from per-minute vendor spend onto capacity we already run, for a small accuracy difference on a surface that tolerates it, and with a better worst case than today's.

### Scope note

The surface is client-declared (`?surface=voice_typing`, sent by `TranscriptionService.batchTranscribe(surface:)`), and unknown values pay full rate. It is a **cost guard, not an authorization boundary** — any HTTP client can claim the rate. Being precise about what still bounds a request when it does: the 200 MB per-request body cap (`_MAX_PCM_BODY_BYTES`, ~104 min of 16 kHz mono) is the only per-request ceiling and is unaffected; `MAX_SESSION_DURATION_S` bounds a streaming PTT session's reservation, not this batch route, where it is only the worst case charged for an unreadable duration; and fair-use's daily audio ceiling meters the listen/sync pipelines and is never consulted here. So the rolling 24 h `DAILY_BUDGET_MS` is effectively the only daily ceiling on this endpoint, and the divisor raises one account's daily audio through it by the same factor — ~2 h to ~20 h. That is the deliberate trade, made knowingly: the audio this admits is served first by the self-hosted deployment, so the marginal cost of the extra ceiling is our own GPU capacity rather than vendor spend. Tightening it later is a budget-key or attestation change on top of this policy module, not a rewrite of it. `PushToTalkManager.batchBudgetSurface` reads `voiceTypeSession.claimsTurn` so the warm-wait and omni batch fallbacks get the rate too when a turn has already latched as typing; a turn that has not latched pays full rate, which under-claims the discount rather than over-claiming it.

## Test plan

- [x] `pytest tests/unit/test_voice_duration_limiter.py` — 51 tests; 9 new covering the metering rate and surface resolution
- [x] `pytest tests/unit/test_desktop_transcribe.py` — 80 tests; 7 new covering chain failover, the truthful provider in the response, bounded fallback labels, and the tenth-rate charge
- [x] `pytest tests/unit/test_prerecorded_language_coverage.py` — 92 tests; 4 new pinning the chain's ordering, its dedup, and a language only one provider serves
- [x] Suites that stub the touched modules, all green: `test_chat_stream_error_fallback`, `test_chat_quota_counting_router`, `test_chat_file_upload_unsupported`, `test_chat_generate_reply_stateless`, `test_jit_citation_envelope_router`, `test_chat_file_gateway_stub_import_contract`, `test_sync_v2`, `test_sync_silent_failure`, `test_fallback_observability`, `test_parakeet_prerecorded`, `test_prerecorded_stt_config`, `test_stt_provider_policy`, `test_speaker_sample`
- [x] `swift build` (desktop) — clean, and the app runs: built and launched from this branch (`run.sh --yolo --full`), boots signed-in against the hosted dev backend
- [x] Rebased onto current `origin/main` (clean, no conflicts) and every suite above re-run green there
- [x] **End-to-end against the real route.** The production app needs GCP/Firebase credentials this machine does not have, so `routers/chat.py` was served on localhost with only the infrastructure boundary stubbed (the same stub set the repo's router tests use); `utils.chat` and `utils.stt.pre_recorded` are the real modules. Parakeet was reached over real HTTP via `HOSTED_PARAKEET_API_URL`; Velma's URL is hardcoded in the provider, so only its hostname was rewritten at the httpx boundary — its client and response parsing ran unmodified.

  | Vendor state | Result |
  |---|---|
  | Parakeet healthy | `200`, `stt_provider: parakeet` |
  | Parakeet `503` | `200`, `stt_provider: modulate`, `stt_model: velma-2` |
  | Parakeet returns nothing on speech-positive audio | `200`, `stt_provider: modulate` |
  | Both down | `502 stt_upstream_error` — the signal that sends the client on-device |
  | Parakeet recovers | `200`, back on `parakeet`, no failover |

  The same request on unmodified `origin/main` returns `502` with `provider: parakeet` — Velma never called. Metering, same 1.5 s of audio each time: no surface `1500 ms`, `surface=voice_typing` `150 ms`, `surface=nonsense` `1500 ms`.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

`PushToTalkManager` gains one computed property and one argument at four existing
`batchTranscribe` call sites. No lifecycle enum, turn boolean, completion timer or
transcript store is added: `batchBudgetSurface` reads the existing
`voiceTypeSession.claimsTurn` latch, and the reducer stays the only owner of turn state.

Line-Count-Exception: backend/routers/chat.py | 2161 -> 2170 | +9 lines: read the metering surface off the query string and charge the discounted cost; the file's split is unrelated to this change and would bury a nine-line diff in a rename.
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 4090 -> 4109 | +19 lines: one computed property (`batchBudgetSurface`, 11 of them its comment) plus a `surface:` argument at four existing call sites; splitting this file is a separate refactor with its own review surface.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dLCDtFazmzD6yPEzyHxDr
<!-- claude:summary:end -->
