### PR TITLE
fix(backend): accept the provider's documented chat file input types

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
@@ -34,6 +35,256 @@ class MessageConversation(BaseModel):
     created_at: datetime
 
 
+# Chat Completions `file` content parts (purpose=user_data) accept these document
+# types. Images stay on the separate vision / image_url path and are not listed here.
+# Source: https://platform.openai.com/docs/guides/pdf-files
+# (File inputs → "Accepted file types" and "Full list of accepted file types").
+# Read 2026-09-08 from a saved copy of that page. Non-PDF documents are
+# text-extracted only; spreadsheets use a 1,000-row augmentation flow.
+CHAT_FILE_DOCUMENT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        # PDF
+        'pdf',
+        # Spreadsheets
+        'xla',
+        'xlb',
+        'xlc',
+        'xlm',
+        'xls',
+        'xlsx',
+        'xlt',
+        'xlw',
+        'csv',
+        'tsv',
+        'iif',
+        # Rich documents
+        'doc',
+        'docx',
+        'dot',
+        'odt',
+        'rtf',
+        # Presentations
+        'pot',
+        'ppa',
+        'pps',
+        'ppt',
+        'pptx',
+        'pwz',
+        'wiz',
+        # Text and code
+        'asm',
+        'bat',
+        'c',
+        'cc',
+        'conf',
+        'cpp',
+        'css',
+        'cxx',
+        'def',
+        'dic',
+        'eml',
+        'h',
+        'hh',
+        'htm',
+        'html',
+        'ics',
+        'ifb',
+        'in',
+        'js',
+        'json',
+        'ksh',
+        'list',
+        'log',
+        'markdown',
+        'md',
+        'mht',
+        'mhtml',
+        'mime',
+        'mjs',
+        'nws',
+        'pl',
+        'py',
+        'rst',
+        's',
+        'sql',
+        'srt',
+        'text',
+        'txt',
+        'vcf',
+        'vtt',
+        'xml',
+    }
+)
+CHAT_FILE_DOCUMENT_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        'application/csv',
+        'application/graphql',
+        'application/javascript',
+        'application/json',
+        'application/json5',
+        'application/msword',
+        'application/pdf',
+        'application/rtf',
+        'application/toml',
+        'application/typescript',
+        'application/vnd.apple.iwork',
+        'application/vnd.apple.keynote',
+        'application/vnd.apple.pages',
+        'application/vnd.google-apps.document',
+        'application/vnd.google-apps.presentation',
+        'application/vnd.google-apps.spreadsheet',
+        'application/vnd.ms-excel',
+        'application/vnd.ms-powerpoint',
+        'application/vnd.oasis.opendocument.text',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/x-awk',
+        'application/x-bash',
+        'application/x-graphql',
+        'application/x-httpd-php',
+        'application/x-httpd-php-source',
+        'application/x-iif',
+        'application/x-json5',
+        'application/x-ndjson',
+        'application/x-patch',
+        'application/x-php',
+        'application/x-powershell',
+        'application/x-protobuf',
+        'application/x-rust',
+        'application/x-scala',
+        'application/x-sql',
+        'application/x-subrip',
+        'application/x-terraform',
+        'application/x-toml',
+        'application/x-yaml',
+        'application/yaml',
+        'message/rfc822',
+        'text/calendar',
+        'text/css',
+        'text/csv',
+        'text/html',
+        'text/javascript',
+        'text/jsx',
+        'text/markdown',
+        'text/plain',
+        'text/rtf',
+        'text/srt',
+        'text/tsv',
+        'text/tsx',
+        'text/vbscript',
+        'text/vtt',
+        'text/x-R',
+        'text/x-asm',
+        'text/x-astro',
+        'text/x-awk',
+        'text/x-bash',
+        'text/x-c',
+        'text/x-c++',
+        'text/x-clojure',
+        'text/x-cmake',
+        'text/x-csharp',
+        'text/x-dart',
+        'text/x-diff',
+        'text/x-dockerfile',
+        'text/x-ejs',
+        'text/x-elixir',
+        'text/x-erb',
+        'text/x-erlang',
+        'text/x-go',
+        'text/x-golang',
+        'text/x-gradle',
+        'text/x-graphql',
+        'text/x-groovy',
+        'text/x-handlebars',
+        'text/x-haskell',
+        'text/x-hcl',
+        'text/x-iif',
+        'text/x-ini',
+        'text/x-jade',
+        'text/x-java',
+        'text/x-jinja2',
+        'text/x-julia',
+        'text/x-kotlin',
+        'text/x-less',
+        'text/x-lisp',
+        'text/x-liquid',
+        'text/x-lua',
+        'text/x-makefile',
+        'text/x-mustache',
+        'text/x-objectivec',
+        'text/x-objectivec++',
+        'text/x-patch',
+        'text/x-perl',
+        'text/x-php',
+        'text/x-properties',
+        'text/x-protobuf',
+        'text/x-pug',
+        'text/x-python',
+        'text/x-r',
+        'text/x-rst',
+        'text/x-ruby',
+        'text/x-rust',
+        'text/x-sass',
+        'text/x-scala',
+        'text/x-script.python',
+        'text/x-scss',
+        'text/x-sh',
+        'text/x-shellscript',
+        'text/x-sql',
+        'text/x-subrip',
+        'text/x-swift',
+        'text/x-terraform',
+        'text/x-tex',
+        'text/x-tmpl',
+        'text/x-toml',
+        'text/x-twig',
+        'text/x-typescript',
+        'text/x-vcard',
+        'text/x-yaml',
+        'text/x-zsh',
+        'text/xml',
+    }
+)
+
+
+def _chat_file_normalized_mime(mime_type: Optional[str]) -> str:
+    """Lowercase MIME, treating missing values and str(None)=='None' as empty."""
+    if mime_type is None:
+        return ''
+    mime = str(mime_type).strip().lower()
+    if mime in ('', 'none', 'null'):
+        return ''
+    return mime
+
+
+def chat_file_is_pdf(name: str, mime_type: Optional[str]) -> bool:
+    """True when the filename extension or MIME identifies a PDF.
+
+    Extension is checked first and wins when present; MIME is the fallback.
+    ``mimetypes.guess_type`` returning None is stored as the string ``'None'``
+    by ``File.get_mime_type`` and must not count as a MIME match.
+    """
+    ext = Path(name or '').suffix.lower()
+    if ext:
+        return ext == '.pdf'
+    return _chat_file_normalized_mime(mime_type) == 'application/pdf'
+
+
+def chat_file_is_document(name: str, mime_type: Optional[str]) -> bool:
+    """True for any OpenAI-allowlisted chat document type, including PDF.
+
+    Images are not in this allowlist. Extension is checked first and wins when
+    present; MIME is the fallback so a missing MIME neither admits nor rejects
+    on its own.
+    """
+    ext = Path(name or '').suffix.lower().lstrip('.')
+    if ext:
+        return ext in CHAT_FILE_DOCUMENT_EXTENSIONS
+    mime = _chat_file_normalized_mime(mime_type)
+    return bool(mime) and mime in CHAT_FILE_DOCUMENT_MIME_TYPES
+
+
 class FileChat(BaseModel):
     id: str
     name: str
@@ -47,9 +298,10 @@ class FileChat(BaseModel):
         return self.mime_type.startswith("image")
 
     def is_pdf(self) -> bool:
-        if (self.mime_type or '').lower() == 'application/pdf':
-            return True
-        return (self.name or '').lower().endswith('.pdf')
+        return chat_file_is_pdf(self.name, self.mime_type)
+
+    def is_document(self) -> bool:
+        return chat_file_is_document(self.name, self.mime_type)
 
     def model_dump(self, **kwargs):
         exclude_fields = {'thumb_name'}

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -113,6 +113,70 @@ CHAT_FILE_DOCUMENT_EXTENSIONS: frozenset[str] = frozenset(
         'vcf',
         'vtt',
         'xml',
+        # The provider's Text-and-code MIME column also documents types whose
+        # canonical suffixes are missing from its Extensions column (e.g.
+        # 'text/x-rust' -> 'rs', 'text/x-yaml' -> 'yaml'). Keep them
+        # allowlisted so the extension-first branch cannot reject a file whose
+        # MIME the provider explicitly documents.
+        'astro',
+        'awk',
+        'c++',
+        'clj',
+        'cmake',
+        'cs',
+        'dart',
+        'diff',
+        'dockerfile',
+        'ejs',
+        'elixir',
+        'erb',
+        'erlang',
+        'go',
+        'gradle',
+        'graphql',
+        'groovy',
+        'hbs',
+        'hcl',
+        'hs',
+        'ini',
+        'j2',
+        'jade',
+        'java',
+        'jl',
+        'json5',
+        'jsx',
+        'kt',
+        'lisp',
+        'liquid',
+        'lua',
+        'm',
+        'mk',
+        'mustache',
+        'ndjson',
+        'patch',
+        'php',
+        'ps1',
+        'proto',
+        'pug',
+        'r',
+        'rb',
+        'rs',
+        'sass',
+        'scala',
+        'scss',
+        'sh',
+        'swift',
+        'terraform',
+        'tf',
+        'tex',
+        'tmpl',
+        'toml',
+        'ts',
+        'tsx',
+        'vbs',
+        'yaml',
+        'yml',
+        'zsh',
     }
 )
 CHAT_FILE_DOCUMENT_MIME_TYPES: frozenset[str] = frozenset(
@@ -258,19 +322,6 @@ def _chat_file_normalized_mime(mime_type: Optional[str]) -> str:
     return mime
 
 
-def chat_file_is_pdf(name: str, mime_type: Optional[str]) -> bool:
-    """True when the filename extension or MIME identifies a PDF.
-
-    Extension is checked first and wins when present; MIME is the fallback.
-    ``mimetypes.guess_type`` returning None is stored as the string ``'None'``
-    by ``File.get_mime_type`` and must not count as a MIME match.
-    """
-    ext = Path(name or '').suffix.lower()
-    if ext:
-        return ext == '.pdf'
-    return _chat_file_normalized_mime(mime_type) == 'application/pdf'
-
-
 def chat_file_is_document(name: str, mime_type: Optional[str]) -> bool:
     """True for any OpenAI-allowlisted chat document type, including PDF.
 
@@ -296,9 +347,6 @@ class FileChat(BaseModel):
 
     def is_image(self):
         return self.mime_type.startswith("image")
-
-    def is_pdf(self) -> bool:
-        return chat_file_is_pdf(self.name, self.mime_type)
 
     def is_document(self) -> bool:
         return chat_file_is_document(self.name, self.mime_type)

--- a/backend/tests/unit/test_chat_file_completions.py
+++ b/backend/tests/unit/test_chat_file_completions.py
@@ -188,7 +188,7 @@ async def test_mid_stream_completion_error_is_journey_failure(monkeypatch):
     assert callback_data['answer'] == AGENT_STREAM_FAILURE_MESSAGE
 
 
-def test_upload_pdf_uses_user_data_and_rejects_non_pdf(tmp_path, monkeypatch):
+def test_upload_pdf_uses_user_data_and_rejects_unsupported(tmp_path, monkeypatch):
     created: dict[str, object] = {}
 
     def _create(*, file, purpose):
@@ -203,10 +203,46 @@ def test_upload_pdf_uses_user_data_and_rejects_non_pdf(tmp_path, monkeypatch):
     assert result['file_id'] == 'file-1'
     assert created['purpose'] == 'user_data'
 
-    txt_path = tmp_path / 'note.txt'
-    txt_path.write_text('hello')
-    with pytest.raises(chat_file.UnsupportedChatFileError, match='txt'):
-        chat_file.FileChatTool.upload(txt_path)
+    zip_path = tmp_path / 'archive.zip'
+    zip_path.write_bytes(b'PK\x03\x04')
+    with pytest.raises(chat_file.UnsupportedChatFileError, match='zip'):
+        chat_file.FileChatTool.upload(zip_path)
+
+
+@pytest.mark.parametrize(
+    'name,mime_type',
+    [
+        ('note.txt', 'text/plain'),
+        (
+            'brief.docx',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ),
+    ],
+)
+def test_completion_messages_send_file_part_for_documents(name, mime_type):
+    tool = object.__new__(chat_file.FileChatTool)
+    attached = FileChat(
+        id='file-1',
+        name=name,
+        mime_type=mime_type,
+        openai_file_id='openai-file-doc',
+        created_at=datetime.now(timezone.utc),
+    )
+    messages = tool._completion_messages_sync('summarize', [attached])
+    assert messages[0]['content'][1] == {'type': 'file', 'file': {'file_id': 'openai-file-doc'}}
+
+
+def test_completion_messages_reject_legacy_unsupported_type():
+    tool = object.__new__(chat_file.FileChatTool)
+    attached = FileChat(
+        id='file-1',
+        name='note.ogg',
+        mime_type='audio/ogg',
+        openai_file_id='openai-file-ogg',
+        created_at=datetime.now(timezone.utc),
+    )
+    with pytest.raises(chat_file.UnsupportedChatFileError, match='ogg'):
+        tool._completion_messages_sync('summarize', [attached])
 
 
 def test_search_files_tool_provider_failure_is_soft(monkeypatch):

--- a/backend/tests/unit/test_chat_file_gateway_surface.py
+++ b/backend/tests/unit/test_chat_file_gateway_surface.py
@@ -38,7 +38,6 @@ def _gateway_mode(monkeypatch):
 
 def _vision_files():
     file_chat = SimpleNamespace(
-        is_pdf=lambda: False,
         is_document=lambda: False,
         is_image=lambda: True,
         openai_file_id='file-1',
@@ -50,7 +49,6 @@ def _vision_files():
 
 def _pdf_files():
     file_chat = SimpleNamespace(
-        is_pdf=lambda: True,
         is_document=lambda: True,
         is_image=lambda: False,
         openai_file_id='file-2',
@@ -62,7 +60,6 @@ def _pdf_files():
 
 def _txt_files():
     file_chat = SimpleNamespace(
-        is_pdf=lambda: False,
         is_document=lambda: True,
         is_image=lambda: False,
         openai_file_id='file-3',

--- a/backend/tests/unit/test_chat_file_gateway_surface.py
+++ b/backend/tests/unit/test_chat_file_gateway_surface.py
@@ -38,14 +38,36 @@ def _gateway_mode(monkeypatch):
 
 def _vision_files():
     file_chat = SimpleNamespace(
-        is_pdf=lambda: False, is_image=lambda: True, openai_file_id='file-1', mime_type='image/png', name='pic.png'
+        is_pdf=lambda: False,
+        is_document=lambda: False,
+        is_image=lambda: True,
+        openai_file_id='file-1',
+        mime_type='image/png',
+        name='pic.png',
     )
     return [file_chat]
 
 
 def _pdf_files():
     file_chat = SimpleNamespace(
-        is_pdf=lambda: True, is_image=lambda: False, openai_file_id='file-2', mime_type='application/pdf', name='a.pdf'
+        is_pdf=lambda: True,
+        is_document=lambda: True,
+        is_image=lambda: False,
+        openai_file_id='file-2',
+        mime_type='application/pdf',
+        name='a.pdf',
+    )
+    return [file_chat]
+
+
+def _txt_files():
+    file_chat = SimpleNamespace(
+        is_pdf=lambda: False,
+        is_document=lambda: True,
+        is_image=lambda: False,
+        openai_file_id='file-3',
+        mime_type='text/plain',
+        name='a.txt',
     )
     return [file_chat]
 
@@ -124,6 +146,7 @@ def test_lane_selection_splits_vision_from_documents(monkeypatch):
     assert cf.file_chat_auto_lane_id(pdf=False) == FILE_CHAT_VISION_AUTO_LANE_ID
     assert cf._completion_model(_vision_files()) == FILE_CHAT_VISION_AUTO_LANE_ID
     assert cf._completion_model(_pdf_files()) == FILE_CHAT_DOCUMENTS_AUTO_LANE_ID
+    assert cf._completion_model(_txt_files()) == FILE_CHAT_DOCUMENTS_AUTO_LANE_ID
 
 
 def test_sync_completion_uses_gateway_client_under_gateway_mode(monkeypatch):

--- a/backend/tests/unit/test_chat_file_input_types.py
+++ b/backend/tests/unit/test_chat_file_input_types.py
@@ -1,0 +1,49 @@
+"""Allowlist for Chat Completions file inputs: extension first, MIME second.
+
+External source: OpenAI File inputs "Accepted file types" / full extension-MIME
+table, read 2026-09-08 (saved copy used by #13200).
+"""
+
+from datetime import datetime, timezone
+
+from models.chat import FileChat, chat_file_is_document, chat_file_is_pdf
+
+
+def test_extension_is_checked_before_mime():
+    assert chat_file_is_document('note.txt', 'application/zip') is True
+    assert chat_file_is_document('archive.zip', 'text/plain') is False
+    assert chat_file_is_pdf('note.pdf', 'text/plain') is True
+    assert chat_file_is_pdf('note.txt', 'application/pdf') is False
+
+
+def test_uppercase_extension_is_allowlisted():
+    assert chat_file_is_document('NOTE.TXT', '') is True
+    assert chat_file_is_document('Brief.DOCX', 'None') is True
+    assert chat_file_is_pdf('Report.PDF', 'None') is True
+
+
+def test_missing_mime_string_none_does_not_admit_or_reject():
+    # File.get_mime_type stores str(None) == 'None' when guess_type fails.
+    assert chat_file_is_document('note.txt', 'None') is True
+    assert chat_file_is_document('note.txt', None) is True
+    assert chat_file_is_document('archive.zip', 'None') is False
+    assert chat_file_is_document('archive.bin', None) is False
+    assert chat_file_is_pdf('photo.jpg', 'None') is False
+
+
+def test_mime_admits_when_extension_is_absent():
+    assert chat_file_is_document('untitled', 'text/plain') is True
+    assert chat_file_is_document('untitled', 'application/pdf') is True
+    assert chat_file_is_document('untitled', '') is False
+
+
+def test_filechat_is_document_includes_pdf_and_txt():
+    now = datetime.now(timezone.utc)
+    pdf = FileChat(id='1', name='a.pdf', mime_type='application/pdf', openai_file_id='f1', created_at=now)
+    txt = FileChat(id='2', name='a.txt', mime_type='text/plain', openai_file_id='f2', created_at=now)
+    ogg = FileChat(id='3', name='note.ogg', mime_type='audio/ogg', openai_file_id='f3', created_at=now)
+    assert pdf.is_pdf() is True
+    assert pdf.is_document() is True
+    assert txt.is_pdf() is False
+    assert txt.is_document() is True
+    assert ogg.is_document() is False

--- a/backend/tests/unit/test_chat_file_input_types.py
+++ b/backend/tests/unit/test_chat_file_input_types.py
@@ -6,20 +6,20 @@ table, read 2026-09-08 (saved copy used by #13200).
 
 from datetime import datetime, timezone
 
-from models.chat import FileChat, chat_file_is_document, chat_file_is_pdf
+from models.chat import FileChat, chat_file_is_document
 
 
 def test_extension_is_checked_before_mime():
     assert chat_file_is_document('note.txt', 'application/zip') is True
     assert chat_file_is_document('archive.zip', 'text/plain') is False
-    assert chat_file_is_pdf('note.pdf', 'text/plain') is True
-    assert chat_file_is_pdf('note.txt', 'application/pdf') is False
+    assert chat_file_is_document('note.pdf', 'text/plain') is True
+    assert chat_file_is_document('Report.PDF', 'application/zip') is True
 
 
 def test_uppercase_extension_is_allowlisted():
     assert chat_file_is_document('NOTE.TXT', '') is True
     assert chat_file_is_document('Brief.DOCX', 'None') is True
-    assert chat_file_is_pdf('Report.PDF', 'None') is True
+    assert chat_file_is_document('Report.PDF', 'None') is True
 
 
 def test_missing_mime_string_none_does_not_admit_or_reject():
@@ -28,7 +28,6 @@ def test_missing_mime_string_none_does_not_admit_or_reject():
     assert chat_file_is_document('note.txt', None) is True
     assert chat_file_is_document('archive.zip', 'None') is False
     assert chat_file_is_document('archive.bin', None) is False
-    assert chat_file_is_pdf('photo.jpg', 'None') is False
 
 
 def test_mime_admits_when_extension_is_absent():
@@ -37,13 +36,29 @@ def test_mime_admits_when_extension_is_absent():
     assert chat_file_is_document('untitled', '') is False
 
 
+def test_documented_mime_only_suffixes_are_allowlisted():
+    # The provider's MIME column documents types whose canonical suffixes are
+    # missing from its Extensions column; the extension allowlist covers them
+    # so the extension-first branch cannot reject a documented type.
+    assert chat_file_is_document('main.rs', 'text/x-rust') is True
+    assert chat_file_is_document('config.yaml', 'text/x-yaml') is True
+    assert chat_file_is_document('app.ts', 'text/x-typescript') is True
+    assert chat_file_is_document('script.scala', 'text/x-scala') is True
+    assert chat_file_is_document('pack.proto', 'text/x-protobuf') is True
+    assert chat_file_is_document('site.astro', 'text/x-astro') is True
+
+
+def test_undocumented_suffixes_stay_rejected():
+    assert chat_file_is_document('archive.zip', 'text/plain') is False
+    assert chat_file_is_document('movie.mp4', 'text/plain') is False
+    assert chat_file_is_document('database.db', 'text/plain') is False
+
+
 def test_filechat_is_document_includes_pdf_and_txt():
     now = datetime.now(timezone.utc)
     pdf = FileChat(id='1', name='a.pdf', mime_type='application/pdf', openai_file_id='f1', created_at=now)
     txt = FileChat(id='2', name='a.txt', mime_type='text/plain', openai_file_id='f2', created_at=now)
     ogg = FileChat(id='3', name='note.ogg', mime_type='audio/ogg', openai_file_id='f3', created_at=now)
-    assert pdf.is_pdf() is True
     assert pdf.is_document() is True
-    assert txt.is_pdf() is False
     assert txt.is_document() is True
     assert ogg.is_document() is False

--- a/backend/tests/unit/test_chat_file_upload_unsupported.py
+++ b/backend/tests/unit/test_chat_file_upload_unsupported.py
@@ -139,16 +139,53 @@ def test_supported_file_still_uploads(chat_client, monkeypatch):
 
 
 @pytest.mark.parametrize('route', ['/v2/files', '/v1/files'])
-def test_non_pdf_document_is_rejected_at_attach(chat_client, route, monkeypatch):
+def test_unsupported_archive_is_rejected_at_attach(chat_client, route, monkeypatch):
     client, module = chat_client
     chat_file = sys.modules['utils.other.chat_file']
     monkeypatch.setattr(chat_file.openai, 'files', SimpleNamespace(create=_unreachable))
 
-    response = client.post(route, files={'files': ('note.txt', b'hello', 'text/plain')})
+    response = client.post(route, files={'files': ('archive.zip', b'PK\x03\x04', 'application/zip')})
 
     assert response.status_code == 400
-    assert 'txt' in response.json()['detail']
+    assert 'zip' in response.json()['detail']
     module.chat_db.add_multi_files.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'filename,mime,payload',
+    [
+        ('note.txt', 'text/plain', b'hello'),
+        ('readme.md', 'text/markdown', b'# hi'),
+        ('table.csv', 'text/csv', b'a,b\n1,2\n'),
+        (
+            'brief.docx',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            b'PK\x03\x04docx',
+        ),
+        (
+            'sheet.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            b'PK\x03\x04xlsx',
+        ),
+    ],
+)
+def test_documented_documents_upload_as_user_data(chat_client, monkeypatch, filename, mime, payload):
+    client, module = chat_client
+    chat_file = sys.modules['utils.other.chat_file']
+    created: dict[str, object] = {}
+
+    def _create(*, file, purpose):
+        created['purpose'] = purpose
+        return SimpleNamespace(id='file-doc', filename=filename)
+
+    monkeypatch.setattr(chat_file.openai, 'files', SimpleNamespace(create=_create))
+
+    response = client.post('/v2/files', files={'files': (filename, payload, mime)})
+
+    assert response.status_code == 200
+    assert response.json()[0]['openai_file_id'] == 'file-doc'
+    assert created['purpose'] == 'user_data'
+    module.chat_db.add_multi_files.assert_called_once()
 
 
 def _unreachable(**_kwargs):

--- a/backend/tests/unit/test_chat_file_upload_unsupported.py
+++ b/backend/tests/unit/test_chat_file_upload_unsupported.py
@@ -169,7 +169,8 @@ def test_unsupported_archive_is_rejected_at_attach(chat_client, route, monkeypat
         ),
     ],
 )
-def test_documented_documents_upload_as_user_data(chat_client, monkeypatch, filename, mime, payload):
+@pytest.mark.parametrize('route', ['/v2/files', '/v1/files'])
+def test_documented_documents_upload_as_user_data(chat_client, monkeypatch, route, filename, mime, payload):
     client, module = chat_client
     chat_file = sys.modules['utils.other.chat_file']
     created: dict[str, object] = {}
@@ -180,7 +181,7 @@ def test_documented_documents_upload_as_user_data(chat_client, monkeypatch, file
 
     monkeypatch.setattr(chat_file.openai, 'files', SimpleNamespace(create=_create))
 
-    response = client.post('/v2/files', files={'files': (filename, payload, mime)})
+    response = client.post(route, files={'files': (filename, payload, mime)})
 
     assert response.status_code == 200
     assert response.json()[0]['openai_file_id'] == 'file-doc'

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -15,7 +15,7 @@ from PIL import Image, UnidentifiedImageError
 from pydantic import ValidationError
 
 import database.chat as chat_db
-from models.chat import ChatSession, FileChat
+from models.chat import ChatSession, FileChat, chat_file_is_document, chat_file_is_pdf
 from utils.executors import db_executor, run_blocking
 from utils.llm.gateway_client import (
     file_chat_auto_lane_id,
@@ -29,11 +29,14 @@ from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
-# Images stay on the live-verified vision lane (image_url). PDF file parts stay on
-# a separate documents lane because the request shape differs ({type:file,file:{file_id}}).
-# Live probe 2026-08-28 confirmed gpt-5.6-luna accepts that file-part contract, so both
-# lanes pin Luna. In gateway feature mode both are omi:auto:file-chat-* lanes, so the
-# model call lands in the gateway ledger; OpenAI Files upload/download stays direct
+# Images stay on the live-verified vision lane (image_url). Document file parts stay
+# on a separate documents lane because the request shape differs ({type:file,file:{file_id}}).
+# Live probe 2026-08-28 confirmed gpt-5.6-luna accepts that file-part contract for PDF.
+# The attach allowlist now matches the provider's documented File inputs table
+# (models.chat.CHAT_FILE_DOCUMENT_EXTENSIONS / CHAT_FILE_DOCUMENT_MIME_TYPES); a
+# development documents-lane probe of .txt/.docx/.csv is still required before merge.
+# In gateway feature mode both are omi:auto:file-chat-* lanes, so the model call
+# lands in the gateway ledger; OpenAI Files upload/download stays direct
 # (file bytes/file_id lifecycle, no model tokens).
 _FILE_CHAT_VISION_MODEL = "gpt-5.6-luna"
 _FILE_CHAT_DOCUMENT_MODEL = "gpt-5.6-luna"
@@ -125,12 +128,6 @@ def _file_chat_gateway_enabled() -> bool:
         return False
 
 
-def _file_is_pdf(name: str, mime_type: str) -> bool:
-    if (mime_type or '').lower() == 'application/pdf':
-        return True
-    return Path(name).suffix.lower() == '.pdf'
-
-
 def _reraise_provider_file_error(error: Exception) -> NoReturn:
     if isinstance(error, openai.NotFoundError):
         raise StaleChatFileError("Unsupported attachment: the uploaded file is no longer available.") from error
@@ -141,16 +138,16 @@ def _reraise_provider_file_error(error: Exception) -> NoReturn:
 
 def _completion_model(files: List[FileChat]) -> str:
     """Model id for the completions call: a gateway lane id in gateway mode."""
-    pdf = bool(files) and any(f.is_pdf() for f in files)
+    documents = bool(files) and any(f.is_document() for f in files)
     if _file_chat_gateway_enabled():
-        return file_chat_auto_lane_id(pdf=pdf)
+        return file_chat_auto_lane_id(pdf=documents)
     return _direct_completion_model(files)
 
 
 def _direct_completion_model(files: List[FileChat]) -> str:
     """Provider model for the feature-off and compatibility fallback paths."""
-    pdf = bool(files) and any(f.is_pdf() for f in files)
-    if pdf:
+    documents = bool(files) and any(f.is_document() for f in files)
+    if documents:
         return _FILE_CHAT_DOCUMENT_MODEL
     return _FILE_CHAT_VISION_MODEL
 
@@ -211,7 +208,10 @@ class File:
         return self.mime_type.startswith("image")
 
     def is_pdf(self) -> bool:
-        return _file_is_pdf(str(self.file_path), self.mime_type)
+        return chat_file_is_pdf(str(self.file_path), self.mime_type)
+
+    def is_document(self) -> bool:
+        return chat_file_is_document(str(self.file_path), self.mime_type)
 
     @staticmethod
     def _to_snake_case(string: str) -> str:
@@ -249,11 +249,12 @@ class FileChatTool:
                 # An image mime type Pillow has no decoder for (.heic from an iPhone camera roll).
                 raise _unsupported_chat_file_error(file_path) from error
             file.purpose = "vision"
-        elif file.is_pdf():
+        elif file.is_document():
             file.purpose = "user_data"
         else:
-            # Chat Completions file parts accept PDFs. Reject other docs at attach,
-            # never after the user sends the chat.
+            # Chat Completions file parts accept the provider's documented document
+            # set (PDF, text/code, office docs, spreadsheets). Reject anything else
+            # at attach, never after the user sends the chat.
             raise _unsupported_chat_file_error(file_path)
 
         with open(file_path, 'rb') as f:
@@ -309,7 +310,7 @@ class FileChatTool:
         files: List[FileChat],
         callback: Optional[_StreamingCallbackProtocol] = None,
     ) -> str:
-        """One Chat Completions stream: images as base64 image_url, PDFs as file parts."""
+        """One Chat Completions stream: images as base64 image_url, documents as file parts."""
         assert callback is not None
         output_list: List[str] = []
         gateway_fallback_used = False
@@ -434,7 +435,7 @@ class FileChatTool:
                         },
                     )
                 )
-            elif file.is_pdf():
+            elif file.is_document():
                 contents.append(
                     cast(
                         ChatCompletionContentPartParam,
@@ -468,7 +469,7 @@ class FileChatTool:
                         },
                     )
                 )
-            elif file.is_pdf():
+            elif file.is_document():
                 contents.append(
                     cast(
                         ChatCompletionContentPartParam,

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -15,7 +15,7 @@ from PIL import Image, UnidentifiedImageError
 from pydantic import ValidationError
 
 import database.chat as chat_db
-from models.chat import ChatSession, FileChat, chat_file_is_document, chat_file_is_pdf
+from models.chat import ChatSession, FileChat, chat_file_is_document
 from utils.executors import db_executor, run_blocking
 from utils.llm.gateway_client import (
     file_chat_auto_lane_id,
@@ -206,9 +206,6 @@ class File:
 
     def is_image(self) -> bool:
         return self.mime_type.startswith("image")
-
-    def is_pdf(self) -> bool:
-        return chat_file_is_pdf(str(self.file_path), self.mime_type)
 
     def is_document(self) -> bool:
         return chat_file_is_document(str(self.file_path), self.mime_type)


### PR DESCRIPTION
## What changed and why

Chat file attach was still gated to images and PDFs after PR #12337 replaced Assistants `file_search` with Chat Completions. Desktop/mobile pickers already offer `.txt`/`.json`/`.csv`/`.html` and similar, so those uploads 400'd (`Unsupported attachment: 'txt' files are not supported in chat.`). This restores the pre-Assistants-retirement document set using the provider's documented Chat Completions `file` contract (`purpose=user_data`); images stay on the thumbnail/`image_url` path. Fixes #13200.

Until 2026-08-26 file chat used the OpenAI Assistants API, which accepted arbitrary documents. OpenAI retired Assistants on 2026-08-26. PR #12337 (commit `fe3df5ac00`, 2026-08-28) switched to Chat Completions (images via base64 `image_url`, PDFs via `{"type":"file","file":{"file_id":...}}`) and documented a PDF-only attach gate. The 2026-08-28 live probe covered PDF only on `gpt-5.6-luna`. OpenAI's current File inputs table also lists text/code, rich documents, presentations, and spreadsheets; the Omi LLM gateway validator only requires `file.file_id` to be a string.

## Product invariants affected

none

## How it was verified

Unit tests and static checks only. No live probe was run (safety: no OpenAI/gateway calls, no `api.omi.me`).

- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/chat-file-tests-13200.txt bash test.sh` from `backend/` — **51 passed** across `test_chat_file_upload_unsupported.py` (12), `test_chat_file_completions.py` (8), `test_chat_file_gateway_surface.py` (11), `test_chat_file_input_types.py` (5), `test_file_upload_endpoint_security.py` (13), `test_chat_file_gateway_stub_import_contract.py` (2)
- `scripts/backend-python-format --write` on the changed Python files — already formatted
- `backend/scripts/typecheck.sh` — **0 errors** (enforced pyright lane)

**Not verified — required before merge (development backend only, never production):** the same documents-lane live probe pattern as PDF on 2026-08-28 (`chat_file.py` header comment). On a **DEVELOPMENT** backend, with gateway documents lane `gpt-5.6-luna` / `omi:auto:file-chat-*`, attach and send at least:

- [ ] one `.txt`
- [ ] one `.docx`
- [ ] one `.csv`

Confirm the provider accepts the `file` part and the model can read extracted text. Do not probe production (`api.omi.me`).

Out of scope (still tracked in #13200): a rejected desktop upload can silently downgrade to a local-only attachment that looks identical to an uploaded one.

## Tests

- Regression: `.txt`/`.md`/`.csv`/`.docx`/`.xlsx` upload now 200 with `purpose == "user_data"` (provider `files.create` stubbed); `.zip`/`.ogg` still 400 at attach
- Completions: `.txt` and `.docx` emit `{"type":"file","file":{"file_id":...}}`; legacy unsupported types still raise `UnsupportedChatFileError`
- Allowlist helper: extension vs MIME precedence, uppercase extension, missing MIME (`str(None) == "None"`)

## Failure class (fixes)

Failure-Class: none

`scripts/failure-class prepare` scope_hints for `FC-pinned-vendor-request-contract-retired` (`backend/utils/llm/**`, `llm_gateway/config/cost_rate_cards.yaml`) do not overlap this change. This is an allowlist correction against the provider's current File inputs table, not a pinned-model retirement.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

