### PR TITLE
fix(usgs): preserve negative earthquake magnitude filters

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -4,6 +4,11 @@
 # Checks that consume PR metadata declare `requires_pr_body: true`; post-merge
 # push runs exclude only that category because no authoritative PR body is available.
 checks:
+  - id: usgs-earthquake-tests
+    command: ["python3", "plugins/omi-usgs-earthquake-app/test_main.py"]
+    triggers: ["plugins/omi-usgs-earthquake-app/**"]
+    lanes: ["local", "ci"]
+    reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/plugins/omi-usgs-earthquake-app/README.md
+++ b/plugins/omi-usgs-earthquake-app/README.md
@@ -29,6 +29,15 @@ Use these values when creating the Omi app:
 | `nearby_earthquakes` | `POST /tools/nearby_earthquakes` | Find earthquakes near coordinates within a radius |
 | `earthquake_details` | `POST /tools/earthquake_details` | Look up one USGS event by event ID |
 
+Both search tools accept negative `min_magnitude` values (for example, `-1`).
+The default is `2.5`; values above `10` are capped at `10`.
+
+Run the hermetic component tests from the repository root:
+
+```bash
+python3 -m unittest discover -s plugins/omi-usgs-earthquake-app -p test_main.py
+```
+
 ## Example prompts
 
 - "Show me earthquakes over magnitude 5 in the last day."

--- a/plugins/omi-usgs-earthquake-app/main.py
+++ b/plugins/omi-usgs-earthquake-app/main.py
@@ -5,6 +5,7 @@ This app gives Omi users no-auth earthquake lookup tools backed by the public
 USGS FDSN event API.
 """
 
+import math
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
@@ -119,12 +120,13 @@ async def _read_json_body(request: Request) -> tuple[Optional[Dict[str, Any]], O
 
 def _query_params(body: Dict[str, Any], default_hours: int = 24) -> Dict[str, Any]:
     hours = _safe_int(body.get("hours"), default=default_hours, minimum=1, maximum=168)
+    min_magnitude = _parse_float(body.get("min_magnitude"))
+    if min_magnitude is None or not math.isfinite(min_magnitude):
+        min_magnitude = 2.5
     return {
         "format": "geojson",
         "starttime": _starttime_from_hours(hours),
-        "minmagnitude": _safe_float(
-            body.get("min_magnitude"), default=2.5, minimum=0.0, maximum=10.0
-        ),
+        "minmagnitude": min(10.0, min_magnitude),
         "limit": _safe_int(body.get("limit"), default=5, minimum=1, maximum=10),
         "orderby": _safe_orderby(body.get("orderby")),
     }

--- a/plugins/omi-usgs-earthquake-app/test_main.py
+++ b/plugins/omi-usgs-earthquake-app/test_main.py
@@ -133,6 +133,40 @@ class UsgsEarthquakeAppTest(unittest.TestCase):
             },
         )
 
+    def test_search_handlers_preserve_magnitude_filters(self):
+        cases = [(-1, -1.0), (-0.5, -0.5), ("-2.5", -2.5), (0, 0.0),
+                 (2.5, 2.5), (12, 10.0), (None, 2.5), ("invalid", 2.5),
+                 ("nan", 2.5), ("inf", 2.5), ("-inf", 2.5)]
+        for handler in (main.tool_recent_earthquakes, main.tool_nearby_earthquakes):
+            for requested, expected in cases:
+                with self.subTest(handler=handler.__name__, minimum=requested):
+                    captured = {}
+
+                    async def fake_usgs_get(params):
+                        captured.update(params)
+                        return {"features": [{"id": "negative-event",
+                                              "properties": {"mag": -0.4}}]
+                                if params["minmagnitude"] <= -0.4 else []}
+
+                    original = main._usgs_get
+                    main._usgs_get = fake_usgs_get
+                    try:
+                        body = {"latitude": 37.7, "longitude": -122.4}
+                        if requested is not None:
+                            body["min_magnitude"] = requested
+                        result = asyncio.run(handler(DummyRequest(body)))
+                    finally:
+                        main._usgs_get = original
+
+                    self.assertTrue(result.success)
+                    self.assertEqual(captured["minmagnitude"], expected)
+                    self.assertEqual(result.data["count"], int(expected <= -0.4))
+                    if expected <= -0.4:
+                        self.assertEqual(result.data["earthquakes"][0]["magnitude"], -0.4)
+                    if handler is main.tool_nearby_earthquakes:
+                        self.assertEqual(captured["latitude"], 37.7)
+                        self.assertEqual(captured["maxradiuskm"], 250.0)
+
     def test_nearby_earthquakes_requires_latitude_and_longitude(self):
         result = asyncio.run(
             main.tool_nearby_earthquakes(DummyRequest({"latitude": 37.7}))


### PR DESCRIPTION
## Summary

Fixes #13250.

Preserve finite negative `min_magnitude` values in the shared query builder used by recent and nearby earthquake searches. USGS defines this parameter as a decimal minimum, not a nonnegative value: https://earthquake.usgs.gov/fdsnws/event/1/#minmagnitude . Negative earthquakes are real catalog records, so replacing a requested -1 with 0 silently excludes matching events.

Keep the 2.5 default and existing upper cap of 10. Invalid/non-finite magnitude inputs use the default. This is an original small correction to the existing integration, not a replacement app.

## Validation

- `python3 plugins/omi-usgs-earthquake-app/test_main.py -v`: 5 tests pass, including both production search handlers across 11 minimum-magnitude cases each. The complete production module is imported with the component's existing dependency stubs; only the provider seam is replaced. No AST extraction.
- The same final tests against unchanged main at `9d5cfa8e3fcf34a6be0f6d64dd54b98ee774da8f` fail in 12 subcases; patched source passes. The synthetic provider excludes its negative event according to the actual outbound filter and exercises production summarization.
- `python3 -m py_compile plugins/omi-usgs-earthquake-app/main.py plugins/omi-usgs-earthquake-app/test_main.py`: pass.
- `git diff --check`: pass.
- Add the component's hermetic suite to the shared local/CI manifest. This is plugin-specific provider contract coverage, not a shared primitive; it catches the concrete defect reported in #13250 in the integration merged by #7450.
- A deployed FastAPI/HTTP end-to-end run was not performed. Runtime dependencies are not installed here.
- `make preflight`: passes all 14 selected local checks after materializing their required source files. The failure-class history ratchet skips because this is a shallow checkout; full-history CI remains authoritative.
- `scripts/pr-preflight --lane local --pr-body-file ../pr-body.md`: passes all 14 selected checks.
- Product invariants affected: none (confirmed by the path-scoped preflight).

Failure-Class: none

## Reward status

The $25 suggestion in #13250 is still unconfirmed. This patch is provided for review under the published contribution process; neither bounty approval nor payment is claimed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

