### PR TITLE
fix(desktop): developer bundles never touch the login keychain

### DIFF
--- a/.github/failure-classes/FC-developer-build-secret-bound-to-user-keychain.json
+++ b/.github/failure-classes/FC-developer-build-secret-bound-to-user-keychain.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-developer-build-secret-bound-to-user-keychain",
+  "violated_contract": "A build that is rebuilt and relaunched unattended (a developer or automation bundle) must not persist its own credentials in a store whose access is bound to the identity of one particular binary. The login keychain binds an item created by a team-less, self-signed bundle to that binary's code hash, so every rebuild is a foreign reader and the next launch parks on a SecurityAgent prompt that only an attended GUI session can answer; a headless host can never get past it.",
+  "canonical_prevention": "The desktop secret-store facade routes by bundle family: only shipped production-family bundles use the login keychain, and every other bundle persists through a file store under its own Application Support root with no SecItem call on the path. Routing and the no-SecItem property are asserted behaviourally with injected backends, and the auth dump/seed scripts read and write that file so a session can be cloned into a rebuilt bundle from a Background session.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/DesktopKeychainStoreRoutingTests.swift",
+    "desktop/macos/Desktop/Tests/DesktopDeveloperSecretStoreTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/DesktopKeychainStore.swift",
+    "desktop/macos/Desktop/Sources/Auth/DesktopDeveloperSecretStore.swift",
+    "desktop/macos/scripts/omi-auth-seed.sh",
+    "desktop/macos/scripts/omi-auth-dump.sh"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Auth/DesktopDeveloperSecretStore.swift
+++ b/desktop/macos/Desktop/Sources/Auth/DesktopDeveloperSecretStore.swift
@@ -1,0 +1,190 @@
+import Foundation
+import OmiSupport
+
+/// File-backed secret store for non-production desktop bundles.
+///
+/// Production-family apps keep using the login keychain. Developer bundles (Omi Dev,
+/// named `omi-*` apps, ad-hoc / Apple Development local builds) persist the same
+/// service/account strings in a JSON file so rebuilds never prompt SecurityAgent.
+///
+/// Layout:
+/// `~/Library/Application Support/<DesktopLocalProfile.storageDirectoryName>/developer-secrets/<bundle-id>.json`.
+/// Omi Dev shares the `Omi` Application Support root with stable, so the file is keyed
+/// by bundle id. Keys are `service + NUL + account` (`"\u{0}"`).
+final class DesktopDeveloperSecretStore: @unchecked Sendable {
+  static let shared = DesktopDeveloperSecretStore()
+
+  static let directoryName = "developer-secrets"
+  static let keySeparator = "\u{0}"
+
+  private let lock = NSLock()
+  private let fileManager: FileManager
+  private let rootDirectoryOverride: URL?
+  private let bundleIdentifierOverride: String?
+  private var cache: [String: String]?
+  private var didLogUnreadableFile = false
+
+  init(
+    rootDirectory: URL? = nil,
+    bundleIdentifier: String? = nil,
+    fileManager: FileManager = .default
+  ) {
+    self.rootDirectoryOverride = rootDirectory
+    self.bundleIdentifierOverride = bundleIdentifier
+    self.fileManager = fileManager
+  }
+
+  static func storageKey(service: String, account: String) -> String {
+    "\(service)\(keySeparator)\(account)"
+  }
+
+  static func fileURL(rootDirectory: URL, bundleIdentifier: String) -> URL {
+    rootDirectory
+      .appendingPathComponent(directoryName, isDirectory: true)
+      .appendingPathComponent("\(bundleIdentifier).json", isDirectory: false)
+  }
+
+  func readString(service: String, account: String) -> String? {
+    lock.lock()
+    defer { lock.unlock() }
+    let values = loadLocked()
+    let key = Self.storageKey(service: service, account: account)
+    guard let value = values[key], !value.isEmpty else {
+      return nil
+    }
+    return value
+  }
+
+  @discardableResult
+  func setString(_ value: String, service: String, account: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    var values = loadLocked()
+    values[Self.storageKey(service: service, account: account)] = value
+    guard persistLocked(values) else {
+      return false
+    }
+    cache = values
+    return true
+  }
+
+  func delete(service: String, account: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    var values = loadLocked()
+    let key = Self.storageKey(service: service, account: account)
+    guard values.removeValue(forKey: key) != nil else {
+      return
+    }
+    if persistLocked(values) {
+      cache = values
+    }
+  }
+
+  func secretsDirectoryURL() -> URL {
+    fileURL().deletingLastPathComponent()
+  }
+
+  func fileURL() -> URL {
+    Self.fileURL(rootDirectory: rootDirectory(), bundleIdentifier: resolvedBundleIdentifier())
+  }
+
+  private func rootDirectory() -> URL {
+    rootDirectoryOverride ?? DesktopLocalProfile.applicationSupportURL()
+  }
+
+  private func resolvedBundleIdentifier() -> String {
+    if let bundleIdentifierOverride, !bundleIdentifierOverride.isEmpty {
+      return bundleIdentifierOverride
+    }
+    if let bundleIdentifier = Bundle.main.bundleIdentifier, !bundleIdentifier.isEmpty {
+      return bundleIdentifier
+    }
+    return "unknown.bundle"
+  }
+
+  private func loadLocked() -> [String: String] {
+    if let cache {
+      return cache
+    }
+    let loaded = readFileLocked()
+    cache = loaded
+    return loaded
+  }
+
+  private func readFileLocked() -> [String: String] {
+    let url = fileURL()
+    guard fileManager.fileExists(atPath: url.path) else {
+      return [:]
+    }
+    do {
+      let data = try Data(contentsOf: url)
+      guard !data.isEmpty else {
+        return [:]
+      }
+      let object = try JSONSerialization.jsonObject(with: data)
+      guard let dictionary = object as? [String: Any] else {
+        logUnreadableFileLocked(url)
+        return [:]
+      }
+      var values: [String: String] = [:]
+      for (key, value) in dictionary {
+        if let string = value as? String {
+          values[key] = string
+        }
+      }
+      return values
+    } catch {
+      logUnreadableFileLocked(url)
+      return [:]
+    }
+  }
+
+  private func logUnreadableFileLocked(_ url: URL) {
+    guard !didLogUnreadableFile else { return }
+    didLogUnreadableFile = true
+    log("DesktopDeveloperSecretStore: ignoring unreadable secrets file at \(url.path)")
+  }
+
+  private func persistLocked(_ values: [String: String]) -> Bool {
+    let url = fileURL()
+    let directory = url.deletingLastPathComponent()
+    do {
+      try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: directory.path
+      )
+      let data = try JSONSerialization.data(
+        withJSONObject: values,
+        options: [.prettyPrinted, .sortedKeys]
+      )
+      let tempURL = directory.appendingPathComponent(
+        ".\(url.lastPathComponent).\(UUID().uuidString)",
+        isDirectory: false
+      )
+      let created = fileManager.createFile(
+        atPath: tempURL.path,
+        contents: data,
+        attributes: [.posixPermissions: 0o600]
+      )
+      guard created else {
+        log("DesktopDeveloperSecretStore: failed to create temp secrets file at \(tempURL.path)")
+        return false
+      }
+      if fileManager.fileExists(atPath: url.path) {
+        _ = try fileManager.replaceItemAt(url, withItemAt: tempURL)
+      } else {
+        try fileManager.moveItem(at: tempURL, to: url)
+      }
+      try fileManager.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: url.path
+      )
+      return true
+    } catch {
+      log("DesktopDeveloperSecretStore: failed to persist secrets file (\(error.localizedDescription))")
+      return false
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -90,9 +90,9 @@ class AuthService {
   // Keys are defined once in `DefaultsKey` and read/written through the typed
   // `UserDefaults` accessors so a typo is a compile error, not a silent nil.
   //
-  // Keychain service is team+bundle scoped so local Dev / named-bundle builds
-  // cannot poison each other or notarized Beta/Prod (login-keychain password
-  // dialog). See DesktopKeychainStore.scopedService.
+  // Secret-store service is team+bundle scoped so local Dev / named-bundle builds
+  // cannot poison each other or notarized Beta/Prod (keychain on shipped bundles,
+  // file store on developer bundles). See DesktopKeychainStore.scopedService.
   private let authTokenKeychainAccount = "firebase-rest-tokens"
   private var authTokenKeychainService: String {
     DesktopKeychainStore.scopedService(DesktopKeychainStore.legacyAuthTokenService)
@@ -121,11 +121,11 @@ class AuthService {
     var deleteKeychainString: (_ service: String, _ account: String) -> Void
     var recordsFallbackTelemetry: Bool
 
-    // Security invariant: new auth tokens live in the Keychain on EVERY build,
-    // including Sparkle beta. Plaintext UserDefaults fallback is disabled for new
-    // sign-ins. The read path remains only for transactional migration of older
-    // installs: keep that already-existing copy until Keychain read-back plus a
-    // forced refresh commit the new store.
+    // Security invariant: new auth tokens live in DesktopKeychainStore on every
+    // build (login keychain on shipped bundles, file store otherwise). Plaintext
+    // UserDefaults fallback is disabled for new sign-ins. The read path remains
+    // only for transactional migration of older installs: keep that existing
+    // copy until secret-store read-back plus a forced refresh commit the new store.
     nonisolated(unsafe) static let live = TokenStorageHooks(
       usesKeychainTokenStorage: { true },
       allowsUserDefaultsFallback: { false },
@@ -1919,11 +1919,11 @@ class AuthService {
   /// the app really uses — so a harness can then relaunch and prove the app refreshes an
   /// expired idToken *without signing the user out*.
   ///
-  /// Why this exists: the tokens moved to the Keychain, so the old harness trick of
+  /// Why this exists: the tokens moved to the secret store, so the old harness trick of
   /// `defaults write <bundle> auth_tokenExpiry -float 1000` now tampers a key the app
   /// no longer reads — the probe silently measured nothing and reported a false
   /// regression. Going through `saveTokens` keeps the seam correct for BOTH backends
-  /// (keychain and the UserDefaults fallback) and is inert if the storage changes again.
+  /// (secret store and the UserDefaults fallback) and is inert if the storage changes again.
   ///
   /// `expiresIn: 0` lands at `now - 300` (saveTokens subtracts the 5-min buffer), i.e.
   /// already expired. Token material never leaves the process — only a redacted status.

--- a/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
+++ b/desktop/macos/Desktop/Sources/BrowserGoogleSession.swift
@@ -259,6 +259,9 @@ struct BrowserGoogleSession: Equatable {
 
 /// Browser Safe Storage strategy for Chromium cookie scraping.
 ///
+/// Production-family bundles only: developer builds return nil without calling
+/// SecItem (login-keychain prompts are production-only).
+///
 /// Primary path: read the browser-created generic-password item in-process via
 /// `SecItemCopyMatching`. macOS attributes the keychain prompt to the *requesting
 /// process*, so the in-process read shows "<this app> wants to access …" — the app
@@ -278,6 +281,27 @@ struct BrowserGoogleSession: Equatable {
 /// We do not duplicate browser Safe Storage secrets into app preferences.
 final class BrowserKeychainCache: @unchecked Sendable {
   static let shared = BrowserKeychainCache()
+
+  /// Test seam: shipped bundles import browser Safe Storage from the login keychain;
+  /// every other bundle must return nil without calling SecItem.
+  nonisolated(unsafe) static var allowsBrowserKeychainImport: (() -> Bool)?
+  /// Test seam: replace the SecItem read so unit tests never touch the real keychain.
+  nonisolated(unsafe) static var safeStoragePasswordProvider:
+    ((_ service: String, _ account: String, _ userInitiated: Bool) -> String?)?
+  private nonisolated(unsafe) static var didLogProductionOnlyRestriction = false
+  private static let productionOnlyLogLock = NSLock()
+
+  static func resetTestHooks() {
+    allowsBrowserKeychainImport = nil
+    safeStoragePasswordProvider = nil
+    productionOnlyLogLock.lock()
+    didLogProductionOnlyRestriction = false
+    productionOnlyLogLock.unlock()
+  }
+
+  static var isBrowserKeychainImportAllowed: Bool {
+    allowsBrowserKeychainImport?() ?? AppBuild.isProductionBundle
+  }
 
   private enum CacheEntry {
     case found(String)
@@ -342,11 +366,18 @@ final class BrowserKeychainCache: @unchecked Sendable {
 
   /// Reads the browser Safe Storage key in-process so the prompt and any durable
   /// "Always Allow" grant belong to this app rather than `/usr/bin/security`.
-  private static func nativeSafeStoragePassword(
+  static func nativeSafeStoragePassword(
     for service: String,
     account: String,
     userInitiated: Bool
   ) -> String? {
+    guard isBrowserKeychainImportAllowed else {
+      logBrowserKeychainImportRestrictedOnce()
+      return nil
+    }
+    if let safeStoragePasswordProvider {
+      return safeStoragePasswordProvider(service, account, userInitiated)
+    }
     // A background connector probe may discover a browser profile, but it must
     // fail closed rather than ask for the login keychain password. An explicit
     // import/read passes userInitiated=true and may show the normal one-time
@@ -369,6 +400,14 @@ final class BrowserKeychainCache: @unchecked Sendable {
       return nil
     }
     return password
+  }
+
+  private static func logBrowserKeychainImportRestrictedOnce() {
+    productionOnlyLogLock.lock()
+    defer { productionOnlyLogLock.unlock() }
+    guard !didLogProductionOnlyRestriction else { return }
+    didLogProductionOnlyRestriction = true
+    log("browser keychain import is production-only")
   }
 
   func password(

--- a/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
+++ b/desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
@@ -2,9 +2,15 @@ import Foundation
 import LocalAuthentication
 import Security
 
-/// File-based (login) keychain helpers for desktop secrets.
+/// Secret-store facade for desktop credentials.
 ///
-/// Design constraints (see #9167 / keychain ACL prompt fix):
+/// Shipped bundles (`com.omi.computer-macos` and `com.omi.computer-macos.beta`,
+/// `AppBuild.isProductionBundle`) persist through the login keychain. Every other
+/// bundle (Omi Dev, named `omi-*` apps, ad-hoc / Apple Development local builds)
+/// uses `DesktopDeveloperSecretStore` so rebuilds never call SecItem and never
+/// prompt SecurityAgent.
+///
+/// Login-keychain constraints (production only; see #9167 / keychain ACL prompt fix):
 /// - Never opt into the data-protection keychain (`kSecUseDataProtectionKeychain`) — this
 ///   non-sandboxed Developer ID app has no `keychain-access-groups` entitlement.
 /// - Never present the macOS keychain password dialog. Reads/writes that would require UI
@@ -18,11 +24,58 @@ import Security
 ///   still surface the login-keychain password sheet (`errSecUserCanceled` / -128). Leave
 ///   orphans alone — UserDefaults migration covers auth continuity for older installs.
 enum DesktopKeychainStore {
+  enum Backend: Equatable {
+    case keychain
+    case developerFile
+  }
+
+  struct KeychainOperations {
+    var readString: (_ service: String, _ account: String) -> ReadResult
+    var setString: (_ value: String, _ service: String, _ account: String) -> Bool
+    var delete: (_ service: String, _ account: String) -> Void
+  }
+
   /// Pre-scoping service names. Kept as constants for dump/seed scripts and docs only —
   /// app runtime must not SecItem-query these (see file header).
   static let legacyAuthTokenService = "com.omi.desktop.firebase-rest-session"
   static let legacyLocalAgentTokenService = "com.omi.desktop.local-agent-api"
   static let legacyClientDeviceService = "com.omi.client-device-id"
+
+  /// Test seam: force a backend instead of `AppBuild.isProductionBundle`.
+  nonisolated(unsafe) static var backendOverride: Backend?
+  /// Test seam: spy or stub the production keychain operations.
+  nonisolated(unsafe) static var keychainOperationsOverride: KeychainOperations?
+  /// Test seam: replace the developer file store (typically a temp-directory instance).
+  nonisolated(unsafe) static var developerSecretStoreOverride: DesktopDeveloperSecretStore?
+
+  static func resetTestHooks() {
+    backendOverride = nil
+    keychainOperationsOverride = nil
+    developerSecretStoreOverride = nil
+    _cachedBackend = nil
+  }
+
+  static func backend(forBundleIdentifier identifier: String) -> Backend {
+    AppBuild.productionFamilyBundleIdentifiers.contains(identifier) ? .keychain : .developerFile
+  }
+
+  static var backend: Backend {
+    if let backendOverride {
+      return backendOverride
+    }
+    if let _cachedBackend {
+      return _cachedBackend
+    }
+    let resolved: Backend = AppBuild.isProductionBundle ? .keychain : .developerFile
+    _cachedBackend = resolved
+    return resolved
+  }
+
+  private nonisolated(unsafe) static var _cachedBackend: Backend?
+
+  private static var developerSecretStore: DesktopDeveloperSecretStore {
+    developerSecretStoreOverride ?? .shared
+  }
 
   /// Signing Team ID of the running binary (e.g. `9536L8KLMP` for Developer ID,
   /// `JVMXE5G542` for a personal Apple Development cert). Falls back to an ad-hoc
@@ -98,6 +151,50 @@ enum DesktopKeychainStore {
   }
 
   static func readString(service: String, account: String) -> ReadResult {
+    switch backend {
+    case .developerFile:
+      if let value = developerSecretStore.readString(service: service, account: account) {
+        return .found(value)
+      }
+      return .missing
+    case .keychain:
+      return keychainOperationsOverride?.readString(service, account)
+        ?? keychainReadString(service: service, account: account)
+    }
+  }
+
+  static func string(service: String, account: String) -> String? {
+    if case .found(let value) = readString(service: service, account: account) {
+      return value
+    }
+    return nil
+  }
+
+  @discardableResult
+  static func setString(_ value: String, service: String, account: String) -> Bool {
+    switch backend {
+    case .developerFile:
+      return developerSecretStore.setString(value, service: service, account: account)
+    case .keychain:
+      return keychainOperationsOverride?.setString(value, service, account)
+        ?? keychainSetString(value, service: service, account: account)
+    }
+  }
+
+  static func delete(service: String, account: String) {
+    switch backend {
+    case .developerFile:
+      developerSecretStore.delete(service: service, account: account)
+    case .keychain:
+      if let keychainOperationsOverride {
+        keychainOperationsOverride.delete(service, account)
+      } else {
+        keychainDelete(service: service, account: account)
+      }
+    }
+  }
+
+  private static func keychainReadString(service: String, account: String) -> ReadResult {
     var query = baseQuery(service: service, account: account)
     query[kSecReturnData as String] = true
     query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -122,15 +219,7 @@ enum DesktopKeychainStore {
     return .unavailable(status)
   }
 
-  static func string(service: String, account: String) -> String? {
-    if case .found(let value) = readString(service: service, account: account) {
-      return value
-    }
-    return nil
-  }
-
-  @discardableResult
-  static func setString(_ value: String, service: String, account: String) -> Bool {
+  private static func keychainSetString(_ value: String, service: String, account: String) -> Bool {
     let data = Data(value.utf8)
     var query = baseQuery(service: service, account: account)
     applySilentAuth(&query)
@@ -180,7 +269,7 @@ enum DesktopKeychainStore {
     return false
   }
 
-  static func delete(service: String, account: String) {
+  private static func keychainDelete(service: String, account: String) {
     var query = baseQuery(service: service, account: account)
     applySilentAuth(&query)
     let status = SecItemDelete(query as CFDictionary)

--- a/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
+++ b/desktop/macos/Desktop/Tests/AuthTokenStorageTests.swift
@@ -247,6 +247,25 @@ final class AuthTokenStorageTests: XCTestCase {
     XCTAssertEqual(UserDefaults.standard.string(forKey: .authUserId), "user-keychain")
   }
 
+  /// Auth tokens always go through DesktopKeychainStore. That facade uses the
+  /// login keychain on shipped bundles and the developer file store otherwise.
+  func testAuthTokensUseKeychainStorageOnAllBuilds() throws {
+    // omi-test-quality: source-inspection -- static contract: TokenStorageHooks.live
+    // must keep using the DesktopKeychainStore facade on every build; backend
+    // routing is asserted behaviorally in DesktopKeychainStoreRoutingTests.
+    let authSource = try sourceFile("AuthService.swift")
+    XCTAssertTrue(authSource.contains("usesKeychainTokenStorage: { true }"))
+    XCTAssertTrue(authSource.contains("DesktopKeychainStore.string(service: service, account: account)"))
+    XCTAssertTrue(authSource.contains("DesktopKeychainStore.setString(value, service: service, account: account)"))
+    XCTAssertTrue(authSource.contains("DesktopKeychainStore.delete(service: service, account: account)"))
+
+    let storeSource = try sourceFile("DesktopKeychainStore.swift")
+    XCTAssertTrue(storeSource.contains("enum Backend"))
+    XCTAssertTrue(storeSource.contains("case keychain"))
+    XCTAssertTrue(storeSource.contains("case developerFile"))
+    XCTAssertTrue(storeSource.contains("AppBuild.isProductionBundle ? .keychain : .developerFile"))
+  }
+
   /// Regression: the token Keychain store must NOT opt into the data-protection keychain.
   /// That requires a `keychain-access-groups` entitlement this non-sandboxed Developer ID
   /// app doesn't have, so on the signed/notarized build every SecItem write failed with
@@ -358,8 +377,8 @@ final class AuthTokenStorageTests: XCTestCase {
   /// Regression: named-bundle auth seed must NOT write tokens via `security
   /// add-generic-password`. That stamps partition list `apple-tool:` only; the app's
   /// SecItemCopyMatching then shows the login-keychain password sheet even when `-T`
-  /// TrustedApplication is set. Seed UserDefaults tokens and let AuthService migrate
-  /// into Keychain on launch (app-created items get the correct teamid: partition).
+  /// TrustedApplication is set. Developer bundles write the file-backed secret store;
+  /// production-family seed still clears a leftover CLI Keychain item.
   func testAuthSeedScriptDoesNotCLIWriteKeychainTokens() throws {
     let source = try scriptFile("omi-auth-seed.sh")
     // Match a real security invocation, not comments that name the forbidden command.
@@ -369,10 +388,13 @@ final class AuthTokenStorageTests: XCTestCase {
       "omi-auth-seed.sh must not CLI-write Keychain tokens (apple-tool: partition prompts the app)")
     XCTAssertTrue(
       source.contains("delete-generic-password"),
-      "omi-auth-seed.sh must clear any prior CLI-written Keychain item before launch")
+      "omi-auth-seed.sh must still clear a leftover CLI Keychain item for production-family targets")
+    XCTAssertTrue(
+      source.contains("developer-secrets"),
+      "omi-auth-seed.sh must write developer-secrets for non-production targets")
     XCTAssertTrue(
       source.contains("auth_idToken"),
-      "omi-auth-seed.sh must seed auth_idToken into UserDefaults for app-side Keychain migrate")
+      "omi-auth-seed.sh must still seed auth-state and token keys into UserDefaults")
   }
 
   private func sourceFile(_ relativePath: String) throws -> String {

--- a/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/BrowserGoogleSessionTests.swift
@@ -7,16 +7,54 @@ final class BrowserGoogleSessionTests: XCTestCase {
 
   override func setUpWithError() throws {
     try super.setUpWithError()
+    BrowserKeychainCache.resetTestHooks()
     tempRoot = FileManager.default.temporaryDirectory
       .appendingPathComponent("browser-google-session-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
   }
 
   override func tearDownWithError() throws {
+    BrowserKeychainCache.resetTestHooks()
     if let tempRoot {
       try? FileManager.default.removeItem(at: tempRoot)
     }
     try super.tearDownWithError()
+  }
+
+  func testNonProductionBundlesSkipBrowserSafeStorageKeychain() {
+    var providerCalls = 0
+    BrowserKeychainCache.allowsBrowserKeychainImport = { false }
+    BrowserKeychainCache.safeStoragePasswordProvider = { _, _, _ in
+      providerCalls += 1
+      return "should-not-be-read"
+    }
+
+    XCTAssertNil(
+      BrowserKeychainCache.nativeSafeStoragePassword(
+        for: "Chrome Safe Storage",
+        account: "Chrome",
+        userInitiated: true))
+    XCTAssertEqual(providerCalls, 0)
+  }
+
+  func testProductionBundlesReadBrowserSafeStorageThroughInjectedProvider() {
+    var providerCalls = 0
+    BrowserKeychainCache.allowsBrowserKeychainImport = { true }
+    BrowserKeychainCache.safeStoragePasswordProvider = { service, account, userInitiated in
+      providerCalls += 1
+      XCTAssertEqual(service, "Chrome Safe Storage")
+      XCTAssertEqual(account, "Chrome")
+      XCTAssertTrue(userInitiated)
+      return "browser-secret"
+    }
+
+    XCTAssertEqual(
+      BrowserKeychainCache.nativeSafeStoragePassword(
+        for: "Chrome Safe Storage",
+        account: "Chrome",
+        userInitiated: true),
+      "browser-secret")
+    XCTAssertEqual(providerCalls, 1)
   }
 
   func testCookiePathsPreferChromiumNetworkCookieStore() throws {

--- a/desktop/macos/Desktop/Tests/DesktopDeveloperSecretStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopDeveloperSecretStoreTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopDeveloperSecretStoreTests: XCTestCase {
+  private var tempRoot = FileManager.default.temporaryDirectory
+  private var store = DesktopDeveloperSecretStore(
+    rootDirectory: FileManager.default.temporaryDirectory, bundleIdentifier: "unset")
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("developer-secrets-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    store = DesktopDeveloperSecretStore(
+      rootDirectory: tempRoot,
+      bundleIdentifier: "com.omi.omi-secret-store-tests"
+    )
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempRoot)
+    try super.tearDownWithError()
+  }
+
+  func testRoundTripReadWrite() throws {
+    XCTAssertNil(store.readString(service: "svc", account: "acct"))
+    XCTAssertTrue(store.setString("secret-value", service: "svc", account: "acct"))
+    XCTAssertEqual(store.readString(service: "svc", account: "acct"), "secret-value")
+  }
+
+  func testOverwriteReplacesValue() throws {
+    XCTAssertTrue(store.setString("first", service: "svc", account: "acct"))
+    XCTAssertTrue(store.setString("second", service: "svc", account: "acct"))
+    XCTAssertEqual(store.readString(service: "svc", account: "acct"), "second")
+  }
+
+  func testDeleteRemovesValue() throws {
+    XCTAssertTrue(store.setString("secret-value", service: "svc", account: "acct"))
+    store.delete(service: "svc", account: "acct")
+    XCTAssertNil(store.readString(service: "svc", account: "acct"))
+  }
+
+  func testMissingFileReadsAsEmpty() throws {
+    let missing = DesktopDeveloperSecretStore(
+      rootDirectory: tempRoot.appendingPathComponent("absent", isDirectory: true),
+      bundleIdentifier: "com.omi.omi-missing"
+    )
+    XCTAssertNil(missing.readString(service: "svc", account: "acct"))
+  }
+
+  func testCorruptFileReadsAsEmpty() throws {
+    let directory = store.secretsDirectoryURL()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data("{not-json".utf8).write(to: store.fileURL())
+    XCTAssertNil(store.readString(service: "svc", account: "acct"))
+    XCTAssertTrue(store.setString("recovered", service: "svc", account: "acct"))
+    XCTAssertEqual(store.readString(service: "svc", account: "acct"), "recovered")
+  }
+
+  func testSeparateServiceAndAccountKeys() throws {
+    XCTAssertTrue(store.setString("one", service: "svc-a", account: "acct"))
+    XCTAssertTrue(store.setString("two", service: "svc-b", account: "acct"))
+    XCTAssertTrue(store.setString("three", service: "svc-a", account: "other"))
+    XCTAssertEqual(store.readString(service: "svc-a", account: "acct"), "one")
+    XCTAssertEqual(store.readString(service: "svc-b", account: "acct"), "two")
+    XCTAssertEqual(store.readString(service: "svc-a", account: "other"), "three")
+  }
+
+  func testSeparateBundleFilesDoNotShareValues() throws {
+    let other = DesktopDeveloperSecretStore(
+      rootDirectory: tempRoot,
+      bundleIdentifier: "com.omi.omi-other-bundle"
+    )
+    XCTAssertTrue(store.setString("mine", service: "svc", account: "acct"))
+    XCTAssertTrue(other.setString("theirs", service: "svc", account: "acct"))
+    XCTAssertEqual(store.readString(service: "svc", account: "acct"), "mine")
+    XCTAssertEqual(other.readString(service: "svc", account: "acct"), "theirs")
+    XCTAssertNotEqual(store.fileURL(), other.fileURL())
+  }
+
+  func testFileModeIsOwnerReadWriteAndDirectoryIsOwnerOnly() throws {
+    XCTAssertTrue(store.setString("secret-value", service: "svc", account: "acct"))
+    let fileAttributes = try FileManager.default.attributesOfItem(atPath: store.fileURL().path)
+    let directoryAttributes = try FileManager.default.attributesOfItem(
+      atPath: store.secretsDirectoryURL().path)
+    let fileMode = try XCTUnwrap(fileAttributes[.posixPermissions] as? NSNumber).intValue
+    let directoryMode = try XCTUnwrap(directoryAttributes[.posixPermissions] as? NSNumber).intValue
+    XCTAssertEqual(fileMode & 0o777, 0o600)
+    XCTAssertEqual(directoryMode & 0o777, 0o700)
+  }
+
+  /// `scripts/omi-auth-seed.sh` writes this file for a bundle from a Background
+  /// session; the app must read it as its own. Pin the on-disk shape the script
+  /// produces (a JSON object whose key is service, NUL, account) so a drift in
+  /// either side shows up here instead of as a slot that boots signed out.
+  func testReadsAFileWrittenInTheSeedScriptShape() throws {
+    let bundleID = "com.omi.omi-seeded"
+    let fileURL = DesktopDeveloperSecretStore.fileURL(rootDirectory: tempRoot, bundleIdentifier: bundleID)
+    try FileManager.default.createDirectory(
+      at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let service = "com.omi.desktop.firebase-rest-session.v2.team.adhoc.\(bundleID).bundle.\(bundleID)"
+    let payload = #"{"idToken":"id","refreshToken":"refresh","expiryTime":1800000000.0,"tokenUserId":"uid"}"#
+    let object: [String: String] = ["\(service)\u{0}firebase-rest-tokens": payload]
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    try data.write(to: fileURL)
+
+    let seeded = DesktopDeveloperSecretStore(rootDirectory: tempRoot, bundleIdentifier: bundleID)
+    XCTAssertEqual(seeded.readString(service: service, account: "firebase-rest-tokens"), payload)
+    XCTAssertNil(seeded.readString(service: service, account: "other"))
+  }
+
+  func testStorageKeyJoinsServiceAndAccountWithNUL() {
+    XCTAssertEqual(
+      DesktopDeveloperSecretStore.storageKey(service: "svc", account: "acct"),
+      "svc\u{0}acct")
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopKeychainStoreRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopKeychainStoreRoutingTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopKeychainStoreRoutingTests: XCTestCase {
+  private var tempRoot = FileManager.default.temporaryDirectory
+  private var fileStore = DesktopDeveloperSecretStore(
+    rootDirectory: FileManager.default.temporaryDirectory, bundleIdentifier: "unset")
+  private var keychainCalls = CallRecorder()
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    DesktopKeychainStore.resetTestHooks()
+    tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("keychain-routing-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    fileStore = DesktopDeveloperSecretStore(
+      rootDirectory: tempRoot,
+      bundleIdentifier: "com.omi.omi-routing-tests"
+    )
+    DesktopKeychainStore.developerSecretStoreOverride = fileStore
+    keychainCalls = CallRecorder()
+  }
+
+  override func tearDownWithError() throws {
+    DesktopKeychainStore.resetTestHooks()
+    try? FileManager.default.removeItem(at: tempRoot)
+    try super.tearDownWithError()
+  }
+
+  func testProductionFamilyBundleIdentifiersUseKeychainBackend() {
+    XCTAssertEqual(
+      DesktopKeychainStore.backend(forBundleIdentifier: AppBuild.productionBundleIdentifier),
+      .keychain)
+    XCTAssertEqual(
+      DesktopKeychainStore.backend(forBundleIdentifier: AppBuild.betaProductionBundleIdentifier),
+      .keychain)
+  }
+
+  func testDeveloperBundleIdentifiersUseFileBackend() {
+    XCTAssertEqual(
+      DesktopKeychainStore.backend(forBundleIdentifier: AppBuild.desktopDevBundleIdentifier),
+      .developerFile)
+    XCTAssertEqual(
+      DesktopKeychainStore.backend(forBundleIdentifier: "com.omi.omi-fix-rewind"),
+      .developerFile)
+    XCTAssertEqual(
+      DesktopKeychainStore.backend(forBundleIdentifier: "com.example.adhoc"),
+      .developerFile)
+  }
+
+  func testFileBackendNeverCallsInjectedKeychainOperations() {
+    DesktopKeychainStore.backendOverride = .developerFile
+    DesktopKeychainStore.keychainOperationsOverride = spyingKeychainOperations()
+
+    XCTAssertTrue(DesktopKeychainStore.setString("file-secret", service: "svc", account: "acct"))
+    XCTAssertEqual(DesktopKeychainStore.string(service: "svc", account: "acct"), "file-secret")
+    DesktopKeychainStore.delete(service: "svc", account: "acct")
+    XCTAssertNil(DesktopKeychainStore.string(service: "svc", account: "acct"))
+    XCTAssertTrue(keychainCalls.all.isEmpty)
+  }
+
+  func testKeychainBackendUsesInjectedOperationsAndSkipsFileStore() {
+    DesktopKeychainStore.backendOverride = .keychain
+    let stored = ValueBox<String>()
+    let calls = keychainCalls
+    DesktopKeychainStore.keychainOperationsOverride = DesktopKeychainStore.KeychainOperations(
+      readString: { _, _ in
+        calls.record("read")
+        if let value = stored.value {
+          return .found(value)
+        }
+        return .missing
+      },
+      setString: { value, _, _ in
+        calls.record("set")
+        stored.value = value
+        return true
+      },
+      delete: { _, _ in
+        calls.record("delete")
+        stored.value = nil
+      }
+    )
+
+    XCTAssertTrue(DesktopKeychainStore.setString("kc-secret", service: "svc", account: "acct"))
+    XCTAssertEqual(DesktopKeychainStore.string(service: "svc", account: "acct"), "kc-secret")
+    DesktopKeychainStore.delete(service: "svc", account: "acct")
+    XCTAssertNil(DesktopKeychainStore.string(service: "svc", account: "acct"))
+    XCTAssertEqual(keychainCalls.all, ["set", "read", "delete", "read"])
+    XCTAssertNil(fileStore.readString(service: "svc", account: "acct"))
+  }
+
+  private func spyingKeychainOperations() -> DesktopKeychainStore.KeychainOperations {
+    let calls = keychainCalls
+    return DesktopKeychainStore.KeychainOperations(
+      readString: { _, _ in
+        calls.record("read")
+        return .missing
+      },
+      setString: { _, _, _ in
+        calls.record("set")
+        return false
+      },
+      delete: { _, _ in
+        calls.record("delete")
+      }
+    )
+  }
+}
+
+private final class CallRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var items: [String] = []
+
+  func record(_ item: String) {
+    lock.lock()
+    items.append(item)
+    lock.unlock()
+  }
+
+  var all: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return items
+  }
+}
+
+private final class ValueBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: Value?
+
+  var value: Value? {
+    get {
+      lock.lock()
+      defer { lock.unlock() }
+      return stored
+    }
+    set {
+      lock.lock()
+      stored = newValue
+      lock.unlock()
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260908-dev-bundles-no-keychain.json
+++ b/desktop/macos/changelog/unreleased/20260908-dev-bundles-no-keychain.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped developer macOS builds from asking for Keychain access on every rebuild"
+}

--- a/desktop/macos/docs/e2e-bundle-pool.md
+++ b/desktop/macos/docs/e2e-bundle-pool.md
@@ -62,29 +62,28 @@ Recurring: macOS 15 and later periodically re-ask whether an app may keep
 recording the screen. `check` reports that as `screen_recording=stale`; one
 click clears it.
 
-### Auth: shared (default in a GUI session) or isolated
+### Auth: shared (default) or isolated
 
 - **shared** — a full launch clones the Omi Dev session before start, exactly
-  as any named bundle does, **when the launcher can read the keychain**: a GUI
-  shell can; a background agent shell (launchd `Background` session, ssh)
-  cannot — the dump comes back empty and the slot keeps whatever session it
-  already has. So sign in once during the grant pass; the session persists in
-  the slot's own keychain item across rebuilds. Tests then run as the
+  as any named bundle does. Developer sources dump from a JSON file under
+  Application Support (`developer-secrets/<bundle-id>.json`), so cloning works
+  from a Background agent shell (launchd `Background` session, ssh) as well as
+  a GUI shell. Rebuilds never prompt for Keychain access. Sign in once to Omi
+  Dev; later slots clone that file-backed session. Tests then run as the
   developer's account against the dev backend, so their writes are real.
 - **isolated** — the slot keeps its own session. Sign in **once** inside the
   slot app with a dedicated test account; the session persists in the slot's
-  own keychain item across rebuilds. The Rewind history is not cloned either.
+  own developer-secrets file across rebuilds. The Rewind history is not cloned either.
   ```bash
   ./scripts/omi-e2e-pool acquire --slot 2 --auth isolated
   ```
   The mode sticks to the slot, not to the lane that set it, and `status` shows
   it.
 
-**Headless default.** An `acquire` from a non-GUI session (`launchctl
-managername` is anything but `Aqua`) defaults the slot to **isolated** instead
-of shared, because a shared slot launched from there can never be seeded — the
-same keychain wall blocks the dump. An explicit `--auth` always wins. GUI
-acquires keep the shared default.
+**Headless default.** Developer-bundle dump/seed no longer needs the login
+keychain, so `--auth shared` works from a Background session. The pool still
+defaults a non-Aqua `acquire` to **isolated** unless `--auth` is passed. An
+explicit `--auth` always wins. GUI acquires keep the shared default.
 
 ## Using a slot from a task
 
@@ -119,14 +118,14 @@ document:
   refused while the installed bundle is fast-reusable** (exit 2). You never
   need it: rebuilds that are genuinely required are not blocked. A rewind
   reseed (`OMI_FORCE_REWIND_SEED=1`) still forces the full lane deliberately.
-- **An empty auth dump never wipes anything.** When seeding cannot run (a
-  background session cannot read the source keychain), the slot keeps its
+- **An empty auth dump never wipes anything.** When seeding cannot run (the
+  source developer-secrets file is missing or has no tokens), the slot keeps its
   existing session and the log says so — there is no "Launching cold" for pool
   slots.
-- **Never reset a pool slot's Keychain.** `omi-local-profile-keychain-reset.sh`
+- **Never reset a pool slot's secret store.** `omi-local-profile-keychain-reset.sh`
   refuses `com.omi.omi-e2e-*` (any pool size and any configured
   `OMI_E2E_POOL_PREFIX`) outright: pool slots are not local-emulator profiles,
-  and their keychain item is the persisted session a human signed in for.
+  and their developer-secrets file is the persisted session a human signed in for.
 - **A signed-out slot is a hard fail.** `check` exits 2 — the same class as a
   missing TCC grant — and points at the one-time human fix. Health-only is not
   ready: the ready gate is `omi-e2e-pool check` for grants/sign-in, then

--- a/desktop/macos/docs/local-code-signing.md
+++ b/desktop/macos/docs/local-code-signing.md
@@ -159,18 +159,19 @@ history. After this, signing works from any session, including background ones.
 `run.sh` detects this failure and prints this remedy with your identity already
 substituted, so you should never have to find this section from a raw error.
 
-### The same wall blocks auth seeding
+### Auth dump/seed for developer bundles does not use the login keychain
 
-`scripts/omi-auth-dump.sh` reads Firebase tokens from a team-scoped Keychain item.
-From a background session it prints `WARNING: no auth_idToken found — is the source
-bundle signed in?` **even when the source bundle is signed in** — the UserDefaults
-half reads fine and the secret does not. Same cause, same shape of fix:
+Developer bundles (Omi Dev, named `omi-*` apps, ad-hoc / Apple Development local
+builds) store Firebase tokens in a JSON file under Application Support
+(`developer-secrets/<bundle-id>.json`). `scripts/omi-auth-dump.sh` and
+`scripts/omi-auth-seed.sh` read and write that file, so they work from a
+Background session with no login-keychain access. Rebuilds never prompt
+SecurityAgent for those tokens.
 
-```bash
-security set-generic-password-partition-list -S apple-tool:,apple:,security: \
-  -s "com.omi.desktop.firebase-rest-session.v2.team.<TEAM>.bundle.com.omi.desktop-dev" \
-  -a firebase-rest-tokens ~/Library/Keychains/login.keychain-db
-```
+Shipped bundles (`com.omi.computer-macos` and `com.omi.computer-macos.beta`)
+still use the login keychain. Dumping a production-family source still calls
+`security find-generic-password` and therefore still needs an Aqua session or a
+partition-list grant on that item.
 
 ## Do not "fix" a launch failure with ad-hoc signing
 

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
   - desktop/macos/Desktop/Sources/Auth/SessionRecoveryView.swift
   - desktop/macos/Desktop/Sources/Auth/AuthStorageCanary.swift
+  - desktop/macos/Desktop/Sources/Auth/DesktopDeveloperSecretStore.swift
   - desktop/macos/Desktop/Sources/DesktopKeychainStore.swift
   - desktop/macos/Desktop/Sources/Logger.swift
   - desktop/macos/Desktop/Sources/Observability/SentryBeforeSendPolicy.swift

--- a/desktop/macos/scripts/omi-auth-dump.sh
+++ b/desktop/macos/scripts/omi-auth-dump.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
-# omi-auth-dump.sh — capture a signed-in dev bundle's auth session to JSON.
+# omi-auth-dump.sh — capture a signed-in bundle's auth session to JSON.
 #
-# Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in the macOS
-# Keychain on ALL builds under a Team+bundle scoped service name derived from
-# "com.omi.desktop.firebase-rest-session" (see DesktopKeychainStore.scopedService).
-# Format: <base>.v2.team.<TeamID>.bundle.<bundleID>
+# Auth tokens (idToken, refreshToken, expiry, tokenUserId) live in
+# DesktopKeychainStore: the login keychain on shipped production-family bundles
+# (com.omi.computer-macos / com.omi.computer-macos.beta), and a JSON file under
+# Application Support for every other bundle. Format of the scoped service name:
+# <base>.v2.team.<TeamID>.bundle.<bundleID>
 # The remaining auth-state keys (isSignedIn, userEmail, userId, names, onboarding)
 # are in UserDefaults. This script reads BOTH so the captured session can be
 # replayed into other test bundles with omi-auth-seed.sh, letting an agent skip
 # the web OAuth login on every run.
+#
+# Developer-bundle dumps read the secrets file and work from a Background
+# (non-Aqua) session. Production-family dumps still use `security find-generic-password`.
 #
 # It does NOT mint or refresh tokens — it copies whatever the source session has.
 # The captured Firebase idToken expires (~1h); re-run this after signing in again.
@@ -34,6 +38,39 @@ KC_SERVICE_BASE="com.omi.desktop.firebase-rest-session"
 KC_ACCOUNT="firebase-rest-tokens"
 
 mkdir -p "$(dirname "$OUT")"
+
+is_production_family_bundle() {
+  case "$1" in
+    com.omi.computer-macos|com.omi.computer-macos.beta) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+application_support_root_for_bundle() {
+  local bid="$1"
+  local base="${HOME}/Library/Application Support"
+  local prefix="com.omi.omi-"
+  if [[ "$bid" == "$prefix"* ]]; then
+    local suffix="${bid#"$prefix"}"
+    if [[ -n "$suffix" && "$suffix" =~ ^[A-Za-z0-9.-]+$ ]]; then
+      printf '%s/Omi Dev Bundles/%s\n' "$base" "$bid"
+      return
+    fi
+  fi
+  if [[ "$bid" == "com.omi.computer-macos.beta" ]]; then
+    printf '%s/Omi Beta\n' "$base"
+    return
+  fi
+  if [[ "${OMI_DESKTOP_LOCAL_PROFILE:-}" == "1" ]]; then
+    printf '%s/%s\n' "$base" "${OMI_LOCAL_PROFILE_STORAGE_NAME:-Omi}"
+    return
+  fi
+  printf '%s/Omi\n' "$base"
+}
+
+developer_secrets_file_for_bundle() {
+  printf '%s/developer-secrets/%s.json\n' "$(application_support_root_for_bundle "$1")" "$1"
+}
 
 # Resolve an installed .app path for the source bundle so we can read its Team ID.
 resolve_app_path() {
@@ -72,12 +109,20 @@ if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
 fi
 KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}.bundle.${SRC}"
 
-python3 - "$SRC" "$OUT" "${UD_KEYS[@]}" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
-import json, subprocess, sys
+TOKEN_SOURCE="keychain"
+SECRETS_FILE=""
+if is_production_family_bundle "$SRC"; then
+  TOKEN_SOURCE="keychain"
+else
+  TOKEN_SOURCE="file"
+  SECRETS_FILE="$(developer_secrets_file_for_bundle "$SRC")"
+fi
 
-src, out = sys.argv[1], sys.argv[2]
-ud_keys = sys.argv[3:-2]
-kc_service, kc_account = sys.argv[-2], sys.argv[-1]
+python3 - "$SRC" "$OUT" "$TOKEN_SOURCE" "$SECRETS_FILE" "$KC_SERVICE" "$KC_ACCOUNT" "${UD_KEYS[@]}" <<'PY'
+import json, os, subprocess, sys
+
+src, out, token_source, secrets_file, kc_service, kc_account = sys.argv[1:7]
+ud_keys = sys.argv[7:]
 
 def defaults(*args):
     return subprocess.run(["defaults", *args], capture_output=True, text=True)
@@ -91,6 +136,21 @@ def read_keychain(service):
         return kc.stdout.strip()
     return None
 
+def read_developer_secrets(path, service):
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as handle:
+            obj = json.load(handle)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    payload = obj.get(service + "\0" + kc_account)
+    if isinstance(payload, str) and payload.strip():
+        return payload
+    return None
+
 data = {}
 for k in ud_keys:
     t = defaults("read-type", src, k)
@@ -101,21 +161,28 @@ for k in ud_keys:
         continue
     data[k] = {"type": t.stdout.strip().replace("Type is ", ""), "value": v.stdout.strip()}
 
-# Only the team+bundle scoped v2 item. Never query the unscoped legacy service —
-# `security find-generic-password` on a poisoned ACL can show the same login-
-# keychain password dialog this PR eliminates. Pre-migration sessions fall
-# through to UserDefaults token keys below.
-payload = read_keychain(kc_service)
+# Production-family sources read the team+bundle scoped v2 keychain item and
+# never query the unscoped legacy service. Developer sources read the JSON file
+# and never call `security`.
+if token_source == "file":
+    payload = read_developer_secrets(secrets_file, kc_service)
+    data["_tokenSource"] = {"type": "string", "value": "developer-secrets"}
+    if secrets_file:
+        data["_developerSecretsFile"] = {"type": "string", "value": secrets_file}
+else:
+    payload = read_keychain(kc_service)
+    data["_tokenSource"] = {"type": "string", "value": "keychain"}
+
 if payload:
     try:
         tokens = json.loads(payload)
         # Validate tokenUserId against the UserDefaults auth_userId to avoid
-        # seeding signed-in state for one user with Keychain tokens belonging
-        # to a different user.
+        # seeding signed-in state for one user with tokens belonging to a
+        # different user.
         kc_uid = tokens.get("tokenUserId", "")
         ud_uid = data.get("auth_userId", {}).get("value", "")
         if ud_uid and kc_uid != ud_uid:
-            print(f"WARNING: Keychain tokenUserId ({kc_uid}) does not match "
+            print(f"WARNING: tokenUserId ({kc_uid}) does not match "
                   f"UserDefaults auth_userId ({ud_uid}) — falling back to "
                   f"UserDefaults token keys.", file=sys.stderr)
         else:
@@ -124,7 +191,7 @@ if payload:
             data["auth_tokenExpiry"] = {"type": "float", "value": str(tokens.get("expiryTime", 0))}
             data["auth_tokenUserId"] = {"type": "string", "value": kc_uid}
             data["_keychainService"] = {"type": "string", "value": kc_service}
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, TypeError):
         pass  # fall through to UserDefaults below
 
 # Legacy fallback: pre-migration bundles may still have token keys in UserDefaults.
@@ -145,7 +212,9 @@ with open(out, "w") as f:
 print(f"Dumped {len(data)} keys from {src} -> {out}")
 print(f"  signed_in={data.get('auth_isSignedIn', {}).get('value')} "
       f"email={data.get('auth_userEmail', {}).get('value')}")
-print(f"  keychain_service={kc_service}")
+print(f"  token_source={token_source} service={kc_service}")
+if token_source == "file":
+    print(f"  developer_secrets_file={secrets_file}")
 if "auth_idToken" not in data or not data["auth_idToken"].get("value"):
     sys.exit("WARNING: no auth_idToken found — is the source bundle signed in?")
 PY

--- a/desktop/macos/scripts/omi-auth-seed.sh
+++ b/desktop/macos/scripts/omi-auth-seed.sh
@@ -2,17 +2,18 @@
 # omi-auth-seed.sh — replay a captured auth session into a test bundle.
 #
 # Writes auth-state UserDefaults (isSignedIn, email, userId, names, onboarding)
-# plus Firebase token keys into the target bundle's domain. On first launch,
-# AuthService.storedTokens() migrates those UserDefaults tokens into the
-# team+bundle scoped Keychain item via SecItemAdd — which stamps the correct
-# teamid: partition so the app can read them without a login-keychain prompt.
+# plus Firebase tokens into the target. Non-production targets persist tokens in
+# the developer-secrets JSON file using the same scoped service name the app
+# computes (`<base>.v2.team.<TeamID>.bundle.<bundleID>`; team-less identities
+# use `adhoc.<bundleID>`). Production-family targets still seed UserDefaults
+# token keys and clear a leftover CLI Keychain item so AuthService can migrate
+# into the login keychain on launch.
 #
-# Why not write Keychain from this script?
+# Why not write Keychain from this script for shipped bundles?
 # The security(1) generic-password *add* path creates items with partition list
 # `apple-tool:` only. TrustedApplication `-T /path/to/App.app` is not enough:
 # the running app still gets the "wants to access key … in your keychain"
-# password sheet. Deleting any prior CLI-written item and seeding UserDefaults
-# avoids that path entirely for named-bundle / agent launches.
+# password sheet.
 #
 # Run this BEFORE launching the bundle (UserDefaults is read at startup).
 #
@@ -35,6 +36,39 @@ APP_PATH_ARG="${3:-${OMI_AUTH_SEED_APP_PATH:-}}"
 
 KC_SERVICE_BASE="com.omi.desktop.firebase-rest-session"
 KC_ACCOUNT="firebase-rest-tokens"
+
+is_production_family_bundle() {
+  case "$1" in
+    com.omi.computer-macos|com.omi.computer-macos.beta) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+application_support_root_for_bundle() {
+  local bid="$1"
+  local base="${HOME}/Library/Application Support"
+  local prefix="com.omi.omi-"
+  if [[ "$bid" == "$prefix"* ]]; then
+    local suffix="${bid#"$prefix"}"
+    if [[ -n "$suffix" && "$suffix" =~ ^[A-Za-z0-9.-]+$ ]]; then
+      printf '%s/Omi Dev Bundles/%s\n' "$base" "$bid"
+      return
+    fi
+  fi
+  if [[ "$bid" == "com.omi.computer-macos.beta" ]]; then
+    printf '%s/Omi Beta\n' "$base"
+    return
+  fi
+  if [[ "${OMI_DESKTOP_LOCAL_PROFILE:-}" == "1" ]]; then
+    printf '%s/%s\n' "$base" "${OMI_LOCAL_PROFILE_STORAGE_NAME:-Omi}"
+    return
+  fi
+  printf '%s/Omi\n' "$base"
+}
+
+developer_secrets_file_for_bundle() {
+  printf '%s/developer-secrets/%s.json\n' "$(application_support_root_for_bundle "$1")" "$1"
+}
 
 resolve_app_path() {
   local bid="$1"
@@ -81,11 +115,17 @@ if [ -z "$TEAM_ID" ] || [ "$TEAM_ID" = "not set" ]; then
 fi
 KC_SERVICE="${KC_SERVICE_BASE}.v2.team.${TEAM_ID}.bundle.${TARGET}"
 
-python3 - "$TARGET" "$IN" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
-import json, subprocess, sys
+TOKEN_SOURCE="file"
+SECRETS_FILE="$(developer_secrets_file_for_bundle "$TARGET")"
+if is_production_family_bundle "$TARGET"; then
+  TOKEN_SOURCE="keychain"
+  SECRETS_FILE=""
+fi
 
-target, inp = sys.argv[1], sys.argv[2]
-kc_service, kc_account = sys.argv[3], sys.argv[4]
+python3 - "$TARGET" "$IN" "$TOKEN_SOURCE" "$SECRETS_FILE" "$KC_SERVICE" "$KC_ACCOUNT" <<'PY'
+import json, os, subprocess, sys, tempfile
+
+target, inp, token_source, secrets_file, kc_service, kc_account = sys.argv[1:7]
 data = json.load(open(inp))
 
 id_token = data.get("auth_idToken", {}).get("value", "")
@@ -99,26 +139,80 @@ if not id_token or not refresh_token:
           "from a signed-in source bundle.", file=sys.stderr)
     sys.exit(1)
 
-# Remove any prior CLI-seeded Keychain item. Those carry partition list
-# apple-tool: only; leaving them makes the app prompt on SecItemCopyMatching
-# even with TrustedApplication -T grants. `security` (apple-tool:) can delete
-# without prompting; the app then migrates UserDefaults → Keychain on boot.
-subprocess.run(
-    ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
-    capture_output=True, text=True,
-)
-print(f"Cleared Keychain item if present ({kc_service}/{kc_account})")
+try:
+    expiry_time = float(token_expiry or "0")
+except ValueError:
+    expiry_time = 0.0
 
-# Token keys are seeded into UserDefaults for one-shot migration by AuthService.
-# Do not CLI-add a generic-password item — that recreates the apple-tool:
-# partition prompt path.
+payload = json.dumps(
+    {
+        "idToken": id_token,
+        "refreshToken": refresh_token,
+        "expiryTime": expiry_time,
+        "tokenUserId": token_uid,
+    },
+    separators=(",", ":"),
+)
+
+if token_source == "keychain":
+    # Remove any prior CLI-seeded Keychain item. Those carry partition list
+    # apple-tool: only; leaving them makes the app prompt on SecItemCopyMatching
+    # even with TrustedApplication -T grants. `security` (apple-tool:) can delete
+    # without prompting; the app then migrates UserDefaults → Keychain on boot.
+    subprocess.run(
+        ["security", "delete-generic-password", "-s", kc_service, "-a", kc_account],
+        capture_output=True, text=True,
+    )
+    print(f"Cleared Keychain item if present ({kc_service}/{kc_account})")
+else:
+    secrets_dir = os.path.dirname(secrets_file)
+    os.makedirs(secrets_dir, mode=0o700, exist_ok=True)
+    try:
+        os.chmod(secrets_dir, 0o700)
+    except OSError:
+        pass
+    obj = {}
+    if os.path.isfile(secrets_file):
+        try:
+            with open(secrets_file, encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            if isinstance(loaded, dict):
+                obj = {
+                    str(key): value if isinstance(value, str) else str(value)
+                    for key, value in loaded.items()
+                }
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            obj = {}
+    obj[kc_service + "\0" + kc_account] = payload
+    fd, tmp_path = tempfile.mkstemp(prefix=".developer-secrets.", dir=secrets_dir)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(obj, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, secrets_file)
+        os.chmod(secrets_file, 0o600)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    print(f"Wrote developer secrets ({secrets_file})")
+
+# Auth-state keys stay in UserDefaults. Token keys go there only for a
+# production-family target, where AuthService migrates them into the login
+# keychain on launch; a developer target already has them in its secrets file
+# and must not keep a second plaintext copy in its defaults domain.
+TOKEN_KEY_NAMES = {"auth_idToken", "auth_refreshToken", "auth_tokenExpiry", "auth_tokenUserId"}
 TOKEN_KEYS = {
     "auth_idToken": id_token,
     "auth_refreshToken": refresh_token,
-    "auth_tokenExpiry": str(token_expiry),
+    "auth_tokenExpiry": str(expiry_time),
     "auth_tokenUserId": token_uid,
-}
-SKIP_META = {"_keychainService"}
+} if token_source == "keychain" else {}
+SKIP_META = {"_keychainService", "_tokenSource", "_developerSecretsFile"}
 
 flag = {"boolean": "-bool", "string": "-string", "integer": "-int",
         "float": "-float", "date": "-date", "data": "-data"}
@@ -139,7 +233,7 @@ for key, val in TOKEN_KEYS.items():
     n += 1
 
 for k, info in data.items():
-    if k in TOKEN_KEYS or k in SKIP_META:
+    if k in TOKEN_KEY_NAMES or k in SKIP_META:
         continue
     typ, val = info["type"], info["value"]
     if typ == "boolean":
@@ -147,7 +241,10 @@ for k, info in data.items():
     subprocess.run(["defaults", "write", target, k, flag.get(typ, "-string"), val], check=True)
     n += 1
 
-print(f"Seeded {n} keys into {target} (tokens via UserDefaults → Keychain migrate on launch)")
+if token_source == "file":
+    print(f"Seeded {n} keys into {target} (tokens via developer-secrets file)")
+else:
+    print(f"Seeded {n} keys into {target} (tokens via UserDefaults → Keychain migrate on launch)")
 PY
 
 echo "Done — launch $TARGET and it boots signed-in (no web login)."

--- a/desktop/macos/tests/test-omi-auth-seed-acl.sh
+++ b/desktop/macos/tests/test-omi-auth-seed-acl.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Hermetic checks: named-bundle auth seed must not CLI-write Keychain tokens
-# (apple-tool: partition → login-keychain password sheet on app read).
+# (apple-tool: partition → login-keychain password sheet on app read), and a
+# developer target must get its tokens in the developer-secrets file only.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -32,7 +33,7 @@ RUN_SRC="$(cat "$RUN")"
 assert_contains "$SEED_SRC" 'delete-generic-password' \
   "omi-auth-seed.sh must clear any prior CLI-written Keychain item before launch"
 assert_contains "$SEED_SRC" 'auth_idToken' \
-  "omi-auth-seed.sh must seed auth_idToken into UserDefaults for app-side Keychain migrate"
+  "omi-auth-seed.sh must seed auth_idToken (UserDefaults for shipped targets, secrets file otherwise)"
 assert_contains "$SEED_SRC" 'UserDefaults' \
   "omi-auth-seed.sh must document/use the UserDefaults → Keychain migrate path"
 # Match a real security invocation, not explanatory comments that name the flag.
@@ -57,17 +58,35 @@ cat >"$TMP/auth.json" <<'JSON'
 JSON
 
 # Use a throwaway defaults domain + fake team via missing app (adhoc.<bundle>).
+# A developer target persists tokens in its developer-secrets file (never the
+# keychain, never UserDefaults); HOME is redirected so the file lands in $TMP.
 BID="com.omi.omi-acl-seed-ud-$$"
 defaults delete "$BID" >/dev/null 2>&1 || true
-"$SEED" "$BID" "$TMP/auth.json" >/dev/null
+mkdir -p "$TMP/home"
+HOME="$TMP/home" "$SEED" "$BID" "$TMP/auth.json" >/dev/null
 ID="$(defaults read "$BID" auth_idToken 2>/dev/null || true)"
 REFRESH="$(defaults read "$BID" auth_refreshToken 2>/dev/null || true)"
 SIGNED="$(defaults read "$BID" auth_isSignedIn 2>/dev/null || true)"
 defaults delete "$BID" >/dev/null 2>&1 || true
+SECRETS="$TMP/home/Library/Application Support/Omi Dev Bundles/$BID/developer-secrets/$BID.json"
 
-if [ "$ID" != "id-token-seed" ] || [ "$REFRESH" != "refresh-token-seed" ]; then
-  echo "FAIL: expected token keys in UserDefaults after seed (id='$ID' refresh='$REFRESH')" >&2
+if [ -n "$ID" ] || [ -n "$REFRESH" ]; then
+  echo "FAIL: developer seed must not leave token keys in UserDefaults (id='$ID' refresh='$REFRESH')" >&2
   FAIL=1
+fi
+if [ ! -f "$SECRETS" ]; then
+  echo "FAIL: expected developer secrets file at $SECRETS" >&2
+  FAIL=1
+else
+  MODE="$(stat -f '%Lp' "$SECRETS")"
+  if [ "$MODE" != "600" ]; then
+    echo "FAIL: developer secrets file must be mode 600 (got $MODE)" >&2
+    FAIL=1
+  fi
+  if ! grep -Fq 'id-token-seed' "$SECRETS" || ! grep -Fq 'firebase-rest-tokens' "$SECRETS"; then
+    echo "FAIL: developer secrets file must carry the seeded tokens under the firebase-rest-tokens account" >&2
+    FAIL=1
+  fi
 fi
 if [ "$SIGNED" != "1" ] && [ "$SIGNED" != "true" ]; then
   echo "FAIL: expected auth_isSignedIn after seed (got '$SIGNED')" >&2


### PR DESCRIPTION
## What changed and why

Ruling (David, 2026-09-08): the login keychain is for shipped bundles only. Stable (`com.omi.computer-macos`) and Omi Beta (`com.omi.computer-macos.beta`) keep using it. Every other bundle — Omi Dev, named `omi-*` dev bundles, ad-hoc and Apple-Development-signed local builds — stops using anything that needs the user keychain.

Why: a developer bundle signed with a team-less identity gets its keychain items bound to the binary's code hash, so every rebuild is a foreign reader and the next launch parks its main thread in `AuthService.loadKeychainTokens` → `SecItemCopyMatching` behind a SecurityAgent prompt. A headless or SSH session can never answer it. Measured with a signed probe (see the run record linked below): under the self-signed identity a rebuilt binary at the same path prompts with the implicit ACL, with an explicit trusted-app ACL, and with an "any application" ACL; under a Team-ID identity it does not. The gate is the item's partition list, which a team-less identity cannot get.

## Fixes

- `DesktopKeychainStore` is now the secret-store facade with a backend resolved once from `AppBuild.isProductionBundle`: `.keychain` for the production family, `.developerFile` for everything else. The developer path makes no SecItem call. `scopedService` is unchanged, so service names stay team+bundle scoped.
- New `Auth/DesktopDeveloperSecretStore.swift`: a JSON file at `~/Library/Application Support/<storage root>/developer-secrets/<bundle-id>.json` (0700 directory, 0600 file, atomic replace, in-memory cache, lock). Keyed by bundle id because Omi Dev shares the `Omi` root with stable.
- `BrowserGoogleSession`: the Chromium Safe Storage read (the browser's own keychain item) is production-only; developer bundles return nil and log once. The `google-connector-read` flow only asserts a classified status, so it still passes; the real import path is now exercised only on shipped bundles.
- `AuthService`: no logic change; comments now describe the facade. `AuthStorageCanary` is untouched (it runs on the signed artifact, which is production-family).
- `scripts/omi-auth-dump.sh` reads a developer source's tokens from its secrets file (production sources still use `security find-generic-password`); `scripts/omi-auth-seed.sh` writes the target's secrets file directly with the same scoped service name the app computes, and only seeds token keys into UserDefaults for production-family targets. Both work from a Background session.
- Docs: `docs/e2e-bundle-pool.md` (shared auth clones from the file and works headless) and `docs/local-code-signing.md`.

Not changed on purpose: `ClientDeviceService` already kept developer bundles on UserDefaults, so its production keychain path is left byte-for-byte as it was.

Migration: a developer bundle that is signed in today has its tokens in a keychain item this build will not read. It starts signed out once; sign in (or seed from a dump) and from then on rebuilds never prompt.

## Product invariants affected

- INV-AUTH-1 — the change is storage routing under `AuthService`'s existing token hooks; session-death ownership, restore validation, attempt generations and the UserDefaults migration path are untouched. Shipped bundles keep the exact keychain behaviour.

## How it was verified

- Hermetic: `xcrun swift test --package-path Desktop --filter 'DesktopDeveloperSecretStore|DesktopKeychainStore|AuthTokenStorage|BrowserGoogleSession|AuthStorageCanary|FailLoudConfig|ClientDevice'` — 64 tests, 0 failures (plus the seed-shape read test added afterwards: 14/14 in the two store suites). swift-format lint, SwiftLint, `check-e2e-flow-coverage.py --strict --base origin/main`, and the line-count ratchet all pass; `make preflight` verdict is in the PR checks.
- Scripts: `omi-auth-seed.sh` then `omi-auth-dump.sh` round-tripped a synthetic session on `com.omi.omi-throwaway-devsecrets` under a temp `HOME` from this Background session: the secrets file is created 0600 with the scoped-service NUL account key, the dump reads it back with `token_source=file`, and the target's defaults domain holds only the auth-state keys, no token keys.
- Live, headless: built this branch into E2E pool slot `omi-e2e-1` twice from a Background (non-Aqua) session, the exact sequence that hung yesterday. Both launches (pids 22287 and 22941, different binaries): no `SecurityAgent` process, zero "main thread busy" bridge lines, no SecItem in the app log, `appState: signed_out` within seconds. Signed out is expected: the slot's old session lives in a keychain item this build no longer reads.
- Not verified live: a signed-in developer bundle surviving a rebuild through the file. That needs one sign-in on the new build (or a dump from a signed-in developer bundle, which none exists yet); the file persistence and the seed-file shape are covered by the store tests instead.

## Tests

- `Desktop/Tests/DesktopDeveloperSecretStoreTests.swift` — round trip, overwrite, delete, missing and corrupt files, key separation, per-bundle files, 0600/0700 modes.
- `Desktop/Tests/DesktopKeychainStoreRoutingTests.swift` — production ids route to the keychain backend, developer ids to the file backend, and the file backend never reaches the keychain operations (asserted with injected backends).
- `Desktop/Tests/BrowserGoogleSessionTests.swift` — the production-only gate on both sides.
- `Desktop/Tests/AuthTokenStorageTests.swift` — the "keychain on every build" contract restated as "facade on every build".

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

New definition `FC-developer-build-secret-bound-to-user-keychain`. Violated contract: a build that is rebuilt and relaunched unattended must not persist its credentials in a store whose access is bound to one binary's identity. Canonical guard: the facade routes by bundle family and the developer path is asserted to make no SecItem call, with the dump/seed scripts reading and writing the same file. Evidence: this PR and the measured ACL matrix in `omi-workspace:data/run-2026-09-08-chat-double-stream/evidence/keychain-acl/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

