### PR TITLE
chore(notifications-job): shadow daily-summary selection on prod (#13210)

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -2247,7 +2247,7 @@ environments:
               value: 'true'
               category: memory_rollout
             DAILY_SUMMARY_SELECTION_MODE:
-              value: legacy
+              value: shadow
               category: rollout
             PINECONE_INDEX_NAME:
               category: integrations

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -400,6 +400,9 @@ overlay:
         env:
           OMI_BACKGROUND_FLEX_CAPABLE:
             value: 'true'
+          DAILY_SUMMARY_SELECTION_MODE:
+            value: shadow
+            category: rollout
           PINECONE_INDEX_NAME:
             value: memories-backend
       daily-memory-sweep-job:


### PR DESCRIPTION
## Summary

- Set `DAILY_SUMMARY_SELECTION_MODE=shadow` on the **prod** `notifications-job` after the #13210 backfill.
- Dev already runs `shadow` (#13244). This does not change what gets sent: legacy remains the send path; indexed is compared and logged.
- Follow-up to #13213 / #13210.

## Test plan

- [x] `compose_runtime_env.py` + `check_runtime_env_compose.sh`
- [x] `validate-backend-runtime-env.py --env prod|dev --check-workflows`
- [ ] Deploy `gcp_notifications_job.yml` `environment=prod`, `branch=main`
- [ ] Wait for two scheduled executions; `only_legacy=0` on every hour line; no `daily_summary_selection_shadow_failed`

## Product invariants affected

- INV-MEM-4


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

