### PR TITLE
test(desktop): isolate the revocation-dissolve test from the shared auth defaults domain

### DIFF
--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -870,6 +870,12 @@ import XCTest
     /// Pinning the mechanism rather than the outcome: if the revocation ever became a
     /// refcount, the body would run genuinely revoked and this assertion would catch that
     /// as the behavior change it is.
+    ///
+    /// The transition only cycles the revocation when the planned owner differs from the
+    /// persisted one, so this must run against an empty, isolated defaults domain. The
+    /// standard domain is shared with every other suite process on the runner (cfprefsd
+    /// routes it past `CFFIXED_USER_HOME`), and a concurrent suite that has `auth_userId`
+    /// set there turns this into a no-op transition that leaves the revocation in place.
     func testAnOwnerTransitionDissolvesAnOutstandingRevocation() async {
       var observedInsideBody: Bool?
 
@@ -878,8 +884,15 @@ import XCTest
           RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress,
           "precondition: the revocation is outstanding on entry")
 
+        let suiteName = "KernelTurnRecordedProjectionTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+          return XCTFail("failed to create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
         await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(
-          "revocation-dissolve-owner"
+          "revocation-dissolve-owner",
+          defaults: defaults
         ) {
           observedInsideBody = RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress
         }


### PR DESCRIPTION
## What changed and why

`KernelTurnRecordedProjectionTests.testAnOwnerTransitionDissolvesAnOutstandingRevocation` (added in #12664) asserts that `withAutomationOwnerIfMissing` cycles the effective-owner revocation. The fence only does that when the planned owner differs from the persisted one, and the test ran against `UserDefaults.standard`. That domain is shared by every suite process on a runner (cfprefsd routes it past `CFFIXED_USER_HOME`, which is why `swift-test-suites.sh` keeps a serial auth cluster). When a concurrent parallel-pool suite has `auth_userId` set there (e.g. `RealtimeHubPlaybackProgressBridgeTests`, `EffectiveOwnerDatabaseBoundaryTests`), the transition becomes a same-owner no-op, the revocation is never ended, and the test fails with `Optional(true) != Optional(false)`.

The test now runs the transition against an isolated `UserDefaults(suiteName:)` domain, the same pattern its sibling `testTemporaryAutomationOwnerKeepsFaultResetOnKernelBoundary` already uses. The assertion is about revocation mechanics, not the standard domain, so this removes the cross-process dependency without changing what is pinned. No product code changes.

This is what failed `Desktop Swift Static & Test Contracts` on #13234 (twice) and #13235 while unrelated desktop PRs passed; both PR bodies called it a main flake, which understated it. It is a scheduling-dependent race that any desktop PR can hit.

## Product invariants affected

None. Test-only change.

## How it was verified

Swift unit tests only, from this worktree at `fix/kernel-revocation-test-isolated-defaults` (base `ca79229de5`).

Reproduced the CI failure before the fix by seeding the shared xctest defaults domain, then confirmed the fix passes under the same condition:

```
cd desktop/macos
defaults write com.apple.dt.xctest.tool auth_userId poison-owner
xcrun swift test --package-path Desktop --filter 'KernelTurnRecordedProjectionTests/testAnOwnerTransitionDissolvesAnOutstandingRevocation'
defaults delete com.apple.dt.xctest.tool auth_userId
```

- Before (main test code): `Executed 1 test, with 1 failure` with the exact CI assertion message.
- After: `Executed 1 test, with 0 failures`.
- Full suite, clean domain: `KernelTurnRecordedProjectionTests` 40 tests, 0 failures.

Also: `./scripts/swift-format-wrapper.sh lint` on the changed file (OK), `python3 desktop/macos/scripts/check_desktop_test_quality.py` (OK), `OMI_PR_BODY_FILE=... make preflight`.

## Tests

- `KernelTurnRecordedProjectionTests.testAnOwnerTransitionDissolvesAnOutstandingRevocation` — now deterministic regardless of what other suite processes hold in the standard auth domain.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

