### PR TITLE
fix(backend): validate static-map coordinates before quantization

### DIFF
--- a/backend/tests/routers/test_static_map.py
+++ b/backend/tests/routers/test_static_map.py
@@ -35,7 +35,19 @@ def _get(pins, width=300, height=150, uid=UID):
 
 
 def test_malformed_pins_are_rejected_with_400():
-    for bad in ['abc', '1.0', '1.0,2.0,3.0', '91,0', '0,181', 'a,b', '']:
+    for bad in [
+        'abc',
+        '1.0',
+        '1.0,2.0,3.0',
+        '91,0',
+        '0,181',
+        'a,b',
+        '',
+        '90.00004,0',
+        '-90.00004,0',
+        '0,180.00004',
+        '0,-180.00004',
+    ]:
         with pytest.raises(HTTPException) as excinfo:
             _get(bad)
         assert excinfo.value.status_code == 400, bad
@@ -119,6 +131,18 @@ def test_parse_pins_quantizes_dedupes_and_sorts():
 def test_parse_pins_caps_at_50():
     raw = '|'.join(f'{i / 100:.2f},0.0' for i in range(80))
     assert len(static_map_mod.parse_pins(raw)) == 50
+
+
+def test_parse_pins_rejects_out_of_bounds_coordinates_before_quantization():
+    # Coordinates just outside legal [-90, 90] and [-180, 180] bounds must not
+    # round onto the legal boundary and get accepted.
+    for bad in ['90.00004,0', '-90.00004,0', '0,180.00004', '0,-180.00004']:
+        with pytest.raises(static_map_mod.MalformedPinsError, match='pin coordinates out of bounds'):
+            static_map_mod.parse_pins(bad)
+
+    # Exact boundary coordinates remain legal and quantize properly.
+    assert static_map_mod.parse_pins('90.0,180.0') == [(90.0, 180.0)]
+    assert static_map_mod.parse_pins('-90.0,-180.0') == [(-90.0, -180.0)]
 
 
 def test_single_pin_url_centers_at_street_zoom():

--- a/backend/utils/static_map.py
+++ b/backend/utils/static_map.py
@@ -99,12 +99,14 @@ def parse_pins(pins: str) -> List[Tuple[float, float]]:
         if len(parts) != 2:
             raise MalformedPinsError('each pin must be lat,lng')
         try:
-            latitude = round(float(parts[0].strip()), _PIN_PRECISION)
-            longitude = round(float(parts[1].strip()), _PIN_PRECISION)
+            raw_lat = float(parts[0].strip())
+            raw_lng = float(parts[1].strip())
         except (ValueError, TypeError):
             raise MalformedPinsError('each pin must be numeric lat,lng')
-        if not -90 <= latitude <= 90 or not -180 <= longitude <= 180:
+        if not -90 <= raw_lat <= 90 or not -180 <= raw_lng <= 180:
             raise MalformedPinsError('pin coordinates out of bounds')
+        latitude = round(raw_lat, _PIN_PRECISION)
+        longitude = round(raw_lng, _PIN_PRECISION)
         if (latitude, longitude) in seen:
             continue
         seen.add((latitude, longitude))


### PR DESCRIPTION
## Summary

In `backend/utils/static_map.py::parse_pins`, latitude and longitude were previously rounded to `_PIN_PRECISION` (4 decimal places) before enforcing the `[-90, 90]` and `[-180, 180]` coordinate bounds. Because of this premature rounding, out-of-range coordinates that slightly exceed legal boundaries (such as `90.00004, 0` or `0, 180.00004`) rounded onto the legal boundary (`90.0` and `180.0`) and were erroneously accepted.

This PR validates the raw parsed float coordinates against the legal bounds before applying the 4-decimal quantization used for de-duplication and cache keys.

Fixes #13249

## Changes

- **`backend/utils/static_map.py`**:
  - Parse `raw_lat` and `raw_lng` as floats first.
  - Enforce `-90 <= raw_lat <= 90` and `-180 <= raw_lng <= 180` before rounding.
  - Apply `round(..., _PIN_PRECISION)` only to valid coordinates.
- **`backend/tests/routers/test_static_map.py`**:
  - Added boundary excursions (`90.00004,0`, `-90.00004,0`, `0,180.00004`, `0,-180.00004`) to `test_malformed_pins_are_rejected_with_400`.
  - Added `test_parse_pins_rejects_out_of_bounds_coordinates_before_quantization` testing both out-of-bounds rejection and exact boundary validity.

## Product Invariants Affected

none

## Failure-Class

Failure-Class: none

## Verification

- Ran unit tests: `pytest tests/routers/test_static_map.py` (22/22 passed in 0.59s).
- Ran formatter: `scripts/backend-python-format --write backend/utils/static_map.py backend/tests/routers/test_static_map.py`.
- Ran manifest preflight: all checks passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

