### PR TITLE
fix(plugins): surface failed Notion page content reads

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -897,6 +897,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "hermetic fixture coverage for the duplicate-route scanner: shadowed duplicate fails with the colliding path, unique routes pass, same path on different apps is not a duplicate, api_route methods expand"
 
+  - id: notion-page-content-tests
+    command: ["python3", "plugins/omi-notion-app/test_main.py"]
+    triggers: ["plugins/omi-notion-app/**"]
+    lanes: ["local", "ci"]
+    reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-notion-app/README.md
+++ b/plugins/omi-notion-app/README.md
@@ -129,5 +129,6 @@ When users connect their Notion workspace, they must grant access to specific pa
 Run `python3 plugins/omi-notion-app/test_main.py` from the repository root.
 The hermetic tests import the production module with framework/storage doubles
 and exercise `get_page` through its real HTTP helper: failed content retrieval
-must return a sanitized tool error, while empty and populated successful reads
+must return a sanitized tool error retaining the independently retrieved page
+metadata (including archive status), while empty and populated successful reads
 retain their output. No live workspace or credentials are used.

--- a/plugins/omi-notion-app/README.md
+++ b/plugins/omi-notion-app/README.md
@@ -123,3 +123,11 @@ When creating/updating the Omi app, use these URLs:
 ## Note on Page Permissions
 
 When users connect their Notion workspace, they must grant access to specific pages. The integration can only access pages that users have explicitly shared with it during the OAuth flow.
+
+## Regression tests
+
+Run `python3 plugins/omi-notion-app/test_main.py` from the repository root.
+The hermetic tests import the production module with framework/storage doubles
+and exercise `get_page` through its real HTTP helper: failed content retrieval
+must return a sanitized tool error, while empty and populated successful reads
+retain their output. No live workspace or credentials are used.

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -513,10 +513,6 @@ async def tool_get_page(request: Request):
 
         # Get page content (blocks)
         blocks = notion_api_request(uid, "GET", f"/blocks/{page_id}/children", params={"page_size": 50})
-        if not blocks or "error" in blocks:
-            status = blocks.get("status_code") if blocks else None
-            detail = f" (HTTP {status})" if isinstance(status, int) else ""
-            return ChatToolResponse(error=f"Failed to retrieve page content{detail}. Please try again.")
 
         title = extract_title(page)
         url = page.get("url", "")
@@ -536,6 +532,14 @@ async def tool_get_page(request: Request):
             result_parts.append(f"**URL:** {url}")
 
         result_parts.append(f"**Page ID:** `{page_id}`")
+
+        if not blocks or "error" in blocks:
+            status = blocks.get("status_code") if blocks else None
+            detail = f" (HTTP {status})" if isinstance(status, int) else ""
+            # Keep independently retrieved metadata, but never report a failed
+            # content read as a successful empty page (including archived pages).
+            metadata = "\n".join(result_parts)
+            return ChatToolResponse(error=f"Failed to retrieve page content{detail}. Please try again.\n\n{metadata}")
 
         # Add content if available
         if blocks and "results" in blocks:

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -513,6 +513,10 @@ async def tool_get_page(request: Request):
 
         # Get page content (blocks)
         blocks = notion_api_request(uid, "GET", f"/blocks/{page_id}/children", params={"page_size": 50})
+        if not blocks or "error" in blocks:
+            status = blocks.get("status_code") if blocks else None
+            detail = f" (HTTP {status})" if isinstance(status, int) else ""
+            return ChatToolResponse(error=f"Failed to retrieve page content{detail}. Please try again.")
 
         title = extract_title(page)
         url = page.get("url", "")

--- a/plugins/omi-notion-app/test_main.py
+++ b/plugins/omi-notion-app/test_main.py
@@ -42,9 +42,15 @@ with patch.dict(sys.modules, stubs):
     spec.loader.exec_module(notion)
 
 class PageReadTests(unittest.TestCase):
-    def read(self, content_response):
+    def read(self, content_response, archived=False):
         metadata = Mock(status_code=200)
-        metadata.json.return_value = {"properties": {}, "id": "test-page"}
+        metadata.json.return_value = {
+            "properties": {"title": {"type": "title", "title": [{"plain_text": "Known title"}]}},
+            "id": "test-page", "archived": archived,
+            "url": "https://www.notion.so/test-page",
+            "created_time": "2026-09-01T00:00:00.000Z",
+            "last_edited_time": "2026-09-08T00:00:00.000Z",
+        }
         request = Mock(json=AsyncMock(return_value={"uid": "test-user", "page_id": "test-page"}))
         with patch.object(notion, "get_valid_access_token", return_value="test-placeholder"), patch.object(notion, "log"), patch.object(notion.requests, "get", side_effect=[metadata, content_response]) as get:
             result = asyncio.run(notion.tool_get_page(request))
@@ -58,13 +64,35 @@ class PageReadTests(unittest.TestCase):
                 with self.subTest(status=status, body=body):
                     result = self.read(Mock(status_code=status, text=body))
                     self.assertIsNone(result.result)
-                    self.assertEqual(result.error, f"Failed to retrieve page content (HTTP {status}). Please try again.")
+                    self.assertTrue(result.error.startswith(f"Failed to retrieve page content (HTTP {status}). Please try again."))
                     self.assertNotIn("private upstream response", result.error)
 
     def test_transport_failure_is_not_success(self):
         result = self.read(RuntimeError("private transport detail"))
         self.assertIsNone(result.result)
-        self.assertEqual(result.error, "Failed to retrieve page content. Please try again.")
+        self.assertTrue(result.error.startswith("Failed to retrieve page content. Please try again."))
+
+    def test_content_errors_retain_known_metadata_without_success(self):
+        # Separate metadata/content endpoints: errors must not erase a successful
+        # metadata read, or claim that unavailable content is an empty page.
+        for archived in (False, True):
+            for status in (404, 403, 429, 500, None):
+                with self.subTest(archived=archived, status=status):
+                    response = (Mock(status_code=status, text="private upstream response")
+                                if status else RuntimeError("private transport detail"))
+                    result = self.read(response, archived=archived)
+                    self.assertIsNone(result.result)
+                    self.assertIn("Failed to retrieve page content", result.error)
+                    if status:
+                        self.assertIn(f"HTTP {status}", result.error)
+                    self.assertIn("**Known title**", result.error)
+                    self.assertIn("**Status:** Archived" if archived else "**Status:** Active", result.error)
+                    self.assertIn("**URL:** https://www.notion.so/test-page", result.error)
+                    self.assertIn("**Created:** 2026-09-01", result.error)
+                    self.assertIn("**Last Edited:** 2026-09-08", result.error)
+                    self.assertIn("**Page ID:** `test-page`", result.error)
+                    self.assertNotIn("**Content:**", result.error)
+                    self.assertNotIn("private", result.error)
 
     def test_successful_empty_and_nonempty_content(self):
         for text in ("", "Useful page content"):
@@ -73,7 +101,7 @@ class PageReadTests(unittest.TestCase):
                 response.json.return_value = {"results": [] if not text else [{"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": text}]}}]}
                 result = self.read(response)
                 self.assertIsNone(result.error)
-                self.assertIn("**Untitled**", result.result)
+                self.assertIn("**Known title**", result.result)
                 self.assertEqual("**Content:**" in result.result, bool(text))
                 if text:
                     self.assertIn(text, result.result)

--- a/plugins/omi-notion-app/test_main.py
+++ b/plugins/omi-notion-app/test_main.py
@@ -1,0 +1,82 @@
+"""Hermetic production-handler tests; HTTP, framework and token storage are doubles."""
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+class Framework:
+    def __init__(self, *args, **kwargs):
+        pass
+    def get(self, *args, **kwargs):
+        return lambda function: function
+    post = get
+
+class Response:
+    result = None
+    error = None
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+def module(name, **attributes):
+    value = types.ModuleType(name)
+    value.__dict__.update(attributes)
+    return value
+
+stubs = {
+    "requests": module("requests", get=Mock()),
+    "dotenv": module("dotenv", load_dotenv=lambda: None),
+    "fastapi": module("fastapi", FastAPI=Framework, Request=Framework, Query=Framework, HTTPException=Exception),
+    "fastapi.responses": module("fastapi.responses", HTMLResponse=Framework, RedirectResponse=Framework, JSONResponse=Framework),
+    "models": module("models", ChatToolResponse=Response),
+    "db": module("db", **{name: Mock() for name in (
+        "store_notion_tokens", "get_notion_tokens", "update_notion_tokens", "delete_notion_tokens",
+        "store_oauth_state", "get_oauth_state", "delete_oauth_state", "store_user_setting", "get_user_setting",
+    )}),
+}
+spec = importlib.util.spec_from_file_location("notion_under_test", Path(__file__).with_name("main.py"))
+notion = importlib.util.module_from_spec(spec)
+with patch.dict(sys.modules, stubs):
+    spec.loader.exec_module(notion)
+
+class PageReadTests(unittest.TestCase):
+    def read(self, content_response):
+        metadata = Mock(status_code=200)
+        metadata.json.return_value = {"properties": {}, "id": "test-page"}
+        request = Mock(json=AsyncMock(return_value={"uid": "test-user", "page_id": "test-page"}))
+        with patch.object(notion, "get_valid_access_token", return_value="test-placeholder"), patch.object(notion, "log"), patch.object(notion.requests, "get", side_effect=[metadata, content_response]) as get:
+            result = asyncio.run(notion.tool_get_page(request))
+        self.assertEqual(get.call_count, 2)
+        self.assertTrue(get.call_args.args[0].endswith("/blocks/test-page/children"))
+        return result
+
+    def test_failed_content_is_not_an_empty_success(self):
+        for status in (403, 429, 500):
+            for body in ("", "private upstream response"):
+                with self.subTest(status=status, body=body):
+                    result = self.read(Mock(status_code=status, text=body))
+                    self.assertIsNone(result.result)
+                    self.assertEqual(result.error, f"Failed to retrieve page content (HTTP {status}). Please try again.")
+                    self.assertNotIn("private upstream response", result.error)
+
+    def test_transport_failure_is_not_success(self):
+        result = self.read(RuntimeError("private transport detail"))
+        self.assertIsNone(result.result)
+        self.assertEqual(result.error, "Failed to retrieve page content. Please try again.")
+
+    def test_successful_empty_and_nonempty_content(self):
+        for text in ("", "Useful page content"):
+            with self.subTest(text=text):
+                response = Mock(status_code=200)
+                response.json.return_value = {"results": [] if not text else [{"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": text}]}}]}
+                result = self.read(response)
+                self.assertIsNone(result.error)
+                self.assertIn("**Untitled**", result.result)
+                self.assertEqual("**Content:**" in result.result, bool(text))
+                if text:
+                    self.assertIn(text, result.result)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Fixes #13181.

Failed Notion page-content reads return a sanitized hard error rather than an empty successful page. The error preserves independently retrieved title, dates, status, URL and page ID, including for archived pages. `result` remains unset. Successful reads are unchanged; no retry, OAuth, pagination, write or API-version changes.

Failure-Class: FC-decoded-outcome-discarded-before-canonical-record

## Verification
- Real production `tool_get_page` and `notion_api_request` execute with HTTP/framework/storage doubles.
- Initial fix: 7 failures on unchanged main. Review correction: 10 failures on published `abcfb3ab4a33a1640413d2b2ba9cfac196e674a4`; all 4 tests / 19 cases pass after correction.
- Covers active/archived metadata followed by 404/403/429/500/transport errors, error privacy, and empty/populated success controls.
- The suite is registered in the shared local/CI manifest. This tests the existing handler boundary and incident #13181, not a new shared primitive.
- `make preflight` and explicit PR-body preflight: all 14 selected local checks pass. Shallow-history ratchets skip unavailable history; full-history CI remains authoritative.
- `git diff --check`: pass.
- No live Notion workspace, HTTP routing, Redis or OAuth validation; no live writes or credentials used.

## Review correction
[Page retrieval](https://developers.notion.com/reference/retrieve-a-page) returns properties separately from [block children](https://developers.notion.com/reference/get-block-children). A failed content read must not erase successfully retrieved metadata or imply successful empty content. The tests inject these separate documented endpoint outcomes; they are not live archived-page captures. The docs do not establish that archived pages universally return 404, so there is no blanket archived-page error bypass. This remains a hard error, not degraded continuation or fallback.

GitHub workflows on the previous head were `action_required`, not verified CI passes.

## Product invariants affected
None (path-based suggestion).

The issue's suggested $25 reward remains unconfirmed; no award or payment is claimed.
