### PR TITLE
fix(desktop): translation detection cache collides on conf: prefixed text (#13267)

### DIFF
--- a/backend/tests/unit/test_translation_optimization.py
+++ b/backend/tests/unit/test_translation_optimization.py
@@ -9,10 +9,12 @@ from utils.translation import (
     TranslationService,
     TranslationStatus,
     classify_translation_need,
+    detect_language,
     detect_language_with_confidence,
     split_into_sentences,
 )
 from utils.translation_cache import should_persist_translation
+from utils.translation_language import detection_cache
 
 
 def test_sentence_splitter_preserves_abbreviations_and_decimals():
@@ -63,6 +65,26 @@ def test_confident_language_detection_handles_short_fillers_and_real_text():
     )
     assert language == 'en'
     assert confidence > 0.5
+
+
+def test_language_detection_cache_keys_do_not_collide_for_conf_prefixed_text():
+    """detect_language and detect_language_with_confidence share detection_cache; their keys
+    must not overlap even when a caller's raw text happens to start with 'conf:'."""
+    detection_cache.clear()
+    text = 'The weather forecast predicts sunshine tomorrow across the region'
+
+    # Prime the plain cache with the literal string that the confidence API used to key on.
+    detect_language('conf:' + text, remove_non_lexical=False)
+
+    language, confidence = detect_language_with_confidence(text, remove_non_lexical=False)
+    assert isinstance(language, str)
+    assert isinstance(confidence, float)
+
+    # And the reverse order: confidence result must not leak into the plain string API.
+    detection_cache.clear()
+    detect_language_with_confidence(text, remove_non_lexical=False)
+    plain_result = detect_language('conf:' + text, remove_non_lexical=False)
+    assert plain_result is None or isinstance(plain_result, str)
 
 
 @pytest.mark.parametrize(

--- a/backend/utils/translation_language.py
+++ b/backend/utils/translation_language.py
@@ -12,8 +12,10 @@ from langdetect.lang_detect_exception import LangDetectException
 
 from models.transcript_segment import SENTENCE_FINDALL_RE
 
-# LRU Cache for language detection (local, free via langdetect)
-detection_cache: "OrderedDict[str, Union[str, Tuple[str, float]]]" = OrderedDict()
+# LRU Cache for language detection (local, free via langdetect).
+# Keys are (kind, text) tuples so plain and confidence-scored results never collide,
+# even when raw text happens to look like the other API's string cache key.
+detection_cache: "OrderedDict[Tuple[str, str], Union[str, Tuple[str, float]]]" = OrderedDict()
 MAX_DETECTION_CACHE_SIZE = 1000
 
 # A set of common English non-lexical utterances that can confuse language detectors.
@@ -225,16 +227,17 @@ def detect_language(text: str, remove_non_lexical: bool = False, hint_language: 
     if not text_for_detection:
         return None
 
-    if text_for_detection in detection_cache:
-        detection_cache.move_to_end(text_for_detection)
-        return cast(str, detection_cache[text_for_detection])
+    cache_key = ('lang', text_for_detection)
+    if cache_key in detection_cache:
+        detection_cache.move_to_end(cache_key)
+        return cast(str, detection_cache[cache_key])
 
     detected_language = _detect_with_langdetect(text_for_detection, hint_language)
 
     if detected_language:
         if len(detection_cache) >= MAX_DETECTION_CACHE_SIZE:
             detection_cache.popitem(last=False)
-        detection_cache[text_for_detection] = detected_language
+        detection_cache[cache_key] = detected_language
         return detected_language
 
     return detected_language
@@ -276,7 +279,7 @@ def detect_language_with_confidence(
         return (None, 0.0)
 
     # Check cache first (reuse existing detection_cache)
-    cache_key = f"conf:{text_for_detection}"
+    cache_key = ('conf', text_for_detection)
     if cache_key in detection_cache:
         detection_cache.move_to_end(cache_key)
         return cast(Tuple[str, float], detection_cache[cache_key])


### PR DESCRIPTION
## Summary
- `detection_cache` in `backend/utils/translation_language.py` is shared between `detect_language()` (keyed on raw text) and `detect_language_with_confidence()` (keyed on `"conf:" + text`). Ordinary text that literally starts with `conf:` collides between the two namespaces: one API can return the other's cached value, and unpacking a bare string as a `(lang, confidence)` tuple raises `TypeError`.
- Fixes #13267.

## Root cause
Two independent lookup APIs shared one `OrderedDict` with overlapping string-key namespaces (`text` vs `"conf:" + text`). A collision is possible whenever the raw input text happens to start with the reserved prefix.

## Fix
Key both APIs with structural `(kind, text)` tuples (`('lang', text)` / `('conf', text)`) instead of string concatenation, so the two caches can never collide by construction. No behavior change for non-colliding input.

## Failure class
Failure-Class: none

## Testing
`BACKEND_UNIT_TEST_FILE_LIST=tests/unit/test_translation_optimization.py bash test.sh` — 39 passed, including new regression test `test_language_detection_cache_keys_do_not_collide_for_conf_prefixed_text`. Verified the new test fails with `AssertionError` (wrong return type) against the pre-fix source and passes after the fix.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

