### PR TITLE
chore(notifications-job): give the cron 2Gi so shadow selection can finish

### DIFF
--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -166,7 +166,7 @@ jobs:
           # Secret Manager binding (no-op on a clean target).
           flags: >-
             ${{ steps.runtime-env.outputs.cloud_run_flags }}
-            --task-timeout=3600s
+            ${{ steps.runtime-env.outputs.notifications_job_flags }}
             --remove-env-vars=MEMORY_MODE,MEMORY_ENABLED_USERS,MEMORY_V3_GET_ENABLED,MEMORY_CANONICAL_MAINTENANCE_ENABLED,MEMORY_CANONICAL_CONSOLIDATION_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_INTERVAL_HOURS,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED,MEMORY_TYPESENSE_COLLECTION,TYPESENSE_HOST,TYPESENSE_HOST_PORT,TYPESENSE_API_KEY,HOSTED_PUSHER_API_URL,${{ steps.runtime-env.outputs.notifications_job_secret_names }}
 
       # If required, use the Cloud Run url output in later steps

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -996,6 +996,7 @@ environments:
         notifications-job:
           flags:
             --task-timeout: 3600s
+            --memory: 2Gi
           secrets:
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
@@ -2222,6 +2223,7 @@ environments:
         notifications-job:
           flags:
             --task-timeout: 3600s
+            --memory: 2Gi
           secrets:
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -623,6 +623,7 @@ environment_shared:
       notifications-job:
         flags:
           --task-timeout: 3600s
+          --memory: 2Gi
         secrets:
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret: OMI_LLM_GATEWAY_SERVICE_TOKEN

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -259,6 +259,8 @@ def test_dev_runtime_manifest_contains_no_removed_first_user_or_capture_admissio
         'PINECONE_API_KEY',
         'OMI_LLM_GATEWAY_SERVICE_TOKEN',
     }
+    assert notifications_job['flags']['--memory'] == '2Gi'
+    assert notifications_job['flags']['--task-timeout'] == '3600s'
 
 
 def test_notifications_deploy_uses_verified_gateway_endpoint_and_vpc_flags():
@@ -364,6 +366,7 @@ def test_notifications_job_workflow_passes_vpc_vars_and_checkout_sha():
     assert 'git rev-parse --short=7 HEAD' in text
     assert 'short_sha=${GITHUB_SHA::7}' not in text
     assert 'render_backend_runtime_env.py --env ${{ vars.ENV }} --job notifications-job' in text
+    assert '${{ steps.runtime-env.outputs.notifications_job_flags }}' in text
     assert 'env_vars_update_strategy: overwrite' not in text
     assert 'secrets_update_strategy: overwrite' not in text
     assert (


### PR DESCRIPTION
## What changed and why

Prod `notifications-job` at 512Mi OOM-kills during `send_daily_notification` (three shadow-image lock holders: `bn4sl`, `4d69x`, `j9r2n`) before `send_daily_summary_notification` can emit `daily_summary_selection_shadow`. Pin the job at 2Gi in the runtime-env contract and deploy that flag through `notifications_job_flags` so the next GitHub deploy cannot revert live capacity. Follow-up to #13213 / #13210.

## Product invariants affected

- INV-MEM-4
- INV-DATA-1

## How it was verified

- `python3 backend/deploy/compose_runtime_env.py` and `bash backend/scripts/check_runtime_env_compose.sh`
- `python3 backend/scripts/validate-backend-runtime-env.py --env prod --check-workflows`
- `python3 backend/scripts/validate-backend-runtime-env.py --env dev --check-workflows`
- `pytest backend/tests/unit/test_render_backend_runtime_env.py backend/tests/unit/test_notifications_job_orchestrator.py backend/tests/unit/test_backend_runtime_env_validator.py`
- Live prod job already updated to 2Gi via `gcloud run jobs update`; image remains `ca79229`, `DAILY_SUMMARY_SELECTION_MODE=shadow`

## Tests

Pin `--memory: 2Gi` on the composed notifications-job and that `gcp_notifications_job.yml` passes `notifications_job_flags`.

## Failure class (fixes)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

