### PR TITLE
chore(notifications-job): cut daily-summary selection over to indexed

### DIFF
--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1022,7 +1022,7 @@ environments:
               value: 'true'
               category: memory_rollout
             DAILY_SUMMARY_SELECTION_MODE:
-              value: shadow
+              value: indexed
               category: rollout
             PINECONE_INDEX_NAME:
               category: integrations
@@ -2249,7 +2249,7 @@ environments:
               value: 'true'
               category: memory_rollout
             DAILY_SUMMARY_SELECTION_MODE:
-              value: shadow
+              value: indexed
               category: rollout
             PINECONE_INDEX_NAME:
               category: integrations

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -487,7 +487,7 @@ overlay:
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware
           DAILY_SUMMARY_SELECTION_MODE:
-            value: shadow
+            value: indexed
             category: rollout
           PINECONE_INDEX_NAME:
             value: memories-backend-dev

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -401,7 +401,7 @@ overlay:
           OMI_BACKGROUND_FLEX_CAPABLE:
             value: 'true'
           DAILY_SUMMARY_SELECTION_MODE:
-            value: shadow
+            value: indexed
             category: rollout
           PINECONE_INDEX_NAME:
             value: memories-backend


### PR DESCRIPTION
## What changed and why

Shadow gate passed on prod (`notifications-job-rfpln` and `notifications-job-zdbjl`): every hour had `only_legacy=0 only_indexed=0`, `daily_summary_job_summary complete=True`, no `daily_summary_selection_shadow_failed`. Flip prod and dev `notifications-job` to `DAILY_SUMMARY_SELECTION_MODE=indexed` so both stop the full legacy `users` scan against the shared `based-hardware` data plane. Follow-up to #13213 / #13210.

## Product invariants affected

- INV-MEM-4

## How it was verified

- Two scheduled prod executions after the 2Gi bump: `rfpln` (08:02Z) and `zdbjl` (08:06Z). All 24 hour lines matched; attempted=168 succeeded=168.
- `compose_runtime_env.py` + `check_runtime_env_compose.sh`
- `validate-backend-runtime-env.py --env prod|dev --check-workflows`

## Tests

No test change: mode is already unit-tested. This is the runtime-env cutover.

## Failure class (fixes)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

