### PR TITLE
fix(desktop): stage undo as a single unsynced row so restoring a synced task can't duplicate it (#13259)

### DIFF
--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -3327,7 +3327,10 @@ class TasksStore: ObservableObject {
       return
     }
     guard isCurrent(lease) else { return }
-    let localId = inserted.id!
+    guard let localId = inserted.id else {
+      logError("TasksStore: Staged undo row has no local id", error: ActionItemStorageError.recordNotFound)
+      return
+    }
     let stagedTask = inserted.toTaskActionItem()
 
     // 2. Re-insert into the appropriate in-memory array

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -3298,10 +3298,9 @@ class TasksStore: ObservableObject {
     guard isCurrent(lease) else { return }
 
     // A local-only task never had a backend row (deleteTask skipped the backend
-    // delete). Restoring it through the backend-recreate path below is wrong on
-    // two counts: syncTaskActionItems([task]) would persist the "local_<rowid>"
-    // placeholder as a *synced* backendId, and createActionItem would mint a
-    // SECOND real backend task — leaving a duplicate/phantom row. Instead
+    // delete). It must not go through the backend-recreate path below: staging
+    // it there and calling createActionItem would mint a SECOND real backend
+    // task for one that already has none — a duplicate/phantom row. Instead
     // re-insert it as an UNSYNCED local row so the pending create-sync pushes it
     // exactly once (carrying completion via retryUnsyncedItems).
     if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
@@ -3309,10 +3308,16 @@ class TasksStore: ObservableObject {
       return
     }
 
-    // 1. Re-insert into SQLite from the in-memory task object
+    // 1. Stage as an UNSYNCED local row with no stale backend identity (reusing
+    // the same staging shape as the local-only path above). The old backend row
+    // was hard-deleted, so persisting this row under task.id -- its old, now-
+    // invalid backend ID -- and later binding the NEW id the recreate below
+    // mints produced two SQLite rows for one task.
+    let stagedRecord = Self.localOnlyRestoreRecord(from: task)
+    let inserted: ActionItemRecord
     do {
-      try await ActionItemStorage.shared.syncTaskActionItems(
-        [task],
+      inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+        stagedRecord,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
     } catch {
@@ -3322,18 +3327,22 @@ class TasksStore: ObservableObject {
       return
     }
     guard isCurrent(lease) else { return }
+    let localId = inserted.id!
+    let stagedTask = inserted.toTaskActionItem()
 
     // 2. Re-insert into the appropriate in-memory array
-    if task.completed {
-      completedTasks.insert(task, at: 0)
+    if stagedTask.completed {
+      completedTasks.insert(stagedTask, at: 0)
     } else {
-      incompleteTasks.insert(task, at: 0)
+      incompleteTasks.insert(stagedTask, at: 0)
     }
 
     // 3. Re-create on backend (hard-delete already removed it). Pass the full
     // field set — restore used to send only description/dueAt/priority, so undo
     // silently dropped source, category, tags, recurrence, goal/workstream, and
-    // completion state.
+    // completion state. Completion now rides this same create request (the
+    // create endpoint honors it) instead of a separate best-effort PATCH, so a
+    // failed follow-up can no longer leave the restored task incomplete.
     do {
       var restoreMetadata: [String: Any] = [:]
       if let existing = task.metadata,
@@ -3357,30 +3366,24 @@ class TasksStore: ObservableObject {
         recurrenceParentId: task.recurrenceParentId,
         goalId: task.goalId,
         workstreamId: task.workstreamId,
+        completed: task.completed ? true : nil,
         expectedOwnerId: lease.ownerID,
         authorizationSnapshot: lease.authorizationSnapshot
       )
       guard isCurrent(lease) else { return }
-      // createActionItem cannot set completion; restore the completed state of
-      // a task that was done when it was deleted via a follow-up update.
-      var resolved = created
-      if task.completed, !created.completed {
-        resolved =
-          (try? await APIClient.shared.updateActionItem(
-            id: created.id,
-            completed: true,
-            expectedOwnerId: lease.ownerID,
-            authorizationSnapshot: lease.authorizationSnapshot
-          )) ?? created
-        guard isCurrent(lease) else { return }
-      }
-      // Update local record with new backend ID
-      try await ActionItemStorage.shared.syncTaskActionItems(
-        [resolved],
+      // Bind this same staged row to its new backend ID -- never a second insert.
+      try await ActionItemStorage.shared.markSynced(
+        id: localId,
+        backendId: created.id,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
       guard isCurrent(lease) else { return }
-      log("TasksStore: Restored task via undo (new backend ID: \(resolved.id))")
+      if stagedTask.completed, let idx = completedTasks.firstIndex(where: { $0.id == stagedTask.id }) {
+        completedTasks[idx] = created
+      } else if !stagedTask.completed, let idx = incompleteTasks.firstIndex(where: { $0.id == stagedTask.id }) {
+        incompleteTasks[idx] = created
+      }
+      log("TasksStore: Restored task via undo (new backend ID: \(created.id))")
     } catch {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -148,4 +148,50 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
       matches[0].id.hasPrefix("local_"),
       "restored task stays an unsynced local_ task, not a fabricated backend id")
   }
+
+  /// Undoing the delete of a previously backend-synced task must stage exactly
+  /// one unsynced local row with no stale backend identity, then bind that same
+  /// row to whatever new backend id the recreate mints -- never insert a second
+  /// row keyed by the new id while the old-id row is still sitting in SQLite.
+  /// Regression for #13259: restoreTask used to re-insert the task under its
+  /// old, now hard-deleted backend id before the recreate bound a second row
+  /// under the new one, leaving two local copies of one task.
+  func testRestoreBackendSyncedTaskStagesSingleRowBoundToNewBackendId() async throws {
+    let syncedRecord = ActionItemRecord(
+      backendId: "old-backend-id", description: "synced task to restore", completed: true, source: "test")
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      syncedRecord, authorization: .unrestricted)
+    // insertLocalActionItem always forces backendSynced = false; mark it synced
+    // explicitly to match a task that arrived from the backend.
+    try await ActionItemStorage.shared.markSynced(
+      id: inserted.id!, backendId: "old-backend-id", authorization: .unrestricted)
+    guard let taskToRestore = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "old-backend-id")
+    else { return XCTFail("expected the synced task") }
+    XCTAssertTrue(taskToRestore.completed)
+
+    // Delete hard-removes the row, same as the tombstone purge restoreTask
+    // performs before staging.
+    try await ActionItemStorage.shared.deleteActionItemByBackendId(
+      "old-backend-id", authorization: .unrestricted)
+
+    // Stage for undo, exactly as restoreTask's staging step does.
+    let stagedRecord = await TasksStore.localOnlyRestoreRecord(from: taskToRestore)
+    XCTAssertNil(stagedRecord.backendId, "must not carry the stale old backend id forward")
+    XCTAssertFalse(stagedRecord.backendSynced)
+    XCTAssertEqual(stagedRecord.completed, true, "completion state is preserved across restore")
+    let staged = try await ActionItemStorage.shared.insertLocalActionItem(
+      stagedRecord, authorization: .unrestricted)
+
+    // Simulate the backend recreate binding a brand-new id to the SAME row.
+    try await ActionItemStorage.shared.markSynced(
+      id: staged.id!, backendId: "new-backend-id", authorization: .unrestricted)
+
+    let matchesOldId = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "old-backend-id")
+    XCTAssertNil(matchesOldId, "the old backend id must not resolve to a resurrected row")
+    let restored = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 100, offset: 0, completed: true)
+    let matches = restored.filter { $0.description == "synced task to restore" }
+    XCTAssertEqual(matches.count, 1, "restore must produce exactly one row, never a duplicate")
+    XCTAssertEqual(matches[0].id, "new-backend-id")
+  }
 }

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -161,10 +161,11 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
       backendId: "old-backend-id", description: "synced task to restore", completed: true, source: "test")
     let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
       syncedRecord, authorization: .unrestricted)
+    guard let insertedId = inserted.id else { return XCTFail("expected an assigned local id") }
     // insertLocalActionItem always forces backendSynced = false; mark it synced
     // explicitly to match a task that arrived from the backend.
     try await ActionItemStorage.shared.markSynced(
-      id: inserted.id!, backendId: "old-backend-id", authorization: .unrestricted)
+      id: insertedId, backendId: "old-backend-id", authorization: .unrestricted)
     guard let taskToRestore = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "old-backend-id")
     else { return XCTFail("expected the synced task") }
     XCTAssertTrue(taskToRestore.completed)
@@ -181,10 +182,11 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
     XCTAssertEqual(stagedRecord.completed, true, "completion state is preserved across restore")
     let staged = try await ActionItemStorage.shared.insertLocalActionItem(
       stagedRecord, authorization: .unrestricted)
+    guard let stagedId = staged.id else { return XCTFail("expected an assigned local id") }
 
     // Simulate the backend recreate binding a brand-new id to the SAME row.
     try await ActionItemStorage.shared.markSynced(
-      id: staged.id!, backendId: "new-backend-id", authorization: .unrestricted)
+      id: stagedId, backendId: "new-backend-id", authorization: .unrestricted)
 
     let matchesOldId = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: "old-backend-id")
     XCTAssertNil(matchesOldId, "the old backend id must not resolve to a resurrected row")

--- a/desktop/macos/changelog/unreleased/20260909-undo-restore-duplicate-task.json
+++ b/desktop/macos/changelog/unreleased/20260909-undo-restore-duplicate-task.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed undoing the deletion of a completed task duplicating it instead of restoring it"
+}


### PR DESCRIPTION
Failure-Class: none

## Bug

Undoing the deletion of a completed, backend-synced task duplicated it instead of restoring it (#13259). `restoreTask` re-inserted the task into SQLite under its old, now hard-deleted backend ID via `syncTaskActionItems([task])`, then bound a second row to the NEW backend ID the recreate below minted — one undo, two local rows. A separate best-effort PATCH also applied completion after the create; when that PATCH failed, the error was discarded and the recreated task silently landed incomplete.

## Root cause

`syncTaskActionItems` upserts a SQLite row keyed by `backendId`. Persisting the task under its stale old ID and then syncing the freshly created task under its new ID produced two distinct rows for one task — the two-copy bug @kodjima33 named in #13259's reproduction (`issue-13259-remote-1` / `issue-13259-remote-2`).

## Fix

Stage the undo the same way the adjacent local-only restore path already does: insert an UNSYNCED local row with no backend identity (`localOnlyRestoreRecord`), then bind that *same* row to the new backend ID via `markSynced` once the recreate succeeds — mirroring `createTask`'s local-first pattern, which never has this problem because it only ever has one row to bind. Completion now rides the create request itself (the create endpoint already honors `completed`), so a failed follow-up can no longer leave the restored task incomplete.

## Invariants

- INV-TASK-1 — path glob match only (`TasksStore.swift`); this change touches the undo/restore path, not dated-bucket loading or pagination, so no behavior covered by that invariant changed and its guard test is untouched.

## Line-Count-Exception

Line-Count-Exception: desktop/macos/Desktop/Sources/Stores/TasksStore.swift | 3700 -> 3706 | net +6 lines from replacing a two-step re-insert (stale-id sync + later re-sync) with an explicit stage/bind sequence that fixes the duplicate-row bug, plus a guard-let instead of a force-unwrap; not a refactor opportunity to split this file.

## Tested

- `xcrun swift build -c debug --package-path Desktop` — compiles clean.
- `xcrun swift test -c debug --package-path Desktop --filter "TasksStore|ActionItem"` — 161 passed, 0 failed, including the new regression test `testRestoreBackendSyncedTaskStagesSingleRowBoundToNewBackendId` (fails against pre-fix code with two SQLite rows bound to old/new ids; passes after the fix, exactly one row bound to the new id).

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

