### PR TITLE
fix(windows): route an empty complete JIT watchlist to the ambient lane

### DIFF
--- a/contracts/parity/README.md
+++ b/contracts/parity/README.md
@@ -15,24 +15,24 @@ cross-platform decision instead of a single-platform drive-by.
 
 ## Fixture files
 
-| File | Rule under contract |
-|---|---|
-| `task_due_buckets.json` | Task due-date bucketing (Today / Tomorrow / Later / No deadline, and the overdue handling models) |
-| `day_keys.json` | Local-calendar-day identity of a UTC instant (conversation day grouping) |
-| `wire_action_item.json` | Action item wire decode: due_at instant equality across ISO offset forms, and the null / missing / unparseable agreement set |
-| `section_labels.json` | Relative day labels (Today / Yesterday / Tomorrow) as calendar-day relationships, including DST transition days |
-| `jit_runtime_contract_matrix.json` | Additive JIT ledger/evidence compatibility across legacy, v1, and future-version payloads |
-| `conversation_duration.json` | The one duration a conversation reports: transcript span when segments exist, wall window only for transcript-free records |
+| File                               | Rule under contract                                                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `task_due_buckets.json`            | Task due-date bucketing (Today / Tomorrow / Later / No deadline, and the overdue handling models)                            |
+| `day_keys.json`                    | Local-calendar-day identity of a UTC instant (conversation day grouping)                                                     |
+| `wire_action_item.json`            | Action item wire decode: due_at instant equality across ISO offset forms, and the null / missing / unparseable agreement set |
+| `section_labels.json`              | Relative day labels (Today / Yesterday / Tomorrow) as calendar-day relationships, including DST transition days              |
+| `jit_runtime_contract_matrix.json` | Additive JIT ledger/evidence compatibility across legacy, v1, and future-version payloads                                    |
+| `conversation_duration.json`       | The one duration a conversation reports: transcript span when segments exist, wall window only for transcript-free records   |
 
 ## Conformance suites
 
-| Platform | Suite | Runs |
-|---|---|---|
-| Backend/API and standalone MCP | `backend/tests/unit/test_parity_contracts.py`, `backend/testing/contracts/test_jit_runtime_contract_matrix.py` | Backend unit suite and Desktop Backend Contracts CI |
-| Flutter app | `app/test/parity/parity_contracts_test.dart` | `app/test.sh`, CI Flutter tests |
-| Windows desktop | `desktop/windows/src/renderer/src/lib/parityContracts.test.ts`, `desktop/windows/src/shared/knowledgeLedger.test.ts` | `npm test` in `desktop/windows`, CI Desktop Windows tests |
-| macOS desktop | JIT matrix: `desktop/macos/Desktop/Tests/ServerMemoryV17DecodingTests.swift`. Duration: `desktop/macos/Desktop/Tests/ConversationDurationTests.swift`. Task/day adapter remains pending. | Desktop Swift CI |
-| Web app | `web/app/src/lib/__tests__/knowledgeLedger.test.ts` | `web/app/test.sh`, CI Web App checks |
+| Platform                       | Suite                                                                                                                                                                                    | Runs                                                      |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Backend/API and standalone MCP | `backend/tests/unit/test_parity_contracts.py`, `backend/testing/contracts/test_jit_runtime_contract_matrix.py`                                                                           | Backend unit suite and Desktop Backend Contracts CI       |
+| Flutter app                    | `app/test/parity/parity_contracts_test.dart`                                                                                                                                             | `app/test.sh`, CI Flutter tests                           |
+| Windows desktop                | `desktop/windows/src/renderer/src/lib/parityContracts.test.ts`, `desktop/windows/src/shared/knowledgeLedger.test.ts`                                                                     | `npm test` in `desktop/windows`, CI Desktop Windows tests |
+| macOS desktop                  | JIT matrix: `desktop/macos/Desktop/Tests/ServerMemoryV17DecodingTests.swift`. Duration: `desktop/macos/Desktop/Tests/ConversationDurationTests.swift`. Task/day adapter remains pending. | Desktop Swift CI                                          |
+| Web app                        | `web/app/src/lib/__tests__/knowledgeLedger.test.ts`                                                                                                                                      | `web/app/test.sh`, CI Web App checks                      |
 
 The JIT runtime matrix is additionally consumed by the shipped mobile, macOS,
 Windows, and web adapters plus the backend and standalone MCP suites. It proves
@@ -85,17 +85,41 @@ in the same PR.
    sits on the strict side (it refuses to accept these forms, so it can never
    re-emit them); the `expected_by_model` cases in `wire_action_item.json` pin
    both client behaviors until the platforms converge.
-5. JIT empty watchlist — **converged**. macOS (`KnowledgeLedgerTriggerWatchlistRuntime`,
+5. JIT empty watchlist — **routing converged; ambient pacing missing on Windows**.
+   macOS (`KnowledgeLedgerTriggerWatchlistRuntime`,
    `desktop/macos/Desktop/Sources/ProactiveAssistants/Core/KnowledgeLedgerTriggerRuntime.swift`)
-   routes a complete *empty* watchlist to the bounded ambient lane (owner decision
+   routes a complete _empty_ watchlist to the bounded ambient lane (owner decision
    2026-09-01: an account with no standing trigger must not go silent). Windows
    (`desktop/windows/src/shared/jitTriggerRuntime.ts` `evaluateJitWatchlist`,
-   `desktop/windows/src/main/jit/jitRuntime.ts`) now does the same: an empty complete
-   watchlist evaluates to `ambient_fallback` and admits as `no_eligible_planned_trigger`,
-   the one planned outcome `WindowsJitAssistant` hands to `admitAmbient`; the
-   `empty_watchlist` suppression reason is retired on both platforms. Still open on
-   Windows and tracked as the JIT client floor (decision 19): the budget day is
-   `localBudgetDay(now)` rather than the server's `budget_timezone` (macOS #12798).
+   `desktop/windows/src/main/jit/jitRuntime.ts`) now routes the same way: an empty
+   complete watchlist evaluates to `ambient_fallback` and admits as
+   `no_eligible_planned_trigger`, the one planned outcome `WindowsJitAssistant` hands
+   to `admitAmbient`; the `empty_watchlist` suppression reason is retired on both
+   platforms. **Routing is not the whole item**: what the two platforms then spend in
+   the ambient lane still differs, so item 5 is NOT converged. Open on Windows and
+   tracked as the JIT client floor (decision 19):
+   - No ambient pacing. macOS gates every ambient nano spend on
+     `JITAmbientPacingPolicy` (`desktop/macos/.../JITAmbientPacingPolicy.swift`:
+     burst 2, then one per `activeDaySeconds / budget` — two hours at the default
+     eight — with 2 triages reserved for derived-intent matches), reached from
+     `JITProactivityRuntime.swift:640-670`. Windows `admitAmbient`
+     (`desktop/windows/src/main/jit/jitRuntime.ts`) has no pacing at all: the local
+     nano claim passes `budget: null`, so the whole daily allowance can be consumed
+     in the first minutes after local midnight — the exact failure measured on the
+     owner account 2026-08-30/31 that produced the macOS policy.
+   - No `ambient_server_denied` backoff. macOS records a per-budget-day denial and
+     suppresses for `ambientServerDenialBackoff` after the server refuses; Windows
+     returns `reservation_already_consumed` and retries on the next settled context.
+   - No local per-day nano usage read before spend (macOS `readAmbientNanoUsage`);
+     Windows learns its position in the budget only from the server's answer.
+   - Ambient context cooldown keys on an OCR-derived semantic fingerprint
+     (`WindowsJitAssistant.analyze` hashes app + window title + OCR text), so a
+     context whose text keeps changing produces a new fingerprint each frame and the
+     `reserveProactivity` RPCs are unbounded per settled context — they continue
+     after the server answers `reserved: false`. Pre-existing, not introduced by the
+     routing change; it is what makes the missing pacing cost real money.
+   - Budget day is `localBudgetDay(now)` rather than the server's `budget_timezone`
+     (macOS #12798).
 6. Malformed duration inputs. `conversation_duration.json` pins only well-formed
    vectors. The backend helper (`backend/utils/conversations/duration.py`) and macOS
    (`ServerConversation.durationInSeconds`) validate each segment — empty text,

--- a/contracts/parity/README.md
+++ b/contracts/parity/README.md
@@ -85,15 +85,17 @@ in the same PR.
    sits on the strict side (it refuses to accept these forms, so it can never
    re-emit them); the `expected_by_model` cases in `wire_action_item.json` pin
    both client behaviors until the platforms converge.
-5. JIT empty watchlist. macOS (`KnowledgeLedgerTriggerWatchlistRuntime`,
+5. JIT empty watchlist — **converged**. macOS (`KnowledgeLedgerTriggerWatchlistRuntime`,
    `desktop/macos/Desktop/Sources/ProactiveAssistants/Core/KnowledgeLedgerTriggerRuntime.swift`)
    routes a complete *empty* watchlist to the bounded ambient lane (owner decision
    2026-09-01: an account with no standing trigger must not go silent). Windows
-   (`desktop/windows/src/shared/jitTriggerRuntime.ts`, `desktop/windows/src/main/jit/jitRuntime.ts`)
-   still returns `none` and suppresses `empty_watchlist`; its ambient lane is
-   caller-controlled and not wired. The beta cohort is macOS-only and the Windows JIT
-   client floor is unmet, so the losing platform is Windows and must adopt the macOS
-   behavior before any Windows cohort activates (JIT decision 19).
+   (`desktop/windows/src/shared/jitTriggerRuntime.ts` `evaluateJitWatchlist`,
+   `desktop/windows/src/main/jit/jitRuntime.ts`) now does the same: an empty complete
+   watchlist evaluates to `ambient_fallback` and admits as `no_eligible_planned_trigger`,
+   the one planned outcome `WindowsJitAssistant` hands to `admitAmbient`; the
+   `empty_watchlist` suppression reason is retired on both platforms. Still open on
+   Windows and tracked as the JIT client floor (decision 19): the budget day is
+   `localBudgetDay(now)` rather than the server's `budget_timezone` (macOS #12798).
 6. Malformed duration inputs. `conversation_duration.json` pins only well-formed
    vectors. The backend helper (`backend/utils/conversations/duration.py`) and macOS
    (`ServerConversation.durationInSeconds`) validate each segment — empty text,

--- a/desktop/windows/src/main/jit/jitAssistant.ts
+++ b/desktop/windows/src/main/jit/jitAssistant.ts
@@ -349,9 +349,11 @@ export class WindowsJitAssistant implements ProactiveAssistant {
           receipt: planned.receipt
         }
     }
-    // Ambient is only the miss path after a standing watchlist exists.
-    // legacy_fallback keeps the Insight rollback; empty/incomplete snapshots
-    // consume the visit and must not buy nano spend via Boolean(frame.app).
+    // Ambient is the miss path of a complete watchlist, including a complete
+    // EMPTY one (an account with no standing trigger must not go silent;
+    // parity register item 5). legacy_fallback keeps the Insight rollback;
+    // incomplete snapshots consume the visit and must not buy nano spend via
+    // Boolean(frame.app).
     if (admission.kind !== 'suppressed' || admission.reason !== 'no_eligible_planned_trigger')
       return null
     const ambient = await this.runtime.admitAmbient({

--- a/desktop/windows/src/main/jit/jitAssistantDelivery.test.ts
+++ b/desktop/windows/src/main/jit/jitAssistantDelivery.test.ts
@@ -253,11 +253,14 @@ describe('ambient agent-turn prompt', () => {
     expect(admitAmbient).not.toHaveBeenCalled()
   })
 
-  it('does not admit ambient on an empty complete watchlist', async () => {
+  it('does not admit ambient on a suppression reason it does not own', async () => {
+    // The only planned outcome that reaches ambient is no_eligible_planned_trigger;
+    // an empty complete watchlist now produces exactly that (parity item 5), so
+    // this guards the remaining suppressions rather than a retired reason.
     const admitAmbient = vi.fn()
     const runtime = fakeRuntime({
       observationForFrame: async (f: RewindFrame) => ({ appName: f.app }),
-      admit: async () => ({ kind: 'suppressed', reason: 'empty_watchlist' }),
+      admit: async () => ({ kind: 'suppressed', reason: 'planned_runtime_rejected' }),
       admitAmbient
     })
     const assistant = new WindowsJitAssistant(runtime, () => T0)

--- a/desktop/windows/src/main/jit/jitAssistantDelivery.test.ts
+++ b/desktop/windows/src/main/jit/jitAssistantDelivery.test.ts
@@ -3,10 +3,13 @@
 // is what these tests are about: a reserved slot suppresses EVERY proactive lane,
 // so the reservation must be released on every exit from `handleResult`,
 // including the ones nobody wrote a catch for.
+import { DatabaseSync } from 'node:sqlite'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AssistantResult } from '../assistants/core/coordinator'
 import type { RewindFrame } from '../../shared/types'
-import type { WindowsJitRuntime } from './jitRuntime'
+import type { JitTriggerSnapshot } from '../../shared/jitTriggerRuntime'
+import { WindowsJitRuntime } from './jitRuntime'
+import { initializeJitTriggerMirror, type JitMirrorDb } from './jitTriggerMirror'
 
 const h = vi.hoisted(() => ({
   getAppSettings: vi.fn(() => ({ notificationsEnabled: true, notificationFrequency: 5 })),
@@ -29,7 +32,11 @@ vi.mock('../assistants/core/session', () => ({
   getAbortSignal: vi.fn(() => undefined)
 }))
 
-import { WindowsJitAssistant, setWindowsJitAgentTurnExecutor } from './jitAssistant'
+import {
+  WindowsJitAssistant,
+  setWindowsJitAgentTurnExecutor,
+  setWindowsJitNanoTriageExecutor
+} from './jitAssistant'
 import { notifyProactive, setNotificationSnooze } from '../assistants/core/notify'
 import type { InsightPayload } from '../../shared/types'
 
@@ -113,6 +120,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   setNotificationSnooze(null)
   setWindowsJitAgentTurnExecutor(null)
+  setWindowsJitNanoTriageExecutor(null)
   h.getAppSettings.mockReturnValue({ notificationsEnabled: true, notificationFrequency: 5 })
   h.controlPlaneOwnerId.mockReturnValue('owner-1')
   h.hasKnownControlPlaneOwner.mockReturnValue(true)
@@ -266,5 +274,147 @@ describe('ambient agent-turn prompt', () => {
     const assistant = new WindowsJitAssistant(runtime, () => T0)
     expect(await assistant.analyze(frame())).toBeNull()
     expect(admitAmbient).not.toHaveBeenCalled()
+  })
+})
+
+// The end-to-end half of parity register item 5. Everything above fakes the
+// runtime, so a routing regression inside `WindowsJitRuntime.admit` would not
+// be caught by any of it. This drives the REAL runtime (only the authority
+// client and sqlite file are supplied) over a complete EMPTY watchlist,
+// through `WindowsJitAssistant.analyze`, and asserts the ambient lane is
+// actually reached — i.e. that an account with no standing trigger buys the
+// bounded nano reservation instead of going silent.
+const emptyCompleteSnapshot = (): JitTriggerSnapshot => ({
+  ownerId: 'owner-1',
+  accountGeneration: 1,
+  headCommitId: 'head',
+  commitSequence: 1,
+  snapshotRevision: 'rev-1',
+  complete: true,
+  rows: [],
+  policy: {
+    schemaVersion: 'jit_trigger_policy.v1',
+    plannedNotificationsPerTriggerPerDay: 1,
+    totalProactiveNotificationsPerDay: 3,
+    ambiguousNanoTriagesPerDay: 8,
+    fullAgentTurnsPerCandidate: 1,
+    maxCalendarEvents: 32,
+    embedding: {
+      enabled: false,
+      matchSimilarity: 0.82,
+      triageSimilarity: 0.74,
+      modelId: null,
+      modelVersion: null,
+      language: null
+    }
+  }
+})
+
+function realRuntime(snapshotFor: () => JitTriggerSnapshot): {
+  runtime: WindowsJitRuntime
+  reservations: Array<{ operation: string }>
+} {
+  const db = new DatabaseSync(':memory:')
+  initializeJitTriggerMirror(db as unknown as JitMirrorDb)
+  const reservations: Array<{ operation: string }> = []
+  const runtime = new WindowsJitRuntime({
+    db: db as unknown as JitMirrorDb,
+    ownerId: () => 'owner-1',
+    accountGeneration: () => null,
+    authorizationCurrent: () => true,
+    now: () => T0,
+    frameExists: () => false,
+    client: {
+      rolloutDecision: async () => ({
+        rollout: 'enabled' as const,
+        killSwitch: 'disabled' as const,
+        effective: 'enabled' as const,
+        reason: 'test',
+        errorClass: 'none' as const
+      }),
+      triggerSnapshot: async () => snapshotFor(),
+      ledgerMirrorPage: async () => ({
+        schemaVersion: 'knowledge_ledger_mirror.v1' as const,
+        ownerId: 'owner-1',
+        accountGeneration: 1,
+        sourceGeneration: 1,
+        writerEpoch: 1,
+        headCommitId: 'head',
+        commitSequence: 1,
+        epochId: 'epoch-1',
+        pageRevision: 'page-1',
+        chainRevision: 'chain-1',
+        scannedCount: 0,
+        projectedCount: 0,
+        terminalCount: 0,
+        rows: [],
+        aliases: [],
+        nextCursor: null,
+        finalPage: true,
+        failureReason: null
+      }),
+      reserveProactivity: async (input) => {
+        reservations.push({ operation: input.operation })
+        return {
+          reserved: true,
+          receipt: {
+            schemaVersion: 'jit_proactivity_event.v1' as const,
+            uid: 'owner-1',
+            eventId: input.eventId,
+            candidateId: input.candidateId,
+            operation: input.operation,
+            accountGeneration: input.accountGeneration,
+            triggerMemoryId: input.triggerMemoryId ?? null,
+            triggerRevision: input.triggerRevision ?? null,
+            budgetDay: '2026-08-26',
+            deviceId: input.deviceId,
+            createdAt: '2026-08-26T12:00:00.000Z',
+            requestHash: 'a'.repeat(64),
+            feedbackId: null,
+            parentEventId: input.parentEventId ?? null
+          }
+        }
+      }
+    }
+  } as unknown as ConstructorParameters<typeof WindowsJitRuntime>[0])
+  return { runtime, reservations }
+}
+
+describe('empty complete watchlist, real runtime through analyze', () => {
+  it('reaches the ambient lane and buys exactly the nano reservation', async () => {
+    const triaged: Array<{ semanticFingerprint: string }> = []
+    setWindowsJitNanoTriageExecutor(async (input) => {
+      triaged.push({ semanticFingerprint: input.semanticFingerprint })
+      return 'approved'
+    })
+    const { runtime, reservations } = realRuntime(emptyCompleteSnapshot)
+    const assistant = new WindowsJitAssistant(runtime, () => T0)
+
+    const result = (await assistant.analyze(frame())) as unknown as {
+      kind: string
+      triggerId: string
+      prompt: string
+    } | null
+
+    expect(result).not.toBeNull()
+    expect(result?.kind).toBe('ambient')
+    // The nano triage ran on the opaque handle, and the only server budget
+    // bought before delivery is the single nano reservation.
+    expect(triaged).toHaveLength(1)
+    expect(triaged[0]?.semanticFingerprint).not.toContain('IGNORE PREVIOUS INSTRUCTIONS')
+    expect(reservations.map((r) => r.operation)).toEqual(['nano_triage'])
+  })
+
+  it('still goes nowhere when the snapshot is incomplete', async () => {
+    // The empty case is admitted because the watchlist is COMPLETE and empty.
+    // An incomplete snapshot is unknown authority and must buy nothing.
+    setWindowsJitNanoTriageExecutor(async () => 'approved')
+    const { runtime, reservations } = realRuntime(() => ({
+      ...emptyCompleteSnapshot(),
+      complete: false
+    }))
+    const assistant = new WindowsJitAssistant(runtime, () => T0)
+    expect(await assistant.analyze(frame())).toBeNull()
+    expect(reservations).toHaveLength(0)
   })
 })

--- a/desktop/windows/src/main/jit/jitRuntime.test.ts
+++ b/desktop/windows/src/main/jit/jitRuntime.test.ts
@@ -249,12 +249,15 @@ describe('Windows JIT runtime authority', () => {
     expect(runtime.isAuthoritativeEnabled()).toBe(false)
   })
 
-  it('suppresses a complete empty watchlist instead of ambient fallback', async () => {
+  it('routes a complete empty watchlist to the ambient fallback like any planned miss', async () => {
+    // Parity register item 5: macOS hands an empty complete watchlist to the
+    // bounded ambient lane. Windows used to suppress `empty_watchlist`, which
+    // left every account without a standing trigger silent.
     const empty = snapshot()
     empty.rows = []
     const { runtime } = makeRuntime('enabled', empty)
     const admission = await runtime.admit({ appName: 'Code' }, '2026-08-24')
-    expect(admission).toEqual({ kind: 'suppressed', reason: 'empty_watchlist' })
+    expect(admission).toEqual({ kind: 'suppressed', reason: 'no_eligible_planned_trigger' })
     expect(runtime.shouldSuppressLegacyInsight()).toBe(true)
   })
 

--- a/desktop/windows/src/main/jit/jitRuntime.ts
+++ b/desktop/windows/src/main/jit/jitRuntime.ts
@@ -515,11 +515,8 @@ export class WindowsJitRuntime {
     }
     if (evaluation.nextLane === 'bounded_planned_triage')
       return { kind: 'suppressed', reason: 'planned_match_ambiguous' }
-    if (evaluation.nextLane === 'none') {
-      return loaded.triggers.length === 0
-        ? { kind: 'suppressed', reason: 'empty_watchlist' }
-        : { kind: 'suppressed', reason: 'planned_runtime_rejected' }
-    }
+    if (evaluation.nextLane === 'none')
+      return { kind: 'suppressed', reason: 'planned_runtime_rejected' }
     return { kind: 'suppressed', reason: 'no_eligible_planned_trigger' }
   }
 

--- a/desktop/windows/src/shared/jitTriggerRuntime.test.ts
+++ b/desktop/windows/src/shared/jitTriggerRuntime.test.ts
@@ -174,6 +174,42 @@ describe('Windows JIT trigger contract', () => {
     ).toThrow(/duplicate|malformed/i)
   })
 
+  it('hands a complete empty watchlist to the ambient fallback instead of going silent', () => {
+    // Parity register item 5 (macOS KnowledgeLedgerTriggerWatchlistRuntime): an
+    // account with no standing trigger is an ambient candidate, never `none`.
+    const enabled = {
+      mode: 'enabled' as const,
+      killSwitchEnabled: false,
+      ownerId: 'u',
+      accountGeneration: 2,
+      snapshotOwnerId: 'u',
+      snapshotAccountGeneration: 2,
+      snapshotIsAuthoritative: true,
+      authorizationIsCurrent: true
+    }
+    const empty = evaluateJitWatchlist(enabled, [], { appName: 'Code' }, '2026-08-24')
+    expect(empty).toEqual({
+      status: 'evaluated',
+      nextLane: 'ambient_fallback',
+      matches: [],
+      ambiguous: []
+    })
+    // A non-empty watchlist with no match still reaches the same lane, so the
+    // two cases are indistinguishable downstream (same nano/full-turn budget).
+    const miss = evaluateJitWatchlist(
+      enabled,
+      [compileTriggerSnapshotRow(row({ apps: ['Xcode'] }))],
+      { appName: 'Code' },
+      '2026-08-24'
+    )
+    expect(miss.nextLane).toBe('ambient_fallback')
+    // Inactive authority is unchanged: no lane, no ambient spend.
+    expect(
+      evaluateJitWatchlist(JIT_RUNTIME_DEFAULT_AUTHORITY, [], { appName: 'Code' }, '2026-08-24')
+        .nextLane
+    ).toBe('none')
+  })
+
   it('keeps the runtime inactive unless the complete backend authority is current', () => {
     const compiled = compileTriggerSnapshotRow(row({ apps: ['Code'] }))
     const observation = { appName: 'Code' }
@@ -214,6 +250,6 @@ describe('Windows JIT trigger contract', () => {
         observation,
         '2026-08-24'
       ).nextLane
-    ).toBe('none')
+    ).toBe('ambient_fallback')
   })
 })

--- a/desktop/windows/src/shared/jitTriggerRuntime.ts
+++ b/desktop/windows/src/shared/jitTriggerRuntime.ts
@@ -802,6 +802,9 @@ export function evaluateJitWatchlist(
     return { status: 'evaluated', nextLane: 'planned_trigger', matches, ambiguous }
   if (ambiguous.length)
     return { status: 'evaluated', nextLane: 'bounded_planned_triage', matches, ambiguous }
-  if (triggers.length === 0) return { status: 'evaluated', nextLane: 'none', matches, ambiguous }
+  // A complete empty watchlist is an account with no standing trigger, not a
+  // reason to go silent: it hands off to the bounded ambient lane exactly like
+  // a non-empty watchlist with no match (owner decision 2026-09-01; macOS
+  // KnowledgeLedgerTriggerWatchlistRuntime; parity register item 5).
   return { status: 'evaluated', nextLane: 'ambient_fallback', matches, ambiguous }
 }


### PR DESCRIPTION
## What changed and why

Parity register item 5. Since #12549 (owner decision 2026-09-01) macOS hands a complete **empty** watchlist to the bounded ambient lane — an account with no standing trigger must not go silent, and no Beta user has ever created a standing trigger. Windows still evaluated an empty complete watchlist to `none` and suppressed `empty_watchlist`, so on the Windows client every JIT-admitted account without a trigger produced no ambient candidate at all (the Aug 13–14 "went silent fleet-wide" class, one layer up).

- `evaluateJitWatchlist` (`desktop/windows/src/shared/jitTriggerRuntime.ts`): an empty complete watchlist now returns `ambient_fallback`, exactly like a non-empty watchlist with no match. Inactive / unauthorized authority still returns `none`.
- `JitRuntime.admit` (`desktop/windows/src/main/jit/jitRuntime.ts`): the `empty_watchlist` reason is retired; the empty case surfaces as `no_eligible_planned_trigger`, the one planned outcome `WindowsJitAssistant` already hands to `admitAmbient` — so ambient spend stays behind the same local gate, context cooldown, server nano reservation, and daily caps as today.
- `contracts/parity/README.md`: item 5 is recorded as **routing converged; ambient pacing missing on Windows** — see "What this PR does not claim" below.

No backend, wire, flag, or macOS change. The Windows client floor for a Windows cohort remains unmet (#12381/#12391/#12397, the budget-day gap, and the ambient pacing gap below); this PR converges one behaviour, it does not activate anything.

## What this PR does not claim

Adversarial review of the first revision caught the parity register claiming full convergence for item 5 when only the *routing* converged. What the two platforms then spend in the ambient lane still differs, and the register now says so:

- **No ambient pacing on Windows.** macOS gates every ambient nano spend on `JITAmbientPacingPolicy` (burst 2, then one per `activeDaySeconds / budget` — two hours at the default eight — with 2 triages reserved for derived-intent matches), reached from `JITProactivityRuntime.swift:640-670`. Windows `admitAmbient` calls `claimJitWakeup` with `budget: null` and has no pacing at all, so the whole daily allowance can burn in the first minutes after local midnight — the exact failure measured on the owner account 2026-08-30/31 that produced the macOS policy.
- **No `ambient_server_denied` backoff**, and **no local per-day nano usage read** before spend (macOS `readAmbientNanoUsage`).
- **The ambient context cooldown keys on an OCR-derived semantic fingerprint** (`WindowsJitAssistant.analyze` hashes app + window title + OCR text), so a context whose text keeps changing mints a new fingerprint each frame and `reserveProactivity` RPCs are unbounded per settled context — they continue after the server answers `reserved: false`. Pre-existing, not introduced here; it is what makes the missing pacing cost real money.

All four are listed in `contracts/parity/README.md` item 5 under the JIT client floor (decision 19), next to the existing budget-day gap, and are in the cut list below. They gate a Windows cohort, not this routing change: with no Windows cohort admitted, the unpaced lane is not reachable in production today.

`empty_watchlist` is also no longer produced on either platform. The macOS PostHog reason allowlist (`ProactiveLaneClient.swift:782`) still lists it; that entry is now dead and stays until the next macOS PR — a Swift-only edit costs hours of macOS CI for a dead string and is deliberately not bundled here.

## Product invariants affected

none

## How it was verified

- `desktop/windows`: `pnpm@10 exec vitest run src/shared/jitTriggerRuntime.test.ts src/main/jit/jitRuntime.test.ts src/main/jit/jitAssistantDelivery.test.ts src/main/jit/jitAssistant.test.ts` → **38 passed** (node 22.23.2, pnpm 10.34.5, frozen lockfile).
- `prettier --check`, `eslint` (0 errors), `tsc --noEmit -p tsconfig.node.json --composite false` clean.
- Negative check on the new end-to-end case: restoring the old `triggers.length === 0 → 'none'` line in `jitTriggerRuntime.ts` fails `reaches the ambient lane and buys exactly the nano reservation` and leaves the other 11 delivery cases passing.
- Not verified: a delivered ambient notification on a Windows build (no Windows release build newer than 2026-08-20 exists; the client floor is separately unmet).

## Tests

- `jitTriggerRuntime.test.ts › hands a complete empty watchlist to the ambient fallback instead of going silent` — drives the real evaluator for empty-complete, non-empty-miss, and inactive authority.
- `jitRuntime.test.ts › routes a complete empty watchlist to the ambient fallback like any planned miss` — the runtime admission surface (`no_eligible_planned_trigger`, legacy Insight still suppressed).
- `jitAssistantDelivery.test.ts › empty complete watchlist, real runtime through analyze` — the seam the other cases fake. Builds the REAL `WindowsJitRuntime` (only the authority client and an in-memory sqlite db supplied) and calls `WindowsJitAssistant.analyze`: an empty **complete** snapshot reaches the ambient lane and buys exactly one `nano_triage` reservation; an **incomplete** snapshot buys nothing.
- `jitAssistantDelivery.test.ts › does not admit ambient on a suppression reason it does not own` — keeps the guard that only `no_eligible_planned_trigger` reaches `admitAmbient`.

## Automatic-or-dead check

The evaluator, runtime, and end-to-end tests each fail if the platform-specific suppression returns; the end-to-end one fails even if the regression is inside `WindowsJitRuntime.admit` rather than the evaluator. `grep -rn "reason: 'empty_watchlist'" desktop/windows/src` is empty (the string survives only in one explanatory test comment), and the parity register entry names both the converged routing and the still-divergent pacing.

## Cut list

- Windows ambient pacing parity (`JITAmbientPacingPolicy` analogue), the `ambient_server_denied` backoff, and the local per-day nano usage read: separate PR, they change `admitAmbient`'s spend decision.
- The OCR-keyed ambient context cooldown (unbounded `reserveProactivity` per settled context): separate PR, it changes the fingerprint contract in `WindowsJitAssistant.analyze`.
- Windows local budget day → server `budget_timezone` (the #12798 analogue): separate PR, it touches the reservation client and `JitAssistant.localBudgetDay`.
- The dead `empty_watchlist` entry in the macOS PostHog reason allowlist: next macOS PR.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
