### PR TITLE
feat(backend): count the lazy desktop deferral lifecycle on a bounded Prometheus counter

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -73,6 +73,7 @@ from utils.conversations.meeting_receipt import record_and_persist_finalized_mee
 from utils.integration_telemetry import emit_posthog_event
 from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
+from utils.metrics import record_lazy_desktop_deferral
 from utils.memory.retraction_scope import retraction_can_be_skipped
 from utils.memory.canonical_memory_adapter import ConversationReplacementConflictError
 from utils import byok
@@ -180,11 +181,14 @@ def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
         reacquired = lifecycle_service.reacquire_deferred_processing(uid, conversation_id)
     except Exception as e:
         logger.error(f"lazy enrich reacquire failed uid={uid} conv={conversation_id}: {e}")
+        record_lazy_desktop_deferral(event='enrich_lost_ownership')
         return conversation
     if not reacquired:
         # The row was terminalized or discarded before reacquisition. A stale
         # processor must not persist derived side effects after ownership loss.
+        record_lazy_desktop_deferral(event='enrich_lost_ownership')
         return conversation
+    record_lazy_desktop_deferral(event='enrich_started')
 
     def _run_enrichment():
         try:
@@ -206,8 +210,10 @@ def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
             if enriched is not None:
                 record_and_persist_finalized_meeting_receipt(uid, enriched)
             logger.info(f"lazy enrich complete uid={uid} conv={conversation_id}")
+            record_lazy_desktop_deferral(event='enrich_complete')
         except Exception as e:
             logger.error(f"lazy enrich failed uid={uid} conv={conversation_id}: {e}")
+            record_lazy_desktop_deferral(event='enrich_failed')
             try:
                 recovered = lifecycle_service.recover_deferred_processing_failure(uid, conversation_id)
                 if not recovered:

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -181,16 +181,21 @@ def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
         reacquired = lifecycle_service.reacquire_deferred_processing(uid, conversation_id)
     except Exception as e:
         logger.error(f"lazy enrich reacquire failed uid={uid} conv={conversation_id}: {e}")
-        record_lazy_desktop_deferral(event='enrich_lost_ownership')
+        # A reacquire that RAISED is a broken dependency, not a lost fence.
+        # `deferred=True` doubles as the concurrency fence and clients poll
+        # during enrichment, so a merged label would bury this in benign polls.
+        record_lazy_desktop_deferral(event='enrich_reacquire_error')
         return conversation
     if not reacquired:
         # The row was terminalized or discarded before reacquisition. A stale
         # processor must not persist derived side effects after ownership loss.
         record_lazy_desktop_deferral(event='enrich_lost_ownership')
         return conversation
-    record_lazy_desktop_deferral(event='enrich_started')
 
     def _run_enrichment():
+        # Counted here, not before the submit: a rejected submit (shut-down
+        # pool during a deploy) would otherwise leave a start with no terminal.
+        record_lazy_desktop_deferral(event='enrich_started')
         try:
             conv_obj = deserialize_conversation(conversation)
             conv_obj.deferred = False

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -203,14 +203,20 @@ def _enrich_deferred_conversation(uid: str, conversation: dict) -> dict:
                     is_reprocess=False,
                     app_usage_attribution=AppUsageAttribution.NON_USER_REPROCESS,
                 )
+            # The enrichment itself succeeded here; count it now so a receipt
+            # publish failure below is not misattributed to enrichment and does
+            # not skew the stored-vs-enrich_complete reconciliation.
+            record_lazy_desktop_deferral(event='enrich_complete')
             # Deferred desktop meetings must publish their exact Chat receipt
             # at the same terminal transition as ordinary finalization. The
             # initial lazy row deliberately skipped this adapter, so doing it
             # here closes the gap without waking Chat for processing rows.
             if enriched is not None:
-                record_and_persist_finalized_meeting_receipt(uid, enriched)
+                try:
+                    record_and_persist_finalized_meeting_receipt(uid, enriched)
+                except Exception:
+                    logger.exception('lazy enrich receipt publish failed uid=%s conv=%s', uid, conversation_id)
             logger.info(f"lazy enrich complete uid={uid} conv={conversation_id}")
-            record_lazy_desktop_deferral(event='enrich_complete')
         except Exception as e:
             logger.error(f"lazy enrich failed uid={uid} conv={conversation_id}: {e}")
             record_lazy_desktop_deferral(event='enrich_failed')

--- a/backend/tests/routers/test_conversations_processing_rollback.py
+++ b/backend/tests/routers/test_conversations_processing_rollback.py
@@ -296,6 +296,57 @@ def test_deferred_enrichment_counts_started_and_complete_on_the_real_counter(mon
     assert _lazy_metric('enrich_failed') == failed_before
 
 
+def test_deferred_enrichment_receipt_failure_does_not_count_as_enrich_failed(monkeypatch):
+    """The counter tracks enrichment outcomes: a Chat receipt publish failure
+    after `process_conversation` already succeeded must not be recorded as
+    `enrich_failed`, or the stored-vs-enrich_complete reconciliation drifts."""
+    import time
+
+    monkeypatch.setattr(lifecycle_service, 'reacquire_deferred_processing', lambda *_args: True)
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'renew_processing_lease', lambda *_args: True)
+    monkeypatch.setattr(lifecycle_service, '_processing_lease_renewal_interval', lambda: 0.001)
+    monkeypatch.setattr(conversations_router.conversations_db, 'update_conversation', MagicMock())
+    conv_obj = SimpleNamespace(id='deferred-conv-receipt-fail', language='en', deferred=False)
+    monkeypatch.setattr(conversations_router, 'deserialize_conversation', lambda _data: conv_obj)
+    monkeypatch.setattr(
+        conversations_router,
+        'process_conversation',
+        MagicMock(return_value=conv_obj),
+    )
+    monkeypatch.setattr(
+        conversations_router,
+        'record_and_persist_finalized_meeting_receipt',
+        MagicMock(side_effect=RuntimeError('receipt backend down')),
+        raising=False,
+    )
+    recover = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        lifecycle_service,
+        'recover_deferred_processing_failure',
+        recover,
+        raising=False,
+    )
+
+    complete_before = _lazy_metric('enrich_complete')
+    failed_before = _lazy_metric('enrich_failed')
+
+    conversations_router._enrich_deferred_conversation(
+        'uid1', {'id': 'deferred-conv-receipt-fail', 'status': 'processing', 'deferred': True, 'language': 'en'}
+    )
+
+    # The receipt failure is swallowed, so there is no recovery call to wait
+    # on; poll for the counter to settle.
+    import time
+
+    for _ in range(200):
+        if _lazy_metric('enrich_complete') == complete_before + 1:
+            break
+        time.sleep(0.01)
+    assert _lazy_metric('enrich_complete') == complete_before + 1
+    assert _lazy_metric('enrich_failed') == failed_before
+    lifecycle_service.recover_deferred_processing_failure.assert_not_called()
+
+
 def test_deferred_enrichment_counts_failed_and_lost_ownership(monkeypatch):
     import threading
     import time

--- a/backend/tests/routers/test_conversations_processing_rollback.py
+++ b/backend/tests/routers/test_conversations_processing_rollback.py
@@ -247,3 +247,98 @@ def test_deferred_enrichment_failure_rearms_retry_through_lifecycle_owner(monkey
     assert recovered.wait(timeout=10.0), 'deferred failure recovery did not run'
     recovery.assert_called_once_with('uid1', 'deferred-conv-1')
     raw_update.assert_not_called()
+
+
+def _lazy_metric(event: str) -> float:
+    from utils.metrics import LAZY_DESKTOP_DEFERRAL_TOTAL
+
+    return LAZY_DESKTOP_DEFERRAL_TOTAL.labels(event=event)._value.get()
+
+
+def test_deferred_enrichment_counts_started_and_complete_on_the_real_counter(monkeypatch):
+    """First-open enrichment is the observed "ever opened" event for the lazy
+    desktop path. It must land on the bounded Prometheus counter, through the
+    actual _enrich_deferred_conversation entry point, not a log line."""
+    import threading
+
+    monkeypatch.setattr(lifecycle_service, 'reacquire_deferred_processing', lambda *_args: True)
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'renew_processing_lease', lambda *_args: True)
+    monkeypatch.setattr(lifecycle_service, '_processing_lease_renewal_interval', lambda: 0.001)
+    monkeypatch.setattr(conversations_router.conversations_db, 'update_conversation', MagicMock())
+    monkeypatch.setattr(
+        conversations_router, 'record_and_persist_finalized_meeting_receipt', MagicMock(), raising=False
+    )
+    conv_obj = SimpleNamespace(id='deferred-conv-metric', language='en', deferred=False)
+    monkeypatch.setattr(conversations_router, 'deserialize_conversation', lambda _data: conv_obj)
+    done = threading.Event()
+
+    def fake_process(_uid, _language, conversation, **_kwargs):
+        done.set()
+        return conversation
+
+    monkeypatch.setattr(conversations_router, 'process_conversation', fake_process)
+    started_before = _lazy_metric('enrich_started')
+    complete_before = _lazy_metric('enrich_complete')
+    failed_before = _lazy_metric('enrich_failed')
+
+    conversations_router._enrich_deferred_conversation(
+        'uid1', {'id': 'deferred-conv-metric', 'status': 'processing', 'deferred': True, 'language': 'en'}
+    )
+
+    assert done.wait(timeout=10.0)
+    deadline = threading.Event()
+    for _ in range(200):
+        if _lazy_metric('enrich_complete') == complete_before + 1:
+            break
+        deadline.wait(0.01)
+    assert _lazy_metric('enrich_started') == started_before + 1
+    assert _lazy_metric('enrich_complete') == complete_before + 1
+    assert _lazy_metric('enrich_failed') == failed_before
+
+
+def test_deferred_enrichment_counts_failed_and_lost_ownership(monkeypatch):
+    import threading
+    import time
+
+    recovered = threading.Event()
+    monkeypatch.setattr(lifecycle_service, 'reacquire_deferred_processing', lambda *_args: True)
+    monkeypatch.setattr(
+        lifecycle_service,
+        'recover_deferred_processing_failure',
+        MagicMock(side_effect=lambda *_args: recovered.set() or True),
+        raising=False,
+    )
+    monkeypatch.setattr(lifecycle_service.jobs_db, 'renew_processing_lease', lambda *_args: True)
+    monkeypatch.setattr(lifecycle_service, '_processing_lease_renewal_interval', lambda: 0.001)
+    monkeypatch.setattr(conversations_router.conversations_db, 'update_conversation', MagicMock())
+    monkeypatch.setattr(
+        conversations_router,
+        'deserialize_conversation',
+        lambda _data: SimpleNamespace(id='deferred-conv-fail', language='en', deferred=False),
+    )
+    monkeypatch.setattr(
+        conversations_router, 'process_conversation', MagicMock(side_effect=RuntimeError('enrichment unavailable'))
+    )
+    failed_before = _lazy_metric('enrich_failed')
+    complete_before = _lazy_metric('enrich_complete')
+    lost_before = _lazy_metric('enrich_lost_ownership')
+
+    conversations_router._enrich_deferred_conversation(
+        'uid1', {'id': 'deferred-conv-fail', 'status': 'processing', 'deferred': True, 'language': 'en'}
+    )
+    assert recovered.wait(timeout=10.0)
+    for _ in range(200):
+        if _lazy_metric('enrich_failed') == failed_before + 1:
+            break
+        time.sleep(0.01)
+    assert _lazy_metric('enrich_failed') == failed_before + 1
+    assert _lazy_metric('enrich_complete') == complete_before
+
+    # Reacquisition loss is counted separately and never as a start.
+    monkeypatch.setattr(lifecycle_service, 'reacquire_deferred_processing', lambda *_args: False)
+    started_before = _lazy_metric('enrich_started')
+    conversations_router._enrich_deferred_conversation(
+        'uid1', {'id': 'deferred-conv-lost', 'status': 'processing', 'deferred': True, 'language': 'en'}
+    )
+    assert _lazy_metric('enrich_lost_ownership') == lost_before + 1
+    assert _lazy_metric('enrich_started') == started_before

--- a/backend/tests/routers/test_conversations_processing_rollback.py
+++ b/backend/tests/routers/test_conversations_processing_rollback.py
@@ -117,6 +117,30 @@ def test_recording_snapshot_wins_over_redis_location_fallback(monkeypatch, conve
     redis_read.assert_not_called()
 
 
+def _isolate_deferral_counter(monkeypatch):
+    """Detach a test that does not assert on `lazy_desktop_deferral_total` from it.
+
+    These tests return as soon as `process_conversation` runs, but the enrichment
+    thread keeps going and records its terminal event afterwards -- which used to
+    land inside a LATER test's before/after window and make the strict counter
+    assertions flaky. Replacing the recorder makes the leak impossible instead of
+    unlikely, and the returned event lets the test join the thread's terminal step.
+    """
+    import threading
+
+    terminal = threading.Event()
+
+    def _record(*, event: str) -> None:
+        if event in ('enrich_complete', 'enrich_failed'):
+            terminal.set()
+
+    monkeypatch.setattr(conversations_router, 'record_lazy_desktop_deferral', _record)
+    monkeypatch.setattr(
+        conversations_router, 'record_and_persist_finalized_meeting_receipt', MagicMock(), raising=False
+    )
+    return terminal
+
+
 def test_deferred_enrichment_renews_processing_lease_during_live_processing(monkeypatch):
     """Lazy enrichment of a deferred conversation must keep its admission lease
     fresh while process_conversation runs in the background thread (#10461
@@ -145,6 +169,7 @@ def test_deferred_enrichment_renews_processing_lease_during_live_processing(monk
 
     monkeypatch.setattr(conversations_router, 'process_conversation', blocking_process)
     monkeypatch.setattr(conversations_router.conversations_db, 'update_conversation', MagicMock())
+    terminal = _isolate_deferral_counter(monkeypatch)
 
     conv_obj = SimpleNamespace(id='deferred-conv-1', language='en', deferred=False)
     monkeypatch.setattr(conversations_router, 'deserialize_conversation', lambda data: conv_obj)
@@ -156,6 +181,7 @@ def test_deferred_enrichment_renews_processing_lease_during_live_processing(monk
     # The enrichment runs in a background thread; wait for it to prove the lease was renewed.
     assert enrichment_done.wait(timeout=10.0), 'deferred enrichment did not complete'
     assert lease_renewed.is_set()
+    assert terminal.wait(timeout=10.0), 'background enrichment did not reach a terminal event'
 
 
 def test_deferred_enrichment_atomically_reacquires_ownership_before_processing(monkeypatch):
@@ -182,6 +208,7 @@ def test_deferred_enrichment_atomically_reacquires_ownership_before_processing(m
     monkeypatch.setattr(conversations_router, 'process_conversation', blocking_process)
     monkeypatch.setattr(lifecycle_service, '_processing_lease_renewal_interval', lambda: 0.001)
     monkeypatch.setattr(conversations_router.conversations_db, 'update_conversation', MagicMock())
+    terminal = _isolate_deferral_counter(monkeypatch)
 
     conv_obj = SimpleNamespace(id='deferred-conv-1', language='en', deferred=False)
     monkeypatch.setattr(conversations_router, 'deserialize_conversation', lambda data: conv_obj)
@@ -192,6 +219,7 @@ def test_deferred_enrichment_atomically_reacquires_ownership_before_processing(m
 
     assert enrichment_done.wait(timeout=10.0), 'deferred enrichment did not complete'
     assert reacquired.is_set(), 'reacquire_deferred_processing was not called'
+    assert terminal.wait(timeout=10.0), 'background enrichment did not reach a terminal event'
 
 
 def test_deferred_enrichment_skips_when_reacquisition_fails(monkeypatch):
@@ -392,4 +420,58 @@ def test_deferred_enrichment_counts_failed_and_lost_ownership(monkeypatch):
         'uid1', {'id': 'deferred-conv-lost', 'status': 'processing', 'deferred': True, 'language': 'en'}
     )
     assert _lazy_metric('enrich_lost_ownership') == lost_before + 1
+    assert _lazy_metric('enrich_started') == started_before
+
+
+def test_deferred_enrichment_reacquire_exception_is_counted_apart_from_lost_ownership(monkeypatch):
+    """A reacquire that RAISED is a broken dependency; a reacquire that returned
+    False is a benign fence loss, and `deferred=True` doubles as that fence while
+    clients poll. One shared label would bury the dependency failure in the polls."""
+    monkeypatch.setattr(
+        lifecycle_service,
+        'reacquire_deferred_processing',
+        MagicMock(side_effect=RuntimeError('lifecycle store unavailable')),
+    )
+    process_called = MagicMock()
+    monkeypatch.setattr(conversations_router, 'process_conversation', process_called)
+
+    error_before = _lazy_metric('enrich_reacquire_error')
+    lost_before = _lazy_metric('enrich_lost_ownership')
+    started_before = _lazy_metric('enrich_started')
+
+    conversations_router._enrich_deferred_conversation(
+        'uid1',
+        {'id': 'deferred-conv-reacquire-error', 'status': 'processing', 'deferred': True, 'language': 'en'},
+    )
+
+    assert _lazy_metric('enrich_reacquire_error') == error_before + 1
+    assert _lazy_metric('enrich_lost_ownership') == lost_before
+    assert _lazy_metric('enrich_started') == started_before
+    process_called.assert_not_called()
+
+
+def test_deferred_enrichment_start_is_counted_inside_the_worker(monkeypatch):
+    """`enrich_started` must be recorded by the worker, not before the submit: a
+    submit rejected by a shut-down pool (deploy) would otherwise leave a start
+    with no terminal event and inflate the started-vs-complete gap."""
+    monkeypatch.setattr(lifecycle_service, 'reacquire_deferred_processing', lambda *_args: True)
+    monkeypatch.setattr(
+        conversations_router,
+        'submit_with_context',
+        MagicMock(side_effect=RuntimeError('executor shut down')),
+    )
+    monkeypatch.setattr(
+        conversations_router,
+        'deserialize_conversation',
+        lambda _data: SimpleNamespace(id='deferred-conv-submit-fail', language='en', deferred=False),
+    )
+
+    started_before = _lazy_metric('enrich_started')
+
+    with pytest.raises(RuntimeError, match='executor shut down'):
+        conversations_router._enrich_deferred_conversation(
+            'uid1',
+            {'id': 'deferred-conv-submit-fail', 'status': 'processing', 'deferred': True, 'language': 'en'},
+        )
+
     assert _lazy_metric('enrich_started') == started_before

--- a/backend/tests/unit/test_jit_rollout_metrics.py
+++ b/backend/tests/unit/test_jit_rollout_metrics.py
@@ -13,6 +13,9 @@ from utils.jit_rollout import (
 )
 from utils.metrics import (
     JIT_FIRST_OPEN_TOTAL,
+    LAZY_DESKTOP_DEFERRAL_EVENTS,
+    LAZY_DESKTOP_DEFERRAL_TOTAL,
+    record_lazy_desktop_deferral,
     JIT_ROLLOUT_DECISION_LATENCY_SECONDS,
     JIT_ROLLOUT_DECISION_TOTAL,
     JIT_WRITER_MODE_TRANSITION_TOTAL,
@@ -57,3 +60,41 @@ async def test_authority_increments_uid_free_rollout_counters():
         error_class='none',
     )._value.get()
     assert after == before + 1
+
+
+def test_lazy_desktop_deferral_metric_is_bounded_and_uid_free():
+    payload = generate_latest().decode()
+    assert 'lazy_desktop_deferral_total' in payload
+    assert LAZY_DESKTOP_DEFERRAL_TOTAL._labelnames == ('event',)
+    assert 'uid' not in LAZY_DESKTOP_DEFERRAL_TOTAL._labelnames
+    assert LAZY_DESKTOP_DEFERRAL_EVENTS == {
+        'stored',
+        'fenced',
+        'enrich_started',
+        'enrich_lost_ownership',
+        'enrich_complete',
+        'enrich_failed',
+    }
+
+
+def _lazy_count(event: str) -> float:
+    return LAZY_DESKTOP_DEFERRAL_TOTAL.labels(event=event)._value.get()
+
+
+def test_lazy_desktop_deferral_unknown_event_collapses_to_other():
+    before_other = _lazy_count('other')
+    before_stored = _lazy_count('stored')
+    record_lazy_desktop_deferral(event='stored')
+    record_lazy_desktop_deferral(event='uid:abc')  # a caller cannot mint a new series
+    assert _lazy_count('stored') == before_stored + 1
+    assert _lazy_count('other') == before_other + 1
+    assert 'uid:abc' not in generate_latest().decode()
+
+
+def test_lazy_desktop_deferral_recorder_never_raises(monkeypatch):
+    # The finalizer and router call this on persistence/enrichment paths; a
+    # registry failure must not change their outcome.
+    monkeypatch.setattr(
+        LAZY_DESKTOP_DEFERRAL_TOTAL, 'labels', lambda **_kw: (_ for _ in ()).throw(RuntimeError('down'))
+    )
+    assert record_lazy_desktop_deferral(event='stored') is None

--- a/backend/tests/unit/test_jit_rollout_metrics.py
+++ b/backend/tests/unit/test_jit_rollout_metrics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from prometheus_client import generate_latest
@@ -98,3 +100,14 @@ def test_lazy_desktop_deferral_recorder_never_raises(monkeypatch):
         LAZY_DESKTOP_DEFERRAL_TOTAL, 'labels', lambda **_kw: (_ for _ in ()).throw(RuntimeError('down'))
     )
     assert record_lazy_desktop_deferral(event='stored') is None
+
+
+def test_lazy_desktop_deferral_unhashable_event_collapses_to_other():
+    # An unhashable/invalid runtime value must not raise before the guarded
+    # metric operation; it collapses to `other` like any unknown label.
+    before_other = _lazy_count('other')
+    before_stored = _lazy_count('stored')
+    bad_event: Any = ['not', 'hashable']
+    assert record_lazy_desktop_deferral(event=bad_event) is None
+    assert _lazy_count('other') == before_other + 1
+    assert _lazy_count('stored') == before_stored

--- a/backend/tests/unit/test_jit_rollout_metrics.py
+++ b/backend/tests/unit/test_jit_rollout_metrics.py
@@ -64,9 +64,15 @@ async def test_authority_increments_uid_free_rollout_counters():
     assert after == before + 1
 
 
+def _rendered_lazy_sample(payload: str, event: str) -> float:
+    prefix = f'lazy_desktop_deferral_total{{event="{event}"}} '
+    for line in payload.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    raise AssertionError(f'no rendered lazy_desktop_deferral_total sample for event={event}')
+
+
 def test_lazy_desktop_deferral_metric_is_bounded_and_uid_free():
-    payload = generate_latest().decode()
-    assert 'lazy_desktop_deferral_total' in payload
     assert LAZY_DESKTOP_DEFERRAL_TOTAL._labelnames == ('event',)
     assert 'uid' not in LAZY_DESKTOP_DEFERRAL_TOTAL._labelnames
     assert LAZY_DESKTOP_DEFERRAL_EVENTS == {
@@ -74,9 +80,29 @@ def test_lazy_desktop_deferral_metric_is_bounded_and_uid_free():
         'fenced',
         'enrich_started',
         'enrich_lost_ownership',
+        'enrich_reacquire_error',
         'enrich_complete',
         'enrich_failed',
     }
+
+    payload = generate_latest().decode()
+    # Every bounded child is pre-seeded, so a healthy but idle process still
+    # exports a sample: "not deployed" and "no captures" must not look alike.
+    for event in LAZY_DESKTOP_DEFERRAL_EVENTS | {'other'}:
+        _rendered_lazy_sample(payload, event)
+
+    # The HELP text has to carry the three constraints on reading the ratio,
+    # because whoever writes the PromQL will not read utils/metrics.py.
+    help_line = next(line for line in payload.splitlines() if line.startswith('# HELP lazy_desktop_deferral_total'))
+    assert 'sum by (event)' in help_line  # stored is emitted by backend AND pusher
+    assert 'pusher' in help_line
+    assert 'attempt/persist ratio' in help_line  # not per-conversation
+    assert 'FREE_TIER_LOCAL_PROCESSING' in help_line  # ratio undefined while on
+
+    # Assert on a rendered sample after a real increment, not just the HELP line.
+    before = _rendered_lazy_sample(payload, 'fenced')
+    record_lazy_desktop_deferral(event='fenced')
+    assert _rendered_lazy_sample(generate_latest().decode(), 'fenced') == before + 1
 
 
 def _lazy_count(event: str) -> float:

--- a/backend/tests/unit/test_process_conversation_free_tier_branch.py
+++ b/backend/tests/unit/test_process_conversation_free_tier_branch.py
@@ -1445,3 +1445,24 @@ def test_flag_on_enrichment_omits_processing_state_while_merge_clearing_the_mark
     last = payloads[-1]
     assert 'processing_state' not in last, 'nothing to say ⇒ the key stays absent, even flag-on'
     assert last[pc.TERMINAL_NO_DERIVED_EFFECTS_FIELD] is None, 'the upgrade marker clear still lands'
+
+
+# The lazy desktop store is the denominator of the observed ever-opened rate.
+# Drive the real _store_deferred_conversation (not a stub) through the legacy
+# flag-off deferral branch and assert the bounded lifecycle events.
+@pytest.mark.parametrize('persisted, expected_event', [(True, 'stored'), (False, 'fenced')])
+def test_legacy_deferral_records_lazy_store_lifecycle(monkeypatch, pc, persisted: bool, expected_event: str) -> None:
+    monkeypatch.setattr(pc, 'free_tier_local_processing_enabled', lambda: False)
+    spies = _spy_managed_effects(monkeypatch, pc)
+    recorded: list[str] = []
+    monkeypatch.setattr(pc, 'record_lazy_desktop_deferral', lambda *, event: recorded.append(event))
+    monkeypatch.setattr(pc.lifecycle_service, 'create_processing_conversation', MagicMock(return_value=persisted))
+    monkeypatch.setattr(pc.lifecycle_service, 'persist_processed_conversation', MagicMock(return_value=persisted))
+
+    result = pc.process_conversation('basic-uid', 'en', _desktop_create())
+
+    assert result.deferred is True
+    assert result.status == ConversationStatus.processing
+    assert recorded == [expected_event]
+    spies['get_structured'].assert_not_called()
+    spies['extract_memories'].assert_not_called()

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -85,7 +85,7 @@ from utils.memory.rejected_memory_feedback import get_recent_rejected_memory_exa
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 from utils.memory.canonical_memory_adapter import extraction_memory_id
 from utils.observability.fallback import record_fallback
-from utils.metrics import record_jit_first_open
+from utils.metrics import record_jit_first_open, record_lazy_desktop_deferral
 from utils.observability.finalization import FinalizationFailureReason, record_finalization_failure
 from utils.product_telemetry import emit_product_event
 from utils.task_intelligence.workstream_association import associate_canonical_evidence
@@ -2003,9 +2003,11 @@ def _store_deferred_conversation(
         persisted = lifecycle_service.persist_processed_conversation(uid, payload)
     if not persisted:
         logger.info('lazy: deferred conversation creation fenced uid=%s conv=%s', uid, conversation.id)
+        record_lazy_desktop_deferral(event='fenced')
         return conversation
 
     logger.info("lazy: stored deferred desktop conversation uid=%s conv=%s", uid, conversation.id)
+    record_lazy_desktop_deferral(event='stored')
     return conversation
 
 

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -146,12 +146,29 @@ def record_jit_first_open(*, event: str, effect: str) -> None:
 # which the JIT first-open deferral for paid tiers is sized against. Bounded
 # label set; anything else collapses to `other` so a new call site cannot mint
 # an unbounded series.
+#
+# Three constraints on reading the ratio (also carried in the HELP text, because
+# whoever writes the PromQL will not read this file):
+#  1. `stored` and `fenced` are emitted by EVERY job that runs the finalizer --
+#     the backend API and the pusher (`routers/pusher.py` ->
+#     `utils/pusher_finalization.py`) -- while `enrich_*` is emitted only by the
+#     backend first-open route. The ratio must therefore be
+#     `sum by (event) (lazy_desktop_deferral_total)` across every such job, and
+#     the pusher scrape target must be live or the denominator is truncated.
+#  2. `enrich_complete / stored` is an attempt-over-persist ratio, NOT a
+#     per-conversation one: a failed enrichment re-arms `deferred`, so the next
+#     open counts a second `enrich_started`, and a retried deferred persist can
+#     count `stored` (or `fenced`) more than once for a single conversation.
+#  3. The ratio is undefined while `FREE_TIER_LOCAL_PROCESSING` is on: the
+#     deferred-store path stops emitting `stored` while the already-stored
+#     backlog keeps emitting `enrich_*`, so the ratio drifts above 100%.
 LAZY_DESKTOP_DEFERRAL_EVENTS = frozenset(
     {
         'stored',
         'fenced',
         'enrich_started',
         'enrich_lost_ownership',
+        'enrich_reacquire_error',
         'enrich_complete',
         'enrich_failed',
     }
@@ -159,9 +176,21 @@ LAZY_DESKTOP_DEFERRAL_EVENTS = frozenset(
 
 LAZY_DESKTOP_DEFERRAL_TOTAL = Counter(
     'lazy_desktop_deferral_total',
-    'Lazy desktop deferral lifecycle: store at capture and first-open enrichment outcomes; never labeled by UID',
+    (
+        'Lazy desktop deferral lifecycle: store at capture and first-open enrichment outcomes; '
+        'never labeled by UID. Aggregate as sum by (event) across BOTH backend and pusher: '
+        'stored/fenced are emitted by every host running the finalizer, enrich_* only by the '
+        'backend first-open route. enrich_complete/stored is an attempt/persist ratio, not a '
+        'per-conversation one (a re-armed retry counts again). The ratio is undefined while '
+        'FREE_TIER_LOCAL_PROCESSING is on: stored stops while the enrich_* backlog drains.'
+    ),
     ['event'],
 )
+
+# Export zero-valued children so a healthy but idle process is distinguishable
+# from an absent scrape target, matching the journey-metric convention above.
+for _lazy_event in LAZY_DESKTOP_DEFERRAL_EVENTS | {'other'}:
+    LAZY_DESKTOP_DEFERRAL_TOTAL.labels(event=_lazy_event)
 
 
 def record_lazy_desktop_deferral(*, event: str) -> None:

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -140,6 +140,39 @@ def record_jit_first_open(*, event: str, effect: str) -> None:
     JIT_FIRST_OPEN_TOTAL.labels(event=event, effect=effect).inc()
 
 
+# Lazy desktop deferral (the pre-JIT free-desktop cost path): a raw transcript is
+# stored at capture and the paid enrichment runs only when the user first opens
+# the conversation. `stored` vs `enrich_*` is the observed ever-opened fraction,
+# which the JIT first-open deferral for paid tiers is sized against. Bounded
+# label set; anything else collapses to `other` so a new call site cannot mint
+# an unbounded series.
+LAZY_DESKTOP_DEFERRAL_EVENTS = frozenset(
+    {
+        'stored',
+        'fenced',
+        'enrich_started',
+        'enrich_lost_ownership',
+        'enrich_complete',
+        'enrich_failed',
+    }
+)
+
+LAZY_DESKTOP_DEFERRAL_TOTAL = Counter(
+    'lazy_desktop_deferral_total',
+    'Lazy desktop deferral lifecycle: store at capture and first-open enrichment outcomes; never labeled by UID',
+    ['event'],
+)
+
+
+def record_lazy_desktop_deferral(*, event: str) -> None:
+    """Never raises: observability must not change a persistence or enrichment outcome."""
+    label = event if event in LAZY_DESKTOP_DEFERRAL_EVENTS else 'other'
+    try:
+        LAZY_DESKTOP_DEFERRAL_TOTAL.labels(event=label).inc()
+    except Exception:
+        pass
+
+
 OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL = Counter(
     'omi_client_journey_accepted_total',
     'Accepted client-segmented product journeys by bounded journey and client kind',

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -166,7 +166,12 @@ LAZY_DESKTOP_DEFERRAL_TOTAL = Counter(
 
 def record_lazy_desktop_deferral(*, event: str) -> None:
     """Never raises: observability must not change a persistence or enrichment outcome."""
-    label = event if event in LAZY_DESKTOP_DEFERRAL_EVENTS else 'other'
+    try:
+        label = event if event in LAZY_DESKTOP_DEFERRAL_EVENTS else 'other'
+    except Exception:
+        # Unhashable/invalid runtime values must not escape the guard; they
+        # collapse to `other` instead of breaking the owning path.
+        label = 'other'
     try:
         LAZY_DESKTOP_DEFERRAL_TOTAL.labels(event=label).inc()
     except Exception:


### PR DESCRIPTION
## What changed and why

The pre-JIT free-desktop cost path stores a raw transcript at capture and runs the paid enrichment (summary, action items, memories, embeddings, apps) only when the user first opens the conversation. The observed **ever-opened fraction** (first-open enrichments ÷ stores) is the number the JIT first-open deferral for paid tiers is sized against (decision 9 in the JIT program), and until now it only existed as two log lines that had to be grepped out of Cloud Logging (09-02..09-08 on prod: 18,229 stores, 7,325 enrich-complete, 458 enrich-failed ≈ 40% opened).

This adds `lazy_desktop_deferral_total{event}` with a **closed** label set (`stored`, `fenced`, `enrich_started`, `enrich_lost_ownership`, `enrich_reacquire_error`, `enrich_complete`, `enrich_failed`; any other value collapses to `other`) and records it at the two boundaries that already exist: `_store_deferred_conversation` in the finalizer and `_enrich_deferred_conversation` in the conversations router. Every bounded child is pre-seeded at zero, so a healthy-but-idle instance is distinguishable from an absent scrape target. The recorder never raises, so observability cannot change a persistence or enrichment outcome. No behaviour change on any processing path.

The HELP string carries the three constraints on reading the ratio, because whoever writes the PromQL will not read `utils/metrics.py`:

1. `stored`/`fenced` are emitted by **every host that runs the finalizer** — the backend API *and* the pusher (`routers/pusher.py` → `utils/pusher_finalization.py`) — while `enrich_*` is emitted only by the backend first-open route. The ratio must be `sum by (event) (lazy_desktop_deferral_total)` across both, and the pusher scrape target must be live or the denominator is truncated.
2. `enrich_complete / stored` is an **attempt-over-persist** ratio, not a per-conversation one: a failed enrichment re-arms `deferred` so the next open counts a second `enrich_started`, and a retried deferred persist can count `stored` (or `fenced`) more than once for one conversation.
3. The ratio is **undefined while `FREE_TIER_LOCAL_PROCESSING` is on**: the deferred-store path stops emitting `stored` while the already-stored backlog keeps emitting `enrich_*`, so the ratio drifts above 100%.

## Product invariants affected

- INV-MEM-4
- INV-TASK-2

Both are cited because the touched files are listed on them; neither behaviour changes. The counter is recorded after the existing persist/reacquire decisions and never on a memory or task write path.

## Review

Two adversarial passes were posted on this PR (plus cubic). Every finding and its resolution:

| # | Finding | Resolution |
| --- | --- | --- |
| P1 | `stored` is emitted by **both** backend and pusher; `enrich_*` only by backend, so a single-job ratio truncates the denominator | HELP string and the block comment now say to aggregate `sum by (event)` across both hosts and that the pusher scrape target must be live. `test_lazy_desktop_deferral_metric_is_bounded_and_uid_free` asserts the HELP line carries it. |
| P2 | `enrich_lost_ownership` conflated the fence-lost path with the reacquire-**exception** path; the benign polls would bury the dependency failure | Split: the exception path at `routers/conversations.py` now records `enrich_reacquire_error`, the `not reacquired` fence loss keeps `enrich_lost_ownership`. New test `test_deferred_enrichment_reacquire_exception_is_counted_apart_from_lost_ownership`. |
| P2 | No zero-valued children pre-seeded, unlike the file's own convention at `utils/metrics.py:82-90`; an idle instance is indistinguishable from a missing target | Added the pre-seed loop over `LAZY_DESKTOP_DEFERRAL_EVENTS | {'other'}` right after the definition; the metrics test asserts a rendered sample exists for every child. |
| P2 | `enrich_complete/stored` is an attempt/persist ratio, not per-conversation; `fenced` mixes idempotent retries with real fences | Stated in the HELP string, the block comment, and this body (constraint 2). No code change — the double count is real and must be read, not hidden. |
| P2 | The ratio silently exceeds 100% once `FREE_TIER_LOCAL_PROCESSING` flips on | Stated in the HELP string and the block comment (constraint 3). |
| P2/P3 | Test race: `test_conversations_processing_rollback.py` asserted strict equality on a module-global counter while two earlier tests leaked a background thread that could land `enrich_complete`/`enrich_failed` in the window (reproduced deterministically by the reviewer) | Added `_isolate_deferral_counter(monkeypatch)`: the two lease/reacquire tests, which do not assert on the counter, now replace the recorder outright (so the leak is impossible, not merely unlikely) and join the worker's terminal event before returning. Strict equality is kept because the leak is closed. |
| P3 | `record_lazy_desktop_deferral` computed the label outside the `try`, so an unhashable `event` raised through the "never raises" docstring | Label computation is inside its own guard and falls back to `other`; covered by the unhashable-event regression test. |
| P3 | `enrich_started` was recorded before `submit_with_context`; a rejected submit (shut-down pool during a deploy) left a start with no terminal | `enrich_started` is now the first line of `_run_enrichment`, so it is recorded by the worker that will produce the terminal. New test `test_deferred_enrichment_start_is_counted_inside_the_worker`. |
| P3 | `enrich_complete` was recorded after the meeting-receipt persist, so a receipt failure counted as `enrich_failed` | `enrich_complete` is recorded immediately after `process_conversation` returns and the receipt publish is wrapped in its own `try/except`; covered by `test_deferred_enrichment_receipt_failure_does_not_count_as_enrich_failed`. |
| P3 | `test_jit_rollout_metrics.py` matched the `# HELP` line only and was vacuous | It now asserts a rendered sample for every pre-seeded child, asserts the four HELP claims, and asserts a rendered sample moves by exactly 1 after a real `record_lazy_desktop_deferral` call. |

## How it was verified

- `backend/.venv/bin/pytest tests/unit/test_jit_rollout_metrics.py tests/routers/test_conversations_processing_rollback.py tests/unit/test_process_conversation_free_tier_branch.py tests/unit/test_reprocess_app_selection.py -q` → **58 passed** (the router tests drive the real `_enrich_deferred_conversation` with the background executor and assert on the real Prometheus counter; the finalizer tests drive the real `_store_deferred_conversation` through the capture pipeline; `test_reprocess_app_selection.py` is included because it also drives the enrichment entry point).
- Race proof: `pytest tests/routers/test_conversations_processing_rollback.py tests/unit/test_jit_rollout_metrics.py -q` run 5 consecutive times under the randomizing order plugin → 18 passed each time.
- Layer measured: backend unit tests in a task worktree. Not deployed; no dashboard or alert consumes the series yet.

## Cut list

- No dashboard/alert rule (Grafana rules are a separate merged-rule≠live-rule path; a follow-up can add a `stored` vs `enrich_complete` panel that already carries the `sum by (event)` aggregation).
- No per-plan label (would need a subscription lookup on the hot path; plan attribution stays in the gateway ledger).
- No change to the double-counting itself (retried persist, re-armed enrichment): the ratio is documented as attempt/persist rather than made per-conversation, which would need a per-conversation dedupe key on the hot path.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2958 -> 2960 | two one-line counter calls at the existing deferred-store persist and fence outcomes; no helper added to the oversized file
Line-Count-Exception: backend/routers/conversations.py | 2210 -> 2227 | one import plus counter calls at the existing reacquire, start, complete, and failure outcomes of the first-open enrichment, and the review follow-ups: a separate `enrich_reacquire_error` label on the exception path, `enrich_started` moved into the worker, and the receipt publish wrapped in its own try/except so a receipt failure is not miscounted as `enrich_failed`

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
