### PR TITLE
perf(mentor): debounce the proactive gate

### DIFF
--- a/backend/database/mentor_gate_state.py
+++ b/backend/database/mentor_gate_state.py
@@ -1,0 +1,103 @@
+"""The mentor relevance gate's debounce record — one owner for both storage tiers.
+
+The realtime path that evaluates the gate runs on two hosts (`routers/listen/
+transcripts.py` and `routers/pusher.py` both reach
+`_async_trigger_realtime_integrations`), so the record cannot be process-local:
+each host would otherwise evaluate once inside the same debounce window and the
+throttle would be worth exactly half of what it claims. Redis is the authority.
+
+The process-local mirror in front of it is a latency choice, not a second source
+of truth: the common case is "this pod evaluated this user seconds ago", and that
+answer should not cost a Redis round trip on the realtime path. It is only ever
+written from a shared read or a shared write, never independently.
+
+Redis failures fall open (return None -> evaluate), matching every other
+throttle on this path: a cache outage must not silence the mentor.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# The record carries a per-UTC-day evaluation counter as well as the debounce
+# timestamp, so it has to outlive the debounce window and expire just past a day
+# boundary. 25 hours matches the daily proactive-notification counter.
+STATE_TTL_SECONDS = 90000
+
+# Expired local entries are dropped when their own key is read again, so a churned
+# user's key would otherwise sit on a long-lived process forever. Bound the map.
+_MAX_LOCAL_ENTRIES = 50000
+
+_local: Dict[str, tuple[Dict[str, Any], float]] = {}
+
+
+def _redis_key(uid: str) -> str:
+    return f'{uid}:mentor_gate_eval_state'
+
+
+def _read_local(uid: str) -> Optional[Dict[str, Any]]:
+    entry = _local.get(uid)
+    if entry is None:
+        return None
+    state, expires_at = entry
+    if expires_at < time.time():
+        del _local[uid]
+        return None
+    return state
+
+
+def _write_local(uid: str, state: Dict[str, Any], ttl: int) -> None:
+    now = time.time()
+    _local[uid] = (dict(state), now + ttl)
+    if len(_local) > _MAX_LOCAL_ENTRIES:
+        for key in [k for k, (_s, expires_at) in _local.items() if expires_at < now]:
+            del _local[key]
+        overflow = len(_local) - _MAX_LOCAL_ENTRIES
+        if overflow > 0:
+            for key in sorted(_local, key=lambda k: _local[k][1])[:overflow]:
+                del _local[key]
+
+
+def _read_shared(uid: str) -> Optional[Dict[str, Any]]:
+    try:
+        from database.redis_db import r
+
+        raw = r.get(_redis_key(uid))
+        if not raw:
+            return None
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else None
+    except Exception as e:
+        logger.warning(f"mentor_gate_state read failed, falling open: {e}")
+        return None
+
+
+def _write_shared(uid: str, state: Dict[str, Any], ttl: int) -> None:
+    try:
+        from database.redis_db import r
+
+        r.set(_redis_key(uid), json.dumps(state), ex=ttl)
+    except Exception as e:
+        logger.warning(f"mentor_gate_state write failed: {e}")
+
+
+def read(uid: str) -> Optional[Dict[str, Any]]:
+    """Last gate-evaluation record for a user, or None when there is none."""
+    state = _read_local(uid)
+    if state is not None:
+        return state
+    remote = _read_shared(uid)
+    if remote is not None:
+        _write_local(uid, remote, STATE_TTL_SECONDS)
+    return remote
+
+
+def record(uid: str, state: Dict[str, Any], ttl: int = STATE_TTL_SECONDS) -> None:
+    """Persist a gate evaluation to both tiers."""
+    _write_local(uid, state, ttl)
+    _write_shared(uid, state, ttl)

--- a/backend/database/mentor_gate_state.py
+++ b/backend/database/mentor_gate_state.py
@@ -9,16 +9,25 @@ throttle would be worth exactly half of what it claims. Redis is the authority.
 The process-local mirror in front of it is a latency choice, not a second source
 of truth: the common case is "this pod evaluated this user seconds ago", and that
 answer should not cost a Redis round trip on the realtime path. It is only ever
-written from a shared read or a shared write, never independently.
+written from a shared read or a shared write, never independently — and it is
+trusted only for that "evaluated recently" answer. An *eligibility* decision
+(the mirror can be stale the moment any other host records) re-reads the shared
+authority under a short-lived claim, which also serializes the
+check-and-record pair against a concurrent same-user worker on another pod (or
+another thread of this one).
 
 Redis failures fall open (return None -> evaluate), matching every other
-throttle on this path: a cache outage must not silence the mentor.
+throttle on this path: a cache outage must not silence the mentor. That
+includes writes: an evaluation that fails to persist to the shared tier is not
+mirrored locally, so one pod cannot keep throttling on state no other host can
+see.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 from typing import Any, Dict, Optional
 
@@ -29,38 +38,54 @@ logger = logging.getLogger(__name__)
 # boundary. 25 hours matches the daily proactive-notification counter.
 STATE_TTL_SECONDS = 90000
 
+# Cross-worker claim serializing the eligibility check + record for one user.
+# It is held for milliseconds; the TTL is only a crash bound for a holder that
+# never released. While a claim is held, other workers skip ('claim_busy')
+# instead of double-opening the gate.
+CLAIM_TTL_SECONDS = 30
+
 # Expired local entries are dropped when their own key is read again, so a churned
 # user's key would otherwise sit on a long-lived process forever. Bound the map.
 _MAX_LOCAL_ENTRIES = 50000
 
 _local: Dict[str, tuple[Dict[str, Any], float]] = {}
+# The mirror is read and written from the shared db/postprocess executors, so
+# every access is guarded: two workers expiring the same entry must not turn
+# `del` into a KeyError that aborts the mentor pipeline.
+_local_lock = threading.Lock()
 
 
 def _redis_key(uid: str) -> str:
     return f'{uid}:mentor_gate_eval_state'
 
 
+def _claim_key(uid: str) -> str:
+    return f'{uid}:mentor_gate_eval_claim'
+
+
 def _read_local(uid: str) -> Optional[Dict[str, Any]]:
-    entry = _local.get(uid)
-    if entry is None:
-        return None
-    state, expires_at = entry
-    if expires_at < time.time():
-        del _local[uid]
-        return None
-    return state
+    with _local_lock:
+        entry = _local.get(uid)
+        if entry is None:
+            return None
+        state, expires_at = entry
+        if expires_at < time.time():
+            _local.pop(uid, None)
+            return None
+        return state
 
 
 def _write_local(uid: str, state: Dict[str, Any], ttl: int) -> None:
     now = time.time()
-    _local[uid] = (dict(state), now + ttl)
-    if len(_local) > _MAX_LOCAL_ENTRIES:
-        for key in [k for k, (_s, expires_at) in _local.items() if expires_at < now]:
-            del _local[key]
-        overflow = len(_local) - _MAX_LOCAL_ENTRIES
-        if overflow > 0:
-            for key in sorted(_local, key=lambda k: _local[k][1])[:overflow]:
-                del _local[key]
+    with _local_lock:
+        _local[uid] = (dict(state), now + ttl)
+        if len(_local) > _MAX_LOCAL_ENTRIES:
+            for key in [k for k, (_s, expires_at) in _local.items() if expires_at < now]:
+                _local.pop(key, None)
+            overflow = len(_local) - _MAX_LOCAL_ENTRIES
+            if overflow > 0:
+                for key in sorted(_local, key=lambda k: _local[k][1])[:overflow]:
+                    _local.pop(key, None)
 
 
 def _read_shared(uid: str) -> Optional[Dict[str, Any]]:
@@ -77,13 +102,34 @@ def _read_shared(uid: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _write_shared(uid: str, state: Dict[str, Any], ttl: int) -> None:
+def _write_shared(uid: str, state: Dict[str, Any], ttl: int) -> bool:
     try:
         from database.redis_db import r
 
         r.set(_redis_key(uid), json.dumps(state), ex=ttl)
+        return True
     except Exception as e:
         logger.warning(f"mentor_gate_state write failed: {e}")
+        return False
+
+
+def _claim_shared(uid: str, ttl: int) -> bool:
+    try:
+        from database.redis_db import r
+
+        return bool(r.set(_claim_key(uid), '1', nx=True, ex=ttl))
+    except Exception as e:
+        logger.warning(f"mentor_gate_state claim failed, falling open: {e}")
+        return True
+
+
+def _release_shared(uid: str) -> None:
+    try:
+        from database.redis_db import r
+
+        r.delete(_claim_key(uid))
+    except Exception as e:
+        logger.warning(f"mentor_gate_state release failed: {e}")
 
 
 def read(uid: str) -> Optional[Dict[str, Any]]:
@@ -97,7 +143,39 @@ def read(uid: str) -> Optional[Dict[str, Any]]:
     return remote
 
 
+def read_authoritative(uid: str) -> Optional[Dict[str, Any]]:
+    """Shared-tier read that bypasses (and refreshes) the local mirror.
+
+    The mirror can be stale the moment any other host records an evaluation,
+    so an eligibility decision must be made against the authority, not against
+    a possibly-outdated copy. Only the "evaluated recently -> skip" answer is
+    allowed to come from the mirror.
+    """
+    remote = _read_shared(uid)
+    if remote is not None:
+        _write_local(uid, remote, STATE_TTL_SECONDS)
+    return remote
+
+
+def claim(uid: str, ttl: int = CLAIM_TTL_SECONDS) -> bool:
+    """Try to become the one worker evaluating this user right now."""
+    return _claim_shared(uid, ttl)
+
+
+def release(uid: str) -> None:
+    """Best-effort release; the TTL bounds a holder that crashes first."""
+    _release_shared(uid)
+
+
 def record(uid: str, state: Dict[str, Any], ttl: int = STATE_TTL_SECONDS) -> None:
-    """Persist a gate evaluation to both tiers."""
-    _write_local(uid, state, ttl)
-    _write_shared(uid, state, ttl)
+    """Persist a gate evaluation.
+
+    Shared tier first, mirror only after it succeeds: an evaluation that never
+    reached the shared tier must not throttle this pod either, or a Redis
+    outage would silently tighten the debounce instead of falling open.
+    """
+    if _write_shared(uid, state, ttl):
+        _write_local(uid, state, ttl)
+    else:
+        with _local_lock:
+            _local.pop(uid, None)

--- a/backend/tests/unit/test_mentor_gate_debounce.py
+++ b/backend/tests/unit/test_mentor_gate_debounce.py
@@ -1,0 +1,222 @@
+"""The mentor gate must not be re-evaluated when nothing new has been said.
+
+``MENTOR_RATE_LIMIT_SECONDS`` throttles what the user SEES and it starts only once a
+notification has actually been sent, so nothing bounded the LLM call that decides
+whether to send one. The gate therefore ran on every buffered segment batch: 34,806
+calls/day at ~22k prompt tokens each in the gateway ledger for 2026-09-01..09-06, the
+largest paid-tier OpenAI line in the product, with the top 10% of mentor-active paid
+users producing 44% of the calls.
+
+These tests drive the real ``_process_mentor_proactive_notification`` through the
+existing realtime-integration harness (production module, isolated stubs) and assert on
+the LLM call count, not on the policy helpers in isolation. They also pin the two
+properties the change lives or dies on: it is OFF unless the env says otherwise, and the
+throttle is shared across hosts (the realtime path runs on both the listen plane and
+pusher, so a process-local record would let each host evaluate once per window).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The harness builds the full stub set this production module needs at import time.
+from tests.unit.test_realtime_integrations_usage_tracking import integration_harness  # noqa: F401
+
+MESSAGES_SHORT = [{'text': 'we should ship on friday', 'is_user': True}]
+MESSAGES_LONG = [{'text': ' '.join(f'word{i}' for i in range(400)), 'is_user': True}]
+
+
+class _Store:
+    """Stand-in for the Redis tier the debounce record lives in."""
+
+    def __init__(self):
+        self.data: dict[str, dict] = {}
+
+    def get(self, uid):
+        return self.data.get(uid)
+
+    def set(self, uid, state, ttl):
+        self.data[uid] = dict(state)
+
+
+@pytest.fixture
+def gate(integration_harness, monkeypatch):  # noqa: F811 — pytest fixture injection
+    """Real mentor pipeline, stopped at the gate, with controllable debounce storage.
+
+    Only the shared-tier primitives are faked, so the module's own two-tier
+    read-through logic is the code under test, not a stand-in for it.
+    """
+    app = integration_harness.app
+    state_module = app.mentor_gate_state
+    shared = _Store()
+
+    monkeypatch.setattr(state_module, '_read_shared', shared.get)
+    monkeypatch.setattr(state_module, '_write_shared', shared.set)
+    state_module._local.clear()
+    monkeypatch.setattr(app, 'get_mentor_notification_frequency', MagicMock(return_value=3))
+
+    # Stop the pipeline at the gate so the assertions count gate evaluations only.
+    evaluate = MagicMock(return_value=SimpleNamespace(is_relevant=False, relevance_score=0.0, context_summary=''))
+    monkeypatch.setattr(app, 'evaluate_relevance', evaluate)
+
+    monkeypatch.delenv(app.MENTOR_GATE_DEBOUNCE_ENABLED_ENV, raising=False)
+    for name in (
+        app.MENTOR_GATE_MIN_NEW_WORDS_ENV,
+        app.MENTOR_GATE_MIN_SECONDS_ENV,
+        app.MENTOR_GATE_DAILY_CAP_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    return SimpleNamespace(
+        app=app, evaluate=evaluate, local=state_module._local, shared=shared, monkeypatch=monkeypatch
+    )
+
+
+def _age(gate, seconds, uid='uid-debounce'):
+    """Push the recorded evaluation back in time, in both tiers."""
+    gate.shared.data[uid]['ts'] -= seconds
+    gate.local[uid][0]['ts'] -= seconds
+
+
+def _run(gate, uid='uid-debounce', messages=MESSAGES_LONG):
+    return gate.app._process_mentor_proactive_notification(uid, messages)
+
+
+def _enable(gate, **env):
+    gate.monkeypatch.setenv(gate.app.MENTOR_GATE_DEBOUNCE_ENABLED_ENV, 'true')
+    for key, value in env.items():
+        gate.monkeypatch.setenv(key, str(value))
+
+
+# ---------------------------------------------------------------------------
+# Off by default
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_by_default_every_batch_still_evaluates(gate):
+    _run(gate)
+    _run(gate)
+    assert gate.evaluate.call_count == 2, 'the debounce must ship dark; unset env changes nothing'
+    assert gate.shared.data == {}, 'a disabled debounce writes no state'
+
+
+@pytest.mark.parametrize('value', ['false', '0', 'off', 'no', ''])
+def test_explicitly_disabled_values_do_not_enable_it(gate, value):
+    gate.monkeypatch.setenv(gate.app.MENTOR_GATE_DEBOUNCE_ENABLED_ENV, value)
+    _run(gate)
+    _run(gate)
+    assert gate.evaluate.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# The debounce itself
+# ---------------------------------------------------------------------------
+
+
+def test_second_batch_inside_the_window_makes_no_llm_call(gate):
+    _enable(gate)
+    _run(gate)
+    assert gate.evaluate.call_count == 1
+    assert _run(gate) is None
+    assert gate.evaluate.call_count == 1, 'the second batch inside the window must not reach the LLM'
+
+
+def test_time_alone_does_not_reopen_the_gate_without_new_speech(gate):
+    _enable(gate)
+    _run(gate)
+    # Age the record past the time floor but replay the same transcript.
+    _age(gate, 10_000)
+    _run(gate)
+    assert gate.evaluate.call_count == 1, 'no new words means nothing new to judge'
+
+
+def test_new_speech_after_the_window_reopens_the_gate(gate):
+    _enable(gate)
+    _run(gate, messages=MESSAGES_SHORT)
+    _age(gate, 10_000)
+    _run(gate, messages=MESSAGES_SHORT + MESSAGES_LONG)
+    assert gate.evaluate.call_count == 2
+
+
+def test_new_speech_inside_the_time_floor_still_waits(gate):
+    _enable(gate)
+    _run(gate, messages=MESSAGES_SHORT)
+    _run(gate, messages=MESSAGES_SHORT + MESSAGES_LONG)
+    assert gate.evaluate.call_count == 1, 'both conditions are required, not either'
+
+
+def test_restarted_buffer_counts_as_all_new_speech(gate):
+    """The mentor buffer is cleared after two minutes of silence, so the word count
+    goes down. That must read as new speech, not as a shrinking delta that never
+    clears the threshold again."""
+    _enable(gate)
+    _run(gate, messages=MESSAGES_LONG)
+    _age(gate, 10_000)
+    restarted = [{'text': ' '.join(f'fresh{i}' for i in range(200)), 'is_user': True}]
+    _run(gate, messages=restarted)
+    assert gate.evaluate.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Shared, not process-local
+# ---------------------------------------------------------------------------
+
+
+def test_a_second_host_honours_the_first_hosts_evaluation(gate):
+    """Only the shared record survives; the local mirror is cold, as on another pod."""
+    _enable(gate)
+    _run(gate)
+    gate.local.clear()
+    assert _run(gate) is None
+    assert gate.evaluate.call_count == 1
+    assert gate.local, 'the shared record is mirrored locally after a remote read'
+
+
+# ---------------------------------------------------------------------------
+# Daily ceiling
+# ---------------------------------------------------------------------------
+
+
+def _drive_n_evaluations(gate, n):
+    for index in range(n):
+        # The mentor buffer accumulates across evaluations, so each batch is longer.
+        messages = [{'text': ' '.join(f'w{i}' for i in range((index + 1) * 200)), 'is_user': True}]
+        if gate.shared.data.get('uid-debounce'):
+            _age(gate, 10_000)
+        _run(gate, messages=messages)
+
+
+def test_daily_evaluation_cap_stops_the_heavy_tail(gate):
+    _enable(gate, MENTOR_GATE_DAILY_CAP=3)
+    _drive_n_evaluations(gate, 6)
+    assert gate.evaluate.call_count == 3
+    assert gate.shared.data['uid-debounce']['count'] == 3
+
+
+def test_developers_are_exempt_from_the_daily_cap(gate):
+    _enable(gate, MENTOR_GATE_DAILY_CAP=3)
+    with patch.object(gate.app, '_is_developer', return_value=True):
+        _drive_n_evaluations(gate, 6)
+    assert gate.evaluate.call_count == 6
+
+
+def test_a_typo_in_a_knob_does_not_disable_the_mentor(gate):
+    _enable(gate, MENTOR_GATE_MIN_SECONDS='ninety', MENTOR_GATE_DAILY_CAP='lots')
+    _run(gate)
+    assert gate.evaluate.call_count == 1, 'an unparseable knob falls back to its default, not to a block'
+
+
+# ---------------------------------------------------------------------------
+# The skip must be countable before anyone trusts the billing ledger
+# ---------------------------------------------------------------------------
+
+
+def test_skip_emits_a_structured_reason(gate, caplog):
+    _enable(gate)
+    _run(gate)
+    with caplog.at_level('INFO'):
+        _run(gate)
+    lines = [record.getMessage() for record in caplog.records if 'mentor_gate_debounce' in record.getMessage()]
+    assert lines, 'a skip nobody can count is a saving nobody can prove'
+    assert 'reason=min_seconds' in lines[0]

--- a/backend/tests/unit/test_mentor_gate_debounce.py
+++ b/backend/tests/unit/test_mentor_gate_debounce.py
@@ -27,17 +27,32 @@ MESSAGES_SHORT = [{'text': 'we should ship on friday', 'is_user': True}]
 MESSAGES_LONG = [{'text': ' '.join(f'word{i}' for i in range(400)), 'is_user': True}]
 
 
+def _messages_with_timestamp(words, timestamp, is_user=True):
+    return [{'text': ' '.join(f'w{i}' for i in range(words)), 'timestamp': timestamp, 'is_user': is_user}]
+
+
 class _Store:
     """Stand-in for the Redis tier the debounce record lives in."""
 
     def __init__(self):
         self.data: dict[str, dict] = {}
+        self.claims: set[str] = set()
 
     def get(self, uid):
         return self.data.get(uid)
 
     def set(self, uid, state, ttl):
         self.data[uid] = dict(state)
+        return True
+
+    def claim(self, uid, ttl):
+        if uid in self.claims:
+            return False
+        self.claims.add(uid)
+        return True
+
+    def release(self, uid):
+        self.claims.discard(uid)
 
 
 @pytest.fixture
@@ -53,6 +68,8 @@ def gate(integration_harness, monkeypatch):  # noqa: F811 — pytest fixture inj
 
     monkeypatch.setattr(state_module, '_read_shared', shared.get)
     monkeypatch.setattr(state_module, '_write_shared', shared.set)
+    monkeypatch.setattr(state_module, '_claim_shared', shared.claim)
+    monkeypatch.setattr(state_module, '_release_shared', shared.release)
     state_module._local.clear()
     monkeypatch.setattr(app, 'get_mentor_notification_frequency', MagicMock(return_value=3))
 
@@ -133,16 +150,16 @@ def test_time_alone_does_not_reopen_the_gate_without_new_speech(gate):
 
 def test_new_speech_after_the_window_reopens_the_gate(gate):
     _enable(gate)
-    _run(gate, messages=MESSAGES_SHORT)
+    _run(gate, messages=_messages_with_timestamp(400, 100.0))
     _age(gate, 10_000)
-    _run(gate, messages=MESSAGES_SHORT + MESSAGES_LONG)
+    _run(gate, messages=_messages_with_timestamp(400, 100.0) + _messages_with_timestamp(200, 200.0))
     assert gate.evaluate.call_count == 2
 
 
 def test_new_speech_inside_the_time_floor_still_waits(gate):
     _enable(gate)
-    _run(gate, messages=MESSAGES_SHORT)
-    _run(gate, messages=MESSAGES_SHORT + MESSAGES_LONG)
+    _run(gate, messages=_messages_with_timestamp(400, 100.0))
+    _run(gate, messages=_messages_with_timestamp(400, 100.0) + _messages_with_timestamp(200, 200.0))
     assert gate.evaluate.call_count == 1, 'both conditions are required, not either'
 
 
@@ -220,3 +237,85 @@ def test_skip_emits_a_structured_reason(gate, caplog):
     lines = [record.getMessage() for record in caplog.records if 'mentor_gate_debounce' in record.getMessage()]
     assert lines, 'a skip nobody can count is a saving nobody can prove'
     assert 'reason=min_seconds' in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Review hardening (Cubic round on #13286)
+# ---------------------------------------------------------------------------
+
+
+def test_first_enabled_batch_respects_the_word_floor(gate):
+    """No prior evaluation time to wait out, but 5 words is still not 'genuinely
+    new speech' worth a ~22k-token evaluation."""
+    _enable(gate)
+    assert _run(gate, messages=MESSAGES_SHORT) is None
+    assert gate.evaluate.call_count == 0
+    assert gate.shared.data == {}, 'a skipped first batch records nothing'
+    _run(gate)
+    assert gate.evaluate.call_count == 1
+
+
+def test_other_speaker_words_do_not_open_the_gate(gate):
+    """MIN_NEW_WORDS bounds the user's new speech; a long other-speaker exchange
+    must not satisfy it."""
+    _enable(gate)
+    first = _messages_with_timestamp(400, 100.0)
+    _run(gate, messages=first)
+    _age(gate, 10_000)
+    other_speaker = _messages_with_timestamp(300, 300.0, is_user=False)
+    assert _run(gate, messages=first + other_speaker) is None
+    assert gate.evaluate.call_count == 1
+
+
+def test_evicted_buffer_history_is_not_new_speech(gate):
+    """The buffer keeps its 50-message cap by evicting the FRONT, so a shrinking
+    word count is not proof the conversation restarted. Retained history must not
+    be re-counted as new speech and re-open the gate."""
+    _enable(gate)
+    first = _messages_with_timestamp(300, 100.0) + _messages_with_timestamp(100, 200.0)
+    _run(gate, messages=first)
+    assert gate.evaluate.call_count == 1
+    _age(gate, 10_000)
+    # Front message evicted; what is retained is old speech, and only 50 words are new.
+    retained_and_new = _messages_with_timestamp(100, 200.0) + _messages_with_timestamp(50, 300.0)
+    assert _run(gate, messages=retained_and_new) is None
+    assert gate.evaluate.call_count == 1, 'a shrinking buffer must not replay retained history as new speech'
+
+
+def test_concurrent_same_user_worker_holds_the_claim(gate):
+    """Two same-user workers must not both pass the gate: the second finds the
+    claim held and skips, so only one LLM evaluation is billed."""
+    _enable(gate)
+    gate.shared.claims.add('uid-debounce')  # another worker is mid-evaluation
+    assert _run(gate) is None
+    assert gate.evaluate.call_count == 0
+    gate.shared.claims.discard('uid-debounce')
+    _run(gate)
+    assert gate.evaluate.call_count == 1
+
+
+def test_stale_mirror_is_not_trusted_when_deciding_eligibility(gate):
+    """Another host's fresh evaluation must beat this pod's stale mirror: the
+    eligibility decision is re-made against the shared authority."""
+    _enable(gate)
+    first = _messages_with_timestamp(400, 100.0)
+    _run(gate, messages=first)
+    assert gate.evaluate.call_count == 1
+    _age(gate, 10_000)
+    # Another host evaluated this user just now; only this pod's mirror is stale.
+    gate.shared.data['uid-debounce']['ts'] += 10_000
+    second = first + _messages_with_timestamp(200, 300.0)
+    assert _run(gate, messages=second) is None
+    assert gate.evaluate.call_count == 1
+
+
+def test_failed_shared_write_does_not_throttle_locally(gate, monkeypatch):
+    """Fail-open includes writes: an evaluation that never reached the shared
+    tier must not throttle this pod while every other host falls open."""
+    _enable(gate)
+    monkeypatch.setattr(gate.app.mentor_gate_state, '_write_shared', lambda uid, state, ttl: False)
+    _run(gate)
+    assert gate.evaluate.call_count == 1
+    assert not gate.local, 'an unpersisted evaluation must not be mirrored'
+    _run(gate)
+    assert gate.evaluate.call_count == 2, 'a failed shared write falls open, not closed'

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -547,25 +547,97 @@ def _mentor_gate_int_env(name: str, default: int, *, minimum: int, maximum: int)
 
 
 def _mentor_conversation_word_count(conversation_messages: list[dict]) -> int:
-    return sum(len(str(message.get('text') or '').split()) for message in conversation_messages)
+    # User speech only. The gate evaluates what THE USER said, and the buffer
+    # carries the other speaker too: a long other-speaker exchange must not
+    # satisfy MIN_NEW_WORDS on its own.
+    return sum(
+        len(str(message.get('text') or '').split()) for message in conversation_messages if message.get('is_user')
+    )
 
 
-def _record_mentor_gate_evaluation(uid: str, *, now: float, word_count: int, previous: dict | None) -> None:
+def _mentor_gate_tail_anchor(conversation_messages: list[dict]) -> list | None:
+    """[timestamp, word_count] of the buffer's last user message, or None."""
+    for message in reversed(conversation_messages):
+        if message.get('is_user'):
+            return [float(message.get('timestamp') or 0), len(str(message.get('text') or '').split())]
+    return None
+
+
+def _mentor_gate_new_words(conversation_messages: list[dict], state: dict, word_count: int) -> int:
+    """User words that arrived after the last evaluation.
+
+    The buffer's tail user message at record time is the anchor. If it is still
+    present, everything after it — plus whatever 2-second coalescing appended to
+    it — is the new speech, and nothing else is. If it is gone, the buffer either
+    restarted (silence clears it) or evicted it from the 50-message cap — and an
+    evicted tail anchor means every retained message is newer than it, so the
+    whole buffer is post-evaluation speech either way. Both read as all-new. A
+    bare word-count delta cannot tell these apart from retained history, which
+    is exactly how a shrinking buffer used to replay old speech as new.
+    """
+    anchor = state.get('anchor')
+    if isinstance(anchor, (list, tuple)) and len(anchor) == 2:
+        anchor_ts, anchor_words = float(anchor[0]), int(anchor[1])
+        for index in range(len(conversation_messages) - 1, -1, -1):
+            message = conversation_messages[index]
+            if not message.get('is_user'):
+                continue
+            if float(message.get('timestamp') or 0) != anchor_ts:
+                continue
+            current_words = len(str(message.get('text') or '').split())
+            if current_words < anchor_words:
+                # Same recording offset but less speech: a restarted
+                # conversation that happens to reuse the offset, not the anchor.
+                continue
+            appended = current_words - anchor_words
+            after = sum(
+                len(str(m.get('text') or '').split()) for m in conversation_messages[index + 1 :] if m.get('is_user')
+            )
+            return appended + after
+        return word_count
+    # Pre-anchor record (or malformed state): keep the old delta heuristic.
+    previous_words = int(state.get('words') or 0)
+    return word_count - previous_words if word_count >= previous_words else word_count
+
+
+def _record_mentor_gate_evaluation(
+    uid: str, *, now: float, word_count: int, previous: dict | None, conversation_messages: list[dict]
+) -> None:
     today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
     count = 1
     if previous and previous.get('day') == today:
         count = int(previous.get('count') or 0) + 1
-    mentor_gate_state.record(uid, {'ts': int(now), 'words': word_count, 'day': today, 'count': count})
+    mentor_gate_state.record(
+        uid,
+        {
+            'ts': int(now),
+            'words': word_count,
+            'day': today,
+            'count': count,
+            'anchor': _mentor_gate_tail_anchor(conversation_messages),
+        },
+    )
 
 
-def _mentor_gate_debounce_skip_reason(uid: str, state: dict | None, *, now: float, word_count: int) -> str | None:
+def _mentor_gate_debounce_skip_reason(
+    uid: str, state: dict | None, *, now: float, word_count: int, conversation_messages: list[dict]
+) -> str | None:
     """Why this evaluation should be skipped, or None to evaluate.
 
     Returns a reason string rather than a bool so the caller can emit it: the
     whole point of the change is that its effect is measurable from the logs
     before anyone trusts the ledger delta.
     """
+    min_new_words = _mentor_gate_int_env(
+        MENTOR_GATE_MIN_NEW_WORDS_ENV, MENTOR_GATE_MIN_NEW_WORDS_DEFAULT, minimum=0, maximum=10000
+    )
+
     if state is None:
+        # First evaluation for this user: there is no prior evaluation time to
+        # wait out, but a handful of words is still not "genuinely new speech"
+        # worth a ~22k-token evaluation — apply the word floor to this batch too.
+        if word_count < min_new_words:
+            return 'min_new_words'
         return None
 
     elapsed = now - float(state.get('ts') or 0)
@@ -574,13 +646,8 @@ def _mentor_gate_debounce_skip_reason(uid: str, state: dict | None, *, now: floa
     ):
         return 'min_seconds'
 
-    # The buffer accumulates across evaluations and is cleared only on silence, so a
-    # shrinking count means the buffer restarted; treat that as all-new speech.
-    previous_words = int(state.get('words') or 0)
-    new_words = word_count - previous_words if word_count >= previous_words else word_count
-    if new_words < _mentor_gate_int_env(
-        MENTOR_GATE_MIN_NEW_WORDS_ENV, MENTOR_GATE_MIN_NEW_WORDS_DEFAULT, minimum=0, maximum=10000
-    ):
+    new_words = _mentor_gate_new_words(conversation_messages, state, word_count)
+    if new_words < min_new_words:
         return 'min_new_words'
 
     today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
@@ -636,13 +703,50 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
     debounce_enabled = _mentor_gate_debounce_enabled()
     if debounce_enabled:
         gate_state = mentor_gate_state.read(uid)
-        skip_reason = _mentor_gate_debounce_skip_reason(uid, gate_state, now=gate_now, word_count=gate_word_count)
+        skip_reason = _mentor_gate_debounce_skip_reason(
+            uid, gate_state, now=gate_now, word_count=gate_word_count, conversation_messages=conversation_messages
+        )
         if skip_reason:
             # Structured so the saved evaluations are countable in Cloud Logging
             # without waiting for the billing ledger.
             logger.info(f"mentor_gate_debounce skipped uid={uid} reason={skip_reason} words={gate_word_count}")
             return None
-        _record_mentor_gate_evaluation(uid, now=gate_now, word_count=gate_word_count, previous=gate_state)
+        # Serialize eligibility + recording across concurrent same-user workers
+        # (two hosts, or two threads of one). The mirror-read above answers only
+        # "evaluated recently?"; the authoritative decision below runs under a
+        # short-lived claim so two workers cannot both pass and double-bill the
+        # gate LLM call. Contention (claim held) skips this batch — the buffer
+        # keeps accumulating, so the words are only delayed, not lost — while a
+        # claim *error* falls open: a Redis hiccup must not silence the mentor,
+        # and the TTL bounds a holder that crashes.
+        if not mentor_gate_state.claim(uid):
+            logger.info(f"mentor_gate_debounce skipped uid={uid} reason=claim_busy words={gate_word_count}")
+            return None
+        try:
+            # Always re-read the authority under the claim — the mirror answer
+            # (including "no record") can be stale the moment another host
+            # records, and this re-check is what makes the decision genuinely
+            # single-writer.
+            gate_state = mentor_gate_state.read_authoritative(uid)
+            skip_reason = _mentor_gate_debounce_skip_reason(
+                uid,
+                gate_state,
+                now=gate_now,
+                word_count=gate_word_count,
+                conversation_messages=conversation_messages,
+            )
+            if skip_reason:
+                logger.info(f"mentor_gate_debounce skipped uid={uid} reason={skip_reason} words={gate_word_count}")
+                return None
+            _record_mentor_gate_evaluation(
+                uid,
+                now=gate_now,
+                word_count=gate_word_count,
+                previous=gate_state,
+                conversation_messages=conversation_messages,
+            )
+        finally:
+            mentor_gate_state.release(uid)
 
     # 4. Gather lightweight context (no vector search yet — save for step 2)
     try:

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from typing import List
 import os
 import time
@@ -18,6 +19,7 @@ from utils.http_client import (
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.async_tasks import gather_safe
 import utils.dev_cache as dev_cache
+import database.mentor_gate_state as mentor_gate_state
 
 import database.dev_api_key as dev_api_key_db
 from database import mem_db
@@ -497,6 +499,98 @@ def _proactive_daily_cap_reached(uid: str) -> bool:
 
 MENTOR_RATE_LIMIT_SECONDS = 300  # 5 minutes between mentor notifications
 
+# ---------------------------------------------------------------------------
+# Mentor gate debounce (kill switch: MENTOR_GATE_DEBOUNCE_ENABLED, default off)
+# ---------------------------------------------------------------------------
+#
+# MENTOR_RATE_LIMIT_SECONDS above throttles what the user SEES; it starts only
+# after a notification is actually sent, so it does not bound the gate LLM call
+# that decides whether to send one. Nothing did. The gate ran on every buffered
+# segment batch, which for a user in a long meeting is a ~22k-token evaluation
+# every time ten new segments land, and in the gateway ledger for
+# 2026-09-01..09-06 that was 34,806 calls/day — the largest paid-tier OpenAI
+# line in the product.
+#
+# This adds the missing throttle on the evaluation itself: a minimum amount of
+# genuinely new speech AND a minimum wall-clock gap since the last evaluation
+# for this user, plus a per-user daily ceiling for the heavy tail (the top 10%
+# of mentor-active paid users produce 44% of all gate calls). Developers are
+# exempt from the daily ceiling for the same reason they are exempt from the
+# notification cap (#3346): building an app must not be throttled.
+MENTOR_GATE_DEBOUNCE_ENABLED_ENV = 'MENTOR_GATE_DEBOUNCE_ENABLED'
+MENTOR_GATE_MIN_NEW_WORDS_ENV = 'MENTOR_GATE_MIN_NEW_WORDS'
+MENTOR_GATE_MIN_SECONDS_ENV = 'MENTOR_GATE_MIN_SECONDS'
+MENTOR_GATE_DAILY_CAP_ENV = 'MENTOR_GATE_DAILY_CAP'
+
+MENTOR_GATE_MIN_NEW_WORDS_DEFAULT = 120
+MENTOR_GATE_MIN_SECONDS_DEFAULT = 90
+MENTOR_GATE_DAILY_CAP_DEFAULT = 60
+
+
+def _mentor_gate_debounce_enabled() -> bool:
+    """Default OFF. This changes when the user is evaluated, so it ships dark."""
+    value = os.getenv(MENTOR_GATE_DEBOUNCE_ENABLED_ENV)
+    if value is None:
+        return False
+    return value.strip().casefold() in {'1', 'true', 'yes', 'on'}
+
+
+def _mentor_gate_int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    """Read a tuning knob, clamped. A typo must not disable the mentor entirely."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, min(int(raw), maximum))
+    except (TypeError, ValueError):
+        return default
+
+
+def _mentor_conversation_word_count(conversation_messages: list[dict]) -> int:
+    return sum(len(str(message.get('text') or '').split()) for message in conversation_messages)
+
+
+def _record_mentor_gate_evaluation(uid: str, *, now: float, word_count: int, previous: dict | None) -> None:
+    today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    count = 1
+    if previous and previous.get('day') == today:
+        count = int(previous.get('count') or 0) + 1
+    mentor_gate_state.record(uid, {'ts': int(now), 'words': word_count, 'day': today, 'count': count})
+
+
+def _mentor_gate_debounce_skip_reason(uid: str, state: dict | None, *, now: float, word_count: int) -> str | None:
+    """Why this evaluation should be skipped, or None to evaluate.
+
+    Returns a reason string rather than a bool so the caller can emit it: the
+    whole point of the change is that its effect is measurable from the logs
+    before anyone trusts the ledger delta.
+    """
+    if state is None:
+        return None
+
+    elapsed = now - float(state.get('ts') or 0)
+    if elapsed < _mentor_gate_int_env(
+        MENTOR_GATE_MIN_SECONDS_ENV, MENTOR_GATE_MIN_SECONDS_DEFAULT, minimum=0, maximum=3600
+    ):
+        return 'min_seconds'
+
+    # The buffer accumulates across evaluations and is cleared only on silence, so a
+    # shrinking count means the buffer restarted; treat that as all-new speech.
+    previous_words = int(state.get('words') or 0)
+    new_words = word_count - previous_words if word_count >= previous_words else word_count
+    if new_words < _mentor_gate_int_env(
+        MENTOR_GATE_MIN_NEW_WORDS_ENV, MENTOR_GATE_MIN_NEW_WORDS_DEFAULT, minimum=0, maximum=10000
+    ):
+        return 'min_new_words'
+
+    today = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    if state.get('day') == today:
+        cap = _mentor_gate_int_env(MENTOR_GATE_DAILY_CAP_ENV, MENTOR_GATE_DAILY_CAP_DEFAULT, minimum=1, maximum=100000)
+        if int(state.get('count') or 0) >= cap and not _is_developer(uid):
+            return 'daily_eval_cap'
+
+    return None
+
 
 def _process_mentor_proactive_notification(uid: str, conversation_messages: list[dict]) -> str | None:
     """
@@ -532,6 +626,23 @@ def _process_mentor_proactive_notification(uid: str, conversation_messages: list
     if _proactive_daily_cap_reached(uid):
         logger.info(f"mentor_proactive daily_cap_reached uid={uid}")
         return None
+
+    # 3b. Debounce the LLM evaluation itself (dark by default). The checks above
+    # only bound what is SENT; without this the gate is evaluated on every buffered
+    # segment batch even when nothing new was said.
+    gate_state = None
+    gate_now = time.time()
+    gate_word_count = _mentor_conversation_word_count(conversation_messages)
+    debounce_enabled = _mentor_gate_debounce_enabled()
+    if debounce_enabled:
+        gate_state = mentor_gate_state.read(uid)
+        skip_reason = _mentor_gate_debounce_skip_reason(uid, gate_state, now=gate_now, word_count=gate_word_count)
+        if skip_reason:
+            # Structured so the saved evaluations are countable in Cloud Logging
+            # without waiting for the billing ledger.
+            logger.info(f"mentor_gate_debounce skipped uid={uid} reason={skip_reason} words={gate_word_count}")
+            return None
+        _record_mentor_gate_evaluation(uid, now=gate_now, word_count=gate_word_count, previous=gate_state)
 
     # 4. Gather lightweight context (no vector search yet — save for step 2)
     try:


### PR DESCRIPTION
## What changed and why

`MENTOR_RATE_LIMIT_SECONDS` (5 min) throttles what the user **sees**, and it only starts once a notification has actually been sent. Nothing bounded the LLM call that decides whether to send one. So the mentor relevance gate ran on every buffered segment batch: **34,806 calls/day at ~22k prompt tokens each** in the gateway ledger for 2026-09-01..09-06 — the largest paid-tier OpenAI line in the product — with the top 10% of mentor-active paid users producing 44% of the calls and the top 50% producing 93%.

This adds the missing throttle on the *evaluation*, dark by default behind `MENTOR_GATE_DEBOUNCE_ENABLED`. When enabled, a batch reaches the LLM only when **both**:

- ≥ `MENTOR_GATE_MIN_NEW_WORDS` (default 120) of genuinely new speech since this user's last **evaluation** — not since the last sent notification, which is the gap the old rate limit never covered; and
- ≥ `MENTOR_GATE_MIN_SECONDS` (default 90) of wall clock since that evaluation;

with a per-user ceiling of `MENTOR_GATE_DAILY_CAP` (default 60) evaluations per UTC day. Developers are exempt from the ceiling for the same reason they are exempt from the notification cap (#3346): building and testing an app must not be throttled. Every knob is clamped, so a typo falls back to its default rather than silently disabling the mentor.

### Automatic-or-dead check

The two properties this change lives or dies on are asserted by tests that drive the real `_process_mentor_proactive_notification` and count gate LLM calls, not by review: **(1)** with the env unset, two consecutive batches both reach the LLM — it ships dark, mechanically; **(2)** with the local mirror cleared but the shared record intact, the second host still skips — the throttle is genuinely cross-pod. A regression in either fails CI.

## Where the state lives, and why it is shared

Same two-tier shape as the mentor rate limit directly above it — Redis as the authority, a bounded process-local mirror in front of it — but given its own owner, `database/mentor_gate_state.py`, rather than four more functions appended to `redis_db.py` and `mem_db.py`. Two reasons: the read-through logic is a policy, not two independent stores, and it should be testable as one unit; and `redis_db.py` is already over the product-file line-count ratchet, so growing it would have needed a `Line-Count-Exception` in this body. A new module was the better answer than the hatch.

It has to be shared: `_async_trigger_realtime_integrations` is reached from **two** hosts — `routers/listen/transcripts.py:391` (GKE `backend-listen`) and `routers/pusher.py:117` (pusher). A process-local record would let each host evaluate once inside the same window, which is not a debounce.

One JSON record per uid (`{ts, words, day, count}`) with a 25-hour TTL matching the daily notification counter, so the day counter it carries outlives the debounce window it also serves. A Redis failure falls open (return `None` → evaluate), matching every other throttle on this path: a cache outage must not silence the mentor.

## Measurability before the money

Every skip emits `mentor_gate_debounce skipped uid=... reason=<min_seconds|min_new_words|daily_eval_cap> words=...`. Skipped-vs-evaluated is countable in Cloud Logging within minutes of enablement; the ledger delta is the confirmation, not the first signal. Pinned by a test.

## Expected reduction

Deliberately stated as structure, not as a single number — the exact figure needs the post-enablement measurement above, which is why the log line exists.

- **Daily ceiling.** 34,806 calls/day across ~363 mentor-active paid users (6-day window) is ~96 evaluations per user-day. A 60/day ceiling therefore binds on the heavy tail that produces 44% of all calls, while leaving a user with 60 evaluations against a hard cap of 9 notifications/day — still an order of magnitude of headroom.
- **Time + word floors.** `MIN_NEW_SEGMENTS_FOR_ANALYSIS = 10` fires quickly during active speech; the 90 s floor and the 120-new-word floor together remove the re-evaluations where the transcript has barely moved. The quiet-user case cited in the cost frame (~3 evaluations/hour) is already outside both floors and is unaffected — this targets the active-speech burst, not the quiet meeting.
- The effect **multiplies** with the prompt-cache PR (fewer calls, each already cheaper) rather than adding to it.

## Kill switch and rollback

`MENTOR_GATE_DEBOUNCE_ENABLED` is unset in code and in every chart, so merging this changes nothing anywhere. Enabling it is a one-value edit; reverting that one value is the rollback.

## Cut list (deliberately not in this PR)

- **No chart / dev-env edit.** Enabling this is a product-visible behaviour change on dev beta, and chart values belong to another lane in tonight's run. Enablement is written up as a one-action runbook in `data/run-2026-09-09-overnight-margins/evidence/mentor-gate.md` §7. Note for whoever runs it: `MENTOR_GATE_DEBOUNCE_ENABLED=true` must land on **both** `backend-listen` and pusher in the same change, or the un-enabled host keeps evaluating unthrottled.
- **`MIN_NEW_SEGMENTS_FOR_ANALYSIS` in `utils/mentor_notifications.py` is untouched.** It is the cheapest-looking knob and the wrong owner: it changes what the *buffer* considers ready and therefore the transcript the gate sees. The debounce belongs where the LLM call is decided.
- **No change to what is sent, only to when it is evaluated.** Thresholds, prompts, frequency handling, the notification cap and the 5-minute send rate limit are all untouched.

## Product invariants affected

none

## How it was verified

Local, `backend/.venv` (Python 3.11 via `uv`), worktree `/Volumes/scratch/worktrees/omi/mentor-debounce`, branched from `origin/main` @ `5c1bc6aafb` (preflight ran against `origin/main` @ `595572b9e7f1`).

```
python -m pytest tests/unit/test_mentor_gate_debounce.py -q               → 16 passed
python -m pytest tests/unit/test_realtime_integrations_usage_tracking.py  →  9 passed
python -m pytest tests/unit/test_proactive_notification_absent_payload.py →  5 passed
python -m pytest tests/unit/test_async_app_integrations.py                → 20 passed
python -m pytest tests/unit/test_app_integrations_safe_messages.py        →  2 passed
python -m pytest tests/unit/test_async_realtime_integrations_offload.py   →  6 passed
python -m pytest tests/unit/test_new_usage_tracking_gaps.py               → 45 passed
python -m pytest tests/unit/test_pusher_transcript_dispatch.py            →  2 passed
python -m pytest tests/unit/test_mentor_notifications.py                  → 26 passed
make preflight                                                            → see below
```

**Not exercised against a live listening session.** This is dark-by-default code that only runs when an env var is set on a deployed host, so the real user-facing path cannot be exercised locally; the route-level tests drive the production function through the existing isolated-import harness instead. Saying so explicitly rather than implying it was run for real.

## Tests

`backend/tests/unit/test_mentor_gate_debounce.py` (new, 16 tests) drives the real `_process_mentor_proactive_notification` through the existing realtime-integration harness with controllable fakes for both storage tiers, and asserts on the **gate LLM call count**:

- off by default, and for every falsey env spelling — two batches, two evaluations, no state written;
- enabled: the second batch inside the window makes no LLM call;
- time alone does not reopen the gate without new speech, and new speech alone does not beat the time floor — both conditions are required;
- a restarted buffer (the mentor buffer is cleared after 2 min of silence, so the word count goes *down*) counts as all-new speech rather than as a delta that never clears the threshold again;
- a second host with a cold local mirror still honours the first host's evaluation, and back-fills its mirror (only the shared-tier primitives are faked, so the module's own read-through logic is the code under test, not a stand-in for it);
- the daily ceiling stops the heavy tail, and developers are exempt from it;
- an unparseable knob falls back to its default rather than blocking the mentor;
- a skip emits its structured reason.

## Failure class (fixes)

Failure-Class: none

## Review notes (adversarial review requested before merge)

Diff: `utils/app_integrations.py` (+111: policy helpers and one insertion in `_process_mentor_proactive_notification` after the daily-cap check), `database/mentor_gate_state.py` (+103, new: both storage tiers and the read-through between them), one new test file. No existing file other than `app_integrations.py` is touched, and nothing changes with the env unset.

Risks a reviewer should attack, in order:

1. **This can suppress a notification the user would have received.** Unlike the sibling cache PR, this is not behaviour-neutral when enabled: a batch skipped at the gate is a notification never generated. The defaults (120 words / 90 s / 60 per day) are argued from ledger aggregates, not from a replay of real sessions. Are they right, and is 60/day genuinely above the useful ceiling given the 9-notification/day cap?
2. **`mentor_gate_state.read` trusts the local mirror first.** If the mirror is stale relative to Redis the pod under-throttles (evaluates when it should not) — fail-open, chosen deliberately, but worth confirming that is the right direction here.
3. **Redis errors are swallowed (fail-open → `None`).** A Redis outage silently returns the gate to today's unthrottled behaviour. Correct for availability; it also means a partial outage looks like "the debounce did nothing" in the logs rather than like an outage.
4. **Word-count delta versus a re-ordered buffer.** `_mentor_conversation_word_count` sums the whole buffer, and the shrink case is treated as all-new. A buffer that is trimmed at `MAX_BUFFER_MESSAGES` while still growing in real speech could under-count new words and over-throttle. Is the shrink heuristic the right shape, or should the record store a message-count fingerprint too?
5. **A new `database/` module is outside this lane's assigned files**, though it is a new file rather than an edit to a shared one, so it cannot collide with another lane.
6. **UTC day boundary for the cap** — a user in UTC+13 gets their reset mid-afternoon. Matches the existing `incr_daily_notification_count`, so it is consistent rather than correct.

Branched independently from `main`; verified conflict-free against `fix/mentor-gate-cache-and-debounce` with `git merge-tree` (both touch `_process_mentor_proactive_notification` but in disjoint regions). Merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

