### PR TITLE
feat(finops): daily true user unit cost job → BigQuery omi_finops

### DIFF
--- a/backend/scripts/finops/README.md
+++ b/backend/scripts/finops/README.md
@@ -1,0 +1,231 @@
+# Omi finops: daily true user unit cost
+
+One command turns a settled usage day into per-user cost by platform cohort and plan, and
+loads it into BigQuery `based-hardware.omi_finops`. It has **no runtime effect**: nothing here
+is imported by the backend, and every source is read-only except the BigQuery load.
+
+```bash
+# one settled day, loaded
+python3 backend/scripts/finops/run_unit_cost.py --date 2026-09-07 --load
+
+# a window (one users snapshot, one GCP query, one ledger pull per date)
+python3 backend/scripts/finops/run_unit_cost.py --date 2026-09-07 --backfill-from 2026-09-01 --load
+
+# recompute one date from raw inputs already on disk, without re-pulling
+python3 backend/scripts/finops/run_unit_cost.py --date 2026-09-07 --reuse-raw \
+    --run-dir /Volumes/scratch/finops-runs/2026-09-01_2026-09-07
+```
+
+## What "settled" means
+
+The GCP billing export keeps landing rows for a usage day for roughly 48 hours after it ends.
+A usage day is treated as **settled at D-2**, which is what `--date` defaults to. Anything later
+is refused unless you pass `--allow-unsettled`, and rows computed that way carry
+`inputs_settled = false` in every BigQuery table so a number can never quietly be half a day.
+`run_manifest.json` also records `settlement_frontier_export`: the maximum `usage_end_time`
+actually present in the export at pull time, which is the empirical version of the same claim.
+
+## Inputs
+
+| Input | Source | Identity | Used for |
+|---|---|---|---|
+| GCP billing export | `gcp_billing_export_resource_v1_01B287_9348DC_02D256` | read-only bot | every GCP component; the pools |
+| LLM gateway ledger | Firestore `llm_gateway_attempts` | read-only bot | measured OpenAI cost per user, Gemini/desktop drivers |
+| Users projection | Firestore `users` (field mask) | read-only bot | platform cohort, plan |
+| Transcription seconds | Firestore collection group `hourly_usage` | read-only bot | audio-pipeline driver |
+| VAD-forwarded audio hours | Prometheus via the Grafana proxy on monitor.omi.me | Grafana token | modelled STT vendor volume |
+| OpenAI invoice | OpenAI admin costs API | org admin key | the LLM residual and the reconciliation |
+| Anthropic invoice | Anthropic admin cost API | org admin key | same |
+| Subscription book | Stripe (read-only key) | Stripe key | `plan_revenue_daily` |
+| DAU by platform | PostHog project 302298 | PostHog MCP | alternative denominators only |
+
+The billing export table is partitioned on `_PARTITIONTIME`; every query filters that **and**
+`usage_start_time`, and runs with `--maximum_bytes_billed=2147483648`. `net = cost + credits`.
+The `..._01B896_918303_539138` table is the predecessor billing account and is never summed in.
+Firestore reads bill under service `App Engine`, so Firestore is matched by SKU, never by service.
+
+## Identities
+
+* Every **read** runs as `read-only-bot-account@based-hardware.iam.gserviceaccount.com`, sourced
+  from `~/.hermes/scripts/omi-prod-gcp-read-only-env.sh`. The documented `~/.hermes/profiles`
+  path does not exist on this host and falls through **silently** to owner credentials, so
+  `gcpauth.assert_readonly_identity()` re-checks `gcloud config get-value account` after
+  sourcing and refuses to pull under any other account.
+* The **BigQuery load** runs as the interactive owner `david@scalingforever.com` and refuses
+  to run under any other account (`gcpauth.assert_writer_identity()`).
+* No token, key or secret is ever printed or written to disk.
+* **No raw uid ever reaches disk.** Uids are hashed `sha256(uid)[:16]` in flight, and
+  `run_unit_cost.validate()` scans the outputs for any hex run of 20+ characters before a load.
+
+## Allocation method
+
+Every dollar lands on a `(day, uid)` row by one of six methods, then rolls up. Component names
+are stable: they are the contract with the 2026-09-09 evidence record and with BigQuery.
+
+| method | components | how |
+|---|---|---|
+| `measured` | `llm_openai_measured` | per-attempt ledger cost joined to the uid |
+| `driver-allocated` | `llm_direct_residual`, `vertex_paygo`, `audio_pipeline_gcp`, `desktop_pools`, `shared_activity` | pool × that user's share of a measured driver (OpenAI ledger $, Gemini ledger $, transcription seconds, desktop-feature ledger $) |
+| `headcount` | `shared_headcount` | pool ÷ that day's cost-active users. Used for the pools no user measurably causes (Firestore, backend Cloud Run, logging, network, Pub/Sub) |
+| `fixed` | `vertex_pt_fixed` | the Vertex provisioned-throughput reservation; excluded from variable cost, present in the fully-loaded view |
+| `modelled` | `stt_vendor_low`, `stt_vendor_high`, `llm_gemini_list_memo`, `gross_total` | no invoice feed exists |
+| `one_time` | `one_time_*` | dated one-off charges. Reported at the day level only, **never** allocated to a user, never in a run rate |
+
+Aggregates (`variable_total`, `variable_total_activity`, `fully_loaded`) carry the weakest method
+they contain, so `gross_total` is `modelled` because it includes the modelled STT vendor line.
+
+"Cost-active user" = at least one ledger row or one transcription-usage row that day. Platform
+cohort is `dual` / `desktop_only` / `mobile_only` / `web_only` / `inactive_7d` from the users
+snapshot's `last_active_at_*`; **dual users are their own segment and are never split**. The
+`platform_union` segment type counts a dual user in *both* `desktop_incl_dual` and
+`mobile_incl_dual`, so those two segments deliberately overlap and must not be added together.
+
+### `one_time`: what it is for
+
+`one_time_events.json` is a dated registry of one-off charges. Each entry is injected as the
+first branch of the component CASE by `pull_gcp.py`, so a matching row gets its own component,
+is reported with `method='one_time'` at `segment_type='total'`, and is excluded from every pool.
+The registered example is the Coldline@30d lifecycle transition of the audio bucket (PR #12631):
+**$13,818.35 on 2026-09-07** on `omi-private-cloud-sync` plus $103.86 on 2026-09-05 on the dev
+bucket — 345M Class A operations in one sweep. Without the rule that single day would put
+roughly **+$6.50 on every cost-active user's day**, an eleven-fold overstatement of run rate.
+Add a rule only with a date bound, a resource or SKU scope, a reason and an owner. Never widen a
+rule to a whole SKU with no date bound: that would hide a real, recurring regression.
+
+### Cohort window
+
+A cohort needs a date from which a snapshot `last_active_at_*` counts as "active on that platform".
+By default that is a **trailing 7-day window ending on the usage day** (`--cohort-lookback-days`),
+evaluated per date. That matters: it makes a date's cohorts identical whether the date is computed
+alone by the daily cron or inside a backfill, so the series does not shift under you. Pass
+`--cohort-window-start` to pin one explicit date instead, which is what reproducing an older report
+needs.
+
+`users.last_active_at_*` are **overwritten in place**, so the snapshot is not replayable:
+`_users_snapshot.json` records `snapshot_at` and the run manifest carries it into BigQuery via
+`run_id`. A rerun of an old date with a fresher snapshot will produce slightly different cohorts,
+and that is a property of the source, not a bug. Plan is unaffected either way.
+
+## Outputs
+
+`derived/` holds `unit_cost_long.csv` (what BigQuery gets), `unit_cost_reconciliation.csv`,
+`user_day_allocated.csv`, the five `unit_cost_by_*.csv` roll-ups, `platform_alt_denominators.csv`
+and `day_summary.json`. `assembly_output.md` is the human report.
+
+BigQuery `based-hardware.omi_finops` (location US, same as the billing export, so the two join):
+
+| table | grain | notes |
+|---|---|---|
+| `unit_cost_daily` | date × segment_type × segment × component × method | `segment_type ∈ {cohort, plan, cohort_plan, platform_union, total}` |
+| `unit_cost_reconciliation` | date × pool | `pool_usd` vs `allocated_usd` vs `delta_pct` |
+| `plan_revenue_daily` | date × plan | Stripe **snapshot**; carries `snapshot_date` because Stripe is not replayable per historical day |
+| `unit_cost_user_day` | date × `uid_hash` | hashed uids only (`sha256[:16]`) |
+
+All four are partitioned by `date` and clustered. Loads are **idempotent per date**: the run's
+dates are deleted and re-inserted inside one BigQuery transaction, so re-running a date replaces
+it rather than doubling it.
+
+## Validation
+
+`run_unit_cost.py` refuses to load unless:
+
+1. every variable pool reconciles within `--recon-tolerance-pct` (default **0.5%**) — including
+   `gcp_total_export`, which is the check that the component classifier loses nothing;
+2. every requested date produced allocated rows;
+3. no output contains a hex run long enough to be a raw uid.
+
+`llm_openai_ledger_coverage` is a **diagnostic** row, not an allocation check: it reports how much
+of the OpenAI invoice the per-attempt ledger explains (the rest becomes `llm_direct_residual`).
+It is excluded from the tolerance gate on purpose.
+
+## Cost of a run
+
+Measured on the 2026-09-01..09-07 backfill:
+
+| item | cost |
+|---|---|
+| BigQuery billing-export queries | 0.35 GiB billed ≈ **$0.002** per window (4 queries; the last three hit cache on a rerun) |
+| Gateway ledger pull | ~560k document reads/day ≈ **$0.27/day** (field-masked, paged, ~90–140 s/day) |
+| Users snapshot (17.2k users, 4 ordered passes) | ≈ **$0.02** |
+| `hourly_usage` collection-group scan | 85k documents for a 7-day window in one month ≈ **$0.04** |
+| Prometheus, PostHog, OpenAI, Anthropic, Stripe | free |
+| BigQuery storage + load DML | < 10 MB, negligible |
+
+**A daily run costs about $0.30**, dominated by the ledger read. A 7-day backfill costs about $2
+and takes ~20 minutes, almost all of it the ledger.
+
+## Backfilling
+
+```bash
+python3 backend/scripts/finops/run_unit_cost.py \
+    --backfill-from 2026-09-01 --date 2026-09-07 --load
+```
+
+Do **not** backfill before **2026-09-01**: desktop ledger attribution rolled out on 09-01, so
+2026-08-31 has no desktop ledger rows and its plan/cohort split is not comparable.
+
+The window is assembled as one run so it shares a single users snapshot; the per-`(day, uid)`
+allocation itself is day-local, so a date computed inside a window and the same date computed
+alone are identical for the same inputs and the same `--cohort-window-start`.
+
+## Accuracy against the 2026-09-09 evidence record
+
+Replaying the record's own raw pulls through this code
+(`assemble_unit_cost.py <raw> <out> 2026-09-01 2026-09-06 2026-08-31`) reproduces
+`derived6/unit_cost_by_{plan,cohort,cohort_plan,platform_union}.csv` and
+`platform_alt_denominators.csv` with **zero value differences** on every shared column.
+
+Two deliberate differences from the code that produced the record:
+
+1. **A new column `shared_activity_per_day`** appears in the roll-up CSVs. `shared_activity` was
+   always computed per user-day and always fed `variable_total_activity`; it simply had no column
+   of its own. No existing value changed.
+2. **`byok_active` parsing.** The old code compared the CSV value to `"True"` while the puller
+   writes `"true"`, so `byok` was always `False`. It is now compared case-insensitively. The field
+   is not used by any allocation, so no number moved.
+
+Re-pulling the same window today gives slightly different figures, for reasons that are data,
+not code. Assembling **today's** pulls over 2026-09-01..09-06 against the record:
+
+| metric | record | re-pulled | Δ |
+|---|---:|---:|---:|
+| variable $/day, five plans | 1,846.77 | 1,829.62 | −17.15/day |
+| audio pipeline $/day, five plans | 406.02 | 388.79 | −17.23/day |
+| `basic` variable $/user-day | 0.6503 | 0.6470 | −0.51% |
+| `unlimited_v2` variable $/user-day | 1.2600 | 1.2409 | −1.52% |
+| mean users/day, `basic` | 1,169.5 | 1,169.7 | +0.02% |
+
+−17.23/day × 6 days = **−$103.4**, which is the dev bucket's $103.86 Coldline transition on
+2026-09-05 that `one_time_storage_lifecycle` now lifts out of `storage_audio`. The residue
+(≈ $1 over six days, and the 0.02% user-count drift) is the users snapshot being three hours
+fresher and the billing export continuing to settle. No allocation logic changed.
+
+## Files
+
+| file | role |
+|---|---|
+| `run_unit_cost.py` | the entrypoint: pull → assemble → validate → load |
+| `assemble_unit_cost.py` | the allocator. Pure functions are unit tested in `backend/tests/unit/test_finops_unit_cost.py` |
+| `load_bigquery.py` | dataset/table creation and idempotent per-date loads |
+| `gcpauth.py` | the two identities, verified by name before use |
+| `pull_gcp.py` + `gcp_component_classifier.sql` + `one_time_events.json` | billing export → components |
+| `pull_ledger.py` | `llm_gateway_attempts` → per-uid and per-group daily aggregates |
+| `pull_users.py` | users projection snapshot |
+| `pull_hourly_usage.py` | transcription seconds per uid-day |
+| `pull_prometheus.py` | VAD-forwarded audio hours |
+| `pull_providers.py` | OpenAI and Anthropic invoices |
+| `pull_stripe.py` | subscription book → MRR/ARPU by plan |
+| `posthog_dau.py` | DAU by platform (denominators only) |
+| `fs.py` | dependency-free Firestore REST client |
+
+## Known gaps
+
+* **STT vendor cost is modelled, not measured.** Modulate carries ~95% of live sessions and there
+  is no invoice feed or contract rate; `stt_vendor_low` uses a $0.0043/min placeholder and
+  `stt_vendor_high` is ×1.8. Replace `STT_VENDOR_RATE_PER_MIN` when the contract rates land.
+* **SaaS with no feed** (PostHog, Sentry, Redis Cloud, ~$500–700/mo) is in no pool at all.
+* **Half of variable cost is shared overhead** split by headcount because no per-uid request or
+  Firestore-read counter exists. `shared_activity` is the alternative, not a better truth.
+* **The ledger's `app_platform` header is written only by `desktop_proactivity`**, so request-level
+  platform is unavailable; platform comes from the users cohort join.
+* **Stripe is a snapshot**, not history. `plan_revenue_daily.snapshot_date` says so on every row.

--- a/backend/scripts/finops/assemble_unit_cost.py
+++ b/backend/scripts/finops/assemble_unit_cost.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""Assemble Omi true user unit cost by platform cohort and plan from the raw pulls.
+
+Inputs (the run's raw/ dir):
+  gcp_components_daily.json, gcp_day_resource_top.json, gcp_day_service_sku.json, gcp_recon.json
+  openai_cost_daily.json, anthropic_cost_daily.json
+  ledger_user_daily.csv, ledger_agg_daily.csv
+  users_active_30d.csv, stt_usage_daily.csv, posthog_dau_daily.csv, prom_stt_7d.json
+
+Method: every dollar lands on a (day, uid) row via one of these classes, then rolls up.
+  measured          - ledger LLM cost priced per attempt, joined to uid
+  driver-allocated  - pool allocated by a measured per-uid driver (transcription seconds,
+                      ledger OpenAI/Gemini share, desktop-feature share)
+  headcount         - pool split evenly across that day's cost-active users (Firestore reads etc.)
+  fixed             - Vertex PT reservation; reported separately, only in the fully-loaded view
+  modelled          - no invoice feed exists (STT vendor volume x a placeholder rate; Gemini list memo)
+  one_time          - dated one-off charges (see one_time_events.json). Reported at the day level,
+                      NEVER allocated to a user and never part of a run rate.
+No raw uids anywhere: inputs are already sha256[:16] hashes.
+
+Usage:
+  assemble_unit_cost.py RAW OUT [START [END [COHORT_WINDOW_START]]] [--cohort-lookback-days N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import datetime as dt
+import json
+import pathlib
+import sys
+
+STT_VENDOR_RATE_PER_MIN = 0.0043  # PLACEHOLDER (Deepgram Nova list). Modulate/Soniox contract rates pending.
+STT_VENDOR_HIGH_MULTIPLIER = 1.8
+
+SHARED = [
+    "firestore_reads",
+    "firestore_other",
+    "cloud_run_other",
+    "logging_monitoring",
+    "network",
+    "pubsub",
+    "other_gcp",
+    "storage_other",
+    "gke_other_compute",
+    "translate",
+]
+AUDIO = ["asr_gpu_fleet", "storage_audio", "listen_pipeline_compute"]
+DESKTOP_POOLS = ["embeddings", "cloud_run_desktop_backend"]
+EXCLUDED_FROM_VARIABLE = ["bigquery", "vertex_pt_reservation"]  # overhead / fixed
+
+COMPS = [
+    "llm_openai_measured",
+    "llm_direct_residual",
+    "vertex_paygo",
+    "audio_pipeline_gcp",
+    "desktop_pools",
+    "shared_headcount",
+    "shared_activity",
+    "variable_total",
+    "variable_total_activity",
+    "vertex_pt_fixed",
+    "fully_loaded",
+    "llm_gemini_list_memo",
+    "stt_vendor_low",
+    "stt_vendor_high",
+    "gross_total",
+]
+
+METHOD = {
+    "llm_openai_measured": "measured",
+    "llm_direct_residual": "driver-allocated",
+    "vertex_paygo": "driver-allocated",
+    "audio_pipeline_gcp": "driver-allocated",
+    "desktop_pools": "driver-allocated",
+    "shared_headcount": "headcount",
+    "shared_activity": "driver-allocated",
+    "vertex_pt_fixed": "fixed",
+    "llm_gemini_list_memo": "modelled",
+    "stt_vendor_low": "modelled",
+    "stt_vendor_high": "modelled",
+    # aggregates take the weakest method they contain
+    "variable_total": "driver-allocated",
+    "variable_total_activity": "driver-allocated",
+    "fully_loaded": "driver-allocated",
+    "gross_total": "modelled",
+}
+
+
+# ---------------------------------------------------------------- pure helpers (unit tested)
+def fnum(x) -> float:
+    try:
+        return float(x or 0)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def is_one_time(component: str) -> bool:
+    return component.startswith("one_time")
+
+
+def classify_cohort(last_desktop: str, last_mobile: str, last_web: str, window_start: str) -> str:
+    """Platform cohort from the users snapshot's last_active_at_* dates.
+
+    A user counts on a platform if they were last seen there on or after `window_start`.
+    Dual users are their own segment: nothing pretends to split a dual user's cost.
+    """
+    d = (last_desktop or "") >= window_start
+    m = (last_mobile or "") >= window_start
+    w = (last_web or "") >= window_start
+    if d and m:
+        return "dual"
+    if d:
+        return "desktop_only"
+    if m:
+        return "mobile_only"
+    if w:
+        return "web_only"
+    return "inactive_7d"
+
+
+def day_pools(
+    components: dict,
+    residual_openai: float,
+    residual_anthropic: float,
+    vad_sent_hours: float,
+    rate_per_min: float = STT_VENDOR_RATE_PER_MIN,
+) -> dict:
+    """The allocatable pools for one usage day. One-time components are never in a pool."""
+    c = {k: v for k, v in components.items() if not is_one_time(k)}
+    return {
+        "shared_gcp": sum(c.get(k, 0.0) for k in SHARED),
+        "audio_pipeline_gcp": sum(c.get(k, 0.0) for k in AUDIO),
+        "vertex_paygo": c.get("vertex_paygo", 0.0),
+        "desktop_pools": sum(c.get(k, 0.0) for k in DESKTOP_POOLS),
+        "llm_direct_residual": residual_openai + residual_anthropic,
+        "vertex_pt_fixed": c.get("vertex_pt_reservation", 0.0),
+        "stt_vendor_low": vad_sent_hours * 60 * rate_per_min,
+        "stt_vendor_high": vad_sent_hours * 60 * rate_per_min * STT_VENDOR_HIGH_MULTIPLIER,
+    }
+
+
+def allocate_user_day(f: dict, pools: dict, totals: dict, n_users: int) -> dict:
+    """Split the day's pools onto one user by that user's measured drivers.
+
+    `f` carries the user's measured facts (llm_openai, llm_gemini, fc_desktop, tx_sec, attempts);
+    `totals` the same quantities summed over the day; `n_users` the day's cost-active headcount.
+    """
+    tot_oai, tot_gem = totals["openai"], totals["gemini"]
+    tot_desk, tot_tx, tot_att = totals["desktop"], totals["tx_sec"], totals["attempts"]
+    oai_share = f["llm_openai"] / tot_oai if tot_oai else 0
+    gem_share = f["llm_gemini"] / tot_gem if tot_gem else 0
+    desk_share = f["fc_desktop"] / tot_desk if tot_desk else 0
+    tx_share = f["tx_sec"] / tot_tx if tot_tx else 0
+    att_share = f["attempts"] / tot_att if tot_att else 0
+    r = {
+        "llm_openai_measured": f["llm_openai"],
+        "llm_gemini_list_memo": f["llm_gemini"],  # NOT added to totals: served by the PT reservation
+        "llm_direct_residual": pools["llm_direct_residual"] * oai_share,
+        "vertex_paygo": pools["vertex_paygo"] * gem_share,
+        "audio_pipeline_gcp": pools["audio_pipeline_gcp"] * tx_share,
+        "desktop_pools": pools["desktop_pools"] * desk_share,
+        "shared_headcount": pools["shared_gcp"] / n_users if n_users else 0.0,
+        "shared_activity": (
+            pools["shared_gcp"] * (0.5 / n_users + 0.25 * att_share + 0.25 * tx_share) if n_users else 0.0
+        ),
+        "vertex_pt_fixed": pools["vertex_pt_fixed"] * gem_share,
+        "stt_vendor_low": pools["stt_vendor_low"] * tx_share,
+        "stt_vendor_high": pools["stt_vendor_high"] * tx_share,
+    }
+    r["variable_total"] = sum(
+        r[k]
+        for k in (
+            "llm_openai_measured",
+            "llm_direct_residual",
+            "vertex_paygo",
+            "audio_pipeline_gcp",
+            "desktop_pools",
+            "shared_headcount",
+        )
+    )
+    r["variable_total_activity"] = r["variable_total"] - r["shared_headcount"] + r["shared_activity"]
+    r["fully_loaded"] = r["variable_total"] + r["vertex_pt_fixed"]
+    r["gross_total"] = r["fully_loaded"] + r["stt_vendor_low"]
+    return r
+
+
+def reconcile_day(
+    date: str,
+    pools: dict,
+    allocated: dict,
+    components: dict,
+    gcp_export_net: float,
+    openai_invoice: float,
+    anthropic_invoice: float,
+    settled: bool,
+) -> list:
+    """One row per pool: what came off an invoice vs what landed on user-days."""
+    one_time = sum(v for k, v in components.items() if is_one_time(k))
+    rows = [
+        (
+            "shared_gcp",
+            pools["shared_gcp"],
+            allocated.get("shared_headcount", 0.0),
+            "gcp_billing_export",
+            "headcount split; activity-weighted alternative in shared_activity",
+        ),
+        (
+            "audio_pipeline_gcp",
+            pools["audio_pipeline_gcp"],
+            allocated.get("audio_pipeline_gcp", 0.0),
+            "gcp_billing_export",
+            "driver = hourly_usage.transcription_seconds",
+        ),
+        (
+            "vertex_paygo",
+            pools["vertex_paygo"],
+            allocated.get("vertex_paygo", 0.0),
+            "gcp_billing_export",
+            "driver = ledger gemini share",
+        ),
+        (
+            "desktop_pools",
+            pools["desktop_pools"],
+            allocated.get("desktop_pools", 0.0),
+            "gcp_billing_export",
+            "driver = ledger desktop-feature share",
+        ),
+        (
+            "vertex_pt_fixed",
+            pools["vertex_pt_fixed"],
+            allocated.get("vertex_pt_fixed", 0.0),
+            "gcp_billing_export",
+            "fixed reservation, fully-loaded view only",
+        ),
+        (
+            "llm_openai",
+            openai_invoice,
+            allocated.get("llm_openai_measured", 0.0) + allocated.get("llm_direct_residual", 0.0) - anthropic_invoice,
+            "openai_admin_api",
+            "ledger measured + residual; anthropic rides the same residual pool",
+        ),
+        (
+            "llm_anthropic",
+            anthropic_invoice,
+            anthropic_invoice,
+            "anthropic_admin_api",
+            "no ledger rows in this era; whole invoice is residual",
+        ),
+        (
+            "llm_openai_ledger_coverage",
+            openai_invoice,
+            allocated.get("llm_openai_measured", 0.0),
+            "openai_admin_api",
+            "DIAGNOSTIC, not an allocation check: how much of the OpenAI invoice the "
+            "per-attempt ledger explains. The remainder is llm_direct_residual.",
+        ),
+        (
+            "stt_vendor_low",
+            pools["stt_vendor_low"],
+            allocated.get("stt_vendor_low", 0.0),
+            "modelled",
+            "vad-sent hours x $%.4f/min placeholder; no vendor invoice feed" % STT_VENDOR_RATE_PER_MIN,
+        ),
+        (
+            "gcp_total_export",
+            gcp_export_net,
+            sum(components.values()),
+            "gcp_billing_export",
+            "classifier must lose nothing: components must equal the export",
+        ),
+        (
+            "one_time",
+            one_time,
+            one_time,
+            "gcp_billing_export",
+            "dated one-off charges, excluded from every per-user pool",
+        ),
+    ]
+    out = []
+    for pool, pool_usd, alloc_usd, src, note in rows:
+        delta = (alloc_usd - pool_usd) / pool_usd * 100 if pool_usd else 0.0
+        out.append(
+            {
+                "date": date,
+                "pool": pool,
+                "pool_usd": round(pool_usd, 6),
+                "allocated_usd": round(alloc_usd, 6),
+                "delta_pct": round(delta, 6),
+                "invoice_source": src,
+                "note": note,
+                "inputs_settled": settled,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------- loading
+def load_components(raw: pathlib.Path):
+    comp = collections.defaultdict(lambda: collections.defaultdict(float))
+    for r in json.load(open(raw / "gcp_components_daily.json")):
+        comp[r["usage_day"]][r["component"]] += fnum(r["net"])
+    # Reclassify listen/pusher GKE pools out of gke_other_compute into listen_pipeline_compute.
+    listen_pool = collections.defaultdict(float)
+    for r in json.load(open(raw / "gcp_day_resource_top.json")):
+        labs = r.get("labels") or "[]"
+        try:
+            labs = json.loads(labs) if isinstance(labs, str) else labs
+        except Exception:  # noqa: BLE001
+            labs = []
+        pool = next((l.get("value") for l in labs if l.get("key") == "goog-k8s-node-pool-name"), "")
+        if pool.startswith(("backend-listen-pool", "pusher-pool")):
+            listen_pool[r["usage_day"]] += fnum(r["net"])
+    for d, v in listen_pool.items():
+        v = min(v, comp[d]["gke_other_compute"])  # resource extract is top-3000 rows; never drive the residual negative
+        comp[d]["gke_other_compute"] -= v
+        comp[d]["listen_pipeline_compute"] += v
+    dev_by_day = collections.defaultdict(float)
+    for r in json.load(open(raw / "gcp_day_service_sku.json")):
+        if r["project_id"] != "based-hardware":
+            dev_by_day[r["usage_day"]] += fnum(r["net"])
+    export_net, max_end = collections.defaultdict(float), {}
+    p = raw / "gcp_recon.json"
+    if p.exists():
+        for r in json.load(open(p)):
+            export_net[r["usage_day"]] += fnum(r["net"])
+            max_end[r["usage_day"]] = r.get("max_usage_end_time")
+    return comp, dev_by_day, export_net, max_end
+
+
+def load_invoices(raw: pathlib.Path):
+    openai_inv, openai_cache_writes = collections.defaultdict(float), collections.defaultdict(float)
+    for b in json.load(open(raw / "openai_cost_daily.json"))["data"]:
+        day = (dt.date.fromisoformat(b["end_time_iso"][:10]) - dt.timedelta(days=1)).isoformat()
+        for x in b["results"]:
+            openai_inv[day] += fnum(x["amount"]["value"])
+            if "cache writes" in x["line_item"]:
+                openai_cache_writes[day] += fnum(x["amount"]["value"])
+    anthropic_inv = collections.defaultdict(float)
+    for b in json.load(open(raw / "anthropic_cost_daily.json"))["data"]:
+        for x in b["results"]:
+            anthropic_inv[b["starting_at"][:10]] += fnum(x["amount_usd"])
+    return openai_inv, openai_cache_writes, anthropic_inv
+
+
+def load_users(raw: pathlib.Path):
+    """Users snapshot, keeping the raw last_active dates so cohort is evaluated per usage day."""
+    users = {}
+    with open(raw / "users_active_30d.csv") as f:
+        for r in csv.DictReader(f):
+            users[r["uid_hash"]] = {
+                "plan": r["plan"] or "none",
+                "desktop": r["last_active_at_desktop"],
+                "mobile": r["last_active_at_mobile"],
+                "web": r["last_active_at_web"],
+                "byok": (r.get("byok_active") or "").lower() == "true",
+            }
+    return users
+
+
+def cohort_window_start_for(date: str, lookback_days: int, fixed: str | None = None) -> str:
+    """The date from which a snapshot last_active_at_* counts as 'active on that platform'.
+
+    Default: a trailing window of `lookback_days` ending on the usage day, so the definition is
+    the same for every date whether it is computed alone or inside a backfill. `fixed` pins one
+    explicit date instead, which is what reproducing an older report needs.
+    """
+    if fixed:
+        return fixed
+    return (dt.date.fromisoformat(date) - dt.timedelta(days=lookback_days - 1)).isoformat()
+
+
+def load_facts(raw: pathlib.Path):
+    fact = collections.defaultdict(
+        lambda: {
+            "llm": 0.0,
+            "llm_openai": 0.0,
+            "llm_gemini": 0.0,
+            "llm_other": 0.0,
+            "fc_desktop": 0.0,
+            "attempts": 0,
+            "unpriced": 0,
+            "tx_sec": 0.0,
+            "tier": None,
+        }
+    )
+    with open(raw / "ledger_user_daily.csv") as f:
+        for r in csv.DictReader(f):
+            k = (r["date"], r["uid_hash"])
+            fact[k]["llm"] += fnum(r["cost_micro_usd_sum"]) / 1e6
+            fact[k]["llm_openai"] += fnum(r.get("cost_openai")) / 1e6
+            fact[k]["llm_gemini"] += fnum(r.get("cost_gemini")) / 1e6
+            fact[k]["llm_other"] += fnum(r.get("cost_other_provider")) / 1e6
+            fact[k]["fc_desktop"] += fnum(r.get("fc_desktop")) / 1e6
+            fact[k]["unpriced"] += int(r.get("attempts_unpriced") or 0)
+            fact[k]["attempts"] += int(r["attempts"] or 0)
+            fact[k]["tier"] = r["subscription_tier"] or r["plan_id"]
+    with open(raw / "stt_usage_daily.csv") as f:
+        for r in csv.DictReader(f):
+            fact[(r["date"], r["uid_hash"])]["tx_sec"] += fnum(r["transcription_seconds"])
+    return fact
+
+
+def load_posthog(raw: pathlib.Path):
+    ph = collections.defaultdict(lambda: collections.defaultdict(float))
+    p = raw / "posthog_dau_daily.csv"
+    if not p.exists():
+        return ph
+    with open(p) as f:
+        for r in csv.DictReader(f):
+            plat = "desktop" if r["os"] in ("macOS", "Windows") else "mobile"
+            ph[r["definition"]][(r["day"], plat)] += int(r["users"])
+    return ph
+
+
+def load_vad_hours(raw: pathlib.Path):
+    vad = collections.defaultdict(float)
+    p = raw / "prom_stt_7d.json"
+    if not p.exists():
+        return vad
+    try:
+        pj = json.load(open(p))
+        for series in pj["daily"]["d_vad_gate_audio_seconds"]["result"]["data"]["result"]:
+            if series["metric"].get("outcome") == "sent":
+                for ts, v in series["values"]:
+                    day = (
+                        (dt.datetime.fromtimestamp(int(ts), dt.timezone.utc) - dt.timedelta(days=1)).date().isoformat()
+                    )
+                    vad[day] += fnum(v) / 3600
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write("prom parse failed: %s\n" % e)
+    return vad
+
+
+# ---------------------------------------------------------------- roll-ups
+def rollup(rows, keyfn, n_days: int):
+    g = collections.defaultdict(lambda: collections.defaultdict(float))
+    ud = collections.Counter()
+    vals = collections.defaultdict(list)
+    for r in rows:
+        k = keyfn(r)
+        ud[k] += 1
+        for c_ in COMPS:
+            g[k][c_] += r[c_]
+        g[k]["tx_hours"] += r["tx_sec"] / 3600
+        g[k]["attempts"] += r["attempts"]
+        vals[k].append(r["variable_total"])
+    out = []
+    for k in sorted(g, key=lambda x: -g[x]["variable_total"]):
+        n = ud[k]
+        v = sorted(vals[k])
+        row = {
+            "segment": k if isinstance(k, str) else " / ".join(k),
+            "user_days": n,
+            "mean_users_per_day": round(n / n_days, 1),
+        }
+        for c_ in COMPS:
+            row[c_ + "_per_day"] = round(g[k][c_] / n_days, 2)
+        for c_ in (
+            "variable_total",
+            "variable_total_activity",
+            "fully_loaded",
+            "gross_total",
+            "llm_openai_measured",
+            "audio_pipeline_gcp",
+            "shared_headcount",
+            "stt_vendor_low",
+            "stt_vendor_high",
+            "vertex_pt_fixed",
+        ):
+            row[c_ + "_per_user_day"] = round(g[k][c_] / n, 4)
+        row["variable_per_user_month_30d"] = round(g[k]["variable_total"] / n * 30, 2)
+        row["p50_user_day"] = round(v[len(v) // 2], 4)
+        row["p90_user_day"] = round(v[int(len(v) * 0.9)], 4)
+        row["p99_user_day"] = round(v[int(len(v) * 0.99)], 4)
+        row["top1pct_share"] = round(sum(v[-max(1, len(v) // 100) :]) / sum(v), 3) if sum(v) else 0
+        row["tx_hours_per_user_day"] = round(g[k]["tx_hours"] / n, 3)
+        row["attempts_per_user_day"] = round(g[k]["attempts"] / n, 1)
+        out.append(row)
+    return out
+
+
+PLATFORM_UNION_MEMBERS = {
+    "desktop_incl_dual": ("desktop_only", "dual"),
+    "mobile_incl_dual": ("mobile_only", "dual"),
+}
+
+
+def long_rows(rows, date_of, segments):
+    """Long-format (date, segment_type, segment, component) sums plus headcount.
+
+    `segments` is a list of (segment_type, keyfn) where keyfn returns a segment name or a
+    list of names (platform_union counts a dual user in both desktop and mobile).
+    """
+    agg = collections.defaultdict(lambda: collections.defaultdict(float))
+    users = collections.defaultdict(set)
+    for r in rows:
+        d = date_of(r)
+        for stype, keyfn in segments:
+            k = keyfn(r)
+            for seg in (k if isinstance(k, list) else [k]):
+                if seg is None:
+                    continue
+                key = (d, stype, seg)
+                users[key].add(r["uid_hash"])
+                for c_ in COMPS:
+                    agg[key][c_] += r[c_]
+    out = []
+    for d, stype, seg in sorted(agg):
+        n = len(users[(d, stype, seg)])
+        for c_ in COMPS:
+            usd = agg[(d, stype, seg)][c_]
+            out.append(
+                {
+                    "date": d,
+                    "segment_type": stype,
+                    "segment": seg,
+                    "component": c_,
+                    "method": METHOD[c_],
+                    "usd": round(usd, 6),
+                    "users": n,
+                    "usd_per_user_day": round(usd / n, 8) if n else None,
+                }
+            )
+    return out
+
+
+def write_csv(path: pathlib.Path, rows: list) -> None:
+    if not rows:
+        path.write_text("")
+        return
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+def assemble(
+    raw: pathlib.Path,
+    out: pathlib.Path,
+    start: str,
+    end: str,
+    cohort_window_start: str | None = None,
+    settled_through: str | None = None,
+    cohort_lookback_days: int = 7,
+) -> dict:
+    out.mkdir(parents=True, exist_ok=True)
+    comp, dev_by_day, export_net, max_end = load_components(raw)
+    openai_inv, openai_cache_writes, anthropic_inv = load_invoices(raw)
+    users = load_users(raw)
+    fact = load_facts(raw)
+    ph = load_posthog(raw)
+    vad_sent_h = load_vad_hours(raw)
+
+    days = sorted(d for d in comp if start <= d <= end)
+    if not days:
+        raise SystemExit("no GCP component rows in window %s..%s" % (start, end))
+
+    cohort_cache: dict[str, dict[str, str]] = {}
+
+    def cohorts_on(date: str) -> dict:
+        """Cohort per uid for one usage day, on that day's own activity window."""
+        ws = cohort_window_start_for(date, cohort_lookback_days, cohort_window_start)
+        if ws not in cohort_cache:
+            cohort_cache[ws] = {uh: classify_cohort(u["desktop"], u["mobile"], u["web"], ws) for uh, u in users.items()}
+        return cohort_cache[ws]
+
+    def plan_of(uid, fallback="unknown"):
+        return users.get(uid, {}).get("plan", fallback)
+
+    rows, day_summary, recon_rows = [], {}, []
+    for d in days:
+        coh = cohorts_on(d)
+
+        def cohort_of(uid, _c=coh):
+            return _c.get(uid, "unknown")
+
+        uids = [u for (dd, u) in fact if dd == d]
+        n = len(uids)
+        totals = {
+            "openai": sum(fact[(d, u)]["llm_openai"] for u in uids),
+            "gemini": sum(fact[(d, u)]["llm_gemini"] for u in uids),
+            "desktop": sum(fact[(d, u)]["fc_desktop"] for u in uids),
+            "tx_sec": sum(fact[(d, u)]["tx_sec"] for u in uids),
+            "attempts": sum(fact[(d, u)]["attempts"] for u in uids),
+        }
+        residual_openai = openai_inv.get(d, 0) - totals["openai"]
+        residual_anthropic = anthropic_inv.get(d, 0)  # no ledger rows: all direct-path
+        c = dict(comp[d])
+        pools = day_pools(c, residual_openai, residual_anthropic, vad_sent_h.get(d, 0))
+        alloc_tot = collections.defaultdict(float)
+        for u in uids:
+            f_ = fact[(d, u)]
+            r = {
+                "date": d,
+                "uid_hash": u,
+                "cohort": cohort_of(u),
+                "plan": plan_of(u, f_["tier"] or "unknown"),
+                "attempts": f_["attempts"],
+                "unpriced_attempts": f_["unpriced"],
+                "tx_sec": f_["tx_sec"],
+            }
+            r.update(allocate_user_day(f_, pools, totals, n))
+            for c_ in COMPS:
+                alloc_tot[c_] += r[c_]
+            rows.append(r)
+        settled = settled_through is None or d <= settled_through
+        recon_rows.extend(
+            reconcile_day(
+                d,
+                pools,
+                alloc_tot,
+                c,
+                export_net.get(d, sum(c.values())),
+                openai_inv.get(d, 0),
+                anthropic_inv.get(d, 0),
+                settled,
+            )
+        )
+        day_summary[d] = {
+            "cost_active_users": n,
+            "gcp_net": sum(c.values()),
+            "gcp_net_excl_one_time": sum(v for k, v in c.items() if not is_one_time(k)),
+            "gcp_one_time": sum(v for k, v in c.items() if is_one_time(k)),
+            "gcp_export_net": export_net.get(d),
+            "max_usage_end_time": max_end.get(d),
+            "gcp_dev": dev_by_day.get(d, 0),
+            "ledger_openai": totals["openai"],
+            "ledger_gemini_list": totals["gemini"],
+            "openai_invoice": openai_inv.get(d, 0),
+            "openai_cache_writes": openai_cache_writes.get(d, 0),
+            "anthropic_invoice": anthropic_inv.get(d, 0),
+            "residual_openai": residual_openai,
+            "tx_hours": totals["tx_sec"] / 3600,
+            "vad_sent_hours": vad_sent_h.get(d, 0),
+            "pools": pools,
+            "inputs_settled": settled,
+            "posthog_clean_desktop": ph["clean"].get((d, "desktop"), 0),
+            "posthog_clean_mobile": ph["clean"].get((d, "mobile"), 0),
+            "posthog_all_desktop": ph["all_events"].get((d, "desktop"), 0),
+            "posthog_all_mobile": ph["all_events"].get((d, "mobile"), 0),
+            "cohort_users": collections.Counter(cohort_of(u) for u in uids),
+            "one_time_components": {k: v for k, v in c.items() if is_one_time(k)},
+        }
+
+    write_csv(out / "user_day_allocated.csv", rows)
+    nd = len(days)
+    by_cohort = rollup(rows, lambda r: r["cohort"], nd)
+    by_plan = rollup(rows, lambda r: r["plan"], nd)
+    by_cohort_plan = rollup(rows, lambda r: (r["cohort"], r["plan"]), nd)
+    by_platform = rollup(
+        rows,
+        lambda r: (
+            "desktop_incl_dual"
+            if r["cohort"] in ("desktop_only", "dual")
+            else "mobile_only" if r["cohort"] == "mobile_only" else "other"
+        ),
+        nd,
+    )
+    by_platform_m = rollup(
+        rows,
+        lambda r: (
+            "mobile_incl_dual"
+            if r["cohort"] in ("mobile_only", "dual")
+            else "desktop_only" if r["cohort"] == "desktop_only" else "other"
+        ),
+        nd,
+    )
+    for name, table in (
+        ("cohort", by_cohort),
+        ("plan", by_plan),
+        ("cohort_plan", by_cohort_plan),
+        ("platform_union", by_platform),
+        ("platform_union_m", by_platform_m),
+    ):
+        write_csv(out / ("unit_cost_by_%s.csv" % name), table)
+
+    def platform_union_key(r):
+        segs = [s for s, members in PLATFORM_UNION_MEMBERS.items() if r["cohort"] in members]
+        return segs or ["other_union"]
+
+    longs = long_rows(
+        rows,
+        lambda r: r["date"],
+        [
+            ("cohort", lambda r: r["cohort"]),
+            ("plan", lambda r: r["plan"]),
+            ("cohort_plan", lambda r: r["cohort"] + " / " + r["plan"]),
+            ("platform_union", platform_union_key),
+            ("total", lambda r: "all"),
+        ],
+    )
+    # one-time charges: day level only, never per user
+    for d in days:
+        for k, v in day_summary[d]["one_time_components"].items():
+            longs.append(
+                {
+                    "date": d,
+                    "segment_type": "total",
+                    "segment": "all",
+                    "component": k,
+                    "method": "one_time",
+                    "usd": round(v, 6),
+                    "users": day_summary[d]["cost_active_users"],
+                    "usd_per_user_day": None,
+                }
+            )
+    write_csv(out / "unit_cost_long.csv", longs)
+    write_csv(out / "unit_cost_reconciliation.csv", recon_rows)
+
+    alt = alt_denoms(rows, day_summary, days)
+    write_csv(out / "platform_alt_denominators.csv", alt)
+    json.dump(
+        {
+            "days": day_summary,
+            "components_mean_per_day": {
+                k: round(sum(comp[d].get(k, 0) for d in days) / nd, 2)
+                for k in sorted({k for d in days for k in comp[d]})
+            },
+        },
+        open(out / "day_summary.json", "w"),
+        indent=1,
+        default=str,
+    )
+    return {
+        "days": days,
+        "rows": rows,
+        "day_summary": day_summary,
+        "long": longs,
+        "recon": recon_rows,
+        "by_cohort": by_cohort,
+        "by_plan": by_plan,
+        "by_cohort_plan": by_cohort_plan,
+        "by_platform": by_platform,
+        "by_platform_m": by_platform_m,
+        "alt": alt,
+        "comp": comp,
+    }
+
+
+def alt_denoms(rows, day_summary, days):
+    tot = collections.defaultdict(float)
+    for r in rows:
+        if r["cohort"] in ("desktop_only", "dual"):
+            tot["desktop_incl_dual"] += r["variable_total"]
+        if r["cohort"] in ("mobile_only", "dual"):
+            tot["mobile_incl_dual"] += r["variable_total"]
+    dd = {
+        k: sum(day_summary[d][k] for d in days)
+        for k in ("posthog_clean_desktop", "posthog_clean_mobile", "posthog_all_desktop", "posthog_all_mobile")
+    }
+    out = []
+    for plat, keyc, keya in (
+        ("desktop_incl_dual", "posthog_clean_desktop", "posthog_all_desktop"),
+        ("mobile_incl_dual", "posthog_clean_mobile", "posthog_all_mobile"),
+    ):
+        members = PLATFORM_UNION_MEMBERS[plat]
+        ud = sum(1 for r in rows if r["cohort"] in members)
+        out.append(
+            {
+                "platform": plat,
+                "variable_per_day": round(tot[plat] / len(days), 2),
+                "per_cost_active_user_day": round(tot[plat] / ud, 3) if ud else None,
+                "per_posthog_clean_dau": round(tot[plat] / dd[keyc], 3) if dd[keyc] else None,
+                "per_posthog_all_events_dau": round(tot[plat] / dd[keya], 3) if dd[keya] else None,
+                "mean_cost_active_users": round(ud / len(days)),
+                "mean_posthog_clean_dau": round(dd[keyc] / len(days)),
+                "mean_posthog_all_dau": round(dd[keya] / len(days)),
+            }
+        )
+    return out
+
+
+def report(res: dict, start: str, end: str) -> None:
+    days, day_summary = res["days"], res["day_summary"]
+
+    def show(title, table, cols):
+        print(f"\n## {title}")
+        print("| " + " | ".join(cols) + " |")
+        print("|" + "---|" * len(cols))
+        for r in table:
+            print("| " + " | ".join(str(r[c]) for c in cols) + " |")
+
+    print(f"# Omi unit cost, usage days {start}..{end} ({len(days)} days)")
+    print("\n## Day summary")
+    for d in days:
+        s = day_summary[d]
+        print(
+            f"{d}: cost-active {s['cost_active_users']}  gcp ${s['gcp_net_excl_one_time']:.0f}"
+            f" (one-time ${s['gcp_one_time']:.0f}, dev ${s['gcp_dev']:.0f})"
+            f"  ledger openai ${s['ledger_openai']:.0f} gemini-list ${s['ledger_gemini_list']:.0f}"
+            f"  openai inv ${s['openai_invoice']:.0f} (cache-writes ${s['openai_cache_writes']:.0f})"
+            f" resid ${s['residual_openai']:.0f}  anthropic inv ${s['anthropic_invoice']:.0f}"
+            f"  tx {s['tx_hours']:.0f}h vad-sent {s['vad_sent_hours']:.0f}h"
+            f"  posthog clean D/M {s['posthog_clean_desktop']:.0f}/{s['posthog_clean_mobile']:.0f}"
+            f"  cohorts {dict(s['cohort_users'])}"
+        )
+    print("\n## GCP components mean $/day")
+    comp = res["comp"]
+    means = {k: sum(comp[d].get(k, 0) for d in days) / len(days) for k in sorted({k for d in days for k in comp[d]})}
+    for k, v in sorted(means.items(), key=lambda x: -x[1]):
+        print(f"  {k:28s} {v:8.2f}{'   [one_time, excluded from run rate]' if is_one_time(k) else ''}")
+    print("\n## Reconciliation (allocated vs pool)")
+    print("| date | pool | pool_usd | allocated_usd | delta_pct | source |")
+    print("|---|---|---:|---:|---:|---|")
+    for r in res["recon"]:
+        print(
+            f"| {r['date']} | {r['pool']} | {r['pool_usd']:.2f} | {r['allocated_usd']:.2f} |"
+            f" {r['delta_pct']:.4f} | {r['invoice_source']} |"
+        )
+    C1 = [
+        "segment",
+        "mean_users_per_day",
+        "variable_total_per_day",
+        "variable_total_per_user_day",
+        "variable_total_activity_per_user_day",
+        "fully_loaded_per_user_day",
+        "variable_per_user_month_30d",
+        "p50_user_day",
+        "p90_user_day",
+        "p99_user_day",
+        "top1pct_share",
+    ]
+    C2 = [
+        "segment",
+        "llm_openai_measured_per_day",
+        "llm_direct_residual_per_day",
+        "vertex_paygo_per_day",
+        "audio_pipeline_gcp_per_day",
+        "desktop_pools_per_day",
+        "shared_headcount_per_day",
+        "variable_total_per_day",
+        "vertex_pt_fixed_per_day",
+        "llm_gemini_list_memo_per_day",
+        "stt_vendor_low_per_day",
+        "stt_vendor_high_per_day",
+        "tx_hours_per_user_day",
+        "attempts_per_user_day",
+    ]
+    show("By platform cohort: unit cost", res["by_cohort"], C1)
+    show("By platform cohort: components $/day", res["by_cohort"], C2)
+    show("By plan: unit cost", res["by_plan"], C1)
+    show("By plan: components $/day", res["by_plan"], C2)
+    show("By cohort x plan (top 15)", res["by_cohort_plan"][:15], C1)
+    show("Platform union views (dual counted in both)", res["by_platform"] + res["by_platform_m"], C1)
+    show("Platform totals under alternative denominators", res["alt"], list(res["alt"][0].keys()))
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("raw", nargs="?", default="raw")
+    ap.add_argument("out", nargs="?", default="derived")
+    ap.add_argument("start", nargs="?", default=None)
+    ap.add_argument("end", nargs="?", default=None)
+    ap.add_argument(
+        "cohort_window_start",
+        nargs="?",
+        default=None,
+        help="pin the date from which a users-snapshot last_active_at_* counts as 'on that platform'. "
+        "Omit for the default trailing window (--cohort-lookback-days ending on each usage day).",
+    )
+    ap.add_argument("--settled-through", default=None)
+    ap.add_argument("--cohort-lookback-days", type=int, default=7)
+    a = ap.parse_args(argv)
+    raw, out = pathlib.Path(a.raw), pathlib.Path(a.out)
+    start = a.start or min(r["usage_day"] for r in json.load(open(raw / "gcp_components_daily.json")))
+    end = a.end or max(r["usage_day"] for r in json.load(open(raw / "gcp_components_daily.json")))
+    res = assemble(raw, out, start, end, a.cohort_window_start, a.settled_through, a.cohort_lookback_days)
+    report(res, start, end)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/fs.py
+++ b/backend/scripts/finops/fs.py
@@ -1,0 +1,125 @@
+"""Minimal dependency-free Firestore REST helper (read-only).
+
+Auth comes from :mod:`gcpauth` (the read-only bot profile), refreshed in-process,
+so a long pull never dies on a 60-minute token expiry and no token is written to disk.
+"""
+
+import json, os, ssl, sys, time, urllib.request, urllib.error, hashlib
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from gcpauth import TOKEN, PROJECT  # noqa: E402
+
+BASE = f"https://firestore.googleapis.com/v1/projects/{PROJECT}/databases/(default)/documents"
+
+
+def token(force=False):
+    return TOKEN.get(force=force)
+
+
+_CTX = ssl.create_default_context()
+
+
+def post(path, body, retries=5):
+    url = BASE + path
+    data = json.dumps(body).encode()
+    last = None
+    for i in range(retries):
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers={
+                "Authorization": "Bearer " + token(),
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, context=_CTX, timeout=180) as r:
+                return json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            body_txt = e.read().decode()[:4000]
+            last = (e.code, body_txt)
+            if e.code == 401 and i == 0:
+                token(force=True)
+                continue
+            if e.code in (429, 500, 503, 504):
+                time.sleep(2 * (i + 1))
+                continue
+            raise RuntimeError(f"HTTP {e.code}: {body_txt}")
+        except Exception as e:
+            last = ("net", str(e))
+            time.sleep(2 * (i + 1))
+            continue
+    raise RuntimeError(f"exhausted retries: {last}")
+
+
+def get(path, params="", retries=5):
+    url = BASE + path + params
+    last = None
+    for i in range(retries):
+        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + token()})
+        try:
+            with urllib.request.urlopen(req, context=_CTX, timeout=180) as r:
+                return json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            body_txt = e.read().decode()[:4000]
+            last = (e.code, body_txt)
+            if e.code == 401 and i == 0:
+                token(force=True)
+                continue
+            if e.code in (429, 500, 503, 504):
+                time.sleep(2 * (i + 1))
+                continue
+            raise RuntimeError(f"HTTP {e.code}: {body_txt}")
+        except Exception as e:
+            last = ("net", str(e))
+            time.sleep(2 * (i + 1))
+            continue
+    raise RuntimeError(f"exhausted retries: {last}")
+
+
+def uid_hash(uid):
+    return hashlib.sha256(uid.encode()).hexdigest()[:16]
+
+
+def unwrap(v):
+    """Firestore Value -> python."""
+    if v is None:
+        return None
+    k = next(iter(v))
+    if k == "nullValue":
+        return None
+    if k == "stringValue":
+        return v[k]
+    if k == "integerValue":
+        return int(v[k])
+    if k == "doubleValue":
+        return float(v[k])
+    if k == "booleanValue":
+        return v[k]
+    if k == "timestampValue":
+        return v[k]
+    if k == "arrayValue":
+        return [unwrap(x) for x in v[k].get("values", [])]
+    if k == "mapValue":
+        return {kk: unwrap(vv) for kk, vv in v[k].get("fields", {}).items()}
+    if k == "referenceValue":
+        return v[k]
+    if k == "geoPointValue":
+        return v[k]
+    if k == "bytesValue":
+        return "<bytes>"
+    return v[k]
+
+
+def typename(v):
+    if v is None:
+        return "missing"
+    k = next(iter(v))
+    if k == "arrayValue":
+        vals = v[k].get("values", [])
+        inner = typename(vals[0]) if vals else "empty"
+        return f"array<{inner}>"
+    if k == "mapValue":
+        return "map{" + ",".join(sorted(v[k].get("fields", {}).keys())) + "}"
+    return k

--- a/backend/scripts/finops/gcp_component_classifier.sql
+++ b/backend/scripts/finops/gcp_component_classifier.sql
@@ -1,0 +1,101 @@
+-- Omi GCP unit-cost component classifier.
+-- Source: `based-hardware.gcp_billing_export.gcp_billing_export_resource_v1_01B287_9348DC_02D256`
+-- (the 01B896_918303_539138 account is the PREDECESSOR account; it has no data after 2026-07-01.)
+--
+-- Requires these expressions in scope (define in a WITH or repeat inline):
+--   node_pool  = (SELECT l.value FROM UNNEST(labels) l WHERE l.key='goog-k8s-node-pool-name' LIMIT 1)
+--   res_name   = IFNULL(resource.global_name, resource.name)
+--
+-- Ordering is load-bearing:
+--   * Cloud Run is matched by RESOURCE before Compute Engine is matched by SERVICE, because
+--     "Compute Flexible Committed Use Discounts - 3 Year" rows carry service.description='Compute Engine'
+--     while their resource is a Cloud Run service (goog-originating-service-id=152E-C115-5142).
+--   * Cloud Storage is matched before the generic network SKU rule so bucket replication/egress
+--     stays with the bucket that caused it.
+--   * Firestore is matched by SKU, never by service name (it bills under service 'App Engine').
+
+CASE
+  ---------------------------------------------------------------- one-off charges
+  -- Injected from one_time_events.json by pull_gcp.py. Dated, resource-scoped rules only.
+  -- These land in their own `one_time_*` component, are reported with method='one_time',
+  -- and are excluded from every per-user allocation pool.
+{{ONE_TIME_RULES}}
+  ---------------------------------------------------------------- overhead
+  WHEN service.description = 'BigQuery' THEN 'bigquery'
+
+  ---------------------------------------------------------------- firestore
+  WHEN sku.description = 'Cloud Firestore Read Ops' THEN 'firestore_reads'
+  WHEN LOWER(sku.description) LIKE '%firestore%'
+    OR service.description = 'Cloud Firestore'                     THEN 'firestore_other'
+
+  ---------------------------------------------------------------- model serving
+  -- 5-GSU gemini-flash flat reservation, ~$298/day net, unit = seconds
+  WHEN sku.description LIKE 'Vertex AI: Provisioned Throughput%'   THEN 'vertex_pt_reservation'
+  WHEN LOWER(sku.description) LIKE '%embedding%'
+    OR LOWER(sku.description) LIKE '%embedcontent%'                THEN 'embeddings'
+  WHEN service.description IN ('Vertex AI','Gemini API',
+                               'Generative Language API',
+                               'Vertex AI Search','Vertex AI Agent Builder')
+    OR LOWER(sku.description) LIKE '%gemini%'
+    OR LOWER(sku.description) LIKE '%generative%'                  THEN 'vertex_paygo'
+
+  ---------------------------------------------------------------- simple service buckets
+  WHEN service.description IN ('Translate','Cloud Translation')    THEN 'translate'
+  WHEN service.description IN ('Cloud Logging','Cloud Monitoring','Cloud Trace',
+                               'Stackdriver Logging','Stackdriver Monitoring',
+                               'Cloud Profiler','Error Reporting')  THEN 'logging_monitoring'
+  WHEN service.description = 'Cloud Pub/Sub'                        THEN 'pubsub'
+
+  ---------------------------------------------------------------- storage (before network rule)
+  WHEN service.description IN ('Cloud Storage','Storage Insights')
+       AND ( IFNULL(resource.global_name, resource.name) LIKE '%/buckets/omi-private-cloud-sync%'
+          OR IFNULL(resource.global_name, resource.name) LIKE '%/buckets/omi-dev-private-cloud-sync%'
+          OR IFNULL(resource.global_name, resource.name) LIKE '%/buckets/syncing-local%' )
+                                                                    THEN 'storage_audio'
+  WHEN service.description IN ('Cloud Storage','Storage Insights')  THEN 'storage_other'
+
+  ---------------------------------------------------------------- Cloud Run (before Compute Engine)
+  WHEN IFNULL(resource.global_name, resource.name) LIKE '//run.googleapis.com/%/services/desktop-backend'
+                                                                    THEN 'cloud_run_desktop_backend'
+  WHEN IFNULL(resource.global_name, resource.name) LIKE '//run.googleapis.com/%'
+    OR IFNULL(resource.global_name, resource.name) LIKE '//cloudfunctions.googleapis.com/%'
+    OR service.description IN ('Cloud Run','Cloud Run Functions','Cloud Functions')
+                                                                    THEN 'cloud_run_other'
+
+  ---------------------------------------------------------------- network
+  WHEN service.description IN ('Networking','Network Security','Cloud DNS',
+                               'Network Topology','Cloud Load Balancing','Network Intelligence Center')
+                                                                    THEN 'network'
+  WHEN service.description = 'Compute Engine'
+       AND ( sku.description LIKE 'Network%'
+          OR sku.description LIKE '%Data Transfer%'
+          OR sku.description LIKE '%External IP%'
+          OR sku.description LIKE '%Forwarding Rule%'
+          OR sku.description LIKE '%Load Balanc%' )                 THEN 'network'
+
+  ---------------------------------------------------------------- ASR / STT GPU fleet
+  WHEN REGEXP_CONTAINS(
+         IFNULL((SELECT l.value FROM UNNEST(labels) l
+                  WHERE l.key='goog-k8s-node-pool-name' LIMIT 1),''),
+         r'(?i)parakeet|nllb|diariz|vad|(^|-)asr|hpfasr|deepgram|whisper|stt')
+                                                                    THEN 'asr_gpu_fleet'
+  WHEN service.description IN ('Compute Engine','Kubernetes Engine')
+       AND ( LOWER(sku.description) LIKE '%gpu%'
+          OR LOWER(sku.description) LIKE '%nvidia%'
+          OR sku.description LIKE 'G2 Instance%' )                  THEN 'asr_gpu_fleet'
+
+  ---------------------------------------------------------------- remaining compute
+  WHEN service.description IN ('Compute Engine','Kubernetes Engine',
+                               'Deep Learning VM','Container Registry Vulnerability Scanning')
+                                                                    THEN 'gke_other_compute'
+
+  ELSE 'other_gcp'
+END AS component,
+
+CASE
+  WHEN <component> = 'vertex_pt_reservation'                        THEN 'fixed'
+  WHEN <component> IN ('embeddings','cloud_run_desktop_backend')    THEN 'desktop'
+  WHEN <component> IN ('asr_gpu_fleet','storage_audio')             THEN 'mobile'
+  WHEN <component> = 'bigquery'                                     THEN 'overhead'
+  ELSE 'shared'
+END AS platform_structural

--- a/backend/scripts/finops/gcpauth.py
+++ b/backend/scripts/finops/gcpauth.py
@@ -1,0 +1,88 @@
+"""Read-only GCP identity helpers for the finops pulls.
+
+Two identities are used, on purpose:
+
+  * ``read-only-bot-account@based-hardware.iam.gserviceaccount.com`` for every READ
+    (BigQuery billing export, Firestore projections). Sourced from
+    ``~/.hermes/scripts/omi-prod-gcp-read-only-env.sh``. The documented
+    ``~/.hermes/profiles`` path does not exist on this host and falls through
+    silently to owner credentials, so the account is verified after sourcing.
+  * the interactive owner account for BigQuery WRITES into ``omi_finops``
+    (dataset/table create, partition replace). Verified by name before any write.
+
+Nothing here prints or persists a token.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+READONLY_ENV = os.path.expanduser("~/.hermes/scripts/omi-prod-gcp-read-only-env.sh")
+READONLY_ACCOUNT = "read-only-bot-account@based-hardware.iam.gserviceaccount.com"
+WRITER_ACCOUNT = "david@scalingforever.com"
+PROJECT = "based-hardware"
+
+
+def _sh(cmd: str, timeout: int = 180) -> str:
+    p = subprocess.run(["bash", "-lc", cmd], capture_output=True, text=True, timeout=timeout)
+    if p.returncode != 0:
+        raise RuntimeError("command failed (%d): %s" % (p.returncode, p.stderr[-400:]))
+    return p.stdout.strip()
+
+
+def readonly_account() -> str:
+    """Account that the read-only env script actually activates."""
+    return _sh('source "%s" >/dev/null 2>&1; gcloud config get-value account 2>/dev/null' % READONLY_ENV)
+
+
+def assert_readonly_identity() -> str:
+    acct = readonly_account()
+    if acct != READONLY_ACCOUNT:
+        raise SystemExit(
+            "read-only identity check failed: got %r, expected %r. "
+            "The env script fell through to owner credentials; refusing to pull." % (acct, READONLY_ACCOUNT)
+        )
+    return acct
+
+
+def assert_writer_identity() -> str:
+    """The active (non-sourced) gcloud account, which is what `bq load` will use."""
+    acct = _sh("gcloud config get-value account 2>/dev/null")
+    if acct != WRITER_ACCOUNT:
+        raise SystemExit(
+            "BigQuery writer identity check failed: got %r, expected %r. "
+            "Refusing to write to omi_finops." % (acct, WRITER_ACCOUNT)
+        )
+    return acct
+
+
+class Token:
+    """Access token for the read-only bot, refreshed lazily (they expire in ~60 min)."""
+
+    TTL = 30 * 60
+
+    def __init__(self) -> None:
+        self._value = ""
+        self._at = 0.0
+
+    def get(self, force: bool = False) -> str:
+        if force or not self._value or (time.time() - self._at) > self.TTL:
+            self._value = _sh('source "%s" >/dev/null 2>&1; gcloud auth print-access-token' % READONLY_ENV)
+            if not self._value:
+                raise RuntimeError("empty access token from the read-only profile")
+            self._at = time.time()
+        return self._value
+
+
+TOKEN = Token()
+
+
+if __name__ == "__main__":
+    which = sys.argv[1] if len(sys.argv) > 1 else "read"
+    if which == "read":
+        print(assert_readonly_identity())
+    else:
+        print(assert_writer_identity())

--- a/backend/scripts/finops/load_bigquery.py
+++ b/backend/scripts/finops/load_bigquery.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Load an assembled run into `based-hardware.omi_finops`.
+
+Writes run as the interactive owner account (verified by name first); every read in the
+pipeline runs as the read-only bot. Loads are IDEMPOTENT per date: rows for the dates in
+this run are deleted and re-inserted inside one BigQuery transaction, so re-running a date
+replaces it rather than doubling it.
+
+Tables (all partitioned by `date`, no partition expiry):
+  unit_cost_daily          long format: date x segment_type x segment x component x method
+  unit_cost_reconciliation what each pool cost vs what landed on user-days
+  plan_revenue_daily       Stripe snapshot, carrying snapshot_date so it stays honest
+  unit_cost_user_day       per (date, uid_hash) allocation. HASHED uids only, never raw.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from assemble_unit_cost import COMPS  # noqa: E402
+from gcpauth import PROJECT, assert_writer_identity  # noqa: E402
+
+DATASET = "omi_finops"
+LOCATION = "US"  # same location as gcp_billing_export, so the two can be joined
+
+SCHEMAS = {
+    "unit_cost_daily": [
+        ("date", "DATE"),
+        ("segment_type", "STRING"),
+        ("segment", "STRING"),
+        ("component", "STRING"),
+        ("method", "STRING"),
+        ("usd", "FLOAT64"),
+        ("users", "INT64"),
+        ("usd_per_user_day", "FLOAT64"),
+        ("run_id", "STRING"),
+        ("computed_at", "TIMESTAMP"),
+        ("inputs_settled", "BOOL"),
+    ],
+    "unit_cost_reconciliation": [
+        ("date", "DATE"),
+        ("pool", "STRING"),
+        ("pool_usd", "FLOAT64"),
+        ("allocated_usd", "FLOAT64"),
+        ("delta_pct", "FLOAT64"),
+        ("invoice_source", "STRING"),
+        ("note", "STRING"),
+        ("run_id", "STRING"),
+        ("computed_at", "TIMESTAMP"),
+        ("inputs_settled", "BOOL"),
+    ],
+    "plan_revenue_daily": [
+        ("date", "DATE"),
+        ("plan", "STRING"),
+        ("paying_subs", "INT64"),
+        ("trialing_subs", "INT64"),
+        ("mrr_usd", "FLOAT64"),
+        ("arpu_usd", "FLOAT64"),
+        ("snapshot_date", "DATE"),
+        ("run_id", "STRING"),
+        ("computed_at", "TIMESTAMP"),
+    ],
+    "unit_cost_user_day": [
+        ("date", "DATE"),
+        ("uid_hash", "STRING"),
+        ("cohort", "STRING"),
+        ("plan", "STRING"),
+        ("attempts", "INT64"),
+        ("unpriced_attempts", "INT64"),
+        ("tx_sec", "FLOAT64"),
+    ]
+    + [(c, "FLOAT64") for c in COMPS]
+    + [
+        ("run_id", "STRING"),
+        ("computed_at", "TIMESTAMP"),
+        ("inputs_settled", "BOOL"),
+    ],
+}
+CLUSTER = {
+    "unit_cost_daily": ["segment_type", "segment", "component"],
+    "unit_cost_reconciliation": ["pool"],
+    "plan_revenue_daily": ["plan"],
+    "unit_cost_user_day": ["cohort", "plan"],
+}
+
+
+def bq(args: list[str], stdin: str | None = None, timeout: int = 1800) -> str:
+    p = subprocess.run(
+        ["bq", "--project_id=" + PROJECT] + args, input=stdin, capture_output=True, text=True, timeout=timeout
+    )
+    if p.returncode != 0:
+        raise SystemExit("bq %s failed:\n%s\n%s" % (" ".join(args[:3]), p.stdout[-1500:], p.stderr[-2000:]))
+    return p.stdout
+
+
+def ensure_dataset() -> None:
+    p = subprocess.run(
+        ["bq", "--project_id=" + PROJECT, "show", "--format=json", "--dataset", "%s:%s" % (PROJECT, DATASET)],
+        capture_output=True,
+        text=True,
+    )
+    if p.returncode == 0:
+        loc = json.loads(p.stdout).get("location")
+        if loc != LOCATION:
+            raise SystemExit("dataset %s exists in %s, expected %s" % (DATASET, loc, LOCATION))
+        sys.stderr.write("dataset %s.%s exists (%s)\n" % (PROJECT, DATASET, loc))
+        return
+    bq(
+        [
+            "mk",
+            "--dataset",
+            "--location=" + LOCATION,
+            "--description=Omi finops: daily true user unit cost, reconciliation and plan revenue. "
+            "Written by backend/scripts/finops/run_unit_cost.py. Hashed uids only.",
+            "%s:%s" % (PROJECT, DATASET),
+        ]
+    )
+    sys.stderr.write("created dataset %s.%s in %s\n" % (PROJECT, DATASET, LOCATION))
+
+
+def ensure_table(name: str) -> None:
+    ref = "%s:%s.%s" % (PROJECT, DATASET, name)
+    p = subprocess.run(["bq", "--project_id=" + PROJECT, "show", "--format=json", ref], capture_output=True, text=True)
+    if p.returncode == 0:
+        sys.stderr.write("table %s exists\n" % name)
+        return
+    schema = ",".join("%s:%s" % (c, t.replace("FLOAT64", "FLOAT").replace("BOOL", "BOOLEAN")) for c, t in SCHEMAS[name])
+    bq(
+        [
+            "mk",
+            "--table",
+            "--time_partitioning_field=date",
+            "--time_partitioning_type=DAY",
+            "--clustering_fields=" + ",".join(CLUSTER[name]),
+            ref,
+            schema,
+        ]
+    )
+    sys.stderr.write("created table %s\n" % name)
+
+
+def load_replace(name: str, rows: list[dict], dates: list[str]) -> int:
+    """Delete the run's dates then insert, in one transaction. Idempotent per date."""
+    if not rows:
+        sys.stderr.write("  %s: nothing to load\n" % name)
+        return 0
+    cols = [c for c, _ in SCHEMAS[name]]
+    stage = "_stage_%s_%d" % (name, int(dt.datetime.now().timestamp()))
+    stage_ref = "%s:%s.%s" % (PROJECT, DATASET, stage)
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        for r in rows:
+            fh.write(json.dumps({c: r.get(c) for c in cols}) + "\n")
+        path = fh.name
+    schema = ",".join("%s:%s" % (c, t.replace("FLOAT64", "FLOAT").replace("BOOL", "BOOLEAN")) for c, t in SCHEMAS[name])
+    try:
+        bq(["load", "--source_format=NEWLINE_DELIMITED_JSON", "--replace", stage_ref, path, schema])
+        in_list = ", ".join("DATE('%s')" % d for d in dates)
+        sql = (
+            "BEGIN TRANSACTION;\n"
+            "DELETE FROM `{p}.{ds}.{t}` WHERE date IN ({dates});\n"
+            "INSERT INTO `{p}.{ds}.{t}` ({cols}) SELECT {cols} FROM `{p}.{ds}.{stage}`;\n"
+            "COMMIT TRANSACTION;"
+        ).format(p=PROJECT, ds=DATASET, t=name, dates=in_list, cols=", ".join(cols), stage=stage)
+        bq(["query", "--use_legacy_sql=false", "--format=none"], stdin=sql)
+    finally:
+        subprocess.run(["bq", "--project_id=" + PROJECT, "rm", "-f", "-t", stage_ref], capture_output=True, text=True)
+        pathlib.Path(path).unlink(missing_ok=True)
+    sys.stderr.write("  %s: replaced %d dates, inserted %d rows\n" % (name, len(dates), len(rows)))
+    return len(rows)
+
+
+def build_rows(
+    derived: pathlib.Path,
+    raw: pathlib.Path,
+    run_id: str,
+    computed_at: str,
+    settled_through: str | None,
+    snapshot_date: str,
+):
+    longs = list(csv.DictReader(open(derived / "unit_cost_long.csv")))
+    recon = list(csv.DictReader(open(derived / "unit_cost_reconciliation.csv")))
+    userday = list(csv.DictReader(open(derived / "user_day_allocated.csv")))
+    dates = sorted({r["date"] for r in longs})
+
+    def settled(d):
+        return settled_through is None or d <= settled_through
+
+    def f(x):
+        return None if x in ("", None) else float(x)
+
+    out = {}
+    out["unit_cost_daily"] = [
+        {
+            "date": r["date"],
+            "segment_type": r["segment_type"],
+            "segment": r["segment"],
+            "component": r["component"],
+            "method": r["method"],
+            "usd": f(r["usd"]),
+            "users": int(r["users"]),
+            "usd_per_user_day": f(r["usd_per_user_day"]),
+            "run_id": run_id,
+            "computed_at": computed_at,
+            "inputs_settled": settled(r["date"]),
+        }
+        for r in longs
+    ]
+    out["unit_cost_reconciliation"] = [
+        {
+            "date": r["date"],
+            "pool": r["pool"],
+            "pool_usd": f(r["pool_usd"]),
+            "allocated_usd": f(r["allocated_usd"]),
+            "delta_pct": f(r["delta_pct"]),
+            "invoice_source": r["invoice_source"],
+            "note": r["note"],
+            "run_id": run_id,
+            "computed_at": computed_at,
+            "inputs_settled": r["inputs_settled"] == "True",
+        }
+        for r in recon
+    ]
+    out["unit_cost_user_day"] = [
+        dict(
+            {
+                "date": r["date"],
+                "uid_hash": r["uid_hash"],
+                "cohort": r["cohort"],
+                "plan": r["plan"],
+                "attempts": int(r["attempts"]),
+                "unpriced_attempts": int(r["unpriced_attempts"]),
+                "tx_sec": f(r["tx_sec"]),
+                "run_id": run_id,
+                "computed_at": computed_at,
+                "inputs_settled": settled(r["date"]),
+            },
+            **{c: f(r[c]) for c in COMPS},
+        )
+        for r in userday
+    ]
+
+    plan_rows = []
+    sp = raw / "stripe_plan_mrr.json"
+    if sp.exists():
+        book = json.load(open(sp))["by_plan"]
+        for d in dates:
+            for x in book:
+                if x["plan"].startswith("unmapped:"):
+                    continue
+                plan_rows.append(
+                    {
+                        "date": d,
+                        "plan": x["plan"],
+                        "paying_subs": x["paying_subs"],
+                        "trialing_subs": x["trialing_subs"],
+                        "mrr_usd": x["mrr_usd"],
+                        "arpu_usd": x["arpu_usd"],
+                        "snapshot_date": snapshot_date,
+                        "run_id": run_id,
+                        "computed_at": computed_at,
+                    }
+                )
+    out["plan_revenue_daily"] = plan_rows
+    return out, dates
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--derived", required=True)
+    ap.add_argument("--raw", required=True)
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--settled-through", default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+    acct = assert_writer_identity()
+    computed_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    snapshot_date = dt.datetime.now(dt.timezone.utc).date().isoformat()
+    tables, dates = build_rows(
+        pathlib.Path(a.derived), pathlib.Path(a.raw), a.run_id, computed_at, a.settled_through, snapshot_date
+    )
+    sys.stderr.write("writer identity: %s | dates: %s\n" % (acct, ", ".join(dates)))
+    for t, rows in tables.items():
+        sys.stderr.write("  %-26s %d rows\n" % (t, len(rows)))
+    if a.dry_run:
+        sys.stderr.write("dry run: nothing written\n")
+        return
+    ensure_dataset()
+    loaded = {}
+    for name in ("unit_cost_daily", "unit_cost_reconciliation", "plan_revenue_daily", "unit_cost_user_day"):
+        ensure_table(name)
+        loaded[name] = load_replace(name, tables[name], dates)
+    print(
+        json.dumps(
+            {"run_id": a.run_id, "dates": dates, "rows_loaded": loaded, "dataset": "%s.%s" % (PROJECT, DATASET)},
+            indent=1,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/one_time_events.json
+++ b/backend/scripts/finops/one_time_events.json
@@ -1,0 +1,14 @@
+{
+  "_doc": "Dated registry of one-off GCP charges that must never enter a per-user run rate. Each rule is injected as the FIRST branch of the component CASE by pull_gcp.py, so a matching row lands in its own `one_time_*` component, is reported as method='one_time', and is excluded from every allocation pool. Add a rule only with a dated reason and an owner; never widen a rule to a whole SKU without a date bound.",
+  "events": [
+    {
+      "component": "one_time_storage_lifecycle",
+      "reason": "Coldline@30d lifecycle transition of the audio bucket, shipped in PR #12631. 345M Class A operations, one sweep, ~$14.7k total; stopped by 2026-09-08 10:00Z. Run-rate storage fell $116 -> $85/day as a result. Matches both the prod bucket omi-private-cloud-sync and the dev bucket omi-dev-private-cloud-sync ($103.86 on 2026-09-05, $822 on 2026-09-08).",
+      "recorded_by": "run-2026-09-09-overnight-margins / finops-infra",
+      "date_from": "2026-09-04",
+      "date_to": "2026-09-09",
+      "sku_like": "%Coldline Class A Operations%",
+      "resource_like": "%private-cloud-sync%"
+    }
+  ]
+}

--- a/backend/scripts/finops/posthog_dau.py
+++ b/backend/scripts/finops/posthog_dau.py
@@ -1,0 +1,62 @@
+"""Pull PostHog DAU by platform for a window: clean core-product DAU and legacy all-events DAU."""
+
+import asyncio, sys, os, json, csv, pathlib
+
+# The PostHog MCP client needs a modern `mcp` package. Whichever python launched this may be
+# on an older one (the hermes agent venv ships an mcp without streamablehttp_client), so
+# re-exec under the skill venv that is known to have it rather than failing at import time.
+_VENV = pathlib.Path.home() / ".hermes/skills/omi/omi-improvements-dashboard/.venv/bin/python"
+try:
+    from mcp.client.streamable_http import streamablehttp_client  # noqa: F401
+except Exception:  # noqa: BLE001
+    if _VENV.exists() and pathlib.Path(sys.executable).resolve() != _VENV.resolve():
+        os.execv(str(_VENV), [str(_VENV), os.path.abspath(__file__), *sys.argv[1:]])
+    raise
+
+sys.path.insert(0, os.path.expanduser("~/.claude/skills/omi-posthog-macos/scripts"))
+from posthog_http import posthog_mcp_session
+
+PROJECT = 302298
+CTX = "Computing daily active users by platform for an Omi unit-cost report across mobile and desktop clients."
+START, END = sys.argv[1], sys.argv[2]  # END exclusive
+CORE_EVENTS = """('Memory Created','Memory Extracted','Action Items Page Opened','Action Item Completed','Action Item Manually Added','Action Item Edited','Task Extracted','Task Promoted','Task Completed','Task Added','Chat Message Sent','chat_agent_query_completed','chat_tool_call_completed','floating_bar_query_sent','floating_bar_ptt_started','Phone Mic Recording Started','Monitoring Started','Conversation List Item Clicked','Conversation Detail Opened','Daily Summary Detail Viewed','Rewind Screenshot Viewed')"""
+Q = {
+    "clean": f"""SELECT toDate(timestamp) AS day, properties['$os'] AS os, uniq(person_id) AS users FROM events
+   WHERE timestamp >= toDateTime('{START} 00:00:00') AND timestamp < toDateTime('{END} 00:00:00')
+   AND properties['$os'] IN ('iOS','Android','macOS','Windows') AND event IN {CORE_EVENTS}
+   AND event NOT LIKE 'cfc_%' GROUP BY day, os ORDER BY day, os""",
+    "all_events": f"""SELECT toDate(timestamp) AS day, properties['$os'] AS os, uniq(person_id) AS users FROM events
+   WHERE timestamp >= toDateTime('{START} 00:00:00') AND timestamp < toDateTime('{END} 00:00:00')
+   AND properties['$os'] IN ('iOS','Android','macOS','Windows') AND event NOT LIKE 'cfc_%'
+   GROUP BY day, os ORDER BY day, os""",
+}
+
+
+def parse(text):
+    lines = [l.strip() for l in text.splitlines() if "|" in l and not l.startswith("Error:")]
+    if not lines:
+        return [], text[:400]
+    h = lines[0].split("|")
+    return [dict(zip(h, l.split("|"))) for l in lines[1:] if len(l.split("|")) == len(h)], ""
+
+
+async def main():
+    out = []
+    async with posthog_mcp_session() as s:
+        await s.call_tool("switch-project", {"projectId": PROJECT, "context": CTX})
+        for name, sql in Q.items():
+            r = await s.call_tool("execute-sql", {"query": sql, "context": CTX})
+            raw = "\n".join(getattr(i, "text", repr(i)) for i in r.content)
+            rows, err = parse(raw)
+            if err:
+                print(name, "ERR", err, file=sys.stderr)
+            for row in rows:
+                out.append({"definition": name, **row})
+    with open(sys.argv[3], "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["definition", "day", "os", "users"])
+        w.writeheader()
+        w.writerows(out)
+    print(len(out), "rows")
+
+
+asyncio.run(main())

--- a/backend/scripts/finops/pull_gcp.py
+++ b/backend/scripts/finops/pull_gcp.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Pull the GCP billing export for a usage-day window, classified into cost components.
+
+Reads `based-hardware.gcp_billing_export.gcp_billing_export_resource_v1_01B287_9348DC_02D256`
+under the read-only bot. Three artefacts, all in the run's raw/ dir:
+
+  gcp_components_daily.json   day x component x platform_structural, gross/credits/net
+  gcp_day_resource_top.json   top-3000 (day, service, sku, resource) rows, with labels
+  gcp_day_service_sku.json    day x project x service x sku (used for the dev-project split)
+  gcp_recon.json              window totals straight off the export, for reconciliation
+
+Rules that are load-bearing and easy to get wrong:
+  * the table is partitioned on _PARTITIONTIME; filter it AND usage_start_time or the scan
+    is unbounded. _PARTITIONTIME is set two days wide of the usage window because a usage
+    day keeps landing in later partitions until it settles (D-2).
+  * net = cost + credits. Never report gross.
+  * `..._01B896_918303_539138` is the PREDECESSOR billing account table. Never sum it in.
+  * Firestore bills under service.description='App Engine'; it is matched by SKU only.
+  * every query runs with --maximum_bytes_billed so a classifier mistake cannot bill a scan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+from gcpauth import READONLY_ENV, assert_readonly_identity, PROJECT  # noqa: E402
+
+TABLE = "based-hardware.gcp_billing_export.gcp_billing_export_resource_v1_01B287_9348DC_02D256"
+MAX_BYTES = 2147483648  # 2 GiB ceiling per query
+
+
+def one_time_case(events_path: pathlib.Path) -> str:
+    """Render the dated one-off rules as leading CASE branches."""
+    if not events_path.exists():
+        return "  -- (no one-time rules registered)"
+    reg = json.load(open(events_path))
+    out = []
+    for e in reg.get("events", []):
+        conds = ["DATE(usage_start_time) BETWEEN '%s' AND '%s'" % (e["date_from"], e["date_to"])]
+        if e.get("sku_like"):
+            conds.append("sku.description LIKE '%s'" % e["sku_like"])
+        if e.get("resource_like"):
+            conds.append("IFNULL(resource.global_name, resource.name) LIKE '%s'" % e["resource_like"])
+        if e.get("service"):
+            conds.append("service.description = '%s'" % e["service"])
+        out.append("  WHEN %s\n       THEN '%s'" % ("\n       AND ".join(conds), e["component"]))
+    return "\n".join(out) if out else "  -- (no one-time rules registered)"
+
+
+def classifier(events_path: pathlib.Path) -> str:
+    sql = (HERE / "gcp_component_classifier.sql").read_text()
+    # the file documents both the component CASE and the platform CASE; take the first only
+    case_sql = sql[sql.index("CASE") : sql.index("END AS component,") + len("END AS component,")]
+    case_sql = case_sql.replace("{{ONE_TIME_RULES}}", one_time_case(events_path))
+    return case_sql[: -len(" AS component,")]  # bare CASE ... END
+
+
+def bq(sql: str, out: pathlib.Path, label: str, max_rows: int = 100000) -> dict:
+    job_id = "finops_%s_%d" % (label, int(dt.datetime.now().timestamp()))
+    cmd = (
+        'source "%s" >/dev/null 2>&1; '
+        "bq query --project_id=%s --job_id=%s --maximum_bytes_billed=%d "
+        "--use_legacy_sql=false --format=json --max_rows=%d" % (READONLY_ENV, PROJECT, job_id, MAX_BYTES, max_rows)
+    )
+    p = subprocess.run(["bash", "-lc", cmd], input=sql, capture_output=True, text=True, timeout=1800)
+    if p.returncode != 0:
+        raise SystemExit("bq query %s failed:\n%s" % (label, p.stderr[-2000:]))
+    out.write_text(p.stdout)
+    stats = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            'source "%s" >/dev/null 2>&1; bq --project_id=%s --format=json show -j %s'
+            % (READONLY_ENV, PROJECT, job_id),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    billed = None
+    try:
+        billed = int(json.loads(stats.stdout)["statistics"]["query"]["totalBytesBilled"])
+    except Exception:
+        pass
+    n = len(json.loads(p.stdout or "[]"))
+    sys.stderr.write("  %-22s rows=%-6d billed=%s bytes  -> %s\n" % (label, n, billed, out.name))
+    return {"job_id": job_id, "rows": n, "bytes_billed": billed}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", required=True, help="first usage day, inclusive (YYYY-MM-DD)")
+    ap.add_argument("--end", required=True, help="last usage day, inclusive (YYYY-MM-DD)")
+    ap.add_argument("--raw", required=True)
+    a = ap.parse_args()
+
+    assert_readonly_identity()
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+    end_excl = (dt.date.fromisoformat(a.end) + dt.timedelta(days=1)).isoformat()
+    # a usage day keeps arriving in later partitions; open the partition filter two days each way
+    p_lo = (dt.date.fromisoformat(a.start) - dt.timedelta(days=2)).isoformat()
+    p_hi = (dt.date.fromisoformat(a.end) + dt.timedelta(days=3)).isoformat()
+    where = (
+        "WHERE _PARTITIONTIME >= TIMESTAMP('%s') AND _PARTITIONTIME < TIMESTAMP('%s')\n"
+        "  AND usage_start_time >= TIMESTAMP('%s') AND usage_start_time < TIMESTAMP('%s')"
+        % (p_lo, p_hi, a.start, end_excl)
+    )
+    case_sql = classifier(HERE / "one_time_events.json")
+    net = "cost + IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c),0)"
+
+    stats = {}
+    stats["components"] = bq(
+        f"""
+WITH base AS (
+  SELECT DATE(usage_start_time) AS usage_day,
+         {case_sql} AS component,
+         usage.amount AS usage_amount,
+         cost AS gross,
+         IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c),0) AS credits
+  FROM `{TABLE}`
+  {where}
+)
+SELECT usage_day, component,
+  CASE
+    WHEN STARTS_WITH(component, 'one_time')                      THEN 'one_time'
+    WHEN component = 'vertex_pt_reservation'                     THEN 'fixed'
+    WHEN component IN ('embeddings','cloud_run_desktop_backend') THEN 'desktop'
+    WHEN component IN ('asr_gpu_fleet','storage_audio')          THEN 'mobile'
+    WHEN component = 'bigquery'                                  THEN 'overhead'
+    ELSE 'shared'
+  END AS platform_structural,
+  ROUND(SUM(gross),6) AS gross, ROUND(SUM(credits),6) AS credits,
+  ROUND(SUM(gross+credits),6) AS net, SUM(usage_amount) AS usage_amount
+FROM base GROUP BY 1,2,3 ORDER BY usage_day, net DESC
+""",
+        raw / "gcp_components_daily.json",
+        "components",
+    )
+
+    stats["resource_top"] = bq(
+        f"""
+SELECT DATE(usage_start_time) AS usage_day, project.id AS project_id,
+       service.description AS service, sku.description AS sku,
+       resource.global_name AS resource_global_name, resource.name AS resource_name,
+       ANY_VALUE(TO_JSON_STRING(labels)) AS labels,
+       ANY_VALUE(TO_JSON_STRING(system_labels)) AS system_labels,
+       SUM(usage.amount) AS usage_amount, ANY_VALUE(usage.unit) AS usage_unit,
+       ROUND(SUM(cost),6) AS gross,
+       ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c),0)),6) AS credits,
+       ROUND(SUM({net}),6) AS net
+FROM `{TABLE}`
+{where}
+GROUP BY 1,2,3,4,5,6 ORDER BY gross DESC LIMIT 3000
+""",
+        raw / "gcp_day_resource_top.json",
+        "resource_top",
+        max_rows=3000,
+    )
+
+    stats["service_sku"] = bq(
+        f"""
+SELECT DATE(usage_start_time) AS usage_day, project.id AS project_id,
+       service.description AS service, sku.description AS sku,
+       SUM(usage.amount) AS usage_amount, ANY_VALUE(usage.unit) AS usage_unit,
+       ROUND(SUM(cost),6) AS gross,
+       ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c),0)),6) AS credits,
+       ROUND(SUM({net}),6) AS net
+FROM `{TABLE}`
+{where}
+GROUP BY 1,2,3,4 ORDER BY usage_day, net DESC
+""",
+        raw / "gcp_day_service_sku.json",
+        "service_sku",
+    )
+
+    stats["recon"] = bq(
+        f"""
+SELECT DATE(usage_start_time) AS usage_day,
+       ROUND(SUM(cost),6) AS gross,
+       ROUND(SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c),0)),6) AS credits,
+       ROUND(SUM({net}),6) AS net, COUNT(*) AS rows_n,
+       MAX(usage_end_time) AS max_usage_end_time
+FROM `{TABLE}`
+{where}
+GROUP BY 1 ORDER BY 1
+""",
+        raw / "gcp_recon.json",
+        "recon",
+    )
+
+    (raw / "_gcp_pull_stats.json").write_text(
+        json.dumps(
+            {
+                "window": [a.start, a.end],
+                "table": TABLE,
+                "queries": stats,
+                "bytes_billed_total": sum(v.get("bytes_billed") or 0 for v in stats.values()),
+            },
+            indent=1,
+        )
+    )
+    tot = sum(v.get("bytes_billed") or 0 for v in stats.values())
+    sys.stderr.write("GCP pull done: %.2f GiB billed (~$%.4f)\n" % (tot / 2**30, tot / 2**40 * 6.25))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_hourly_usage.py
+++ b/backend/scripts/finops/pull_hourly_usage.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Per-user transcription seconds per day, from the users/{uid}/hourly_usage collection group.
+
+Only (year, month) equality is index-supported at collection-group scope; a range on `id`
+needs an index that does not exist, so the day filter is applied client-side and the scan
+covers whole months. Aggregates to (date, uid_hash) and writes `stt_usage_daily.csv`, which
+is the DRIVER for the audio pipeline pool. `transcription_seconds` is the field to use
+(wall-clock streamed audio); `speech_seconds` is sparsely populated.
+
+No raw uid ever reaches disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import datetime as dt
+import json
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import fs  # noqa: E402
+from gcpauth import assert_readonly_identity  # noqa: E402
+
+PAGE = 3000
+SEL = {
+    "fields": [
+        {"fieldPath": n}
+        for n in ["id", "day", "transcription_seconds", "speech_seconds", "words_transcribed", "platforms"]
+    ]
+}
+
+
+def months_in(start: str, end: str):
+    """(year, month, first_day, last_day) tuples covering an inclusive date window."""
+    d0, d1 = dt.date.fromisoformat(start), dt.date.fromisoformat(end)
+    out, y, m = [], d0.year, d0.month
+    while (y, m) <= (d1.year, d1.month):
+        first = dt.date(y, m, 1)
+        nxt = dt.date(y + (m == 12), (m % 12) + 1, 1)
+        last = nxt - dt.timedelta(days=1)
+        out.append((y, m, max(d0, first).day, min(d1, last).day))
+        y, m = nxt.year, nxt.month
+    return out
+
+
+def pull(year: int, month: int, day_lo: int, day_hi: int, acc: dict):
+    cursor, page, seen, kept = None, 0, 0, 0
+    while True:
+        q = {
+            "from": [{"collectionId": "hourly_usage", "allDescendants": True}],
+            "select": SEL,
+            "where": {
+                "compositeFilter": {
+                    "op": "AND",
+                    "filters": [
+                        {
+                            "fieldFilter": {
+                                "field": {"fieldPath": "year"},
+                                "op": "EQUAL",
+                                "value": {"integerValue": str(year)},
+                            }
+                        },
+                        {
+                            "fieldFilter": {
+                                "field": {"fieldPath": "month"},
+                                "op": "EQUAL",
+                                "value": {"integerValue": str(month)},
+                            }
+                        },
+                    ],
+                }
+            },
+            "orderBy": [{"field": {"fieldPath": "__name__"}, "direction": "ASCENDING"}],
+            "limit": PAGE,
+        }
+        if cursor:
+            q["startAt"] = {"values": [{"referenceValue": cursor}], "before": False}
+        res = fs.post(":runQuery", {"structuredQuery": q})
+        docs = [r["document"] for r in res if "document" in r]
+        page += 1
+        if not docs:
+            break
+        for d in docs:
+            seen += 1
+            uid = d["name"].split("/documents/")[-1].split("/")[1]
+            f = d.get("fields", {})
+            did = fs.unwrap(f.get("id")) if "id" in f else d["name"].split("/")[-1]
+            date = did[:10]
+            if not (day_lo <= int(date[8:10]) <= day_hi):
+                continue
+            kept += 1
+            a = acc.setdefault((date, fs.uid_hash(uid)), [0, 0, 0, set()])
+            a[0] += fs.unwrap(f.get("transcription_seconds")) or 0
+            a[1] += fs.unwrap(f.get("speech_seconds")) or 0
+            a[2] += fs.unwrap(f.get("words_transcribed")) or 0
+            pf = fs.unwrap(f.get("platforms"))
+            for x in (pf if isinstance(pf, list) else [pf] if pf else []):
+                if x:
+                    a[3].add(str(x))
+        cursor = docs[-1]["name"]
+        if page % 5 == 0 or len(docs) < PAGE:
+            sys.stderr.write("  %d-%02d page %d seen=%d kept=%d keys=%d\n" % (year, month, page, seen, kept, len(acc)))
+        if len(docs) < PAGE:
+            break
+    sys.stderr.write("%d-%02d done: seen=%d kept=%d\n" % (year, month, seen, kept))
+    return {"seen": seen, "kept": kept}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", required=True)
+    ap.add_argument("--end", required=True)
+    ap.add_argument("--raw", required=True)
+    a = ap.parse_args()
+    assert_readonly_identity()
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+
+    acc, stats = {}, {}
+    for y, m, lo, hi in months_in(a.start, a.end):
+        stats["%04d-%02d" % (y, m)] = pull(y, m, lo, hi, acc)
+
+    users = {}
+    upath = raw / "users_active_30d.csv"
+    if upath.exists():
+        users = {r["uid_hash"]: r for r in csv.DictReader(open(upath))}
+
+    rows = []
+    for (date, uh), v in sorted(acc.items()):
+        u = users.get(uh) or {}
+        rows.append(
+            [
+                date,
+                uh,
+                u.get("last_active_platform", ""),
+                u.get("plan") or "unknown",
+                v[0],
+                v[1],
+                v[2],
+                "|".join(sorted(v[3])),
+            ]
+        )
+    path = raw / "stt_usage_daily.csv"
+    with open(path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(
+            [
+                "date",
+                "uid_hash",
+                "last_active_platform",
+                "plan",
+                "transcription_seconds",
+                "speech_seconds",
+                "words_transcribed",
+                "platforms_field",
+            ]
+        )
+        w.writerows(rows)
+    (raw / "_hourly_pull_stats.json").write_text(
+        json.dumps({"window": [a.start, a.end], "months": stats, "rows": len(rows)}, indent=1)
+    )
+    byday = collections.Counter()
+    for r in rows:
+        byday[r[0]] += r[4]
+    for d in sorted(byday):
+        sys.stderr.write("  %s transcription %.1f h\n" % (d, byday[d] / 3600))
+    sys.stderr.write("wrote %s rows=%d\n" % (path, len(rows)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_ledger.py
+++ b/backend/scripts/finops/pull_ledger.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Pull llm_gateway_attempts from prod Firestore and aggregate to per-day CSVs.
+
+Read-only. Dependency-free (stdlib only). Never writes raw user_uid to disk:
+uids are hashed sha256(uid)[:16] in flight.
+
+Usage:
+  python3 pull_ledger.py --out DIR --dates 2026-09-06 [2026-09-05 ...]
+Optional: --page-size 5000 --project based-hardware --collection llm_gateway_attempts
+"""
+
+import argparse, collections, csv, hashlib, json, os, subprocess, sys, time, urllib.error, urllib.request
+
+PROJECT_DEFAULT = "based-hardware"
+COLLECTION_DEFAULT = "llm_gateway_attempts"
+ENV_SCRIPT = os.path.expanduser("~/.hermes/scripts/omi-prod-gcp-read-only-env.sh")
+
+FIELDS = [
+    "user_uid",
+    "app_platform",
+    "feature",
+    "subscription_tier",
+    "plan_id",
+    "provider",
+    "payer",
+    "caller",
+    "cost_status",
+    "cost_attribution_status",
+    "estimated_cost_micro_usd",
+    "prompt_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "outcome",
+    "configured_model",
+    "rate_card_id",
+]
+
+GROUP_KEYS = [
+    "app_platform",
+    "feature",
+    "subscription_tier",
+    "plan_id",
+    "provider",
+    "payer",
+    "caller",
+    "cost_status",
+    "cost_attribution_status",
+]
+
+UNATTR = "unattributed"
+
+
+def get_token():
+    """Bearer token from the read-only bot profile (subshell: the env script clobbers PATH)."""
+    out = subprocess.run(
+        ["bash", "-c", 'source "%s" >/dev/null 2>&1; gcloud auth print-access-token' % ENV_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    tok = out.stdout.strip()
+    if not tok:
+        raise RuntimeError("token fetch failed: %s" % out.stderr[-500:])
+    return tok
+
+
+def sval(f):
+    """Scalar value out of a Firestore typed field."""
+    if f is None:
+        return None
+    if "stringValue" in f:
+        return f["stringValue"]
+    if "integerValue" in f:
+        return int(f["integerValue"])
+    if "doubleValue" in f:
+        return f["doubleValue"]
+    if "booleanValue" in f:
+        return f["booleanValue"]
+    if "nullValue" in f:
+        return None
+    return None
+
+
+def s(v):
+    return "" if v is None else str(v)
+
+
+def i(v):
+    return v if isinstance(v, int) else 0
+
+
+class Api:
+    def __init__(self, project, collection, timeout=300):
+        self.base = "https://firestore.googleapis.com/v1/projects/%s/databases/(default)/documents" % project
+        self.collection = collection
+        self.timeout = timeout
+        self.token = get_token()
+        self.doc_prefix = self.base + "/" + collection + "/"
+
+    def _post(self, url, body, attempt_refresh=True):
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode(),
+            headers={"Authorization": "Bearer " + self.token, "Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as r:
+                return json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and attempt_refresh:
+                sys.stderr.write("  [401] refreshing token\n")
+                self.token = get_token()
+                return self._post(url, body, attempt_refresh=False)
+            raise
+
+    def post_retry(self, url, body, tries=3):
+        last = None
+        for n in range(tries):
+            try:
+                return self._post(url, body)
+            except Exception as e:
+                last = e
+                detail = ""
+                if isinstance(e, urllib.error.HTTPError):
+                    try:
+                        detail = e.read().decode()[:300]
+                    except Exception:
+                        pass
+                sys.stderr.write("  [retry %d/%d] %s %s\n" % (n + 1, tries, e, detail))
+                time.sleep(3 * (n + 1))
+        raise last
+
+    def page(self, date, page_size, start_after=None):
+        q = {
+            "from": [{"collectionId": self.collection}],
+            "select": {"fields": [{"fieldPath": f} for f in FIELDS]},
+            "where": {"fieldFilter": {"field": {"fieldPath": "date"}, "op": "EQUAL", "value": {"stringValue": date}}},
+            "orderBy": [{"field": {"fieldPath": "__name__"}, "direction": "ASCENDING"}],
+            "limit": page_size,
+        }
+        if start_after:
+            q["startAt"] = {"values": [{"referenceValue": start_after}], "before": False}
+        return self.post_retry(self.base + ":runQuery", {"structuredQuery": q})
+
+    def aggregate(self, date):
+        q = {
+            "structuredQuery": {
+                "from": [{"collectionId": self.collection}],
+                "where": {
+                    "fieldFilter": {"field": {"fieldPath": "date"}, "op": "EQUAL", "value": {"stringValue": date}}
+                },
+            },
+            "aggregations": [
+                {"alias": "cnt", "count": {}},
+                {"alias": "cost", "sum": {"field": {"fieldPath": "estimated_cost_micro_usd"}}},
+            ],
+        }
+        res = self.post_retry(self.base + ":runAggregationQuery", {"structuredAggregationQuery": q})
+        cnt = cost = None
+        for chunk in res:
+            agg = chunk.get("result", {}).get("aggregateFields", {})
+            if "cnt" in agg:
+                cnt = sval(agg["cnt"])
+            if "cost" in agg:
+                cost = sval(agg["cost"])
+        return cnt, cost
+
+
+class DayAgg:
+    """Streaming aggregator: one day of rows in, three shapes of summary out."""
+
+    def __init__(self, date):
+        self.date = date
+        self.groups = collections.defaultdict(
+            lambda: {"attempts": 0, "cost": 0, "pt": 0, "ct": 0, "ot": 0, "uids": set()}
+        )
+        self.users = collections.defaultdict(
+            lambda: {
+                "attempts": 0,
+                "cost": 0,
+                "plat": collections.Counter(),
+                "tier": collections.Counter(),
+                "plan": collections.Counter(),
+                "prov": collections.Counter(),
+                "fc": collections.Counter(),
+                "unpriced": 0,
+            }
+        )
+        self.attempts = 0
+        self.cost = 0
+        self.cost_omi = 0
+        self.cost_unattr = 0
+        self.attempts_unattr = 0
+
+    def add(self, f):
+        plat = sval(f.get("app_platform")) or UNATTR
+        uid = sval(f.get("user_uid"))
+        uh = hashlib.sha256(uid.encode()).hexdigest()[:16] if uid else "anonymous"
+        cost = i(sval(f.get("estimated_cost_micro_usd")))
+        tier = s(sval(f.get("subscription_tier")))
+        plan = s(sval(f.get("plan_id")))
+
+        key = (
+            plat,
+            s(sval(f.get("feature"))),
+            tier,
+            plan,
+            s(sval(f.get("provider"))),
+            s(sval(f.get("payer"))),
+            s(sval(f.get("caller"))),
+            s(sval(f.get("cost_status"))),
+            s(sval(f.get("cost_attribution_status"))),
+        )
+        g = self.groups[key]
+        g["attempts"] += 1
+        g["cost"] += cost
+        g["pt"] += i(sval(f.get("prompt_tokens")))
+        g["ct"] += i(sval(f.get("cached_input_tokens")))
+        g["ot"] += i(sval(f.get("output_tokens")))
+        g["uids"].add(uh)
+
+        u = self.users[uh]
+        u["attempts"] += 1
+        u["cost"] += cost
+        u["plat"][plat] += 1
+        u["tier"][tier] += 1
+        u["plan"][plan] += 1
+        prov = s(sval(f.get("provider")))
+        u["prov"][prov] += cost
+        feat = s(sval(f.get("feature")))
+        fc = (
+            "desktop"
+            if feat.startswith("desktop_")
+            else (
+                "proactive_notification"
+                if feat == "proactive_notification"
+                else (
+                    "chat"
+                    if feat.startswith("chat") or feat.startswith("persona")
+                    else (
+                        "translation"
+                        if feat == "translation"
+                        else "embeddings" if "embedding" in feat else "extraction"
+                    )
+                )
+            )
+        )
+        u["fc"][fc] += cost
+        if s(sval(f.get("cost_status"))) != "estimated":
+            u["unpriced"] += 1
+
+        self.attempts += 1
+        self.cost += cost
+        if s(sval(f.get("payer"))) == "omi":
+            self.cost_omi += cost
+        if plat == UNATTR:
+            self.cost_unattr += cost
+            self.attempts_unattr += 1
+
+
+def open_csv(path, header):
+    new = not os.path.exists(path)
+    fh = open(path, "a", newline="")
+    w = csv.writer(fh)
+    if new:
+        w.writerow(header)
+    return fh, w
+
+
+def run_day(api, date, out, page_size):
+    t0 = time.time()
+    agg = DayAgg(date)
+    cursor, pages = None, 0
+    while True:
+        res = api.page(date, page_size, cursor)
+        got, last = 0, None
+        for chunk in res:
+            doc = chunk.get("document")
+            if not doc:
+                continue
+            got += 1
+            last = doc["name"]
+            agg.add(doc.get("fields", {}))
+        pages += 1
+        if pages % 10 == 0 or got < page_size:
+            sys.stderr.write(
+                "  %s page %d rows=%d total=%d %.0fs\n" % (date, pages, got, agg.attempts, time.time() - t0)
+            )
+            sys.stderr.flush()
+        if got < page_size or last is None:
+            break
+        cursor = last
+
+    agg_count, agg_cost = api.aggregate(date)
+    elapsed = time.time() - t0
+
+    fh, w = open_csv(
+        os.path.join(out, "ledger_agg_daily.csv"),
+        ["date"]
+        + GROUP_KEYS
+        + [
+            "attempts",
+            "cost_micro_usd_sum",
+            "prompt_tokens_sum",
+            "cached_input_tokens_sum",
+            "output_tokens_sum",
+            "distinct_uids",
+        ],
+    )
+    for k, g in sorted(agg.groups.items(), key=lambda kv: -kv[1]["cost"]):
+        w.writerow([date] + list(k) + [g["attempts"], g["cost"], g["pt"], g["ct"], g["ot"], len(g["uids"])])
+    fh.close()
+
+    fh, w = open_csv(
+        os.path.join(out, "ledger_user_daily.csv"),
+        [
+            "date",
+            "uid_hash",
+            "app_platform_mode",
+            "platforms_seen",
+            "subscription_tier",
+            "plan_id",
+            "attempts",
+            "cost_micro_usd_sum",
+            "cost_openai",
+            "cost_gemini",
+            "cost_other_provider",
+            "attempts_unpriced",
+            "fc_desktop",
+            "fc_proactive_notification",
+            "fc_extraction",
+            "fc_chat",
+            "fc_translation",
+            "fc_embeddings",
+        ],
+    )
+    for uh, u in sorted(agg.users.items(), key=lambda kv: -kv[1]["cost"]):
+        pv = u["prov"]
+        fc = u["fc"]
+        w.writerow(
+            [
+                date,
+                uh,
+                u["plat"].most_common(1)[0][0],
+                "|".join(sorted(u["plat"])),
+                u["tier"].most_common(1)[0][0],
+                u["plan"].most_common(1)[0][0],
+                u["attempts"],
+                u["cost"],
+                pv.get("openai", 0),
+                pv.get("gemini", 0),
+                sum(v for k, v in pv.items() if k not in ("openai", "gemini")),
+                u["unpriced"],
+                fc.get("desktop", 0),
+                fc.get("proactive_notification", 0),
+                fc.get("extraction", 0),
+                fc.get("chat", 0),
+                fc.get("translation", 0),
+                fc.get("embeddings", 0),
+            ]
+        )
+    fh.close()
+
+    fh, w = open_csv(
+        os.path.join(out, "ledger_daily_totals.csv"),
+        [
+            "date",
+            "attempts",
+            "cost_usd_total",
+            "cost_usd_payer_omi",
+            "cost_usd_unattributed_platform",
+            "attempts_unattributed_platform",
+            "share_unattributed",
+            "agg_count",
+            "agg_cost_usd",
+            "distinct_uids",
+            "wall_seconds",
+        ],
+    )
+    w.writerow(
+        [
+            date,
+            agg.attempts,
+            round(agg.cost / 1e6, 6),
+            round(agg.cost_omi / 1e6, 6),
+            round(agg.cost_unattr / 1e6, 6),
+            agg.attempts_unattr,
+            round(agg.attempts_unattr / agg.attempts, 6) if agg.attempts else 0,
+            agg_count,
+            round((agg_cost or 0) / 1e6, 6),
+            len(agg.users),
+            round(elapsed, 1),
+        ]
+    )
+    fh.close()
+
+    sys.stderr.write(
+        "DONE %s attempts=%d agg_count=%s cost=$%.2f agg_cost=$%.2f uids=%d %.0fs\n"
+        % (date, agg.attempts, agg_count, agg.cost / 1e6, (agg_cost or 0) / 1e6, len(agg.users), elapsed)
+    )
+    sys.stderr.flush()
+    return elapsed
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", required=True)
+    p.add_argument("--dates", nargs="+", required=True)
+    p.add_argument("--page-size", type=int, default=5000)
+    p.add_argument("--project", default=PROJECT_DEFAULT)
+    p.add_argument("--collection", default=COLLECTION_DEFAULT)
+    p.add_argument("--max-day-seconds", type=float, default=1500.0)
+    a = p.parse_args()
+    os.makedirs(a.out, exist_ok=True)
+    api = Api(a.project, a.collection)
+    for d in a.dates:
+        el = run_day(api, d, a.out, a.page_size)
+        if el > a.max_day_seconds:
+            sys.stderr.write("STOP: %s took %.0fs (> %.0fs budget)\n" % (d, el, a.max_day_seconds))
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_prometheus.py
+++ b/backend/scripts/finops/pull_prometheus.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""VAD-gated audio hours actually forwarded to the cloud STT vendors, per usage day.
+
+`omi_vad_gate_audio_seconds_total{outcome="sent"}` is the only measured quantity of vendor
+STT volume we have: there is no Modulate/Soniox invoice feed. Multiplying it by a rate gives
+the `stt_vendor_*` MODELLED component -- it is never presented as measured.
+
+Read through the Grafana datasource proxy on monitor.omi.me (kubectl port-forward is denied
+to the read-only identity). Token from ~/.hermes/skills/devops/omi-prometheus/references/.env;
+never printed. Output shape matches what assemble_unit_cost.py expects:
+  daily.d_vad_gate_audio_seconds.result.data.result[].values -> [ts, seconds]
+with the bucket at time T carrying increase(...[1d]) over (T-1d, T], i.e. usage day T-1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+ENV = pathlib.Path.home() / ".hermes/skills/devops/omi-prometheus/references/.env"
+
+DAILY = {
+    "d_vad_gate_audio_seconds": 'sum by (outcome, mode) (increase(omi_vad_gate_audio_seconds_total[1d]))',
+    "d_live_stt_accepted": "sum by (provider) (increase(omi_live_stt_accepted_total[1d]))",
+    "d_parakeet_audio_duration_sum": "sum (increase(parakeet_audio_duration_seconds_sum[1d]))",
+}
+
+
+def load_env() -> tuple[str, str]:
+    for line in ENV.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k, v)
+    ep = os.environ.get("OMI_PROMETHEUS_ENDPOINT", "https://monitor.omi.me").rstrip("/")
+    return ep + "/api/datasources/proxy/uid/prometheus/api/v1", os.environ["OMI_PROMETHEUS_TOKEN"]
+
+
+def call(base: str, tok: str, api: str, params) -> dict:
+    cmd = ["curl", "-fsS", "-H", "Authorization: Bearer " + tok, "--get", f"{base}/{api}"]
+    for k, v in params:
+        cmd += ["--data-urlencode", f"{k}={v}"]
+    p = subprocess.run(cmd, text=True, capture_output=True, timeout=300)
+    if p.returncode:
+        return {"status": "error", "error": p.stderr[:300]}
+    try:
+        return json.loads(p.stdout)
+    except Exception as e:  # noqa: BLE001
+        return {"status": "error", "error": str(e)}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", required=True, help="first usage day, inclusive")
+    ap.add_argument("--end", required=True, help="last usage day, inclusive")
+    ap.add_argument("--raw", required=True)
+    a = ap.parse_args()
+    base, tok = load_env()
+    # evaluation points are one day AFTER each usage day: increase(...[1d]) at T covers day T-1
+    t0 = dt.datetime.fromisoformat(a.start).replace(tzinfo=dt.timezone.utc) + dt.timedelta(days=1)
+    t1 = dt.datetime.fromisoformat(a.end).replace(tzinfo=dt.timezone.utc) + dt.timedelta(days=1)
+    out = {
+        "window": {"start": a.start, "end": a.end},
+        "method": "query_range step=86400 with increase(...[1d]); bucket at T is usage day T-1",
+        "endpoint": "Grafana datasource proxy uid=prometheus on monitor.omi.me",
+        "daily": {},
+    }
+    for name, q in DAILY.items():
+        r = call(
+            base,
+            tok,
+            "query_range",
+            [("query", q), ("start", str(int(t0.timestamp()))), ("end", str(int(t1.timestamp()))), ("step", "86400")],
+        )
+        out["daily"][name] = {"query": q, "result": r}
+        n = len(r.get("data", {}).get("result", [])) if r.get("status") == "success" else 0
+        sys.stderr.write("%s: %s series=%d\n" % (name, r.get("status"), n))
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+    (raw / "prom_stt_7d.json").write_text(json.dumps(out, indent=1))
+    sent = {}
+    for s in out["daily"]["d_vad_gate_audio_seconds"].get("result", {}).get("data", {}).get("result", []):
+        if s["metric"].get("outcome") == "sent":
+            for ts, v in s["values"]:
+                day = (dt.datetime.fromtimestamp(int(ts), dt.timezone.utc) - dt.timedelta(days=1)).date().isoformat()
+                sent[day] = sent.get(day, 0.0) + float(v) / 3600
+    for d in sorted(sent):
+        sys.stderr.write("  %s vad sent %.0f h\n" % (d, sent[d]))
+    if not sent:
+        sys.stderr.write("WARNING: no VAD 'sent' series; stt_vendor_* will be zero for this window\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_providers.py
+++ b/backend/scripts/finops/pull_providers.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""OpenAI and Anthropic organization cost, per usage day, straight off the provider APIs.
+
+These are the INVOICE side of the LLM reconciliation: the gateway ledger explains most of
+the OpenAI bill per user, and the difference (`llm_direct_residual`) is spread by each
+user's OpenAI share. Anthropic has no ledger rows in this era (direct path), so the whole
+Anthropic invoice is residual.
+
+Bucket-to-day mapping, which is easy to get wrong:
+  * OpenAI buckets are labelled by END time; usage day = end_time_iso - 1 day.
+  * Anthropic buckets are labelled by START time; usage day = starting_at[:10].
+Credentials live inside the two admin scripts; nothing is printed here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import subprocess
+import sys
+
+OPENAI = pathlib.Path.home() / ".hermes/skills/openai-platform-admin/scripts/openai_admin.py"
+ANTHROPIC = (
+    pathlib.Path.home() / ".hermes/skills/openai-platform-admin/anthropic-platform/scripts/anthropic_platform.py"
+)
+
+
+def run_json(cmd: list[str]) -> dict:
+    p = subprocess.run([sys.executable] + cmd, capture_output=True, text=True, timeout=900)
+    if p.returncode != 0:
+        raise SystemExit("provider pull failed: %s\n%s" % (cmd[0], p.stderr[-1500:]))
+    return json.loads(p.stdout)
+
+
+def openai_costs(start: str, end_excl: str) -> dict:
+    t0 = int(dt.datetime.fromisoformat(start).replace(tzinfo=dt.timezone.utc).timestamp())
+    t1 = int(dt.datetime.fromisoformat(end_excl).replace(tzinfo=dt.timezone.utc).timestamp())
+    days = max(1, (t1 - t0) // 86400)
+    merged = None
+    while True:
+        page = run_json(
+            [
+                str(OPENAI),
+                "costs",
+                "--start-time",
+                str(t0),
+                "--end-time",
+                str(t1),
+                "--bucket-width",
+                "1d",
+                "--limit",
+                str(min(180, days)),
+                "--group-by",
+                "line_item,project_id",
+            ]
+        )
+        if merged is None:
+            merged = page
+        else:
+            merged["data"].extend(page["data"])
+        if not page.get("has_more") or not page.get("next_page"):
+            break
+        # the admin script has no cursor flag; advance the window past the last bucket instead
+        last_end = max(b["end_time"] for b in page["data"])
+        if last_end >= t1:
+            break
+        t0 = last_end
+    merged["has_more"] = False
+    merged["next_page"] = None
+    return merged
+
+
+def anthropic_costs(start: str, end_excl: str) -> dict:
+    return run_json(
+        [str(ANTHROPIC), "cost", "--start", start + "T00:00:00Z", "--end", end_excl + "T00:00:00Z", "--limit", "31"]
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--start", required=True)
+    ap.add_argument("--end", required=True, help="last usage day, inclusive")
+    ap.add_argument("--raw", required=True)
+    a = ap.parse_args()
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+    end_excl = (dt.date.fromisoformat(a.end) + dt.timedelta(days=1)).isoformat()
+
+    oai = openai_costs(a.start, end_excl)
+    (raw / "openai_cost_daily.json").write_text(json.dumps(oai, indent=1))
+    tot = {}
+    for b in oai["data"]:
+        d = (dt.date.fromisoformat(b["end_time_iso"][:10]) - dt.timedelta(days=1)).isoformat()
+        tot[d] = tot.get(d, 0.0) + sum(float(x["amount"]["value"]) for x in b["results"])
+    for d in sorted(tot):
+        sys.stderr.write("  openai %s $%.2f\n" % (d, tot[d]))
+
+    ant = anthropic_costs(a.start, end_excl)
+    (raw / "anthropic_cost_daily.json").write_text(json.dumps(ant, indent=1))
+    tot = {}
+    for b in ant["data"]:
+        d = b["starting_at"][:10]
+        tot[d] = tot.get(d, 0.0) + sum(float(x["amount_usd"]) for x in b["results"])
+    for d in sorted(tot):
+        sys.stderr.write("  anthropic %s $%.2f\n" % (d, tot[d]))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_stripe.py
+++ b/backend/scripts/finops/pull_stripe.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Live Stripe read-only: subscriptions -> paying subs, trialing subs, MRR and ARPU by plan.
+
+This is a SNAPSHOT of the subscription book at the moment it runs. Stripe is not replayable
+per historical day from this endpoint, so `plan_revenue_daily` carries `snapshot_date`
+alongside `date`: the same snapshot is written against each loaded usage day and the two
+columns say plainly that revenue is as-of the snapshot, not as-of the usage day.
+
+Rules baked in:
+  * price_id -> plan_id comes from backend/config/plan_catalog.json (prod prices only).
+  * trialing subscriptions count in `trialing_subs` and contribute $0 MRR.
+  * coupons are applied (percent_off then amount_off).
+  * subscriptions carrying metadata.app_id are marketplace app subscriptions, not Omi plans.
+  * yearly/weekly/daily intervals are normalised to a monthly figure.
+The API key is read from the omi-stripe skill env and never printed or written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import collections
+import json
+import os
+import pathlib
+import sys
+import urllib.parse
+import urllib.request
+
+HERE = pathlib.Path(__file__).resolve().parent
+CATALOG = HERE.parent.parent / "config" / "plan_catalog.json"
+ENV = pathlib.Path.home() / ".hermes/skills/omi/omi-stripe/references/.env"
+COUNTED_STATUSES = ("active", "trialing", "past_due")
+
+
+def auth_header() -> str:
+    key = ""
+    for line in ENV.read_text().splitlines():
+        if line.startswith("STRIPE_API_KEY="):
+            key = line.split("=", 1)[1].strip().strip("\"'")
+    if not key:
+        raise SystemExit("no STRIPE_API_KEY in %s" % ENV)
+    return "Basic " + base64.b64encode((key + ":").encode()).decode()
+
+
+def monthly_amount(price: dict, qty: int) -> float:
+    amt = (price.get("unit_amount") or 0) / 100.0 * qty
+    rec = price.get("recurring") or {}
+    iv, ic = rec.get("interval"), rec.get("interval_count") or 1
+    if iv == "month":
+        return amt / ic
+    if iv == "year":
+        return amt / (12 * ic)
+    if iv == "week":
+        return amt * (4.33 / ic)
+    if iv == "day":
+        return amt * 30 / ic
+    return 0.0
+
+
+def apply_coupon(monthly: float, sub: dict) -> float:
+    disc = sub.get("discount") or {}
+    c = disc.get("coupon") or {}
+    if c.get("percent_off"):
+        return monthly * (1 - c["percent_off"] / 100)
+    if c.get("amount_off"):
+        return max(0.0, monthly - c["amount_off"] / 100)
+    return monthly
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw", required=True)
+    a = ap.parse_args()
+    hdr = auth_header()
+
+    def get(path: str, **params):
+        q = urllib.parse.urlencode(params, doseq=True)
+        req = urllib.request.Request("https://api.stripe.com/v1" + path + "?" + q, headers={"Authorization": hdr})
+        return json.load(urllib.request.urlopen(req, timeout=60))
+
+    price_plan = {}
+    if CATALOG.exists():
+        cat = json.load(open(CATALOG))
+        price_plan = {
+            x["price_id"]: x["plan_id"]
+            for x in cat.get("recognized_stripe_prices", [])
+            if x.get("environment") == "prod"
+        }
+
+    by_plan = collections.defaultdict(
+        lambda: {"paying_subs": 0, "trialing_subs": 0, "mrr_usd": 0.0, "cancel_at_period_end": 0}
+    )
+    by_price = collections.defaultdict(lambda: {"subs": 0, "trialing": 0, "mrr": 0.0})
+    starting, scanned = None, 0
+    while True:
+        params = dict(limit=100, status="all")
+        if starting:
+            params["starting_after"] = starting
+        r = get("/subscriptions", **params)
+        for s in r["data"]:
+            if s["status"] not in COUNTED_STATUSES:
+                continue
+            if (s.get("metadata") or {}).get("app_id"):
+                continue
+            scanned += 1
+            for it in s["items"]["data"]:
+                p = it["price"]
+                plan = price_plan.get(p["id"], "unmapped:" + p["id"])
+                m = apply_coupon(monthly_amount(p, it.get("quantity") or 1), s)
+                g = by_plan[plan]
+                if s["status"] == "trialing":
+                    g["trialing_subs"] += 1
+                else:
+                    g["paying_subs"] += 1
+                    g["mrr_usd"] += m
+                g["cancel_at_period_end"] += bool(s.get("cancel_at_period_end"))
+                q = by_price[(plan, p["id"], (p.get("recurring") or {}).get("interval"), p.get("unit_amount"))]
+                q["subs"] += 1
+                q["trialing"] += s["status"] == "trialing"
+                q["mrr"] += 0.0 if s["status"] == "trialing" else m
+        if not r.get("has_more"):
+            break
+        starting = r["data"][-1]["id"]
+
+    rows = []
+    for plan, g in by_plan.items():
+        rows.append(
+            {
+                "plan": plan,
+                "paying_subs": g["paying_subs"],
+                "trialing_subs": g["trialing_subs"],
+                "mrr_usd": round(g["mrr_usd"], 2),
+                "arpu_usd": round(g["mrr_usd"] / g["paying_subs"], 4) if g["paying_subs"] else 0.0,
+                "cancel_at_period_end": g["cancel_at_period_end"],
+            }
+        )
+    rows.sort(key=lambda x: -x["mrr_usd"])
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+    (raw / "stripe_plan_mrr.json").write_text(
+        json.dumps(
+            {
+                "subscriptions_scanned": scanned,
+                "by_plan": rows,
+                "by_price": [
+                    {"plan": k[0], "price_id": k[1], "interval": k[2], "unit_amount": k[3], **v}
+                    for k, v in sorted(by_price.items(), key=lambda kv: -kv[1]["mrr"])
+                ],
+            },
+            indent=1,
+        )
+    )
+    for x in rows:
+        sys.stderr.write(
+            "  %-24s paying=%-5d trial=%-4d mrr=$%-10.2f arpu=$%.2f\n"
+            % (x["plan"], x["paying_subs"], x["trialing_subs"], x["mrr_usd"], x["arpu_usd"])
+        )
+    sys.stderr.write("subscriptions scanned: %d\n" % scanned)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/pull_users.py
+++ b/backend/scripts/finops/pull_users.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Snapshot the users projection from prod Firestore. Writes hashed uids only.
+
+`users.last_active_at_*` are overwritten in place, so this file is a SNAPSHOT taken at a
+point in time, not history: it says where each user was last seen as of `snapshot_at`, and
+the platform cohort for a past day is inferred from it. The snapshot time is recorded in
+`_users_snapshot.json` and carried into the BigQuery run manifest so a number can always be
+traced back to the snapshot it was computed from. Re-running this script for an older date
+does NOT reconstruct that date's cohort.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import fs  # noqa: E402
+from gcpauth import assert_readonly_identity  # noqa: E402
+
+PAGE = 5000
+FIELDS = [
+    "last_active_at",
+    "last_active_at_desktop",
+    "last_active_at_mobile",
+    "last_active_at_web",
+    "last_active_platform",
+    "platforms_used",
+    "signup_platform",
+    "created_at",
+    "subscription.plan",
+    "subscription.status",
+    "byok.active",
+]
+SEL = {"fields": [{"fieldPath": f} for f in FIELDS]}
+ORDER_FIELDS = ["last_active_at", "last_active_at_desktop", "last_active_at_mobile", "last_active_at_web"]
+
+
+def pull(order_field: str, cutoff: str) -> dict:
+    out, cursor, page = {}, None, 0
+    while True:
+        q = {
+            "from": [{"collectionId": "users"}],
+            "select": SEL,
+            "where": {
+                "fieldFilter": {
+                    "field": {"fieldPath": order_field},
+                    "op": "GREATER_THAN_OR_EQUAL",
+                    "value": {"timestampValue": cutoff},
+                }
+            },
+            "orderBy": [
+                {"field": {"fieldPath": order_field}, "direction": "ASCENDING"},
+                {"field": {"fieldPath": "__name__"}, "direction": "ASCENDING"},
+            ],
+            "limit": PAGE,
+        }
+        if cursor:
+            q["startAt"] = {"values": cursor, "before": False}
+        res = fs.post(":runQuery", {"structuredQuery": q})
+        docs = [r["document"] for r in res if "document" in r]
+        page += 1
+        if not docs:
+            break
+        for d in docs:
+            out[d["name"].split("/")[-1]] = {k: fs.unwrap(v) for k, v in d.get("fields", {}).items()}
+        last = docs[-1]
+        lf = last.get("fields", {}).get(order_field)
+        cursor = [lf if lf else {"nullValue": None}, {"referenceValue": last["name"]}]
+        sys.stderr.write("  %s page %d: +%d (total %d)\n" % (order_field, page, len(docs), len(out)))
+        if len(docs) < PAGE:
+            break
+    return out
+
+
+def day(ts):
+    return ts[:10] if ts else ""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw", required=True)
+    ap.add_argument(
+        "--cutoff",
+        default=None,
+        help="ISO timestamp; users with any last_active_at_* at or after it. Default: 33 days back.",
+    )
+    a = ap.parse_args()
+    assert_readonly_identity()
+    cutoff = a.cutoff or (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=33)).strftime("%Y-%m-%dT00:00:00Z")
+    snapshot_at = dt.datetime.now(dt.timezone.utc).isoformat()
+
+    merged = {}
+    for fld in ORDER_FIELDS:
+        got = pull(fld, cutoff)
+        sys.stderr.write("%s -> %d docs\n" % (fld, len(got)))
+        merged.update(got)
+    sys.stderr.write("union: %d users\n" % len(merged))
+
+    raw = pathlib.Path(a.raw)
+    raw.mkdir(parents=True, exist_ok=True)
+    path = raw / "users_active_30d.csv"
+    with open(path, "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(
+            [
+                "uid_hash",
+                "plan",
+                "sub_status",
+                "byok_active",
+                "signup_platform",
+                "last_active_platform",
+                "platforms_used",
+                "created_at",
+                "last_active_at_desktop",
+                "last_active_at_mobile",
+                "last_active_at_web",
+                "last_active_at",
+            ]
+        )
+        for uid in sorted(merged):
+            r = merged[uid]
+            sub = r.get("subscription") or {}
+            byok = r.get("byok") or {}
+            w.writerow(
+                [
+                    fs.uid_hash(uid),
+                    sub.get("plan") or "none",
+                    sub.get("status") or "",
+                    "" if byok.get("active") is None else ("true" if byok.get("active") else "false"),
+                    r.get("signup_platform") or "",
+                    r.get("last_active_platform") or "",
+                    "|".join(r.get("platforms_used") or []),
+                    day(r.get("created_at")),
+                    day(r.get("last_active_at_desktop")),
+                    day(r.get("last_active_at_mobile")),
+                    day(r.get("last_active_at_web")),
+                    day(r.get("last_active_at")),
+                ]
+            )
+    (raw / "_users_snapshot.json").write_text(
+        json.dumps(
+            {
+                "snapshot_at": snapshot_at,
+                "cutoff": cutoff,
+                "users": len(merged),
+                "note": "last_active_at_* are overwritten in place; this is a point-in-time snapshot.",
+            },
+            indent=1,
+        )
+    )
+    sys.stderr.write("wrote %s (%d users, snapshot_at=%s)\n" % (path, len(merged), snapshot_at))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/finops/run_unit_cost.py
+++ b/backend/scripts/finops/run_unit_cost.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""One entrypoint for the daily Omi unit-cost job: pull -> assemble -> validate -> load.
+
+  run_unit_cost.py --date 2026-09-07 [--backfill-from 2026-09-01] [--load]
+
+What it does, in order:
+  1. picks a run directory and records a manifest (window, identities, settlement)
+  2. pulls the raw inputs for the window (GCP billing export, gateway ledger, users snapshot,
+     hourly_usage transcription seconds, Prometheus VAD hours, OpenAI/Anthropic invoices,
+     Stripe subscription book, PostHog DAU)
+  3. assembles the allocation (backend/scripts/finops/assemble_unit_cost.py)
+  4. validates: every variable pool must reconcile within --recon-tolerance-pct, the window
+     must be settled, and no raw uid may appear in any output
+  5. optionally loads BigQuery `based-hardware.omi_finops`, idempotently per date
+
+Identities: every READ runs as read-only-bot-account@based-hardware; only the BigQuery load
+runs as the interactive owner, and it refuses to run under any other account.
+
+Settlement: the GCP billing export lands a usage day over the following ~48 h, so a date is
+only treated as settled at D-2. `--date` defaults to today-2. Unsettled dates can still be
+computed with --allow-unsettled; the rows carry inputs_settled=false.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import time
+import uuid
+
+HERE = pathlib.Path(__file__).resolve().parent
+RUN_ROOT = pathlib.Path(
+    os.environ.get("FINOPS_RUN_ROOT", os.environ.get("SCRATCH_ROOT", "/Volumes/scratch") + "/finops-runs")
+)
+SETTLEMENT_LAG_DAYS = 2
+
+
+def sh(argv: list[str], log: pathlib.Path, label: str, required: bool = True) -> bool:
+    t0 = time.time()
+    sys.stderr.write("[%s] %s\n" % (label, " ".join(str(x) for x in argv)))
+    with open(log, "a") as fh:
+        fh.write("\n===== %s: %s\n" % (label, " ".join(str(x) for x in argv)))
+        fh.flush()
+        p = subprocess.run([sys.executable] + argv, stdout=fh, stderr=subprocess.STDOUT)
+    ok = p.returncode == 0
+    sys.stderr.write("[%s] %s in %.0fs\n" % (label, "ok" if ok else "FAILED rc=%d" % p.returncode, time.time() - t0))
+    if not ok and required:
+        raise SystemExit("required pull %s failed; see %s" % (label, log))
+    return ok
+
+
+def daterange(a: str, b: str) -> list[str]:
+    d0, d1 = dt.date.fromisoformat(a), dt.date.fromisoformat(b)
+    return [(d0 + dt.timedelta(days=i)).isoformat() for i in range((d1 - d0).days + 1)]
+
+
+def check_no_raw_uids(paths: list[pathlib.Path]) -> None:
+    """Outputs may only carry sha256[:16] hashes.
+
+    Two checks. Structural: every value in a `uid_hash` column must be exactly 16 lowercase
+    hex characters (or the `anonymous` sentinel the gateway writes when an attempt carries no
+    uid). Generic: no long token that looks like a Firebase uid (>=20 characters, >=3 letters
+    and >=1 digit) may appear anywhere. A long run of digits is a float and a single-letter
+    exponent is scientific notation, so neither is flagged.
+    """
+    hashish = re.compile(r"^([0-9a-f]{16}|anonymous)$")
+    uidish = re.compile(
+        r"\b(?=[0-9A-Za-z_-]{20,}\b)(?=(?:[^A-Za-z\s,]*[A-Za-z]){3})(?=[^\s,]*[0-9])[0-9A-Za-z_-]{20,}\b"
+    )
+    bad = []
+    for p in paths:
+        if not p.exists():
+            continue
+        if p.suffix == ".csv":
+            with open(p, newline="") as fh:
+                for i, row in enumerate(csv.DictReader(fh)):
+                    if i > 200000:
+                        break
+                    v = row.get("uid_hash")
+                    if v is not None and not hashish.match(v):
+                        bad.append("%s:%d uid_hash=%r" % (p.name, i + 2, v[:12]))
+                        break
+        with open(p, errors="ignore") as fh:
+            for i, line in enumerate(fh):
+                if i > 20000:
+                    break
+                m = uidish.search(line)
+                if m:
+                    bad.append("%s:%d %s..." % (p.name, i + 1, m.group()[:10]))
+                    break
+    if bad:
+        raise SystemExit("possible raw identifiers in outputs: %s" % "; ".join(bad))
+
+
+def validate(derived: pathlib.Path, raw: pathlib.Path, tol_pct: float, dates: list[str]) -> list[dict]:
+    recon = list(csv.DictReader(open(derived / "unit_cost_reconciliation.csv")))
+    variable = {
+        "shared_gcp",
+        "audio_pipeline_gcp",
+        "vertex_paygo",
+        "desktop_pools",
+        "vertex_pt_fixed",
+        "llm_openai",
+        "llm_anthropic",
+        "stt_vendor_low",
+        "gcp_total_export",
+        "one_time",
+    }
+    failures = []
+    for r in recon:
+        if r["pool"] not in variable:
+            continue
+        if abs(float(r["delta_pct"])) > tol_pct:
+            failures.append(r)
+    if failures:
+        for r in failures:
+            sys.stderr.write(
+                "RECON FAIL %s %s pool=%.2f allocated=%.2f delta=%.4f%%\n"
+                % (r["date"], r["pool"], float(r["pool_usd"]), float(r["allocated_usd"]), float(r["delta_pct"]))
+            )
+        raise SystemExit("reconciliation outside %.2f%% on %d rows" % (tol_pct, len(failures)))
+    got = sorted({r["date"] for r in csv.DictReader(open(derived / "unit_cost_long.csv"))})
+    missing = [d for d in dates if d not in got]
+    if missing:
+        raise SystemExit("no allocated rows for %s" % ", ".join(missing))
+    check_no_raw_uids(
+        [
+            derived / "unit_cost_long.csv",
+            derived / "user_day_allocated.csv",
+            raw / "ledger_user_daily.csv",
+            raw / "users_active_30d.csv",
+            raw / "stt_usage_daily.csv",
+        ]
+    )
+    return recon
+
+
+def settlement_frontier(raw: pathlib.Path) -> str | None:
+    p = raw / "gcp_recon.json"
+    if not p.exists():
+        return None
+    ends = [r.get("max_usage_end_time") for r in json.load(open(p)) if r.get("max_usage_end_time")]
+    return max(ends) if ends else None
+
+
+def main() -> None:
+    today = dt.date.today()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--date",
+        default=(today - dt.timedelta(days=SETTLEMENT_LAG_DAYS)).isoformat(),
+        help="last usage day, inclusive. Default: today-%d (the settlement frontier)." % SETTLEMENT_LAG_DAYS,
+    )
+    ap.add_argument("--backfill-from", default=None, help="first usage day, inclusive. Default: --date.")
+    ap.add_argument("--load", action="store_true", help="load BigQuery omi_finops (owner identity)")
+    ap.add_argument("--run-dir", default=None)
+    ap.add_argument(
+        "--cohort-window-start",
+        default=None,
+        help="pin the date from which a users-snapshot last_active_at_* counts as 'on that platform'. "
+        "Omit for the default trailing window, which is the same definition for every usage day "
+        "whether it is computed alone or inside a backfill.",
+    )
+    ap.add_argument("--cohort-lookback-days", type=int, default=7)
+    ap.add_argument("--reuse-raw", action="store_true", help="skip the pulls and use the run dir as-is")
+    ap.add_argument(
+        "--skip", default="", help="comma-separated pulls to skip: gcp,ledger,users,stt,prom,providers,stripe,posthog"
+    )
+    ap.add_argument("--recon-tolerance-pct", type=float, default=0.5)
+    ap.add_argument("--allow-unsettled", action="store_true")
+    a = ap.parse_args()
+
+    start = a.backfill_from or a.date
+    end = a.date
+    if start > end:
+        raise SystemExit("--backfill-from %s is after --date %s" % (start, end))
+    frontier = (today - dt.timedelta(days=SETTLEMENT_LAG_DAYS)).isoformat()
+    if end > frontier and not a.allow_unsettled:
+        raise SystemExit(
+            "%s is not settled yet (frontier %s at D-%d); pass --allow-unsettled to compute anyway"
+            % (end, frontier, SETTLEMENT_LAG_DAYS)
+        )
+    dates = daterange(start, end)
+    run_id = "%s_%s_%s" % (start, end, uuid.uuid4().hex[:8])
+    run = pathlib.Path(a.run_dir) if a.run_dir else RUN_ROOT / ("%s_%s" % (start, end))
+    raw, derived = run / "raw", run / "derived"
+    raw.mkdir(parents=True, exist_ok=True)
+    log = run / "pull.log"
+    skip = {s.strip() for s in a.skip.split(",") if s.strip()}
+    t0 = time.time()
+
+    if not a.reuse_raw:
+        if "gcp" not in skip:
+            sh([str(HERE / "pull_gcp.py"), "--start", start, "--end", end, "--raw", str(raw)], log, "gcp")
+        if "ledger" not in skip:
+            for f in ("ledger_agg_daily.csv", "ledger_user_daily.csv", "ledger_daily_totals.csv"):
+                (raw / f).unlink(missing_ok=True)  # pull_ledger appends; never double-count a rerun
+            sh([str(HERE / "pull_ledger.py"), "--out", str(raw), "--dates"] + dates, log, "ledger")
+        if "users" not in skip:
+            sh([str(HERE / "pull_users.py"), "--raw", str(raw)], log, "users")
+        if "stt" not in skip:
+            sh([str(HERE / "pull_hourly_usage.py"), "--start", start, "--end", end, "--raw", str(raw)], log, "stt")
+        if "prom" not in skip:
+            sh([str(HERE / "pull_prometheus.py"), "--start", start, "--end", end, "--raw", str(raw)], log, "prom")
+        if "providers" not in skip:
+            sh([str(HERE / "pull_providers.py"), "--start", start, "--end", end, "--raw", str(raw)], log, "providers")
+        if "stripe" not in skip:
+            sh([str(HERE / "pull_stripe.py"), "--raw", str(raw)], log, "stripe", required=False)
+        if "posthog" not in skip:
+            # denominator colour only; the allocation does not depend on it
+            nxt = (dt.date.fromisoformat(end) + dt.timedelta(days=1)).isoformat()
+            sh(
+                [str(HERE / "posthog_dau.py"), start, nxt, str(raw / "posthog_dau_daily.csv")],
+                log,
+                "posthog",
+                required=False,
+            )
+
+    cws = a.cohort_window_start
+    with open(run / "assembly_output.md", "w") as fh:
+        p = subprocess.run(
+            [sys.executable, str(HERE / "assemble_unit_cost.py"), str(raw), str(derived), start, end]
+            + ([cws] if cws else [])
+            + [
+                "--settled-through",
+                frontier,
+                "--cohort-lookback-days",
+                str(a.cohort_lookback_days),
+            ],
+            stdout=fh,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    if p.returncode != 0:
+        sys.stderr.write(p.stderr[-3000:])
+        raise SystemExit("assembly failed")
+
+    recon = validate(derived, raw, a.recon_tolerance_pct, dates)
+    manifest = {
+        "run_id": run_id,
+        "window": [start, end],
+        "dates": dates,
+        "cohort_window_start": cws or "trailing %dd per usage day" % a.cohort_lookback_days,
+        "settled_through": frontier,
+        "settlement_frontier_export": settlement_frontier(raw),
+        "computed_at": dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat(),
+        "run_dir": str(run),
+        "recon_tolerance_pct": a.recon_tolerance_pct,
+        "users_snapshot": (
+            json.load(open(raw / "_users_snapshot.json")) if (raw / "_users_snapshot.json").exists() else None
+        ),
+        "gcp_bytes_billed": (
+            json.load(open(raw / "_gcp_pull_stats.json")).get("bytes_billed_total")
+            if (raw / "_gcp_pull_stats.json").exists()
+            else None
+        ),
+        "wall_seconds": round(time.time() - t0, 1),
+    }
+    (run / "run_manifest.json").write_text(json.dumps(manifest, indent=1))
+
+    loaded = None
+    if a.load:
+        p = subprocess.run(
+            [
+                sys.executable,
+                str(HERE / "load_bigquery.py"),
+                "--derived",
+                str(derived),
+                "--raw",
+                str(raw),
+                "--run-id",
+                run_id,
+                "--settled-through",
+                frontier,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        sys.stderr.write(p.stderr)
+        if p.returncode != 0:
+            raise SystemExit("BigQuery load failed")
+        loaded = json.loads(p.stdout)
+        manifest["bigquery"] = loaded
+        (run / "run_manifest.json").write_text(json.dumps(manifest, indent=1))
+
+    # ---- short stdout summary (this is what the cron job delivers)
+    summary = json.load(open(derived / "day_summary.json"))["days"]
+    print("Omi unit cost %s..%s  (run %s)" % (start, end, run_id))
+    worst = max(
+        (abs(float(r["delta_pct"])) for r in recon if r["pool"] not in ("llm_openai_ledger_coverage",)), default=0.0
+    )
+    print(
+        "reconciliation: worst |delta| %.4f%% (tolerance %.2f%%)  |  %s"
+        % (worst, a.recon_tolerance_pct, "LOADED" if loaded else "not loaded")
+    )
+    plan_rows = [
+        r
+        for r in csv.DictReader(open(derived / "unit_cost_long.csv"))
+        if r["segment_type"] == "plan" and r["component"] == "gross_total"
+    ]
+    by_plan = {}
+    for r in plan_rows:
+        g = by_plan.setdefault(r["segment"], [0.0, 0])
+        g[0] += float(r["usd"])
+        g[1] += int(r["users"])
+    for d in dates:
+        s = summary.get(d)
+        if not s:
+            continue
+        print(
+            "  %s users %-5d gcp $%-8.0f openai $%-7.0f gross/user-day $%.3f%s"
+            % (
+                d,
+                s["cost_active_users"],
+                s["gcp_net_excl_one_time"],
+                s["openai_invoice"],
+                sum(float(r["usd"]) for r in plan_rows if r["date"] == d)
+                / max(1, sum(int(r["users"]) for r in plan_rows if r["date"] == d)),
+                "  one-time $%.0f" % s["gcp_one_time"] if s["gcp_one_time"] else "",
+            )
+        )
+    print(
+        "  gross $/user-day by plan: "
+        + ", ".join("%s %.2f" % (k, v[0] / v[1]) for k, v in sorted(by_plan.items(), key=lambda kv: -kv[1][0])[:8])
+    )
+    print("  run dir: %s" % run)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_finops_unit_cost.py
+++ b/backend/tests/unit/test_finops_unit_cost.py
@@ -1,0 +1,299 @@
+"""Unit tests for the finops unit-cost allocator's pure functions.
+
+These cover the arithmetic that decides how many dollars land on a user, not the pulls.
+They are deliberately hermetic: no GCP, no Firestore, no network.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "finops_assemble",
+    pathlib.Path(__file__).resolve().parents[2] / "scripts" / "finops" / "assemble_unit_cost.py",
+)
+alloc = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(alloc)
+
+
+# ---------------------------------------------------------------- fnum / is_one_time
+@pytest.mark.parametrize(
+    "value,expected",
+    [("1.5", 1.5), ("", 0.0), (None, 0.0), ("not a number", 0.0), (3, 3.0), ("-2", -2.0)],
+)
+def test_fnum_never_raises(value, expected):
+    assert alloc.fnum(value) == expected
+
+
+def test_one_time_components_are_recognised_by_prefix():
+    assert alloc.is_one_time("one_time_storage_lifecycle")
+    assert not alloc.is_one_time("storage_audio")
+    assert not alloc.is_one_time("firestore_reads")
+
+
+# ---------------------------------------------------------------- cohort classification
+@pytest.mark.parametrize(
+    "desktop,mobile,web,expected",
+    [
+        ("2026-09-03", "2026-09-02", "", "dual"),
+        ("2026-09-03", "", "", "desktop_only"),
+        ("", "2026-09-03", "", "mobile_only"),
+        ("", "", "2026-09-03", "web_only"),
+        ("2026-08-20", "2026-08-21", "2026-08-22", "inactive_7d"),
+        ("", "", "", "inactive_7d"),
+        # boundary: the window start itself counts as inside the window
+        ("2026-09-01", "", "", "desktop_only"),
+        ("2026-08-31", "", "", "inactive_7d"),
+        # desktop+web without mobile is still desktop_only: web never promotes to dual
+        ("2026-09-02", "", "2026-09-02", "desktop_only"),
+    ],
+)
+def test_classify_cohort(desktop, mobile, web, expected):
+    assert alloc.classify_cohort(desktop, mobile, web, "2026-09-01") == expected
+
+
+# ---------------------------------------------------------------- day pools
+COMPONENTS = {
+    "firestore_reads": 400.0,
+    "cloud_run_other": 100.0,
+    "asr_gpu_fleet": 150.0,
+    "storage_audio": 50.0,
+    "listen_pipeline_compute": 25.0,
+    "vertex_paygo": 40.0,
+    "embeddings": 30.0,
+    "cloud_run_desktop_backend": 20.0,
+    "vertex_pt_reservation": 300.0,
+    "bigquery": 9.0,
+    "one_time_storage_lifecycle": 13818.0,
+}
+
+
+def test_day_pools_group_components_as_documented():
+    p = alloc.day_pools(COMPONENTS, residual_openai=30.0, residual_anthropic=5.0, vad_sent_hours=1000.0)
+    assert p["shared_gcp"] == 500.0  # firestore_reads + cloud_run_other
+    assert p["audio_pipeline_gcp"] == 225.0  # asr + audio bucket + listen/pusher pools
+    assert p["desktop_pools"] == 50.0  # embeddings + desktop-backend
+    assert p["vertex_paygo"] == 40.0
+    assert p["vertex_pt_fixed"] == 300.0
+    assert p["llm_direct_residual"] == 35.0
+
+
+def test_day_pools_exclude_one_time_and_overhead():
+    """A one-off charge must never reach a pool, and BigQuery overhead is not shared cost."""
+    p = alloc.day_pools(COMPONENTS, 0.0, 0.0, 0.0)
+    assert all(13818.0 not in (v,) for v in p.values())
+    assert p["shared_gcp"] == 500.0  # bigquery ($9) is not in SHARED
+
+
+def test_day_pools_one_time_is_not_silently_swallowed_by_shared():
+    with_one_time = alloc.day_pools(COMPONENTS, 0.0, 0.0, 0.0)
+    without = alloc.day_pools({k: v for k, v in COMPONENTS.items() if not alloc.is_one_time(k)}, 0.0, 0.0, 0.0)
+    assert with_one_time == without
+
+
+def test_stt_pool_is_hours_times_rate_with_a_high_case():
+    p = alloc.day_pools({}, 0.0, 0.0, vad_sent_hours=1000.0, rate_per_min=0.0043)
+    assert p["stt_vendor_low"] == pytest.approx(1000 * 60 * 0.0043)
+    assert p["stt_vendor_high"] == pytest.approx(p["stt_vendor_low"] * alloc.STT_VENDOR_HIGH_MULTIPLIER)
+
+
+# ---------------------------------------------------------------- per-user allocation
+POOLS = {
+    "shared_gcp": 1000.0,
+    "audio_pipeline_gcp": 200.0,
+    "vertex_paygo": 40.0,
+    "desktop_pools": 50.0,
+    "llm_direct_residual": 30.0,
+    "vertex_pt_fixed": 300.0,
+    "stt_vendor_low": 100.0,
+    "stt_vendor_high": 180.0,
+}
+TOTALS = {"openai": 100.0, "gemini": 20.0, "desktop": 10.0, "tx_sec": 3600.0, "attempts": 1000}
+
+
+def _fact(**kw):
+    base = {"llm_openai": 0.0, "llm_gemini": 0.0, "fc_desktop": 0.0, "tx_sec": 0.0, "attempts": 0}
+    base.update(kw)
+    return base
+
+
+def test_allocate_user_day_uses_each_driver():
+    r = alloc.allocate_user_day(
+        _fact(llm_openai=25.0, llm_gemini=5.0, fc_desktop=2.0, tx_sec=900.0, attempts=250), POOLS, TOTALS, n_users=10
+    )
+    assert r["llm_openai_measured"] == 25.0  # measured, passed through
+    assert r["llm_direct_residual"] == pytest.approx(30.0 * 0.25)
+    assert r["vertex_paygo"] == pytest.approx(40.0 * 0.25)
+    assert r["audio_pipeline_gcp"] == pytest.approx(200.0 * 0.25)
+    assert r["desktop_pools"] == pytest.approx(50.0 * 0.20)
+    assert r["shared_headcount"] == pytest.approx(100.0)  # 1000 / 10 users
+    assert r["vertex_pt_fixed"] == pytest.approx(300.0 * 0.25)
+    assert r["stt_vendor_low"] == pytest.approx(100.0 * 0.25)
+
+
+def test_gemini_list_price_is_a_memo_not_a_cost():
+    """Gemini is served by the PT reservation; its ledger list price must not enter any total."""
+    r = alloc.allocate_user_day(_fact(llm_gemini=5.0), POOLS, TOTALS, n_users=10)
+    assert r["llm_gemini_list_memo"] == 5.0
+    assert r["variable_total"] == pytest.approx(r["shared_headcount"] + r["vertex_paygo"])
+    assert r["llm_gemini_list_memo"] not in (r["variable_total"], r["fully_loaded"], r["gross_total"])
+
+
+def test_aggregate_components_compose_as_documented():
+    r = alloc.allocate_user_day(
+        _fact(llm_openai=25.0, llm_gemini=5.0, fc_desktop=2.0, tx_sec=900.0, attempts=250), POOLS, TOTALS, n_users=10
+    )
+    assert r["variable_total"] == pytest.approx(
+        r["llm_openai_measured"]
+        + r["llm_direct_residual"]
+        + r["vertex_paygo"]
+        + r["audio_pipeline_gcp"]
+        + r["desktop_pools"]
+        + r["shared_headcount"]
+    )
+    assert r["fully_loaded"] == pytest.approx(r["variable_total"] + r["vertex_pt_fixed"])
+    assert r["gross_total"] == pytest.approx(r["fully_loaded"] + r["stt_vendor_low"])
+    assert r["variable_total_activity"] == pytest.approx(
+        r["variable_total"] - r["shared_headcount"] + r["shared_activity"]
+    )
+
+
+def test_activity_weighting_is_half_headcount_quarter_attempts_quarter_transcription():
+    r = alloc.allocate_user_day(_fact(tx_sec=1800.0, attempts=500), POOLS, TOTALS, n_users=10)
+    assert r["shared_activity"] == pytest.approx(1000.0 * (0.5 / 10 + 0.25 * 0.5 + 0.25 * 0.5))
+
+
+def test_zero_drivers_never_divide_by_zero():
+    empty = {"openai": 0.0, "gemini": 0.0, "desktop": 0.0, "tx_sec": 0.0, "attempts": 0}
+    r = alloc.allocate_user_day(_fact(), POOLS, empty, n_users=0)
+    assert r["shared_headcount"] == 0.0
+    assert r["variable_total"] == 0.0
+    assert r["gross_total"] == 0.0
+
+
+def test_allocation_is_conservative_across_users():
+    """Every pool must be fully spent across the day's users and never over-spent."""
+    facts = [
+        _fact(llm_openai=60.0, llm_gemini=12.0, fc_desktop=6.0, tx_sec=2000.0, attempts=600),
+        _fact(llm_openai=40.0, llm_gemini=8.0, fc_desktop=4.0, tx_sec=1600.0, attempts=400),
+    ]
+    rows = [alloc.allocate_user_day(f, POOLS, TOTALS, n_users=len(facts)) for f in facts]
+    for component, pool_key in (
+        ("audio_pipeline_gcp", "audio_pipeline_gcp"),
+        ("vertex_paygo", "vertex_paygo"),
+        ("desktop_pools", "desktop_pools"),
+        ("llm_direct_residual", "llm_direct_residual"),
+        ("vertex_pt_fixed", "vertex_pt_fixed"),
+        ("stt_vendor_low", "stt_vendor_low"),
+    ):
+        assert sum(r[component] for r in rows) == pytest.approx(POOLS[pool_key])
+    assert sum(r["shared_headcount"] for r in rows) == pytest.approx(POOLS["shared_gcp"])
+    assert sum(r["shared_activity"] for r in rows) == pytest.approx(POOLS["shared_gcp"])
+
+
+# ---------------------------------------------------------------- reconciliation
+def test_reconcile_day_closes_on_a_complete_allocation():
+    facts = [_fact(llm_openai=100.0, llm_gemini=20.0, fc_desktop=10.0, tx_sec=3600.0, attempts=1000)]
+    rows = [alloc.allocate_user_day(f, POOLS, TOTALS, n_users=1) for f in facts]
+    allocated = {c: sum(r[c] for r in rows) for c in alloc.COMPS}
+    recon = alloc.reconcile_day(
+        "2026-09-07",
+        POOLS,
+        allocated,
+        COMPONENTS,
+        gcp_export_net=sum(COMPONENTS.values()),
+        openai_invoice=130.0,
+        anthropic_invoice=0.0,
+        settled=True,
+    )
+    by_pool = {r["pool"]: r for r in recon}
+    for pool in (
+        "shared_gcp",
+        "audio_pipeline_gcp",
+        "vertex_paygo",
+        "desktop_pools",
+        "vertex_pt_fixed",
+        "stt_vendor_low",
+        "gcp_total_export",
+    ):
+        assert abs(by_pool[pool]["delta_pct"]) < 0.5, pool
+
+
+def test_reconcile_day_reports_one_time_separately_and_flags_a_lossy_classifier():
+    recon = alloc.reconcile_day(
+        "2026-09-07",
+        POOLS,
+        {},
+        COMPONENTS,
+        gcp_export_net=sum(COMPONENTS.values()) + 500.0,
+        openai_invoice=0.0,
+        anthropic_invoice=0.0,
+        settled=False,
+    )
+    by_pool = {r["pool"]: r for r in recon}
+    assert by_pool["one_time"]["pool_usd"] == 13818.0
+    assert by_pool["one_time"]["allocated_usd"] == 13818.0
+    assert abs(by_pool["gcp_total_export"]["delta_pct"]) > 0.5  # 500 unclassified dollars must show
+    assert by_pool["one_time"]["inputs_settled"] is False
+
+
+def test_every_component_has_a_declared_method():
+    assert set(alloc.COMPS) == set(alloc.METHOD)
+    assert set(alloc.METHOD.values()) <= {"measured", "driver-allocated", "headcount", "fixed", "modelled"}
+
+
+# ---------------------------------------------------------------- roll-up
+def test_rollup_divides_totals_by_the_window_length():
+    rows = []
+    for date in ("2026-09-01", "2026-09-02"):
+        for uid in ("aaaa", "bbbb"):
+            r = {"date": date, "uid_hash": uid, "cohort": "dual", "plan": "plus", "attempts": 10, "tx_sec": 3600.0}
+            r.update({c: 1.0 for c in alloc.COMPS})
+            rows.append(r)
+    out = alloc.rollup(rows, lambda r: r["plan"], n_days=2)
+    assert len(out) == 1
+    assert out[0]["user_days"] == 4
+    assert out[0]["mean_users_per_day"] == 2.0
+    assert out[0]["variable_total_per_day"] == 2.0  # 4 user-days x $1 over 2 days
+    assert out[0]["variable_total_per_user_day"] == 1.0
+
+
+def test_long_rows_count_a_dual_user_in_both_platform_unions():
+    rows = []
+    for cohort in ("dual", "mobile_only"):
+        r = {"date": "2026-09-01", "uid_hash": cohort, "cohort": cohort, "plan": "basic", "attempts": 0, "tx_sec": 0.0}
+        r.update({c: 1.0 for c in alloc.COMPS})
+        rows.append(r)
+
+    def union(r):
+        segs = [s for s, members in alloc.PLATFORM_UNION_MEMBERS.items() if r["cohort"] in members]
+        return segs or ["other_union"]
+
+    out = alloc.long_rows(rows, lambda r: r["date"], [("platform_union", union), ("total", lambda r: "all")])
+    seg = {(r["segment_type"], r["segment"], r["component"]): r for r in out}
+    assert seg[("platform_union", "desktop_incl_dual", "variable_total")]["users"] == 1
+    assert seg[("platform_union", "mobile_incl_dual", "variable_total")]["users"] == 2
+    assert seg[("total", "all", "variable_total")]["usd"] == 2.0
+    assert seg[("total", "all", "variable_total")]["usd_per_user_day"] == 1.0
+
+
+def test_long_rows_carry_the_method_for_every_component():
+    r = {"date": "2026-09-01", "uid_hash": "aaaa", "cohort": "dual", "plan": "plus", "attempts": 0, "tx_sec": 0.0}
+    r.update({c: 1.0 for c in alloc.COMPS})
+    out = alloc.long_rows([r], lambda x: x["date"], [("total", lambda x: "all")])
+    assert {x["component"] for x in out} == set(alloc.COMPS)
+    assert all(x["method"] == alloc.METHOD[x["component"]] for x in out)
+
+
+# ---------------------------------------------------------------- cohort window
+def test_cohort_window_is_a_trailing_window_ending_on_the_usage_day():
+    """The same usage day must get the same cohort window alone or inside a backfill."""
+    assert alloc.cohort_window_start_for("2026-09-07", 7) == "2026-09-01"
+    assert alloc.cohort_window_start_for("2026-09-01", 7) == "2026-08-26"
+    assert alloc.cohort_window_start_for("2026-09-07", 1) == "2026-09-07"
+
+
+def test_cohort_window_can_be_pinned_to_reproduce_an_older_report():
+    assert alloc.cohort_window_start_for("2026-09-07", 7, fixed="2026-08-31") == "2026-08-31"
+    assert alloc.cohort_window_start_for("2026-09-01", 7, fixed="2026-08-31") == "2026-08-31"


### PR DESCRIPTION
## What

Turns the one-off unit-cost analysis behind the 2026-09-09 evidence record into a production-shaped daily job. One entrypoint pulls a settled usage day's inputs, allocates every dollar onto a `(day, user)` row, validates the result against the invoices, and loads BigQuery `based-hardware.omi_finops` idempotently per date.

```bash
python3 backend/scripts/finops/run_unit_cost.py --date 2026-09-07 --load
```

**No runtime effect.** Nothing under `backend/scripts/finops/` is imported by the backend; this adds scripts, a README and unit tests. Every source is read-only except the BigQuery load.

## Inputs

| Input | Source |
|---|---|
| GCP billing export | `gcp_billing_export_resource_v1_01B287_9348DC_02D256` (partitioned on `_PARTITIONTIME`; every query filters that **and** `usage_start_time`, capped with `--maximum_bytes_billed`; `net = cost + credits`) |
| LLM gateway ledger | Firestore `llm_gateway_attempts`, field-masked and paged |
| Users projection | Firestore `users` (snapshot, with `snapshot_at` recorded) |
| Transcription seconds | Firestore collection group `hourly_usage` |
| VAD-forwarded audio hours | Prometheus via the Grafana proxy on monitor.omi.me |
| OpenAI / Anthropic invoices | provider admin cost APIs |
| Subscription book | Stripe read-only |
| DAU by platform | PostHog project 302298 (alternative denominators only) |

## Identities

* Every **read** runs as `read-only-bot-account@based-hardware.iam.gserviceaccount.com`. The documented `~/.hermes/profiles` path does not exist on this host and falls through *silently* to owner credentials, so the account is re-read from `gcloud config get-value account` after sourcing and the pull aborts on anything else.
* The **BigQuery load** runs as the interactive owner and refuses to run under any other account.
* No token, key or secret is printed or written. **No raw uid reaches disk**: uids are hashed `sha256(uid)[:16]` in flight, and the entrypoint scans every output for a uid-shaped identifier before it will load.

## Tables

Dataset `based-hardware.omi_finops` (location US, same as the billing export). All partitioned by `date`, clustered:

* `unit_cost_daily` — long format: date × segment_type × segment × component × method
* `unit_cost_reconciliation` — what each pool cost vs what landed on user-days
* `plan_revenue_daily` — Stripe snapshot, carrying `snapshot_date` because Stripe is not replayable per historical day
* `unit_cost_user_day` — per `(date, uid_hash)`, hashed uids only

Loads delete and re-insert the run's dates inside one transaction, so a rerun replaces a date rather than doubling it.

## What is new versus the analysis it replaces

* **A `one_time` component class**, driven by a dated registry (`one_time_events.json`). The 2026-09-07 Coldline lifecycle sweep of the audio bucket ($13,818.35 on `omi-private-cloud-sync`, plus $103.86 on the dev bucket) is reported at the day level and excluded from every per-user pool. Left in, that one day would have added ~$6.50 to every cost-active user-day.
* **Reconciliation as a gate**, not a footnote: every pool must close within 0.5%, including a check that the component classifier loses nothing against the raw export. The backfill closes at 0.0000% on all seven days.
* **Settlement is explicit**: a date is settled at D-2, anything later is refused unless asked for, and those rows carry `inputs_settled = false`.
* **A stable cohort window**: a trailing 7 days ending on the usage day, evaluated per date, so a date's cohort labels are the same whether the date is computed alone by the daily job or inside a backfill. `--cohort-window-start` pins an explicit date for reproducing an older report.
* The remaining pull scripts, a README (inputs, identities, run cost, backfill, what "settled" means), and 34 unit tests on the allocator's pure functions.

The allocation itself is unchanged: replaying the evidence record's own raw pulls through this code reproduces every roll-up CSV with **zero value differences**.

## Backfill

2026-09-01..09-07 loaded: 4,487 rows in `unit_cost_daily`, 77 in `unit_cost_reconciliation`, 35 in `plan_revenue_daily`, 13,993 in `unit_cost_user_day`. 2026-08-31 is deliberately excluded — desktop ledger attribution rolled out on 09-01.

Registered as hermes cron `d23863b14bf7` (`omi-finops-unit-cost-daily`, 10:30 America/New_York, script-only, Telegram delivery).

## Run cost

≈ **$0.30 per daily run**, dominated by the gateway ledger read (~560k Firestore document reads/day). BigQuery billing-export queries were 0.35 GiB billed for the whole 7-day window (~$0.002); the users snapshot and `hourly_usage` scan are a few cents; Prometheus, PostHog, OpenAI, Anthropic and Stripe are free. The 7-day backfill cost about $2.

## Still modelled

`stt_vendor_low` / `stt_vendor_high` use a $0.0043/min placeholder against measured VAD-forwarded hours, because Modulate and Soniox have no invoice feed and no contract rate yet. They are tagged `method='modelled'` and never presented as measured. PostHog, Sentry and Redis Cloud have no feed at all and are in no pool.

## Test

```
backend/.venv/bin/python -m pytest tests/unit/test_finops_unit_cost.py -q
34 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

