### PR TITLE
fix(backend): follow Asana project pagination

### DIFF
--- a/backend/routers/task_integrations.py
+++ b/backend/routers/task_integrations.py
@@ -468,22 +468,34 @@ async def get_asana_projects(workspace_gid: str, uid: str = Depends(auth.get_cur
         raise HTTPException(status_code=401, detail="Asana not authenticated")
 
     try:
+        projects = []
+        params = {'workspace': workspace_gid, 'archived': 'false', 'opt_fields': 'name,gid,owner', 'limit': 100}
+        seen_offsets = set()
 
         async def _request(client, token):
             return await client.get(
-                f'https://app.asana.com/api/1.0/projects?workspace={workspace_gid}&archived=false&opt_fields=name,gid,owner',
+                'https://app.asana.com/api/1.0/projects',
+                params=params,
                 headers={'Authorization': f'Bearer {token}'},
             )
 
-        response, data, err = await perform_request_with_token_retry(uid, 'asana', data, _request)
-        if err:
-            raise HTTPException(status_code=401, detail="Asana authentication expired. Please reconnect.")
+        while True:
+            response, data, err = await perform_request_with_token_retry(uid, 'asana', data, _request)
+            if err:
+                raise HTTPException(status_code=401, detail="Asana authentication expired. Please reconnect.")
+            if response.status_code != 200:
+                raise HTTPException(status_code=response.status_code, detail="Failed to fetch Asana projects")
 
-        if response.status_code == 200:
             result = response.json()
-            return {'projects': result.get('data', [])}
-        else:
-            raise HTTPException(status_code=response.status_code, detail="Failed to fetch Asana projects")
+            projects.extend(result.get('data', []))
+            next_page = result.get('next_page')
+            if not next_page:
+                return {'projects': projects}
+            offset = next_page.get('offset')
+            if not isinstance(offset, str) or not offset or offset in seen_offsets:
+                raise HTTPException(status_code=502, detail="Invalid Asana project pagination cursor")
+            seen_offsets.add(offset)
+            params['offset'] = offset
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -89,6 +89,20 @@ an exact-set pin — add its file to `tests/slow_guardrail_manifest.txt` so
 whose job is to notice a change nobody anticipated cannot be gated on the change set that triggered the run.
 Stress and network tests still belong in `slow` with no manifest entry.
 
+## Asana project chooser regression
+
+From the repository root, with the locked backend environment installed:
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/unit/test_asana_project_pagination.py backend/tests/unit/test_asana_project_pagination_http.py -q
+```
+
+These hermetic unit tests cover project continuation offsets, preserved query
+filters, OAuth retry across pages, and propagation of later-page errors. The HTTP
+cases mount the production router with fake provider/database boundaries and
+check response serialization; they do not contact Asana or exercise live OAuth.
+Both files are discovered by the existing backend unit runner.
+
 ## Integration Tests
 
 Integration tests live under `tests/integration/` and are not run by `bash test.sh`. They may require Redis,

--- a/backend/tests/unit/test_asana_project_pagination.py
+++ b/backend/tests/unit/test_asana_project_pagination.py
@@ -1,0 +1,116 @@
+"""Execute the production handler and retry helper without service imports.
+
+Only decorators/default dependency bindings are removed from the handler AST;
+its body and the retry helper are compiled unchanged, not reimplemented.
+Asana wire contract: https://developers.asana.com/docs/pagination
+"""
+
+import ast
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlsplit
+
+
+class HTTPError(Exception):
+    def __init__(self, status_code, detail):
+        self.status_code = status_code
+        self.detail = detail
+
+
+def load_function(path, name, namespace):
+    tree = ast.parse(path.read_text())
+    node = next(n for n in tree.body if isinstance(n, ast.AsyncFunctionDef) and n.name == name)
+    node.decorator_list = []
+    node.args.defaults = [] if name == 'get_asana_projects' else [ast.Constant(None)]
+    node.returns = None
+    for arg in node.args.args:
+        arg.annotation = None
+    module = ast.fix_missing_locations(ast.Module(body=[node], type_ignores=[]))
+    exec(compile(module, str(path), 'exec'), namespace)
+    return namespace[name]
+
+
+class AsanaProjectPaginationTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.pages = []
+        self.calls = []
+        self.integration = {'connected': True, 'access_token': 'initial'}
+        self.refresh = AsyncMock(return_value={'connected': True, 'access_token': 'renewed'})
+        self.ns = {
+            'HTTPException': HTTPError,
+            'db_executor': None,
+            'run_blocking': AsyncMock(return_value=self.integration),
+            'users_db': SimpleNamespace(get_task_integration=None),
+            'ensure_valid_oauth_token': AsyncMock(return_value=self.integration),
+            'get_http_client': lambda: SimpleNamespace(get=self.get),
+            'refresh_oauth_token': self.refresh,
+            'logger': logging.getLogger(__name__),
+        }
+        backend = Path(__file__).resolve().parents[2]
+        load_function(backend / 'utils/task_integrations_ops.py', 'perform_request_with_token_retry', self.ns)
+        self.handler = load_function(backend / 'routers/task_integrations.py', 'get_asana_projects', self.ns)
+
+    async def get(self, url, headers, params=None):
+        query = parse_qs(urlsplit(url).query)
+        query.update({k: [str(v)] for k, v in (params or {}).items()})
+        self.calls.append((urlsplit(url)._replace(query='').geturl(), query, headers.copy()))
+        status, body = self.pages.pop(0)
+        return SimpleNamespace(status_code=status, json=lambda: body)
+
+    async def test_multiple_pages_keep_filters_and_opaque_cursor(self):
+        cursor = 'a+b/=& c'
+        self.pages = [
+            (200, {'data': [{'gid': '1'}], 'next_page': {'offset': cursor}}),
+            (200, {'data': [{'gid': '2'}], 'next_page': None}),
+        ]
+        result = await self.handler('workspace', 'uid')
+        self.assertEqual(result, {'projects': [{'gid': '1'}, {'gid': '2'}]})
+        self.assertEqual(len(self.calls), 2)
+        for url, query, _ in self.calls:
+            self.assertEqual(url, 'https://app.asana.com/api/1.0/projects')
+            self.assertEqual(query['workspace'], ['workspace'])
+            self.assertEqual(query['archived'], ['false'])
+            self.assertEqual(query['opt_fields'], ['name,gid,owner'])
+            self.assertEqual(query['limit'], ['100'])
+        self.assertNotIn('offset', self.calls[0][1])
+        self.assertEqual(self.calls[1][1]['offset'], [cursor])
+
+    async def test_empty_final_page(self):
+        self.pages = [(200, {'data': [], 'next_page': None})]
+        self.assertEqual(await self.handler('workspace', 'uid'), {'projects': []})
+        self.assertEqual(len(self.calls), 1)
+
+    async def test_later_failure_never_returns_partial_success(self):
+        self.pages = [(200, {'data': [{'gid': '1'}], 'next_page': {'offset': 'next'}}), (503, {})]
+        with self.assertRaises(HTTPError) as error:
+            await self.handler('workspace', 'uid')
+        self.assertEqual(error.exception.status_code, 503)
+
+    async def test_later_page_token_retry_is_carried_forward(self):
+        self.pages = [
+            (200, {'data': [], 'next_page': {'offset': 'second'}}),
+            (401, {}),
+            (200, {'data': [{'gid': '2'}], 'next_page': {'offset': 'third'}}),
+            (200, {'data': [{'gid': '3'}], 'next_page': None}),
+        ]
+        self.assertEqual(await self.handler('workspace', 'uid'), {'projects': [{'gid': '2'}, {'gid': '3'}]})
+        self.assertEqual(
+            [c[2]['Authorization'] for c in self.calls],
+            ['Bearer initial', 'Bearer initial', 'Bearer renewed', 'Bearer renewed'],
+        )
+        self.assertEqual(self.calls[1][1], self.calls[2][1])
+        self.refresh.assert_awaited_once()
+
+    async def test_repeated_cursor_fails_without_looping(self):
+        self.pages = [(200, {'data': [], 'next_page': {'offset': 'same'}})] * 2
+        with self.assertRaises(HTTPError) as error:
+            await self.handler('workspace', 'uid')
+        self.assertEqual(error.exception.status_code, 502)
+        self.assertEqual(len(self.calls), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/unit/test_asana_project_pagination_http.py
+++ b/backend/tests/unit/test_asana_project_pagination_http.py
@@ -1,0 +1,52 @@
+"""HTTP response/serialization coverage for the Asana chooser pagination contract."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def asana_client(monkeypatch):
+    from routers import task_integrations as ti
+    from utils import task_integrations_ops as ops
+
+    integration = {'connected': True, 'access_token': 'fixture-token'}
+    monkeypatch.setattr(ti, 'run_blocking', AsyncMock(return_value=integration))
+    monkeypatch.setattr(ti, 'ensure_valid_oauth_token', AsyncMock(return_value=integration))
+    get = AsyncMock()
+    monkeypatch.setattr(ops, 'get_http_client', lambda: SimpleNamespace(get=get))
+    app = FastAPI()
+    app.include_router(ti.router)
+    app.dependency_overrides[ti.auth.get_current_user_uid] = lambda: 'fixture-uid'
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client, get
+
+
+def response(status, body):
+    return SimpleNamespace(status_code=status, json=lambda: body)
+
+
+def test_chooser_http_returns_projects_from_both_pages(asana_client):
+    client, get = asana_client
+    get.side_effect = [
+        response(200, {'data': [{'gid': '1', 'name': 'First'}], 'next_page': {'offset': 'next'}}),
+        response(200, {'data': [{'gid': '2', 'name': 'Second'}], 'next_page': None}),
+    ]
+    result = client.get('/v1/task-integrations/asana/projects/workspace')
+    assert result.status_code == 200
+    assert [p['gid'] for p in result.json()['projects']] == ['1', '2']
+    assert get.await_count == 2
+
+
+def test_chooser_http_propagates_later_page_failure(asana_client):
+    client, get = asana_client
+    get.side_effect = [
+        response(200, {'data': [{'gid': '1', 'name': 'First'}], 'next_page': {'offset': 'next'}}),
+        response(503, {}),
+    ]
+    result = client.get('/v1/task-integrations/asana/projects/workspace')
+    assert result.status_code == 503
+    assert result.json() == {'detail': 'Failed to fetch Asana projects'}


### PR DESCRIPTION
## Summary
Fixes #13164.

Fetch Asana projects with explicit `limit=100` and follow opaque `next_page.offset` tokens. Preserve workspace/archive/field filters, the projects response shape, and the shared OAuth retry helper on every page. Later-page errors propagate rather than returning partial success; invalid or repeated cursors in a nonempty next-page object return HTTP 502.

## Evidence and verification
Pinned main `e0308b66dd699bed67dc59be1f1e47237c81f387` ignores `next_page`. Five hermetic cases execute the actual compiled handler and production retry helper with dependency/decorator bindings replaced. Two additional cases import the production router and use FastAPI TestClient to verify real response serialization and later-page HTTP errors. Before on Python 3.11: six failures out of seven cases. After: seven cases pass (opaque cursor/filter preservation, empty final page, later failure, real-helper 401 retry and refreshed token carry-forward, repeated cursor). This reproduces continuation loss when Asana returns `next_page`; it does not establish that every live unpaginated request truncates.

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_asana_project_pagination.py backend/tests/unit/test_asana_project_pagination_http.py -q`: **7 passed** on Python 3.11.15 with the pinned backend dependencies.
- `make preflight`: 27 selected checks pass (131.44s) with the pinned Python 3.11 OpenAPI runner. Initial missing-tool/Python 3.13 setup failures were resolved before this successful run.
- `scripts/pr-preflight --lane local --pr-body-file <final-body>`: final committed-tree validation recorded before PR creation.
- Backend Hermetic Merge Gate is IN SCOPE: `bash backend/testing/e2e/run.sh -q --tb=short` passes 119 tests, with 3 skipped (82.82s).
- Both listen/pusher and sync/cloud-tasks emulator gauntlets were attempted and stopped at their Java 21 prerequisite. Java/Firebase emulators and Redis are not provisioned; those gates remain unverified, not passed. Maintainer CI is required.
- No live Asana/OAuth, app chooser, separately served endpoint or deployed HTTP verification. The two TestClient cases execute the production router with fake provider/database boundaries, not a live provider.
- History-dependent ratchets skip in this shallow checkout.

External contract: https://developers.asana.com/docs/pagination and https://developers.asana.com/reference/getprojects (limit 1–100 and opaque offset).

## Scope and primitive
No request/response schema change, new endpoint, registry change, provider URL following, task creation change or other integration pagination. This belongs in the Asana collection reader; existing shared OAuth retry is reused. A generic paginator for incompatible integration protocols would unnecessarily expand scope. The regression catches actual continuation loss in #13164; no new static guard or CI lane.

## Product invariants affected
none

Failure-Class: none
No existing registry class covers ignored external-provider continuation; FC-raw-page-limit-before-visibility-filter addresses server-side visibility filtering, not this contract.

## Bounty
The issue suggests US$25 under the contribution guide invitation; this is not funded or confirmed. Merge and maintainer eligibility discretion are required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

