### PR TITLE
fix(python-sdk): preserve query params and build valid Parakeet WS URLs

### DIFF
--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 from asyncio import Queue
 from typing import Callable, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -11,14 +12,24 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 def parakeet_ws_url(api_url: str, sample_rate: int = 16000) -> str:
     """Build Parakeet WebSocket URL with proper path and query composition."""
     api_url = api_url.strip()
-    parsed = urlsplit(api_url)
+    if not api_url:
+        raise ValueError("api_url cannot be empty")
 
-    # Scheme mapping: http -> ws, https -> wss
+    if api_url.startswith("//"):
+        normalized_url = "https:" + api_url
+    elif not re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", api_url):
+        normalized_url = "https://" + api_url
+    else:
+        normalized_url = api_url
+
+    parsed = urlsplit(normalized_url)
+    if not parsed.netloc:
+        raise ValueError(f"Invalid Parakeet API URL, missing host: {api_url!r}")
+
+    # Scheme mapping: http/ws -> ws, otherwise wss
     scheme = parsed.scheme.lower()
-    if scheme == "http":
+    if scheme in ("http", "ws"):
         new_scheme = "ws"
-    elif scheme in ("https", "wss", "ws"):
-        new_scheme = "wss" if scheme == "https" else scheme
     else:
         new_scheme = "wss"
 

--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -5,12 +5,44 @@ import json
 import os
 from asyncio import Queue
 from typing import Callable, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 def parakeet_ws_url(api_url: str, sample_rate: int = 16000) -> str:
-    base = api_url.strip().rstrip("/")
-    base = base.replace("https://", "wss://").replace("http://", "ws://")
-    return f"{base}/v3/stream?sample_rate={sample_rate}"
+    """Build Parakeet WebSocket URL with proper path and query composition."""
+    api_url = api_url.strip()
+    parsed = urlsplit(api_url)
+
+    # Scheme mapping: http -> ws, https -> wss
+    scheme = parsed.scheme.lower()
+    if scheme == "http":
+        new_scheme = "ws"
+    elif scheme in ("https", "wss", "ws"):
+        new_scheme = "wss" if scheme == "https" else scheme
+    else:
+        new_scheme = "wss"
+
+    # Path composition: append /v3/stream
+    path = parsed.path.rstrip("/")
+    new_path = f"{path}/v3/stream" if path else "/v3/stream"
+
+    # Query parameters: preserve repeated and blank values, update sample_rate
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    updated_pairs = []
+    found_sample_rate = False
+    for k, v in query_pairs:
+        if k == "sample_rate":
+            updated_pairs.append((k, str(sample_rate)))
+            found_sample_rate = True
+        else:
+            updated_pairs.append((k, v))
+    if not found_sample_rate:
+        updated_pairs.append(("sample_rate", str(sample_rate)))
+
+    new_query = urlencode(updated_pairs)
+
+    # Omit fragment
+    return urlunsplit((new_scheme, parsed.netloc, new_path, new_query, ""))
 
 
 class ParakeetTranscriber:

--- a/sdks/python/tests/test_stt_engines.py
+++ b/sdks/python/tests/test_stt_engines.py
@@ -3,7 +3,32 @@ from omi.stt import SttEngine, create_transcriber
 
 
 def test_parakeet_ws_url():
+    # Plain base URL with and without trailing slash
     assert parakeet_ws_url("https://parakeet.example/") == "wss://parakeet.example/v3/stream?sample_rate=16000"
+    assert parakeet_ws_url("https://parakeet.example") == "wss://parakeet.example/v3/stream?sample_rate=16000"
+    assert parakeet_ws_url("http://localhost:8000") == "ws://localhost:8000/v3/stream?sample_rate=16000"
+
+    # Query-bearing base URL preserves path and query parameters
+    assert (
+        parakeet_ws_url("https://parakeet.example/proxy?tenant=demo")
+        == "wss://parakeet.example/proxy/v3/stream?tenant=demo&sample_rate=16000"
+    )
+
+    # Existing sample_rate in query is replaced with the configured sample_rate
+    assert (
+        parakeet_ws_url("https://parakeet.example/api?tenant=demo&sample_rate=8000", sample_rate=16000)
+        == "wss://parakeet.example/api/v3/stream?tenant=demo&sample_rate=16000"
+    )
+
+    # Preserves repeated parameters, blank parameters, and query parameters containing https://
+    url_with_nested = (
+        "https://parakeet.example/v1/?redirect=https://other.example&flag&opt=1&opt=2#ignored"
+    )
+    expected_nested = (
+        "wss://parakeet.example/v1/v3/stream"
+        "?redirect=https%3A%2F%2Fother.example&flag=&opt=1&opt=2&sample_rate=16000"
+    )
+    assert parakeet_ws_url(url_with_nested) == expected_nested
 
 
 def test_whisper_requires_dep_or_runner():

--- a/sdks/python/tests/test_stt_engines.py
+++ b/sdks/python/tests/test_stt_engines.py
@@ -30,6 +30,30 @@ def test_parakeet_ws_url():
     )
     assert parakeet_ws_url(url_with_nested) == expected_nested
 
+    # Scheme-less URLs normalized to wss
+    assert parakeet_ws_url("parakeet.example") == "wss://parakeet.example/v3/stream?sample_rate=16000"
+    assert (
+        parakeet_ws_url("parakeet.example/gateway?region=eu")
+        == "wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000"
+    )
+    assert (
+        parakeet_ws_url("//parakeet.example/gateway")
+        == "wss://parakeet.example/gateway/v3/stream?sample_rate=16000"
+    )
+
+    # Empty or host-less inputs raise ValueError
+    try:
+        parakeet_ws_url("")
+        assert False, "Expected ValueError for empty api_url"
+    except ValueError:
+        pass
+
+    try:
+        parakeet_ws_url("   ")
+        assert False, "Expected ValueError for blank api_url"
+    except ValueError:
+        pass
+
 
 def test_whisper_requires_dep_or_runner():
     try:


### PR DESCRIPTION
Resolves #13289
/claim #13289

### Summary of Changes

- Use urllib.parse (urlsplit, urlunsplit, parse_qsl, urlencode) to compose path and query components separately in parakeet_ws_url().
- Fixes request target mangling when base URLs contain query parameters (e.g. https://parakeet.example/proxy?tenant=demo now correctly maps to wss://parakeet.example/proxy/v3/stream?tenant=demo&sample_rate=16000).
- Properly overrides/updates sample_rate if already present in base URL query.
- Preserves repeated and blank query parameters while omitting fragments.
- Prevents accidental string replacement of https:// occurrences inside query parameter values.
- Added comprehensive unit tests in sdks/python/tests/test_stt_engines.py verifying all edge cases (query strings, scheme transitions, parameter preservation). All 24 unit tests passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

