### PR TITLE
fix(typescript-sdk): preserve query params and build valid Parakeet WS URLs (#13263)

### DIFF
--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -134,6 +134,10 @@ describe('parakeetWsUrl', () => {
     const url = parakeetWsUrl('https://parakeet.example', 8000);
     expect(url).toBe('wss://parakeet.example/v3/stream?sample_rate=8000');
   });
+
+  test('rejects unsupported protocols', () => {
+    expect(() => parakeetWsUrl('ftp://parakeet.example')).toThrow(TypeError);
+  });
 });
 
 describe('createParakeetTranscriber', () => {

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import {
   createDeepgramTranscriber,
+  createParakeetTranscriber,
   createTranscriber,
   createWhisperTranscriber,
   deepgramWsUrl,
+  parakeetWsUrl,
 } from './index.ts';
 
 describe('deepgramWsUrl', () => {
@@ -99,5 +101,62 @@ describe('createWhisperTranscriber', () => {
     await Promise.resolve();
 
     expect(transcripts).toEqual(['final transcript']);
+  });
+});
+
+describe('parakeetWsUrl', () => {
+  test('converts https to wss and appends streaming endpoint', () => {
+    const url = parakeetWsUrl('https://parakeet.example');
+    expect(url).toBe('wss://parakeet.example/v3/stream?sample_rate=16000');
+  });
+
+  test('converts http to ws', () => {
+    const url = parakeetWsUrl('http://parakeet.example:8080');
+    expect(url).toBe('ws://parakeet.example:8080/v3/stream?sample_rate=16000');
+  });
+
+  test('preserves existing path and query parameters', () => {
+    const url = parakeetWsUrl('https://parakeet.example/gateway?region=eu');
+    expect(url).toBe('wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000');
+  });
+
+  test('strips trailing slashes from path before appending stream endpoint', () => {
+    const url = parakeetWsUrl('https://parakeet.example/gateway/');
+    expect(url).toBe('wss://parakeet.example/gateway/v3/stream?sample_rate=16000');
+  });
+
+  test('removes hash fragments', () => {
+    const url = parakeetWsUrl('https://parakeet.example/gateway?region=eu#debug');
+    expect(url).toBe('wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000');
+  });
+
+  test('supports custom sample rate', () => {
+    const url = parakeetWsUrl('https://parakeet.example', 8000);
+    expect(url).toBe('wss://parakeet.example/v3/stream?sample_rate=8000');
+  });
+});
+
+describe('createParakeetTranscriber', () => {
+  test('connects to parakeetWsUrl with query params preserved', () => {
+    let openedUrl: string | undefined;
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(url: string) {
+        openedUrl = url;
+      }
+      send(_data: any) {}
+      close() {}
+    }
+
+    createParakeetTranscriber({
+      apiUrl: 'https://parakeet.example/gateway?region=eu',
+      sampleRate: 16000,
+      onTranscript: () => {},
+      WebSocketImpl: FakeWebSocket as any,
+    });
+
+    expect(openedUrl).toBe('wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000');
   });
 });

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -13,8 +13,10 @@ export function parakeetWsUrl(apiUrl: string, sampleRate = 16000): string {
   const parsed = new URL(rawUrl);
   if (parsed.protocol === 'http:' || parsed.protocol === 'ws:') {
     parsed.protocol = 'ws:';
-  } else {
+  } else if (parsed.protocol === 'https:' || parsed.protocol === 'wss:') {
     parsed.protocol = 'wss:';
+  } else {
+    throw new TypeError(`Unsupported Parakeet API URL protocol: ${parsed.protocol}`);
   }
   const cleanPath = parsed.pathname.replace(/\/+$/, '');
   parsed.pathname = `${cleanPath}/v3/stream`.replace(/^\/+/, '/');

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -6,9 +6,21 @@ export interface StreamingTranscriber {
 }
 
 export function parakeetWsUrl(apiUrl: string, sampleRate = 16000): string {
-  let base = apiUrl.trim().replace(/\/+$/, '');
-  base = base.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
-  return `${base}/v3/stream?sample_rate=${sampleRate}`;
+  const trimmed = apiUrl.trim();
+  const rawUrl = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  const parsed = new URL(rawUrl);
+  if (parsed.protocol === 'http:' || parsed.protocol === 'ws:') {
+    parsed.protocol = 'ws:';
+  } else {
+    parsed.protocol = 'wss:';
+  }
+  const cleanPath = parsed.pathname.replace(/\/+$/, '');
+  parsed.pathname = `${cleanPath}/v3/stream`.replace(/^\/+/, '/');
+  parsed.searchParams.set('sample_rate', sampleRate.toString());
+  parsed.hash = '';
+  return parsed.toString();
 }
 
 export function deepgramWsUrl(sampleRate = 16000): string {


### PR DESCRIPTION
## Summary
Resolves #13263.

Fixes an issue where `parakeetWsUrl` in the TypeScript device SDK appended `/v3/stream` directly onto the URL string, corrupting query parameters when query-bearing base URLs were passed (e.g. `https://parakeet.example/gateway?region=eu` produced `wss://parakeet.example/gateway?region=eu/v3/stream?sample_rate=16000`).

### Changes
- Parse `apiUrl` using standard `URL` parser.
- Map protocol schemes (`http:` -> `ws:`, `https:` -> `wss:`).
- Cleanly append `/v3/stream` to the URL `pathname`, stripping trailing slashes.
- Preserve all existing query parameters and set `sample_rate`.
- Strip any hash fragments.
- Add regression unit tests in `src/stt/index.test.ts` for `parakeetWsUrl` and `createParakeetTranscriber`.

### Verification
- `bun test`: All 19 tests passed (0 failures).
- `bun run typecheck`: Passed with 0 errors.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

