### PR TITLE
fix(cli): reject non-finite JSON numbers before HTTP serialization (#13300)

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -247,6 +247,10 @@ omi
 
 `conversation from-segments` reads JSON files as UTF-8 (with or without a BOM),
 UTF-16, or UTF-32, independently of the system's default text encoding.
+Both transcript JSON and `local call --args-json` require finite numbers:
+`NaN`, `Infinity`, `-Infinity`, and values outside Python's finite floating-point
+range are rejected before opening an API client. In `--json` mode, these input
+errors are reported as JSON on stderr.
 
 ## Global flags
 

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -12,6 +12,7 @@ import typer
 
 from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import UsageError
+from omi_cli.json_input import load_json_input
 from omi_cli.models import ConversationTextSource
 from omi_cli.output import shorten
 
@@ -151,8 +152,8 @@ def from_segments(
     if not segments_file.exists():
         raise UsageError(message=f"File not found: {segments_file}")
     try:
-        payload = json.loads(segments_file.read_bytes())
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        payload = load_json_input(segments_file.read_bytes())
+    except (ValueError, UnicodeDecodeError) as exc:
         raise UsageError(message=f"Invalid JSON in {segments_file}", detail=str(exc))
 
     segments = payload.get("transcript_segments") if isinstance(payload, dict) else payload

--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -15,6 +15,7 @@ import typer
 
 from omi_cli import config as cfg
 from omi_cli.errors import UsageError
+from omi_cli.json_input import load_json_input
 from omi_cli.local_client import existing_path
 
 if TYPE_CHECKING:
@@ -99,9 +100,9 @@ def call(
 ) -> None:
     ctx = _ctx(typer_ctx)
     try:
-        parsed = json.loads(args_json)
-    except json.JSONDecodeError as exc:
-        raise UsageError(message="--args-json must be valid JSON") from exc
+        parsed = load_json_input(args_json)
+    except ValueError as exc:
+        raise UsageError(message="--args-json must be valid JSON", detail=str(exc)) from exc
     if not isinstance(parsed, Mapping):
         raise UsageError(message="--args-json must be a JSON object")
     _emit_tool(ctx, tool_name, parsed)

--- a/sdks/python-cli/omi_cli/json_input.py
+++ b/sdks/python-cli/omi_cli/json_input.py
@@ -1,0 +1,27 @@
+"""Decode user-provided JSON without numbers the HTTP serializer cannot send."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, NoReturn
+
+
+def _reject_constant(value: str) -> NoReturn:
+    raise ValueError(f"JSON numbers must be finite; got {value}")
+
+
+def _finite_float(value: str) -> float:
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("JSON number is outside the supported finite range")
+    return number
+
+
+def load_json_input(value: str | bytes) -> Any:
+    """Reject NaN, infinities, and exponents that overflow Python's float range.
+
+    JSON strings are unchanged, and bytes retain json.loads' encoding detection.
+    Invalid input raises ValueError (including JSONDecodeError).
+    """
+    return json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)

--- a/sdks/python-cli/tests/test_json_input_commands.py
+++ b/sdks/python-cli/tests/test_json_input_commands.py
@@ -1,0 +1,75 @@
+"""User-supplied JSON must be encodable before a command starts an API call."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from omi_cli.local_client import LocalOmiClient
+from omi_cli.main import app, main
+
+
+@pytest.mark.parametrize("number", ["NaN", "Infinity", "-Infinity", "1e400", "-1e400"])
+@pytest.mark.parametrize("command", ["local", "conversation"])
+@pytest.mark.parametrize("authenticated", [False, True])
+def test_json_input_rejects_non_finite_numbers(
+    number, command, authenticated, config_path, tmp_path, monkeypatch, respx_mock, capsys
+) -> None:
+    # Check both configured and fresh installs. Bad JSON should never be
+    # mistaken for a credentials problem or reach the HTTP serializer.
+    if authenticated:
+        monkeypatch.setenv("OMI_API_KEY", "omi_dev_" + "x" * 32)
+        monkeypatch.setenv("OMI_LOCAL_API_URL", "http://127.0.0.1:47778")
+        monkeypatch.setenv("OMI_LOCAL_TOKEN", "synthetic-local-token")
+    if command == "local":
+        args = ["local", "call", "search_screen_history", "--args-json", '{"nested":[' + number + ']}']
+        expected_error = "--args-json must be valid JSON"
+    else:
+        source = tmp_path / "segments.json"
+        source.write_text('[{"text":"hello","start":0,"end":' + number + '}]', encoding="utf-8")
+        args = ["conversation", "from-segments", str(source)]
+        expected_error = f"Invalid JSON in {source}"
+
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", *args])
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+    captured = capsys.readouterr()
+    assert exit_info.value.code == 1
+    assert captured.out == ""
+    error = json.loads(captured.err)
+    assert error["error"] == expected_error
+    assert "finite" in error["detail"]
+    assert not respx_mock.calls
+
+
+@pytest.mark.parametrize("command", ["local", "conversation"])
+def test_json_input_preserves_finite_numbers_and_literal_strings(
+    command, authed_profile, respx_mock, cli_runner, tmp_path, monkeypatch
+) -> None:
+    from omi_cli.main import AppContext
+
+    value = {"text": "NaN Infinity -Infinity", "start": -1.5e2, "end": 1e300}
+    if command == "local":
+        # Use the actual command and HTTP serializer with a test-only client.
+        monkeypatch.setattr(
+            AppContext,
+            "make_local_client",
+            lambda self: LocalOmiClient(api_url=authed_profile.api_base, token="synthetic-local-token"),
+        )
+        route = respx_mock.post("/v1/local/tool").respond(json={"ok": True})
+        args = ["local", "call", "test_tool", "--args-json", json.dumps(value)]
+    else:
+        source = tmp_path / "segments.json"
+        source.write_text(json.dumps([value]), encoding="utf-8")
+        route = respx_mock.post("/v1/dev/user/conversations/from-segments").respond(
+            json={"id": "test-conversation", "status": "queued"}
+        )
+        args = ["conversation", "from-segments", str(source)]
+
+    result = cli_runner.invoke(app, ["--json", *args])
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert (body["arguments"] if command == "local" else body["transcript_segments"][0]) == value


### PR DESCRIPTION
## Summary
Resolves #13300.

Credit & Attribution: The original report, implementation proposal, and test cases were prepared and published by @vvv7zmmf7t-sketch in #13300. This PR packages and integrates their patch including the README updates and GitHub ID-based co-authorship.

User-provided JSON input in `omi local call --args-json` and `omi conversation from-segments` parsed with Python's standard `json.loads` accepts non-finite values (`NaN`, `Infinity`, `-Infinity`, and overflowing floats like `1e400`). When later passed to HTTP serializers, these fail unexpectedly or escape validation.

### Changes
- Add `load_json_input()` helper in `omi_cli/json_input.py` using `parse_constant` and `parse_float` to reject `NaN`, `Infinity`, `-Infinity`, and floats outside the finite range.
- Use `load_json_input()` in `omi local call` and `omi conversation from-segments`.
- Update `sdks/python-cli/README.md` documenting finite number requirements.
- Add test coverage in `tests/test_json_input_commands.py` validating rejection of non-finite numbers across commands and authentication states, as well as preservation of valid finite values and literal strings.

### Verification
- Ran `pytest tests/test_json_input_commands.py`: all 22 tests pass.
- Verified `--json` error reporting returns clean JSON with failure detail.

Failure-Class: none

/claim #13300
