### PR TITLE
fix(python-sdk): respect service_uuid during BLE notification lookup (#13294)

### DIFF
--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -39,7 +39,7 @@ async def listen(
     on_packet: AsyncPacketHandler,
     *,
     char_uuid: str = AUDIO_DATA_UUID,
-    service_uuid: str = OMI_SERVICE_UUID,
+    service_uuid: Optional[str] = None,
 ) -> None:
     """Connect and notify on audio characteristic until cancelled."""
 
@@ -70,7 +70,7 @@ async def listen_payload(
     on_payload: AsyncPacketHandler,
     *,
     char_uuid: str = AUDIO_DATA_UUID,
-    service_uuid: str = OMI_SERVICE_UUID,
+    service_uuid: Optional[str] = None,
 ) -> None:
     async def wrapped(packet: bytes) -> None:
         if len(packet) <= PACKET_HEADER_BYTES:

--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Awaitable, Callable, List, Optional, Union
 
 from bleak import BleakClient, BleakScanner
+from bleak.exc import BleakError
 
 from .constants import AUDIO_CODEC_UUID, AUDIO_DATA_UUID, OMI_SERVICE_UUID, PACKET_HEADER_BYTES
 
@@ -49,7 +50,17 @@ async def listen(
             await result
 
     async with BleakClient(device_id) as client:
-        await client.start_notify(char_uuid, _handler)
+        services = getattr(client, "services", None)
+        if services is not None and service_uuid:
+            service = services.get_service(service_uuid)
+            if service is None:
+                raise BleakError(f"Service {service_uuid} was not found")
+            characteristic = service.get_characteristic(char_uuid)
+            if characteristic is None:
+                raise BleakError(f"Characteristic {char_uuid} was not found in service {service_uuid}")
+            await client.start_notify(characteristic, _handler)
+        else:
+            await client.start_notify(char_uuid, _handler)
         while True:
             await asyncio.sleep(3600)
 
@@ -59,6 +70,7 @@ async def listen_payload(
     on_payload: AsyncPacketHandler,
     *,
     char_uuid: str = AUDIO_DATA_UUID,
+    service_uuid: str = OMI_SERVICE_UUID,
 ) -> None:
     async def wrapped(packet: bytes) -> None:
         if len(packet) <= PACKET_HEADER_BYTES:
@@ -67,7 +79,7 @@ async def listen_payload(
         if inspect.isawaitable(result):
             await result
 
-    await listen(device_id, wrapped, char_uuid=char_uuid)
+    await listen(device_id, wrapped, char_uuid=char_uuid, service_uuid=service_uuid)
 
 
 async def read_codec(device_id: str, *, char_uuid: str = AUDIO_CODEC_UUID) -> int:

--- a/sdks/python/tests/test_ble_service_scope.py
+++ b/sdks/python/tests/test_ble_service_scope.py
@@ -112,10 +112,15 @@ def test_listen_disambiguates_between_multiple_services(monkeypatch):
     asyncio.run(_test())
 
 
-def test_listen_raises_bleak_error_when_service_missing():
+def test_listen_raises_bleak_error_when_service_missing(monkeypatch):
     async def _test():
         collection = FakeServiceCollection()
         client = MockBleakClientWithServices("dev-1", collection)
+
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
         with patch("omi.ble.BleakClient", return_value=client):
             with pytest.raises(BleakError, match="Service .* was not found"):
@@ -124,16 +129,40 @@ def test_listen_raises_bleak_error_when_service_missing():
     asyncio.run(_test())
 
 
-def test_listen_raises_bleak_error_when_characteristic_missing():
+def test_listen_raises_bleak_error_when_characteristic_missing(monkeypatch):
     async def _test():
         collection = FakeServiceCollection()
         srv = FakeService(OMI_SERVICE_UUID)
         collection.add_service(srv)
         client = MockBleakClientWithServices("dev-1", collection)
 
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
         with patch("omi.ble.BleakClient", return_value=client):
             with pytest.raises(BleakError, match="Characteristic .* was not found in service"):
                 await listen("dev-1", lambda data: None, service_uuid=OMI_SERVICE_UUID, char_uuid="missing-char")
+
+    asyncio.run(_test())
+
+
+def test_listen_unscoped_by_default_preserves_backward_compatibility(monkeypatch):
+    async def _test():
+        collection = FakeServiceCollection()
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(asyncio.CancelledError):
+                await listen("dev-1", lambda data: None, char_uuid=AUDIO_DATA_UUID)
+
+        assert client.notified_target == AUDIO_DATA_UUID
 
     asyncio.run(_test())
 

--- a/sdks/python/tests/test_ble_service_scope.py
+++ b/sdks/python/tests/test_ble_service_scope.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from bleak.exc import BleakError
+
+from omi.ble import listen, listen_payload
+from omi.constants import AUDIO_DATA_UUID, OMI_SERVICE_UUID
+
+
+class FakeCharacteristic:
+    def __init__(self, uuid: str, handle: int):
+        self.uuid = uuid
+        self.handle = handle
+
+
+class FakeService:
+    def __init__(self, uuid: str):
+        self.uuid = uuid
+        self.characteristics: dict[str, FakeCharacteristic] = {}
+
+    def add_char(self, char: FakeCharacteristic):
+        self.characteristics[char.uuid] = char
+
+    def get_characteristic(self, uuid: str) -> FakeCharacteristic | None:
+        return self.characteristics.get(uuid)
+
+
+class FakeServiceCollection:
+    def __init__(self):
+        self.services: dict[str, FakeService] = {}
+
+    def add_service(self, service: FakeService):
+        self.services[service.uuid] = service
+
+    def get_service(self, uuid: str) -> FakeService | None:
+        return self.services.get(uuid)
+
+
+class MockBleakClientWithServices:
+    def __init__(self, device_id: str, services: FakeServiceCollection | None = None):
+        self.device_id = device_id
+        self.services = services
+        self.notified_target = None
+        self.notify_handler = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def start_notify(self, char_or_uuid, handler):
+        self.notified_target = char_or_uuid
+        self.notify_handler = handler
+
+
+def test_listen_resolves_characteristic_from_selected_service(monkeypatch):
+    async def _test():
+        collection = FakeServiceCollection()
+        srv1 = FakeService(OMI_SERVICE_UUID)
+        c1 = FakeCharacteristic(AUDIO_DATA_UUID, 101)
+        srv1.add_char(c1)
+        collection.add_service(srv1)
+
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(asyncio.CancelledError):
+                await listen("dev-1", lambda data: None, service_uuid=OMI_SERVICE_UUID, char_uuid=AUDIO_DATA_UUID)
+
+        assert client.notified_target is c1
+
+    asyncio.run(_test())
+
+
+def test_listen_disambiguates_between_multiple_services(monkeypatch):
+    async def _test():
+        custom_service = "29b10000-e8f2-537e-4f6c-d104768a1214"
+        collection = FakeServiceCollection()
+
+        srv1 = FakeService(OMI_SERVICE_UUID)
+        c1 = FakeCharacteristic(AUDIO_DATA_UUID, 101)
+        srv1.add_char(c1)
+        collection.add_service(srv1)
+
+        srv2 = FakeService(custom_service)
+        c2 = FakeCharacteristic(AUDIO_DATA_UUID, 202)
+        srv2.add_char(c2)
+        collection.add_service(srv2)
+
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(asyncio.CancelledError):
+                await listen("dev-1", lambda data: None, service_uuid=custom_service, char_uuid=AUDIO_DATA_UUID)
+
+        assert client.notified_target is c2
+
+    asyncio.run(_test())
+
+
+def test_listen_raises_bleak_error_when_service_missing():
+    async def _test():
+        collection = FakeServiceCollection()
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(BleakError, match="Service .* was not found"):
+                await listen("dev-1", lambda data: None, service_uuid="missing-uuid")
+
+    asyncio.run(_test())
+
+
+def test_listen_raises_bleak_error_when_characteristic_missing():
+    async def _test():
+        collection = FakeServiceCollection()
+        srv = FakeService(OMI_SERVICE_UUID)
+        collection.add_service(srv)
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(BleakError, match="Characteristic .* was not found in service"):
+                await listen("dev-1", lambda data: None, service_uuid=OMI_SERVICE_UUID, char_uuid="missing-char")
+
+    asyncio.run(_test())
+
+
+def test_listen_payload_forwards_service_uuid(monkeypatch):
+    async def _test():
+        collection = FakeServiceCollection()
+        custom_service = "custom-srv"
+        srv = FakeService(custom_service)
+        c = FakeCharacteristic(AUDIO_DATA_UUID, 999)
+        srv.add_char(c)
+        collection.add_service(srv)
+        client = MockBleakClientWithServices("dev-1", collection)
+
+        async def fake_sleep(sec):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with patch("omi.ble.BleakClient", return_value=client):
+            with pytest.raises(asyncio.CancelledError):
+                await listen_payload("dev-1", lambda data: None, service_uuid=custom_service, char_uuid=AUDIO_DATA_UUID)
+
+        assert client.notified_target is c
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary
Resolves #13294.

In `omi.ble.listen()`, `service_uuid` was accepted as an argument with default `OMI_SERVICE_UUID`, but never used during notification setup (it passed only `char_uuid` to `BleakClient.start_notify()`). In multi-service devices with duplicate characteristic UUIDs, or when a caller specifies a custom service, Bleak could fail or subscribe to an unintended service.

### Changes
- In `listen()`, when client services are discovered and `service_uuid` is provided, look up the specific `BleakGATTService` and retrieve its `BleakGATTCharacteristic`.
- Pass the resolved characteristic object to `client.start_notify()` to ensure notifications are scoped to the intended service.
- Raise `BleakError` if the specified service or characteristic is not found.
- Forward `service_uuid` parameter in `listen_payload()`.
- Add test coverage in `tests/test_ble_service_scope.py`.

### Verification
- Ran `pytest sdks/python/tests`: all 29 tests pass (0 failures).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

