### PR TITLE
fix(go-sdk): preserve query params and build valid Parakeet WS URLs (#13177)

### DIFF
--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -27,10 +27,28 @@ type StreamingTranscriber interface {
 }
 
 func ParakeetWSURL(apiURL string, sampleRate int) string {
-	base := strings.TrimRight(strings.TrimSpace(apiURL), "/")
-	base = strings.Replace(base, "https://", "wss://", 1)
-	base = strings.Replace(base, "http://", "ws://", 1)
-	return fmt.Sprintf("%s/v3/stream?sample_rate=%d", base, sampleRate)
+	trimmed := strings.TrimSpace(apiURL)
+	raw := trimmed
+	if !strings.Contains(trimmed, "://") {
+		raw = "https://" + trimmed
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "ws":
+		u.Scheme = "ws"
+	default:
+		u.Scheme = "wss"
+	}
+	cleanPath := strings.TrimRight(u.Path, "/")
+	u.Path = cleanPath + "/v3/stream"
+	q := u.Query()
+	q.Set("sample_rate", fmt.Sprintf("%d", sampleRate))
+	u.RawQuery = q.Encode()
+	u.Fragment = ""
+	return u.String()
 }
 
 type wsTranscriber struct {

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -28,12 +28,20 @@ type StreamingTranscriber interface {
 
 func ParakeetWSURL(apiURL string, sampleRate int) string {
 	trimmed := strings.TrimSpace(apiURL)
+	if trimmed == "" {
+		return ""
+	}
 	raw := trimmed
-	if !strings.Contains(trimmed, "://") {
-		raw = "https://" + trimmed
+	if strings.HasPrefix(trimmed, "//") {
+		raw = "https:" + trimmed
+	} else {
+		schemeSep := strings.Index(trimmed, "://")
+		if schemeSep < 0 || strings.ContainsAny(trimmed[:schemeSep], "/?#") {
+			raw = "https://" + trimmed
+		}
 	}
 	u, err := url.Parse(raw)
-	if err != nil {
+	if err != nil || u.Host == "" {
 		return ""
 	}
 	switch strings.ToLower(u.Scheme) {
@@ -42,11 +50,33 @@ func ParakeetWSURL(apiURL string, sampleRate int) string {
 	default:
 		u.Scheme = "wss"
 	}
+
 	cleanPath := strings.TrimRight(u.Path, "/")
 	u.Path = cleanPath + "/v3/stream"
-	q := u.Query()
-	q.Set("sample_rate", fmt.Sprintf("%d", sampleRate))
-	u.RawQuery = q.Encode()
+	if u.RawPath != "" {
+		u.RawPath = strings.TrimRight(u.RawPath, "/") + "/v3/stream"
+	}
+
+	var newParts []string
+	foundSampleRate := false
+	if u.RawQuery != "" {
+		for _, part := range strings.Split(u.RawQuery, "&") {
+			if part == "" {
+				continue
+			}
+			k, _, _ := strings.Cut(part, "=")
+			if k == "sample_rate" {
+				newParts = append(newParts, fmt.Sprintf("sample_rate=%d", sampleRate))
+				foundSampleRate = true
+			} else {
+				newParts = append(newParts, part)
+			}
+		}
+	}
+	if !foundSampleRate {
+		newParts = append(newParts, fmt.Sprintf("sample_rate=%d", sampleRate))
+	}
+	u.RawQuery = strings.Join(newParts, "&")
 	u.Fragment = ""
 	return u.String()
 }

--- a/sdks/device/go/omidevice/stt/stt_test.go
+++ b/sdks/device/go/omidevice/stt/stt_test.go
@@ -3,10 +3,51 @@ package stt
 import "testing"
 
 func TestParakeetWSURL(t *testing.T) {
-	got := ParakeetWSURL("https://parakeet.example/", 16000)
-	want := "wss://parakeet.example/v3/stream?sample_rate=16000"
-	if got != want {
-		t.Fatalf("got %s want %s", got, want)
+	tests := []struct {
+		name       string
+		apiURL     string
+		sampleRate int
+		want       string
+	}{
+		{
+			name:       "trailing slash",
+			apiURL:     "https://parakeet.example/",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/v3/stream?sample_rate=16000",
+		},
+		{
+			name:       "http to ws",
+			apiURL:     "http://parakeet.example:8080",
+			sampleRate: 16000,
+			want:       "ws://parakeet.example:8080/v3/stream?sample_rate=16000",
+		},
+		{
+			name:       "preserve query and path",
+			apiURL:     "https://parakeet.example/gateway?region=eu",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000",
+		},
+		{
+			name:       "strip trailing slash from path",
+			apiURL:     "https://parakeet.example/gateway/",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/gateway/v3/stream?sample_rate=16000",
+		},
+		{
+			name:       "remove fragment",
+			apiURL:     "https://parakeet.example/gateway?region=eu#debug",
+			sampleRate: 8000,
+			want:       "wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=8000",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParakeetWSURL(tc.apiURL, tc.sampleRate)
+			if got != tc.want {
+				t.Fatalf("ParakeetWSURL(%q, %d) = %q, want %q", tc.apiURL, tc.sampleRate, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/sdks/device/go/omidevice/stt/stt_test.go
+++ b/sdks/device/go/omidevice/stt/stt_test.go
@@ -39,6 +39,24 @@ func TestParakeetWSURL(t *testing.T) {
 			sampleRate: 8000,
 			want:       "wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=8000",
 		},
+		{
+			name:       "schemeless with query containing protocol",
+			apiURL:     "parakeet.example/gateway?redirect=https://other.example",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/gateway/v3/stream?redirect=https://other.example&sample_rate=16000",
+		},
+		{
+			name:       "preserve percent-escaped path and query",
+			apiURL:     "https://parakeet.example/gateway%2Fv1?region=eu%20zone",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/gateway%2Fv1/v3/stream?region=eu%20zone&sample_rate=16000",
+		},
+		{
+			name:       "replace sample_rate and strip fragment",
+			apiURL:     "https://parakeet.example/gateway?sample_rate=8000&token=abc#frag",
+			sampleRate: 16000,
+			want:       "wss://parakeet.example/gateway/v3/stream?sample_rate=16000&token=abc",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
Resolves #13177.

In the Go device SDK, `stt.ParakeetWSURL()` concatenated `/v3/stream` directly to the end of the base URL string, causing existing query parameters to be corrupted (e.g. `https://parakeet.example/gateway?region=eu` produced `wss://parakeet.example/gateway?region=eu/v3/stream?sample_rate=16000`).

### Changes
- Parse `apiURL` using Go standard library `net/url`.
- Map scheme (`http`/`ws` -> `ws`, otherwise `wss`).
- Cleanly append `/v3/stream` to the URL `Path` without trailing slashes.
- Preserve existing query parameters and set `sample_rate`.
- Clear `Fragment`.
- Add table-driven tests for `ParakeetWSURL` in `sdks/device/go/omidevice/stt/stt_test.go`.

### Verification
- Ran `go test -v ./...` in `sdks/device/go`: all tests passed cleanly (0 failures).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

