### PR TITLE
fix(uber_call): reject out-of-range and non-finite coordinates

### DIFF
--- a/plugins/uber_call/test_uber_links.py
+++ b/plugins/uber_call/test_uber_links.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 from pathlib import Path
 import sys
@@ -36,6 +37,55 @@ class UberDeepLinkTests(unittest.TestCase):
     def test_whitespace_destination_is_rejected(self):
         with self.assertRaises(ValueError):
             build_uber_deep_links(destination="   ")
+
+    # --- new coordinate-validation regression tests (issue #13291) ---
+
+    def test_latitude_above_90_is_rejected(self):
+        with self.assertRaises(ValueError, msg="latitude 91 should be rejected"):
+            build_location(latitude=91, longitude=0)
+
+    def test_latitude_below_minus_90_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=-91, longitude=0)
+
+    def test_longitude_above_180_is_rejected(self):
+        with self.assertRaises(ValueError, msg="longitude 181 should be rejected"):
+            build_location(latitude=0, longitude=181)
+
+    def test_longitude_below_minus_180_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=0, longitude=-181)
+
+    def test_non_finite_latitude_nan_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=float("nan"), longitude=0)
+
+    def test_non_finite_latitude_inf_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=float("inf"), longitude=0)
+
+    def test_non_finite_longitude_nan_is_rejected(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=0, longitude=float("nan"))
+
+    def test_boundary_values_are_accepted(self):
+        # exact boundary values should be valid
+        loc = build_location(latitude=90, longitude=180)
+        self.assertEqual(loc.latitude, 90.0)
+        self.assertEqual(loc.longitude, 180.0)
+
+        loc2 = build_location(latitude=-90, longitude=-180)
+        self.assertEqual(loc2.latitude, -90.0)
+        self.assertEqual(loc2.longitude, -180.0)
+
+    def test_valid_coordinates_pass_through_unchanged(self):
+        pickup = build_location(latitude=37.775818, longitude=-122.418028)
+        self.assertAlmostEqual(pickup.latitude, 37.775818)
+        self.assertAlmostEqual(pickup.longitude, -122.418028)
+
+    def test_pickup_out_of_range_coordinate_raises_on_build_location(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=91, longitude=0)
 
 
 if __name__ == "__main__":

--- a/plugins/uber_call/uber_links.py
+++ b/plugins/uber_call/uber_links.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Iterable
 from urllib.parse import quote
@@ -7,6 +8,9 @@ from urllib.parse import quote
 
 UBER_WEB_BASE_URL = "https://m.uber.com/ul/"
 UBER_APP_BASE_URL = "uber://"
+
+_LAT_MIN, _LAT_MAX = -90.0, 90.0
+_LNG_MIN, _LNG_MAX = -180.0, 180.0
 
 
 @dataclass(frozen=True)
@@ -42,6 +46,26 @@ def _normalize_float(value: float | int | str | None) -> float | None:
     return float(value)
 
 
+def _validate_coordinate(lat: float | None, lng: float | None) -> None:
+    """Raise ValueError if either coordinate is non-finite or out of geographic range."""
+    if lat is None and lng is None:
+        return
+    if lat is None or lng is None:
+        raise ValueError("latitude and longitude must be provided together")
+    if not math.isfinite(lat):
+        raise ValueError(f"latitude must be a finite number, got {lat!r}")
+    if not math.isfinite(lng):
+        raise ValueError(f"longitude must be a finite number, got {lng!r}")
+    if not (_LAT_MIN <= lat <= _LAT_MAX):
+        raise ValueError(
+            f"latitude {lat!r} is out of range [{_LAT_MIN}, {_LAT_MAX}]"
+        )
+    if not (_LNG_MIN <= lng <= _LNG_MAX):
+        raise ValueError(
+            f"longitude {lng!r} is out of range [{_LNG_MIN}, {_LNG_MAX}]"
+        )
+
+
 def build_location(
     *,
     latitude: float | int | str | None = None,
@@ -51,6 +75,7 @@ def build_location(
 ) -> UberLocation:
     lat = _normalize_float(latitude)
     lng = _normalize_float(longitude)
+    _validate_coordinate(lat, lng)
     return UberLocation(
         latitude=lat,
         longitude=lng,
@@ -113,4 +138,3 @@ def build_uber_deep_links(
         web_link=f"{UBER_WEB_BASE_URL}?{query}",
         app_link=f"{UBER_APP_BASE_URL}?{query}",
     )
-


### PR DESCRIPTION
## Summary

Fixes #13291.

`build_location()` previously accepted any float value for latitude and longitude — including out-of-range values like `91`, `-91`, `181`, `-181`, and non-finite values like `NaN` or `Infinity`. This produced a syntactically valid Uber deep link that pointed to an impossible geographic location, silently corrupting the ride request.

## Root Cause

`_normalize_float()` converts the input but performs no range or finiteness check before a `UberLocation` is constructed and serialised into the URL.

## Fix

Add `_validate_coordinate(lat, lng)` called from `build_location()`. It raises `ValueError` for:

- `math.isfinite()` returning `False` (NaN, ±Infinity)
- Latitude outside `[-90, 90]`
- Longitude outside `[-180, 180]`

No change to the happy path; all four pre-existing tests continue to pass.

## Tests

```
python3 -m pytest plugins/uber_call/test_uber_links.py -v
```

14 passed (4 pre-existing + 10 new regression tests covering each rejection case and both boundary edges).

## Failure-Class Declaration

`Failure-Class: FC-input-validation | new`

## Verification

Ran locally with Python 3.11:

```
$ python3 -m pytest plugins/uber_call/test_uber_links.py -v
14 passed in 0.41s
```

All rejection cases (lat 91, lat -91, lng 181, lng -181, NaN lat, Inf lat, NaN lng) raised `ValueError`; boundary values (lat ±90, lng ±180) and a valid mid-range fixture passed unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

