### PR TITLE
feat(plugins): add PyPI package and release lookup tools

### DIFF
--- a/backend/tests/unit/test_pypi_plugin.py
+++ b/backend/tests/unit/test_pypi_plugin.py
@@ -1,0 +1,212 @@
+"""Hermetic HTTP contract tests for the standalone PyPI Omi plugin."""
+
+import importlib.util
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+ASYNC_CLIENT = httpx.AsyncClient
+
+
+@pytest.fixture
+def plugin():
+    path = Path(__file__).resolve().parents[3] / 'plugins' / 'omi-pypi-app' / 'main.py'
+    assert path.is_file(), 'The PyPI plugin implementation must exist'
+    spec = importlib.util.spec_from_file_location('omi_pypi_plugin', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client(plugin):
+    with TestClient(plugin.app) as client:
+        yield client
+
+
+def upstream(plugin, monkeypatch, handler):
+    real_client = ASYNC_CLIENT
+
+    def factory(**kwargs):
+        assert 0 < kwargs['timeout'] <= 20
+        assert kwargs['follow_redirects'] is False
+        return real_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(plugin.httpx, 'AsyncClient', factory)
+
+
+def test_health_and_discovery(client):
+    assert client.get('/health').json() == {'status': 'ok'}
+    tools = client.get('/.well-known/omi-tools.json').json()['tools']
+    assert [tool['name'] for tool in tools] == ['get_pypi_package', 'get_pypi_release']
+    for tool in tools:
+        assert tool['method'] == 'POST'
+        assert tool['auth_required'] is False
+        assert tool['endpoint'] == '/tools/' + tool['name']
+        assert 'package' in tool['parameters']['required']
+    assert tools[1]['parameters']['required'] == ['package', 'version']
+
+
+@pytest.mark.parametrize('version', [None, '1!2.3rc1.post2.dev3+cpu.1'])
+def test_lookup_metadata(client, plugin, monkeypatch, version):
+    expected_version = version or '2.3'
+
+    def handler(request):
+        suffix = f'/{expected_version}' if version else ''
+        assert request.url.host == 'pypi.org'
+        assert request.url.scheme == 'https'
+        assert request.url.path == f'/pypi/demo-pkg{suffix}/json'
+        assert request.method == 'GET'
+        return httpx.Response(
+            200,
+            json={
+                'info': {
+                    'name': 'Demo-Pkg',
+                    'version': expected_version,
+                    'summary': 'A demo',
+                    'requires_python': '>=3.9',
+                    'license_expression': 'MIT',
+                    'license': 'legacy',
+                    'project_urls': {'Source': 'https://example.com/repo'},
+                    'requires_dist': ['httpx>=0.28; python_version >= "3.9"'],
+                    'yanked': True,
+                    'yanked_reason': 'Broken release',
+                }
+            },
+        )
+
+    upstream(plugin, monkeypatch, handler)
+    body = {'package': 'Demo_Pkg'}
+    if version:
+        body['version'] = version
+    result = client.post('/tools/get_pypi_release' if version else '/tools/get_pypi_package', json=body).json()
+    assert result['error'] is None
+    for text in [
+        'Demo-Pkg',
+        expected_version,
+        'A demo',
+        '>=3.9',
+        'MIT',
+        'https://example.com/repo',
+        'httpx>=0.28',
+        'Yanked: yes',
+        'Broken release',
+        'publisher-supplied',
+        'not a safety verification',
+    ]:
+        assert text in result['result']
+    assert 'legacy' not in result['result']
+    suffix = "/" + quote(version, safe="") if version else ''
+    assert f'PyPI source: https://pypi.org/project/demo-pkg{suffix}/' in result['result']
+
+
+@pytest.mark.parametrize(
+    'body,route',
+    [
+        ({'package': '../x'}, 'package'),
+        ({'package': 'https://example.com'}, 'package'),
+        ({'package': 'x?foo'}, 'package'),
+        ({'package': ''}, 'package'),
+        ({'package': 'a' * 201}, 'package'),
+        ({'package': ['x']}, 'package'),
+        ({}, 'package'),
+        ({'package': 'x', 'version': '../1'}, 'release'),
+        ({'package': 'x', 'version': '1/2'}, 'release'),
+        ({'package': 'x', 'version': '1%2f2'}, 'release'),
+        ({'package': 'x', 'version': 'banana'}, 'release'),
+        ({'package': 'x'}, 'release'),
+    ],
+)
+def test_invalid_inputs_do_not_contact_pypi(client, plugin, monkeypatch, body, route):
+    def handler(request):
+        pytest.fail('Invalid inputs must not contact an upstream')
+
+    upstream(plugin, monkeypatch, handler)
+    response = client.post('/tools/get_pypi_' + route, json=body)
+    assert response.status_code in (200, 422)
+    assert response.json()['error']
+    assert len(response.text) < 300
+
+
+@pytest.mark.parametrize(
+    'failure,expected',
+    [
+        (404, 'not found'),
+        (503, 'unavailable'),
+        (302, 'unavailable'),
+        ('timeout', 'timed out'),
+        ('network', 'unavailable'),
+        ('json', 'invalid metadata'),
+        ('shape', 'invalid metadata'),
+    ],
+)
+def test_upstream_errors_are_concise(client, plugin, monkeypatch, failure, expected):
+    def handler(request):
+        if failure == 'timeout':
+            raise httpx.ReadTimeout('PRIVATE DETAILS', request=request)
+        if failure == 'network':
+            raise httpx.ConnectError('PRIVATE DETAILS', request=request)
+        if failure == 'json':
+            return httpx.Response(200, text='PRIVATE DETAILS')
+        if failure == 'shape':
+            return httpx.Response(200, json={'info': []})
+        return httpx.Response(failure, headers={'Location': 'https://example.com'}, text='PRIVATE DETAILS')
+
+    upstream(plugin, monkeypatch, handler)
+    body = client.post('/tools/get_pypi_package', json={'package': 'demo'}).json()
+    assert body['result'] is None
+    assert expected in body['error']
+    assert 'PRIVATE DETAILS' not in body['error']
+
+
+def test_missing_metadata_and_bounded_output(client, plugin, monkeypatch):
+    upstream(
+        plugin, monkeypatch, lambda request: httpx.Response(200, json={'info': {'name': 'demo', 'version': '1.0'}})
+    )
+    result = client.post('/tools/get_pypi_package', json={'package': 'demo'}).json()['result']
+    for label in [
+        'Summary',
+        'Requires Python',
+        'License',
+        'Project links',
+        'Declared dependencies',
+        'Yanked',
+    ]:
+        assert f'{label}: unknown' in result
+
+    upstream(
+        plugin,
+        monkeypatch,
+        lambda request: httpx.Response(
+            200,
+            json={
+                'info': {
+                    'name': 'demo',
+                    'version': '1.0',
+                    'summary': 'x' * 10000,
+                    'license': 'BSD',
+                    'requires_dist': ['d' * 1000] * 100,
+                    'project_urls': {f'link{i}': 'u' * 1000 for i in range(100)},
+                    'yanked': False,
+                }
+            },
+        ),
+    )
+    result = client.post('/tools/get_pypi_package', json={'package': 'demo'}).json()['result']
+    assert len(result) <= 6000
+    assert 'truncated' in result
+    assert 'License: BSD' in result
+    assert 'Yanked: no' in result
+
+
+@pytest.mark.parametrize(
+    'info', [{}, {'name': 'demo'}, {'name': 'demo', 'version': []}, {'name': ' ', 'version': '1.0'}]
+)
+def test_missing_identity_is_invalid_metadata(client, plugin, monkeypatch, info):
+    upstream(plugin, monkeypatch, lambda request: httpx.Response(200, json={'info': info}))
+    body = client.post('/tools/get_pypi_package', json={'package': 'demo'}).json()
+    assert body['result'] is None
+    assert body['error'] == 'PyPI returned invalid metadata.'

--- a/plugins/omi-pypi-app/README.md
+++ b/plugins/omi-pypi-app/README.md
@@ -1,0 +1,81 @@
+# Omi PyPI lookup
+
+Read public Python package metadata from Omi chat. Ask “What Python version does
+httpx require?” or “What dependencies did requests 2.32.3 declare?”
+
+This standalone FastAPI integration uses the [PyPI JSON API](https://docs.pypi.org/api/json/).
+It needs no PyPI account or API key and never downloads or executes packages.
+
+## Run
+
+Use Python 3.11. From this directory:
+
+```bash
+python3.11 -m venv .venv
+.venv/bin/python -m pip install -r requirements.txt
+.venv/bin/uvicorn main:app --host 127.0.0.1 --port 8080
+```
+
+```bash
+curl -s http://127.0.0.1:8080/health
+curl -s http://127.0.0.1:8080/tools/get_pypi_package \
+  -H 'Content-Type: application/json' -d '{"package":"sampleproject"}'
+curl -s http://127.0.0.1:8080/tools/get_pypi_release \
+  -H 'Content-Type: application/json' -d '{"package":"sampleproject","version":"4.0.0"}'
+```
+
+## Omi registration
+
+Deploy this directory as an independent Python web service with HTTPS, install
+`requirements.txt`, and start `uvicorn main:app --host 0.0.0.0 --port $PORT`.
+The host must permit outbound HTTPS to `pypi.org`. Hosting is not provisioned by
+this contribution.
+
+Register the two POST chat tools from `/.well-known/omi-tools.json` in the Omi
+app's external integration configuration. Use your service's HTTPS origin plus
+the manifest's endpoint for each URL. No authentication or OAuth flow is required
+for these public lookups. The manifest supplies the parameter schemas and
+required fields. `/health` reports only that this service is running, not PyPI's
+availability.
+
+| Tool | Required parameters | Result |
+| --- | --- | --- |
+| `get_pypi_package` | `package` | Metadata for PyPI's current version |
+| `get_pypi_release` | `package`, `version` | Metadata for the requested version |
+
+Responses use Omi's `result` / `error` text envelope. Missing, wrongly typed or overlong parameters return HTTP 422. Invalid
+package/version syntax and unsuccessful upstream lookups return HTTP 200 with
+a readable error envelope; inspect `error` before using `result`.
+Use package names, not PyPI URLs. Hyphens, underscores and dots in names follow
+PyPI normalization. Versions follow PEP 440.
+
+## What the answer means
+
+The response presents publisher-supplied metadata: version, Python requirement,
+summary, license, project links, declared dependencies and yanked status.
+Missing fields are reported as unavailable. Long fields and dependency lists are
+bounded for chat; the PyPI project link provides the source for fuller details.
+Dependencies are declarations, including environment markers and extras; this
+service does not resolve them for the user's machine. A yanked release is not
+recommended merely because it is retrievable.
+
+Metadata is not a package audit, compatibility guarantee or safety endorsement.
+Project links are displayed as source data and are never fetched. Only the
+requested package name and optional version are sent to PyPI; Omi user IDs,
+conversation history and account credentials are neither required nor stored.
+Do not put secrets in query parameters. The standalone service is unauthenticated;
+operators should apply their hosting platform's normal access/rate controls.
+
+## Tests
+
+The hermetic endpoint tests live at
+`backend/tests/unit/test_pypi_plugin.py` so the backend unit CI discovers them.
+From the repository root, after setting up the backend test environment:
+
+```bash
+backend/.venv/bin/python -m pytest backend/tests/unit/test_pypi_plugin.py -q
+```
+
+The tests execute the actual ASGI routes while replacing only outbound HTTP with
+a deterministic transport. They require no PyPI access or Omi credentials. The
+curl examples above are optional live smoke checks, separate from hermetic CI.

--- a/plugins/omi-pypi-app/main.py
+++ b/plugins/omi-pypi-app/main.py
@@ -1,0 +1,154 @@
+"""Read-only Omi chat tools for publisher-supplied PyPI metadata."""
+
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, Field
+
+PYPI_BASE = "https://pypi.org/pypi"
+TIMEOUT = 10.0
+MAX_RESULT = 6000
+NAME_PATTERN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
+app = FastAPI(title="PyPI Omi Integration", version="1.0.0")
+
+
+class PackageInput(BaseModel):
+    package: str = Field(min_length=1, max_length=200)
+
+
+class ReleaseInput(PackageInput):
+    version: str = Field(min_length=1, max_length=200)
+
+
+class ChatToolResponse(BaseModel):
+    result: str | None = None
+    error: str | None = None
+
+
+@app.exception_handler(RequestValidationError)
+async def invalid_request(request, exc):
+    return JSONResponse(status_code=422, content={"result": None, "error": "Invalid package or version input."})
+
+
+def clean(value: Any, limit: int = 400) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "unknown"
+    value = " ".join(value.split())
+    return value if len(value) <= limit else value[:limit] + " [truncated]"
+
+
+def metadata_text(info: dict, source_url: str) -> str:
+    links = info.get("project_urls")
+    if isinstance(links, dict) and links:
+        link_text = "; ".join(f"{clean(k, 50)}: {clean(v, 200)}" for k, v in list(links.items())[:5])
+        if len(links) > 5:
+            link_text += "; [truncated]"
+    else:
+        link_text = "unknown"
+    dependencies = info.get("requires_dist")
+    if isinstance(dependencies, list):
+        dependency_text = "; ".join(clean(dep, 200) for dep in dependencies[:10]) or "none declared"
+        if len(dependencies) > 10:
+            dependency_text += "; [truncated]"
+    else:
+        dependency_text = "unknown"
+    yanked = info.get("yanked")
+    yanked_text = "yes" if yanked is True else "no" if yanked is False else "unknown"
+    lines = [
+        "PyPI publisher-supplied metadata; not a safety verification.",
+        f"PyPI source: {source_url}",
+        f"Name: {clean(info.get('name'), 200)}",
+        f"Version: {clean(info.get('version'), 200)}",
+        f"Summary: {clean(info.get('summary'), 500)}",
+        f"Requires Python: {clean(info.get('requires_python'), 200)}",
+        f"License: {clean(info.get('license_expression') or info.get('license'), 300)}",
+        f"Yanked: {yanked_text}",
+        f"Yank reason: {clean(info.get('yanked_reason'), 200)}",
+        f"Project links: {link_text}",
+        f"Declared dependencies: {dependency_text}",
+    ]
+    result = "\n".join(lines)
+    return result if len(result) <= MAX_RESULT else result[: MAX_RESULT - 12] + " [truncated]"
+
+
+async def lookup(package: str, version: str | None = None) -> ChatToolResponse:
+    package = package.strip()
+    if not NAME_PATTERN.fullmatch(package):
+        return ChatToolResponse(error="Invalid package name. Use a PyPI project name, not a URL.")
+    package = re.sub(r"[-_.]+", "-", package).lower()
+    path = f"/{package}"
+    if version is not None:
+        version = version.strip()
+        if not re.fullmatch(r"[A-Za-z0-9.!+_-]+", version):
+            return ChatToolResponse(error="Invalid release version. Use a PEP 440 version.")
+        try:
+            Version(version)
+        except InvalidVersion:
+            return ChatToolResponse(error="Invalid release version. Use a PEP 440 version.")
+        path += f"/{quote(version, safe='')}"
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, follow_redirects=False) as client:
+            response = await client.get(f"{PYPI_BASE}{path}/json")
+            response.raise_for_status()
+            data = response.json()
+    except httpx.TimeoutException:
+        return ChatToolResponse(error="PyPI request timed out. Try again later.")
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return ChatToolResponse(error="PyPI package or release not found.")
+        return ChatToolResponse(error="PyPI is unavailable. Try again later.")
+    except httpx.RequestError:
+        return ChatToolResponse(error="PyPI is unavailable. Try again later.")
+    except ValueError:
+        return ChatToolResponse(error="PyPI returned invalid metadata.")
+    if not isinstance(data, dict) or not isinstance(data.get("info"), dict):
+        return ChatToolResponse(error="PyPI returned invalid metadata.")
+    info = data["info"]
+    if any(not isinstance(info.get(key), str) or not info[key].strip() for key in ("name", "version")):
+        return ChatToolResponse(error="PyPI returned invalid metadata.")
+    return ChatToolResponse(result=metadata_text(info, f"https://pypi.org/project{path}/"))
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/.well-known/omi-tools.json")
+async def get_omi_tools_manifest():
+    tools = []
+    for name, description, required in [
+        ("get_pypi_package", "Look up a PyPI project's current metadata", ["package"]),
+        ("get_pypi_release", "Look up metadata for an exact PyPI release", ["package", "version"]),
+    ]:
+        properties = {"package": {"type": "string", "description": "PyPI project name, e.g. httpx"}}
+        if "version" in required:
+            properties["version"] = {"type": "string", "description": "Exact PEP 440 version, e.g. 0.28.0"}
+        tools.append(
+            {
+                "name": name,
+                "description": description + ". Publisher-supplied metadata, not a safety verification.",
+                "endpoint": f"/tools/{name}",
+                "method": "POST",
+                "parameters": {"type": "object", "properties": properties, "required": required},
+                "auth_required": False,
+                "status_message": "Fetching PyPI metadata...",
+            }
+        )
+    return {"tools": tools}
+
+
+@app.post("/tools/get_pypi_package", response_model=ChatToolResponse)
+async def get_pypi_package(payload: PackageInput):
+    return await lookup(payload.package)
+
+
+@app.post("/tools/get_pypi_release", response_model=ChatToolResponse)
+async def get_pypi_release(payload: ReleaseInput):
+    return await lookup(payload.package, payload.version)

--- a/plugins/omi-pypi-app/requirements.txt
+++ b/plugins/omi-pypi-app/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.121.0
+uvicorn==0.30.5
+httpx==0.28.0
+pydantic==2.11.10
+packaging==24.2


### PR DESCRIPTION
## Summary

Add two read-only Omi chat tools for looking up a Python package's current PyPI metadata or a specified release. Users can retrieve version, Python requirement, declared dependencies, license, project links and yank information without installing packages or supplying credentials.

The standalone plugin uses PyPI's public JSON API and the existing Omi tool response/manifest conventions. Registry metadata is publisher-supplied information, not a security endorsement. Lookup transport is fixed to PyPI; requests do not include Omi account data.

Related integration bounty discussion: https://github.com/BasedHardware/omi/issues/3120#issuecomment-5602282124 . The proposed $50 reward is unapproved; this PR does not imply an award.

## Product invariants

No product invariant path matches were identified for the standalone plugin and its hermetic tests by the local preflight.

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_pypi_plugin.py -q`: 27 passed, covering both actual ASGI endpoints, validation, normalization, fixed-host requests, metadata rendering, and upstream failure handling.
- Started the service locally with Uvicorn and exercised health, manifest, current `sampleproject`, exact `sampleproject` release `4.0.0`, and a nonexistent package against the live PyPI API: all five checks passed.
- `PATH="$PWD/backend/.venv/bin:$PATH" OMI_PR_BODY_FILE=<body-file> make preflight`: 26 checks passed. The local checkout is shallow, so the 90-day failure-class history ratchet was skipped locally; full-history CI remains authoritative.
- No deployed Omi app or physical-device validation was performed.

The new backend test file triggers the existing backend CI for this PR. Future plugin-only edits will need the documented test command explicitly: the existing workflow path filters do not include `plugins/**`.

## Contribution disclosure

Prepared with Codex AI assistance for gigogigo64. No private account data or payment details are included. The PayPal payout request is subject to maintainer approval independently of merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

