### PR TITLE
fix(typescript-sdk): reject explicit unsupported Whisper sampleRate (#13122)

### DIFF
--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -100,4 +100,60 @@ describe('createWhisperTranscriber', () => {
 
     expect(transcripts).toEqual(['final transcript']);
   });
+
+  test('rejects explicit unsupported sample rate', () => {
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 8000,
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 44100,
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+  });
+
+  test('accepts explicit 16000 Hz or default sample rate', () => {
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 16000,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+      }),
+    ).not.toThrow();
+  });
+
+  test('createTranscriber rejects unsupported sampleRate for whisper', () => {
+    expect(() =>
+      createTranscriber('whisper', {
+        sampleRate: 8000,
+        whisperRunner: () => 'test',
+        onTranscript: () => {},
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+  });
+
+  test('createTranscriber accepts explicit 16000 Hz sampleRate for whisper', () => {
+    expect(() =>
+      createTranscriber('whisper', {
+        sampleRate: 16000,
+        whisperRunner: () => 'test',
+        onTranscript: () => {},
+      }),
+    ).not.toThrow();
+  });
 });
+

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -146,9 +146,6 @@ export function createTranscriber(
     return createParakeetTranscriber({ ...opts, apiUrl } as any);
   }
   if (engine === 'whisper') {
-    if (opts.sampleRate !== undefined && opts.sampleRate !== 16000) {
-      throw new Error('Whisper requires 16000 Hz PCM; resample audio before transcription');
-    }
     if (!opts.whisperRunner) throw new Error('Whisper requires whisperRunner');
     return createWhisperTranscriber({
       runner: opts.whisperRunner,

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -88,7 +88,11 @@ export function createWhisperTranscriber(opts: {
   runner: (pcm: Uint8Array) => Promise<string> | string;
   onTranscript: TranscriptHandler;
   batchSeconds?: number;
+  sampleRate?: number;
 }): StreamingTranscriber {
+  if (opts.sampleRate !== undefined && opts.sampleRate !== 16000) {
+    throw new Error('Whisper requires 16000 Hz PCM; resample audio before transcription');
+  }
   const batchBytes = (opts.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
@@ -142,8 +146,15 @@ export function createTranscriber(
     return createParakeetTranscriber({ ...opts, apiUrl } as any);
   }
   if (engine === 'whisper') {
+    if (opts.sampleRate !== undefined && opts.sampleRate !== 16000) {
+      throw new Error('Whisper requires 16000 Hz PCM; resample audio before transcription');
+    }
     if (!opts.whisperRunner) throw new Error('Whisper requires whisperRunner');
-    return createWhisperTranscriber({ runner: opts.whisperRunner, onTranscript: opts.onTranscript });
+    return createWhisperTranscriber({
+      runner: opts.whisperRunner,
+      onTranscript: opts.onTranscript,
+      sampleRate: opts.sampleRate,
+    });
   }
   throw new Error(`Unknown engine ${engine}`);
 }


### PR DESCRIPTION
Resolves #13122.

### Summary
The device PCM contract specifies 16 kHz. `createWhisperTranscriber()` and `createTranscriber('whisper', ...)` previously dropped `opts.sampleRate`, silently accepting unsupported sample rates (such as 8000 Hz) while hardcoding batch sizing to 16,000 Hz.

### Changes
- In `createWhisperTranscriber()`: validate that if `opts.sampleRate` is defined, it must equal `16000`, throwing `Error('Whisper requires 16000 Hz PCM; resample audio before transcription')` otherwise.
- In `createTranscriber()`: perform fail-fast validation for whisper and forward `sampleRate` to `createWhisperTranscriber()`.
- Added unit tests in `src/stt/index.test.ts` verifying that unsupported sample rates (8000, 44100) are rejected with the descriptive error, and supported rates (16000, default) succeed.

### Verification
- `bun test`: 16/16 tests pass.
- `bun run typecheck`: clean TypeScript validation (`bunx tsc --noEmit`).

Credit to @TheO1dF for the original issue report and reproduction.

/claim #13122


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

