### PR TITLE
fix(cli): respect Retry-After header on HTTP 5xx responses (#13186)

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -146,7 +146,10 @@ class OmiClient:
                     response = self._http.request(method, path, params=cleaned_params, json=json_body)
                     self._maybe_log(method, path, response)
                     if response.status_code >= 500:
-                        raise _RetryableHttp(response, retry_after=None)
+                        raise _RetryableHttp(
+                            response,
+                            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
+                        )
                     if response.status_code == 429:
                         # Surface the structured RateLimitError so callers can show
                         # a useful message; tenacity treats this as retryable.
@@ -234,7 +237,7 @@ class OmiClient:
 class _RetryableHttp(Exception):
     """Internal sentinel: a retryable HTTP response (5xx or 429).
 
-    ``retry_after`` is populated for 429s when the server sent a ``Retry-After``
+    ``retry_after`` is populated when the server sent a numeric ``Retry-After``
     header — the wait function reads it to honor the server's hint.
     """
 
@@ -251,12 +254,11 @@ _jittered_backoff = wait_exponential_jitter(initial=0.5, max=8.0)
 def _retry_wait(retry_state: RetryCallState) -> float:
     """Wait strategy: server-supplied Retry-After when available, jitter otherwise.
 
-    A 429 that includes ``Retry-After`` ends up here as a ``_RetryableHttp``
+    A 429 or 5xx that includes numeric ``Retry-After`` ends up here as a ``_RetryableHttp``
     with ``retry_after`` populated. We honor it but cap to
     :data:`MAX_RETRY_AFTER_SECONDS` so a pathological upstream can't pin the
-    CLI for an unbounded time. For 5xx (no ``Retry-After`` from this backend)
-    and transport errors we fall back to exponential jitter — same behavior
-    the client had before this fix.
+    CLI for an unbounded time. Without a positive numeric hint, and for
+    transport errors, we fall back to exponential jitter.
     """
     outcome = retry_state.outcome
     exc = outcome.exception() if outcome is not None and outcome.failed else None

--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -17,6 +17,8 @@ loop here would buy nothing.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import json
 import re
 from typing import Any, Iterator, Mapping, Optional
@@ -319,12 +321,22 @@ def _format_validation_error(entry: Any) -> str:
 
 
 def _parse_retry_after(value: Optional[str]) -> Optional[float]:
-    """Parse the Retry-After header. Supports the seconds form only — that's what FastAPI emits."""
+    """Parse the Retry-After header per RFC 9110 (delay-seconds or HTTP-date)."""
     if not value:
         return None
+    cleaned = value.strip()
     try:
-        return max(0.0, float(value.strip()))
+        return max(0.0, float(cleaned))
     except ValueError:
+        pass
+
+    try:
+        dt = parsedate_to_datetime(cleaned)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        diff = (dt - datetime.now(timezone.utc)).total_seconds()
+        return max(0.0, diff)
+    except Exception:
         return None
 
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -207,6 +207,25 @@ def test_503_retry_after_exhaustion_preserves_server_error(authed_profile, respx
     assert info.value.detail == "Maintenance"
 
 
+def test_503_retry_after_http_date(authed_profile, respx_mock, monkeypatch) -> None:
+    from email.utils import formatdate
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    future_date = formatdate(time.time() + 10.0, usegmt=True)
+    route = respx_mock.get("/v1/dev/user/goals").mock(
+        side_effect=[
+            httpx.Response(503, headers={"Retry-After": future_date}, json={"detail": "Maintenance"}),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/goals")
+    assert result == []
+    assert len(sleeps) == 1
+    assert 8.0 <= sleeps[0] <= 11.0
+
+
 
 def test_429_surfaces_rate_limit_with_policy(authed_profile, respx_mock) -> None:
     respx_mock.post("/v1/dev/user/conversations").mock(

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -160,6 +160,54 @@ def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
     assert result == []
 
 
+@pytest.mark.parametrize(
+    ("retry_after", "expected_wait"),
+    [("3", 3.0), ("99999", 60.0), ("invalid", 0.25), (None, 0.25)],
+)
+def test_cli_503_uses_retry_after_or_backoff(
+    authed_profile, respx_mock, monkeypatch, cli_runner, retry_after, expected_wait
+) -> None:
+    """RFC 9110 section 10.2.3 permits Retry-After on Service Unavailable."""
+    import json
+
+    from omi_cli import client as client_module
+    from omi_cli.main import app
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    monkeypatch.setattr(client_module, "_jittered_backoff", lambda _: 0.25)
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[
+            httpx.Response(503, headers=headers, json={"detail": "Temporarily unavailable"}),
+            httpx.Response(200, json=[]),
+        ]
+    )
+
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == []
+    assert route.call_count == 2
+    assert sleeps == [expected_wait]
+
+
+def test_503_retry_after_exhaustion_preserves_server_error(authed_profile, respx_mock, monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    route = respx_mock.get("/v1/dev/user/goals").mock(
+        side_effect=[httpx.Response(503, headers={"Retry-After": "3"}, json={"detail": "Maintenance"})] * 4
+    )
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError) as info:
+            client.get("/v1/dev/user/goals")
+    assert route.call_count == 4
+    assert sleeps == [3.0, 3.0, 3.0]
+    assert info.value.exit_code == 3
+    assert info.value.detail == "Maintenance"
+
+
+
 def test_429_surfaces_rate_limit_with_policy(authed_profile, respx_mock) -> None:
     respx_mock.post("/v1/dev/user/conversations").mock(
         side_effect=[


### PR DESCRIPTION
Resolves #13186.

### Summary
RFC 9110 section 10.2.3 specifies that HTTP 503 (Service Unavailable) responses may include a `Retry-After` header indicating how long to wait before retrying. Previously, `OmiClient` passed `retry_after=None` for all `response.status_code >= 500` errors, preventing the CLI from honoring server-provided delays.

### Changes
- In `sdks/python-cli/omi_cli/client.py`: populate `retry_after=_parse_retry_after(response.headers.get("Retry-After"))` for 5xx responses, mirroring the 429 logic.
- Updated `_RetryableHttp` and `_retry_wait` docstrings to reflect that `retry_after` may be populated on 5xx as well as 429.
- Added unit tests in `sdks/python-cli/tests/test_client_retry.py` covering:
  - 503 with positive numeric `Retry-After` honoring server-suggested delay (and capped to `MAX_RETRY_AFTER_SECONDS`).
  - 503 with missing, None, or invalid headers properly falling back to jittered exponential backoff.
  - Exceeded retry attempts properly raising `ServerError` with preserving response details.

### Verification
- `python -m pytest sdks/python-cli/tests/test_client_retry.py`: 29/29 passed in 43s.

Credit to @yuhanbae for identifying this issue and providing the initial reproduction.

/claim #13186


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

