### PR TITLE
fix(python-sdk): raise ConnectionError on device disconnect in BLE listeners (#13290)

### DIFF
--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -48,10 +48,33 @@ async def listen(
         if inspect.isawaitable(result):
             await result
 
-    async with BleakClient(device_id) as client:
+    disconnected_event = asyncio.Event()
+
+    def _on_disconnect(_client: BleakClient) -> None:
+        disconnected_event.set()
+
+    try:
+        client = BleakClient(device_id, disconnected_callback=_on_disconnect)
+    except TypeError:
+        client = BleakClient(device_id)
+        if hasattr(client, "set_disconnected_callback"):
+            client.set_disconnected_callback(_on_disconnect)
+
+    async with client:
         await client.start_notify(char_uuid, _handler)
-        while True:
-            await asyncio.sleep(3600)
+        while not disconnected_event.is_set():
+            disconnect_task = asyncio.create_task(disconnected_event.wait())
+            sleep_task = asyncio.create_task(asyncio.sleep(3600))
+            done, pending = await asyncio.wait(
+                [disconnect_task, sleep_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for p in pending:
+                p.cancel()
+            for d in done:
+                if d is sleep_task and d.exception():
+                    raise d.exception()
+        raise ConnectionError(f"Device {device_id} disconnected")
 
 
 async def listen_payload(

--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -65,12 +65,18 @@ async def listen(
         while not disconnected_event.is_set():
             disconnect_task = asyncio.create_task(disconnected_event.wait())
             sleep_task = asyncio.create_task(asyncio.sleep(3600))
-            done, pending = await asyncio.wait(
-                [disconnect_task, sleep_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for p in pending:
-                p.cancel()
+            try:
+                done, pending = await asyncio.wait(
+                    [disconnect_task, sleep_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for task in (disconnect_task, sleep_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(
+                    disconnect_task, sleep_task, return_exceptions=True
+                )
             for d in done:
                 if d is sleep_task and d.exception():
                     raise d.exception()

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -45,12 +45,18 @@ async def listen_to_omi(
         while not disconnected_event.is_set():
             disconnect_task = asyncio.create_task(disconnected_event.wait())
             sleep_task = asyncio.create_task(asyncio.sleep(99999))
-            done, pending = await asyncio.wait(
-                [disconnect_task, sleep_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for p in pending:
-                p.cancel()
+            try:
+                done, pending = await asyncio.wait(
+                    [disconnect_task, sleep_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for task in (disconnect_task, sleep_task):
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(
+                    disconnect_task, sleep_task, return_exceptions=True
+                )
             for d in done:
                 if d is sleep_task and d.exception():
                     raise d.exception()

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -26,8 +26,32 @@ async def listen_to_omi(
         char_uuid: UUID of the audio characteristic (use AUDIO_DATA_UUID)
         data_handler: Callback function to handle incoming audio data
     """
-    async with BleakClient(mac_address) as client:
+    disconnected_event = asyncio.Event()
+
+    def _on_disconnect(_client: BleakClient) -> None:
+        disconnected_event.set()
+
+    try:
+        client = BleakClient(mac_address, disconnected_callback=_on_disconnect)
+    except TypeError:
+        client = BleakClient(mac_address)
+        if hasattr(client, "set_disconnected_callback"):
+            client.set_disconnected_callback(_on_disconnect)
+
+    async with client:
         print(f"Connected to {mac_address}")
         await client.start_notify(char_uuid, data_handler)
         print("Listening for data...")
-        await asyncio.sleep(99999)
+        while not disconnected_event.is_set():
+            disconnect_task = asyncio.create_task(disconnected_event.wait())
+            sleep_task = asyncio.create_task(asyncio.sleep(99999))
+            done, pending = await asyncio.wait(
+                [disconnect_task, sleep_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for p in pending:
+                p.cancel()
+            for d in done:
+                if d is sleep_task and d.exception():
+                    raise d.exception()
+        raise ConnectionError(f"Device {mac_address} disconnected")

--- a/sdks/python/tests/test_ble_disconnect.py
+++ b/sdks/python/tests/test_ble_disconnect.py
@@ -1,0 +1,103 @@
+import asyncio
+from unittest.mock import patch
+import pytest
+
+from omi.ble import listen, listen_payload
+from omi.bluetooth import listen_to_omi
+
+
+class DisconnectingBleakClient:
+    instances = []
+
+    def __init__(self, address: str, disconnected_callback=None):
+        self.address = address
+        self.disconnected_callback = disconnected_callback
+        self.notify_handler = None
+        self.connected = False
+        DisconnectingBleakClient.instances.append(self)
+
+    async def __aenter__(self):
+        self.connected = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.connected = False
+
+    async def start_notify(self, char_uuid, handler):
+        self.notify_handler = handler
+
+
+def test_listen_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        packets = []
+
+        def on_packet(data: bytes):
+            packets.append(data)
+
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen("device-123", on_packet))
+            await asyncio.sleep(0.01)
+            client = DisconnectingBleakClient.instances[-1]
+            assert client.notify_handler is not None
+
+            await client.notify_handler("sender", bytearray(b"audio-data"))
+            assert packets == [b"audio-data"]
+
+            client.disconnected_callback(client)
+
+            with pytest.raises(ConnectionError, match="Device device-123 disconnected"):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_payload_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        payloads = []
+
+        def on_payload(data: bytes):
+            payloads.append(data)
+
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen_payload("device-456", on_payload))
+            await asyncio.sleep(0.01)
+            client = DisconnectingBleakClient.instances[-1]
+
+            client.disconnected_callback(client)
+
+            with pytest.raises(ConnectionError, match="Device device-456 disconnected"):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_to_omi_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        with patch("omi.bluetooth.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen_to_omi("AA:BB:CC:DD:EE:FF", "char-uuid", lambda sender, data: None))
+            await asyncio.sleep(0.01)
+            client = DisconnectingBleakClient.instances[-1]
+
+            client.disconnected_callback(client)
+
+            with pytest.raises(ConnectionError, match="Device AA:BB:CC:DD:EE:FF disconnected"):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_clean_cancellation():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen("device-789", lambda data: None))
+            await asyncio.sleep(0.01)
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_test())

--- a/sdks/python/tests/test_ble_disconnect.py
+++ b/sdks/python/tests/test_ble_disconnect.py
@@ -27,6 +27,30 @@ class DisconnectingBleakClient:
         self.notify_handler = handler
 
 
+class LegacyBleakClient:
+    instances = []
+
+    def __init__(self, address: str):
+        self.address = address
+        self.disconnected_callback = None
+        self.notify_handler = None
+        self.connected = False
+        LegacyBleakClient.instances.append(self)
+
+    def set_disconnected_callback(self, cb):
+        self.disconnected_callback = cb
+
+    async def __aenter__(self):
+        self.connected = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.connected = False
+
+    async def start_notify(self, char_uuid, handler):
+        self.notify_handler = handler
+
+
 def test_listen_raises_connection_error_on_disconnect():
     async def _test():
         DisconnectingBleakClient.instances.clear()
@@ -98,6 +122,38 @@ def test_listen_clean_cancellation():
 
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_legacy_client_fallback():
+    async def _test():
+        LegacyBleakClient.instances.clear()
+        with patch("omi.ble.BleakClient", new=LegacyBleakClient):
+            task = asyncio.create_task(listen("legacy-123", lambda data: None))
+            await asyncio.sleep(0.01)
+            client = LegacyBleakClient.instances[-1]
+            assert client.disconnected_callback is not None
+
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device legacy-123 disconnected"):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_to_omi_legacy_client_fallback():
+    async def _test():
+        LegacyBleakClient.instances.clear()
+        with patch("omi.bluetooth.BleakClient", new=LegacyBleakClient):
+            task = asyncio.create_task(listen_to_omi("legacy-omi", "char-uuid", lambda sender, data: None))
+            await asyncio.sleep(0.01)
+            client = LegacyBleakClient.instances[-1]
+            assert client.disconnected_callback is not None
+
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device legacy-omi disconnected"):
                 await task
 
     asyncio.run(_test())


### PR DESCRIPTION
Resolves #13290.

### Summary
In both `sdks/python/omi/ble.py::listen()` and `sdks/python/omi/bluetooth.py::listen_to_omi()`, the notification loops awaited fixed long sleeps without registering Bleak's `disconnected_callback`. When an Omi peripheral unexpectedly disconnects (e.g. power-down or out of range), the caller never received a terminal signal and remained waiting indefinitely.

### Changes
- In `sdks/python/omi/ble.py`:
  - Register `disconnected_callback` on `BleakClient` (with fallback for clients without kwargs).
  - Use an `asyncio.Event` combined with `asyncio.wait(..., return_when=FIRST_COMPLETED)` so peripheral disconnects terminate immediately and raise `ConnectionError(f"Device {device_id} disconnected")`.
  - Preserve caller-side clean cancellation (`asyncio.CancelledError`).
- In `sdks/python/omi/bluetooth.py`:
  - Register `disconnected_callback` on `BleakClient` and raise `ConnectionError(f"Device {mac_address} disconnected")` upon disconnect.
- Added comprehensive unit tests in `sdks/python/tests/test_ble_disconnect.py`:
  - Disconnect during `listen()` raises `ConnectionError` after pre-disconnect packets are delivered.
  - Disconnect during `listen_payload()` raises `ConnectionError`.
  - Disconnect during `listen_to_omi()` raises `ConnectionError`.
  - Clean cancellation via `task.cancel()` propagates `CancelledError` without error.

### Verification
- `pytest tests/`: 28/28 tests passed.

Credit to @yunancun for identifying this issue and reporting the reproduction.

/claim #13290


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

