### PR TITLE
feat(python-sdk): configurable batch duration for local Whisper transcription (#13155)

### DIFF
--- a/sdks/python/omi/stt/whisper.py
+++ b/sdks/python/omi/stt/whisper.py
@@ -11,7 +11,26 @@ class WhisperTranscriber:
     Feature gate: only importable/usable when a runner is provided or whisper is installed.
     """
 
-    def __init__(self, *, model_name: str = "tiny.en", runner: Optional[Callable[[bytes], str]] = None) -> None:
+    def __init__(
+        self,
+        *,
+        model_name: str = "tiny.en",
+        runner: Optional[Callable[[bytes], str]] = None,
+        batch_seconds: float = 5.0,
+    ) -> None:
+        """Batch 0.1-30 seconds of 16 kHz mono s16le PCM before inference.
+
+        This is an audio-duration threshold, not a wall-clock deadline. The
+        complete queue chunk that reaches the threshold is retained, just as
+        with the default five-second batching behavior.
+        """
+        if not (isinstance(batch_seconds, (int, float)) and not isinstance(batch_seconds, bool)) or not (
+            0.1 <= batch_seconds <= 30.0
+        ):
+            raise ValueError("batch_seconds must be between 0.1 and 30 seconds")
+        self.batch_seconds = float(batch_seconds)
+        # Quantize to complete PCM samples, never an odd number of bytes (16000 samples/sec * 2 bytes/sample).
+        self._target_bytes = int(16000 * self.batch_seconds) * 2
         self.model_name = model_name
         self.runner = runner
         self._model = None
@@ -32,7 +51,7 @@ class WhisperTranscriber:
     ) -> None:
         # Batch PCM for a simple offline-style loop (parity surface, not ultra-low-latency).
         buffer = bytearray()
-        target = 16000 * 2 * 5  # ~5s mono s16le
+        target = self._target_bytes
         while True:
             chunk = await audio_queue.get()
             buffer.extend(chunk)

--- a/sdks/python/tests/test_whisper_batching.py
+++ b/sdks/python/tests/test_whisper_batching.py
@@ -1,0 +1,74 @@
+import asyncio
+import contextlib
+import pytest
+from omi.stt.whisper import WhisperTranscriber
+from omi.transcribe import transcribe
+
+
+def test_whisper_batch_seconds_validation():
+    def dummy_runner(pcm):
+        return "ok"
+
+    # Default
+    t = WhisperTranscriber(runner=dummy_runner)
+    assert t.batch_seconds == 5.0
+    assert t._target_bytes == 16000 * 2 * 5
+
+    # Valid values
+    t1 = WhisperTranscriber(runner=dummy_runner, batch_seconds=1.0)
+    assert t1.batch_seconds == 1.0
+    assert t1._target_bytes == 16000 * 2 * 1
+
+    t2 = WhisperTranscriber(runner=dummy_runner, batch_seconds=0.1)
+    assert t2._target_bytes == int(16000 * 0.1) * 2
+
+    t3 = WhisperTranscriber(runner=dummy_runner, batch_seconds=30.0)
+    assert t3._target_bytes == 16000 * 30 * 2
+
+    # Invalid values
+    for invalid in [0.0, 0.05, 30.1, -1.0, 100, "5", None, True, False]:
+        with pytest.raises(ValueError, match="batch_seconds must be between 0.1 and 30 seconds"):
+            WhisperTranscriber(runner=dummy_runner, batch_seconds=invalid)
+
+
+def test_whisper_transcribe_custom_batch_seconds():
+    async def _test():
+        queue = asyncio.Queue()
+        # Put 1 second of audio (16000 samples * 2 bytes)
+        one_second_pcm = b"\x01\x00" * 16000
+        queue.put_nowait(one_second_pcm)
+
+        loop = asyncio.get_running_loop()
+        transcript_fut = loop.create_future()
+        batches = []
+
+        def runner(pcm):
+            batches.append(pcm)
+            return "synthetic transcript"
+
+        task = asyncio.create_task(
+            transcribe(
+                queue,
+                "",
+                transcript_fut.set_result,
+                engine="whisper",
+                runner=runner,
+                batch_seconds=1.0,
+            )
+        )
+
+        try:
+            done, _ = await asyncio.wait(
+                (task, transcript_fut),
+                timeout=3,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            assert transcript_fut in done, "Transcript callback was not called"
+            assert transcript_fut.result() == "synthetic transcript"
+            assert batches == [one_second_pcm]
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_test())


### PR DESCRIPTION
Resolves #13155.

### Summary
Previously, `WhisperTranscriber` hardcoded a fixed 5-second PCM batch duration (`16000 * 2 * 5`). For applications utilizing faster local runners or needing lower-latency batch intervals, this change introduces an optional `batch_seconds` parameter (default `5.0`).

### Changes
- In `sdks/python/omi/stt/whisper.py`:
  - Add `batch_seconds: float = 5.0` to `WhisperTranscriber.__init__()`.
  - Validate that `0.1 <= batch_seconds <= 30.0` (raising `ValueError` on invalid values, non-numbers, or booleans).
  - Quantize `_target_bytes = int(16000 * batch_seconds) * 2` to align with complete 16-bit mono PCM samples.
  - Forwarded through existing `create_transcriber('whisper', **kwargs)` and `transcribe(engine='whisper', **engine_kwargs)`.
- Added unit tests in `sdks/python/tests/test_whisper_batching.py`:
  - Valid and invalid parameter bounds validation.
  - End-to-end PCM batching through `transcribe()` verifying target buffer sizing and dispatch.

### Verification
- `pytest tests/`: 26/26 tests pass.

Credit to @mimienco for the proposal and test specifications.

/claim #13155


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

