### PR TITLE
feat(rust-sdk): expose underlying error causes via Error::source (#13142)

### DIFF
--- a/sdks/rust/omi-device/src/lib.rs
+++ b/sdks/rust/omi-device/src/lib.rs
@@ -382,7 +382,14 @@ impl<E: fmt::Display> fmt::Display for OmiError<E> {
     }
 }
 
-impl<E: Error + 'static> Error for OmiError<E> {}
+impl<E: Error + 'static> Error for OmiError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Transport(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+        }
+    }
+}
 
 impl<E> From<ProtocolError> for OmiError<E> {
     fn from(error: ProtocolError) -> Self {
@@ -589,5 +596,22 @@ mod tests {
         payload[RING_AUDIO_PAYLOAD_SIZE - 3] = 2;
         payload[RING_AUDIO_PAYLOAD_SIZE - 2..].copy_from_slice(&[7, 8]);
         assert!(audio_frames(&payload).is_empty());
+    }
+
+    #[test]
+    fn exposes_underlying_causes_through_error_source() {
+        let transport_err: OmiError<TestError> = OmiError::Transport(TestError);
+        let dyn_err: &dyn Error = &transport_err;
+        assert!(dyn_err.source().is_some());
+        assert!(dyn_err.source().unwrap().is::<TestError>());
+
+        let protocol_err: OmiError<TestError> = OmiError::Protocol(ProtocolError::Truncated {
+            message: "test",
+            expected: 4,
+            actual: 2,
+        });
+        let dyn_err: &dyn Error = &protocol_err;
+        assert!(dyn_err.source().is_some());
+        assert!(dyn_err.source().unwrap().is::<ProtocolError>());
     }
 }


### PR DESCRIPTION
Resolves #13142
/claim #13142

### Description
In `sdks/rust/omi-device/src/lib.rs`, `OmiError<E>` implemented `std::error::Error` with empty default methods. This prevented callers from traversing underlying error causes using standard error chaining (`Error::source()`), making debugging across transport and protocol boundaries difficult.

This PR implements `source(&self) -> Option<&(dyn Error + 'static)>` for `OmiError<E>`, returning:
- `Some(error)` for `OmiError::Transport(error)`
- `Some(error)` for `OmiError::Protocol(error)`

### Changes
- Implemented `std::error::Error::source` on `OmiError<E>`.
- Added unit test `exposes_underlying_causes_through_error_source` verifying that both `Transport` and `Protocol` variants properly return their inner error references as `&(dyn Error + 'static)`.

### Verification
- `cargo check --tests` in `sdks/rust/omi-device` passed cleanly.
- `cargo clippy --tests` in `sdks/rust/omi-device` passed cleanly with 0 warnings.

Failure-Class: none
Co-authored-by: Kgruben0133 <326547184+Kgruben0133@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

