### PR TITLE
feat(python-sdk): support optional service_uuids filter in scan (#13078)

### DIFF
--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from dataclasses import dataclass
-from typing import Awaitable, Callable, List, Optional, Union
+from typing import Any, Awaitable, Callable, List, Optional, Sequence, Union
 
 from bleak import BleakClient, BleakScanner
 
@@ -23,8 +23,21 @@ PacketHandler = Callable[[bytes], None]
 AsyncPacketHandler = Callable[[bytes], Union[None, Awaitable[None]]]
 
 
-async def scan(timeout: float = 5.0) -> List[Device]:
-    found = await BleakScanner.discover(timeout=timeout)
+async def scan(
+    timeout: float = 5.0,
+    *,
+    service_uuids: Optional[Sequence[str]] = None,
+) -> List[Device]:
+    """Scan for nearby Bluetooth devices, optionally filtering by service UUIDs.
+
+    Args:
+        timeout: Duration in seconds to scan for.
+        service_uuids: Optional sequence of service UUID strings to filter discovered devices.
+    """
+    kwargs: dict[str, Any] = {}
+    if service_uuids is not None:
+        kwargs["service_uuids"] = list(service_uuids)
+    found = await BleakScanner.discover(timeout=timeout, **kwargs)
     out: List[Device] = []
     for d in found:
         name = d.name or ""

--- a/sdks/python/tests/test_ble_api.py
+++ b/sdks/python/tests/test_ble_api.py
@@ -12,3 +12,59 @@ def test_ble_module_importable_without_adapter():
 
     assert AUDIO_DATA_UUID.startswith("19b10001")
     assert OMI_SERVICE_UUID.startswith("19b10000")
+
+
+def test_scan_defaults_and_filtering():
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    from omi.ble import scan, Device
+    from omi.constants import OMI_SERVICE_UUID
+
+    class MockBLEDevice:
+        def __init__(self, address: str, name: str | None, rssi: int = -50):
+            self.address = address
+            self.name = name
+            self.rssi = rssi
+
+    fake_devices = [
+        MockBLEDevice("11:22:33:44:55:66", "Omi Device", -45),
+        MockBLEDevice("AA:BB:CC:DD:EE:FF", None, -70),
+    ]
+
+    # 1. Test default scan without service_uuids
+    with patch("omi.ble.BleakScanner.discover", new_callable=AsyncMock) as mock_discover:
+        mock_discover.return_value = fake_devices
+        devices = asyncio.run(scan())
+        mock_discover.assert_awaited_once_with(timeout=5.0)
+        assert len(devices) == 2
+        assert devices[0] == Device(id="11:22:33:44:55:66", name="Omi Device", rssi=-45)
+        assert devices[1] == Device(id="AA:BB:CC:DD:EE:FF", name="", rssi=-70)
+
+    # 2. Test scan with custom timeout
+    with patch("omi.ble.BleakScanner.discover", new_callable=AsyncMock) as mock_discover:
+        mock_discover.return_value = []
+        devices = asyncio.run(scan(timeout=2.5))
+        mock_discover.assert_awaited_once_with(timeout=2.5)
+        assert devices == []
+
+    # 3. Test scan with service_uuids list
+    with patch("omi.ble.BleakScanner.discover", new_callable=AsyncMock) as mock_discover:
+        mock_discover.return_value = [fake_devices[0]]
+        devices = asyncio.run(scan(timeout=3.0, service_uuids=[OMI_SERVICE_UUID]))
+        mock_discover.assert_awaited_once_with(timeout=3.0, service_uuids=[OMI_SERVICE_UUID])
+        assert len(devices) == 1
+        assert devices[0].id == "11:22:33:44:55:66"
+
+    # 4. Test scan with sequence (tuple) of service_uuids
+    with patch("omi.ble.BleakScanner.discover", new_callable=AsyncMock) as mock_discover:
+        mock_discover.return_value = []
+        asyncio.run(scan(service_uuids=(OMI_SERVICE_UUID, "custom-uuid")))
+        mock_discover.assert_awaited_once_with(timeout=5.0, service_uuids=[OMI_SERVICE_UUID, "custom-uuid"])
+
+    # 5. Test error propagation
+    with patch("omi.ble.BleakScanner.discover", new_callable=AsyncMock) as mock_discover:
+        mock_discover.side_effect = RuntimeError("Bluetooth adapter unavailable")
+        import pytest
+        with pytest.raises(RuntimeError, match="Bluetooth adapter unavailable"):
+            asyncio.run(scan(service_uuids=[OMI_SERVICE_UUID]))
+


### PR DESCRIPTION
Resolves #13078
/claim #13078

### Description
In `sdks/python/omi/ble.py`, `scan(timeout=5.0)` did not expose service UUID filtering, making it impossible for applications to restrict Bleak discovery to Omi service UUIDs or other specific BLE services.

This PR adds an optional keyword-only `service_uuids: Optional[Sequence[str]] = None` argument to `scan()`, cleanly forwarding it to `BleakScanner.discover(timeout=timeout, service_uuids=...)` when supplied, while preserving default unfiltered discovery and error propagation.

### Changes
- Updated `scan(timeout: float = 5.0, *, service_uuids: Optional[Sequence[str]] = None) -> List[Device]` in `sdks/python/omi/ble.py`.
- Added unit tests in `sdks/python/tests/test_ble_api.py` verifying:
  - Default scan without `service_uuids` retains existing discovery behavior.
  - Forwarding of `service_uuids` list/sequence when provided.
  - Custom timeout handling and device mapping.
  - Exception propagation when the underlying BLE scanner raises.

### Verification
- Ran `pytest tests -o pythonpath=.` in `sdks/python`: 25 passed in 0.24s.

Failure-Class: none
Co-authored-by: gabinwilliams <78612204+gabinwilliams@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

