### PR TITLE
fix(plugins): reject non-finite string amounts in Frankfurter conversion (#13189)

### DIFF
--- a/plugins/omi-frankfurter-app/main.py
+++ b/plugins/omi-frankfurter-app/main.py
@@ -101,6 +101,9 @@ def _parse_amount(value: str | float | int) -> Decimal:
     except InvalidOperation as exc:
         raise ValueError("amount must be a number") from exc
 
+    if not amount.is_finite():
+        raise ValueError("amount must be a finite number")
+
     if amount <= 0:
         raise ValueError("amount must be greater than 0")
     return amount

--- a/plugins/omi-frankfurter-app/test_main.py
+++ b/plugins/omi-frankfurter-app/test_main.py
@@ -1,0 +1,96 @@
+import math
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import _parse_amount, app
+
+
+def test_parse_amount_valid():
+    assert _parse_amount(50) == Decimal("50")
+    assert _parse_amount("19.95") == Decimal("19.95")
+    assert _parse_amount(0.01) == Decimal(str(0.01))
+
+
+def test_parse_amount_zero_and_negative():
+    with pytest.raises(ValueError, match="amount must be greater than 0"):
+        _parse_amount(0)
+
+    with pytest.raises(ValueError, match="amount must be greater than 0"):
+        _parse_amount(-1)
+
+    with pytest.raises(ValueError, match="amount must be greater than 0"):
+        _parse_amount("-50.25")
+
+
+def test_parse_amount_invalid_text():
+    with pytest.raises(ValueError, match="amount must be a number"):
+        _parse_amount("not-a-number")
+
+
+def test_parse_amount_non_finite_rejected():
+    non_finite_values = [
+        "NaN",
+        "nan",
+        "sNaN",
+        "-NaN",
+        "Infinity",
+        "+Infinity",
+        "-Infinity",
+        "inf",
+        "-inf",
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+    ]
+    for val in non_finite_values:
+        with pytest.raises(ValueError, match="amount must be a finite number"):
+            _parse_amount(val)
+
+
+def test_convert_currency_rejects_non_finite_amounts_without_500():
+    client = TestClient(app)
+
+    for bad_amount in ["NaN", "sNaN", "Infinity", "-Infinity"]:
+        resp = client.post(
+            "/tools/convert_currency",
+            json={
+                "amount": bad_amount,
+                "from_currency": "USD",
+                "to_currencies": ["EUR"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["result"] is None
+        assert "amount must be a finite number" in data["error"]
+
+
+def test_convert_currency_valid_amount_success():
+    client = TestClient(app)
+
+    mock_rates = {
+        "amount": 50.0,
+        "base": "USD",
+        "date": "2026-09-09",
+        "rates": {"EUR": 45.5, "GBP": 39.2},
+    }
+
+    with patch("main._request_json", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = mock_rates
+        resp = client.post(
+            "/tools/convert_currency",
+            json={
+                "amount": 50,
+                "from_currency": "USD",
+                "to_currencies": ["EUR", "GBP"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["error"] is None
+        assert "50 USD on 2026-09-09:" in data["result"]
+        assert "- EUR: 45.5" in data["result"]
+        assert "- GBP: 39.2" in data["result"]

--- a/plugins/omi-frankfurter-app/test_main.py
+++ b/plugins/omi-frankfurter-app/test_main.py
@@ -1,4 +1,3 @@
-import math
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 


### PR DESCRIPTION
Resolves #13189
/claim #13189

### Description
In `plugins/omi-frankfurter-app/main.py`, `_parse_amount` accepted string amounts and converted them using `Decimal(str(value))`, but checked `amount <= 0` prior to checking whether the Decimal was finite. Because comparing non-finite Decimals (`NaN`, `sNaN`) raises `decimal.InvalidOperation`, requests like `{"amount":"NaN", ...}` caused unhandled HTTP 500 crashes instead of normal tool errors. Additionally, `"Infinity"` bypassed the positivity check and crashed later during format quantization.

This PR adds an explicit `not amount.is_finite()` validation to `_parse_amount` before comparison, raising `ValueError("amount must be a finite number")`. The existing error handling catches `ValueError` and cleanly returns a structured `ChatToolResponse.error` message with HTTP 200.

### Changes
- Updated `_parse_amount` in `plugins/omi-frankfurter-app/main.py` to reject non-finite Decimals (`NaN`, `sNaN`, `Infinity`, `-Infinity`).
- Added unit and endpoint regression tests in `plugins/omi-frankfurter-app/test_main.py` verifying that:
  - Non-finite values are rejected with `ValueError("amount must be a finite number")`.
  - Zero and negative values raise `ValueError("amount must be greater than 0")`.
  - The `/tools/convert_currency` endpoint returns HTTP 200 with structured `error` rather than an unhandled 500 error on non-finite input.
  - Normal finite amounts continue to convert successfully.

### Verification
- Ran `pytest test_main.py` in `plugins/omi-frankfurter-app`: 6 passed in 0.23s.

Failure-Class: none
Co-authored-by: Zhepyrx <85368727+Zhepyrx@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

