### PR TITLE
fix(plugins): preserve Unicode subjects and encode query path in Open Library (#13187)

### DIFF
--- a/plugins/omi-open-library-app/main.py
+++ b/plugins/omi-open-library-app/main.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from html import unescape
 import re
 from typing import Any, Optional
+from urllib.parse import quote
 
 import httpx
 from fastapi import FastAPI
@@ -20,6 +21,7 @@ OPEN_LIBRARY_BASE_URL = "https://openlibrary.org"
 REQUEST_TIMEOUT_SECONDS = 10
 MAX_LIMIT = 10
 USER_AGENT = "omi-open-library-app/1.0 (https://omi.me)"
+_SUBJECT_CHARS_TO_DROP = frozenset(""";/?:@&=+$,<>#%"{}|\\^[]`\n\r""")
 
 _open_library_client: Optional[httpx.AsyncClient] = None
 
@@ -118,12 +120,12 @@ def _safe_isbn(value: Any) -> Optional[str]:
 
 
 def _subject_slug(subject: Any) -> Optional[str]:
-    text = _clean_text(subject).lower()
+    text = _clean_text(subject).strip().lower()
     if not text:
         return None
-    text = re.sub(r"[^a-z0-9]+", "_", text)
-    text = re.sub(r"_+", "_", text).strip("_")
-    return text[:80] or None
+    slug = "".join("_" if c == " " else c for c in text if c not in _SUBJECT_CHARS_TO_DROP)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug[:80] or None
 
 
 def _format_book(doc: dict[str, Any], index: int) -> str:
@@ -396,7 +398,8 @@ async def search_subject(payload: dict[str, Any]):
         return ChatToolResponse(error="Provide a subject to browse.")
 
     try:
-        data = await _request_json(f"/subjects/{slug}.json", params={"limit": limit})
+        encoded_slug = quote(slug)
+        data = await _request_json(f"/subjects/{encoded_slug}.json", params={"limit": limit})
         works = data.get("works", [])[:limit]
         if not works:
             return ChatToolResponse(result=f"No books found for subject {subject}.")

--- a/plugins/omi-open-library-app/test_main.py
+++ b/plugins/omi-open-library-app/test_main.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, patch
 from urllib.parse import unquote
 
-import pytest
 from fastapi.testclient import TestClient
 
 from main import _subject_slug, app

--- a/plugins/omi-open-library-app/test_main.py
+++ b/plugins/omi-open-library-app/test_main.py
@@ -1,0 +1,104 @@
+from unittest.mock import AsyncMock, patch
+from urllib.parse import unquote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import _subject_slug, app
+
+
+def test_subject_slug_ascii():
+    assert _subject_slug("science fiction") == "science_fiction"
+    assert _subject_slug("history") == "history"
+    assert _subject_slug("  space   flight  ") == "space_flight"
+
+
+def test_subject_slug_unicode():
+    assert _subject_slug("español") == "español"
+    assert _subject_slug("中文") == "中文"
+    assert _subject_slug("música") == "música"
+    assert _subject_slug("日本語") == "日本語"
+
+
+def test_subject_slug_punctuation_dropped():
+    assert _subject_slug("science / fiction?") == "science_fiction"
+    assert _subject_slug("art & design") == "art_design"
+    assert _subject_slug("c++") == "c"
+    assert _subject_slug("history: ancient") == "history_ancient"
+
+
+def test_subject_slug_blank_and_invalid():
+    assert _subject_slug("") is None
+    assert _subject_slug("   ") is None
+    assert _subject_slug("???///") is None
+    assert _subject_slug(None) is None
+
+
+def test_search_subject_unicode_encoding_and_response():
+    client = TestClient(app)
+
+    mock_data = {
+        "name": "español",
+        "works": [
+            {
+                "key": "/works/OL123W",
+                "title": "Don Quijote",
+                "authors": [{"name": "Miguel de Cervantes"}],
+                "first_publish_year": 1605,
+            }
+        ],
+    }
+
+    with patch("main._request_json", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = mock_data
+
+        resp = client.post("/tools/search_subject", json={"subject": "español", "limit": 5})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["error"] is None
+        assert "Don Quijote" in data["result"]
+
+        mock_req.assert_awaited_once()
+        called_path = mock_req.await_args[0][0]
+        assert called_path == "/subjects/espa%C3%B1ol.json"
+        # Verify decoding matches canonical subject
+        slug_segment = called_path.removeprefix("/subjects/").removesuffix(".json")
+        assert unquote(slug_segment) == "español"
+
+
+def test_search_subject_non_latin_chinese():
+    client = TestClient(app)
+
+    mock_data = {
+        "name": "中文",
+        "works": [
+            {
+                "key": "/works/OL456W",
+                "title": "Chinese Literature",
+                "authors": [{"name": "Lu Xun"}],
+                "first_publish_year": 1918,
+            }
+        ],
+    }
+
+    with patch("main._request_json", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = mock_data
+
+        resp = client.post("/tools/search_subject", json={"subject": "中文", "limit": 2})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["error"] is None
+        assert "Chinese Literature" in data["result"]
+
+        mock_req.assert_awaited_once()
+        called_path = mock_req.await_args[0][0]
+        assert called_path == "/subjects/%E4%B8%AD%E6%96%87.json"
+        slug_segment = called_path.removeprefix("/subjects/").removesuffix(".json")
+        assert unquote(slug_segment) == "中文"
+
+
+def test_search_subject_missing_subject():
+    client = TestClient(app)
+    resp = client.post("/tools/search_subject", json={"subject": "   "})
+    assert resp.status_code == 200
+    assert resp.json()["error"] == "Provide a subject to browse."


### PR DESCRIPTION
Resolves #13187
/claim #13187

### Description
In `plugins/omi-open-library-app/main.py`, `_subject_slug` stripped all non-ASCII characters with `re.sub(r"[^a-z0-9]+", "_", text)`. As a result:
- Non-ASCII/accented subjects like `español` were corrupted into `espa_ol`.
- Non-Latin subjects like `中文` or `日本語` became completely empty and were erroneously rejected as missing subjects.
- In addition, the formatted slug was placed raw into the URL path without URL-encoding.

This PR aligns `_subject_slug` with Open Library's canonical `normalize_subject_name` specification:
- Preserves Unicode characters while converting whitespace to underscores.
- Drops characters in Open Library's canonical drop set (`;/?:@&=+$,<>#%"{}|\^[]`\n\r`).
- Applies `urllib.parse.quote` to the slug segment before constructing `/subjects/{slug}.json`.

### Changes
- Updated `_subject_slug` in `plugins/omi-open-library-app/main.py` with `_SUBJECT_CHARS_TO_DROP`.
- Added `quote` encoding to `/subjects/{encoded_slug}.json` in `search_subject`.
- Added regression tests in `plugins/omi-open-library-app/test_main.py` covering ASCII, accented, non-Latin (Chinese/Japanese), punctuation filtering, and endpoint integration.

### Verification
- Ran `pytest test_main.py` in `plugins/omi-open-library-app`: 7 passed in 0.20s.

Failure-Class: none
Co-authored-by: kaijakagi-sys <225030874+kaijakagi-sys@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

