### PR TITLE
fix(whoop): follow pagination in weekly summary

### DIFF
--- a/plugins/omi-whoop-app/main.py
+++ b/plugins/omi-whoop-app/main.py
@@ -8,7 +8,7 @@ import os
 import sys
 import secrets
 from datetime import datetime, timedelta
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from urllib.parse import urlencode
 
 import requests
@@ -153,6 +153,36 @@ def whoop_api_request(uid: str, method: str, endpoint: str, params: dict = None)
     except Exception as e:
         log(f"Whoop API request error: {e}")
         return {"error": str(e)}
+
+
+# Safety cap on continuation pages per collection; a real Whoop week of data
+# never needs anywhere near this many pages.
+MAX_COLLECTION_PAGES = 20
+
+
+def whoop_fetch_all_records(uid: str, endpoint: str, params: dict) -> Tuple[Optional[List[dict]], Optional[str]]:
+    """Fetch every page of a Whoop collection endpoint, following next_token/nextToken.
+
+    Returns (records, None) on success, or (None, error) if any page failed, so
+    callers can tell an empty collection apart from an incomplete fetch.
+    """
+    records: List[dict] = []
+    page_params = dict(params)
+
+    for _ in range(MAX_COLLECTION_PAGES):
+        result = whoop_api_request(uid, "GET", endpoint, params=page_params)
+        if not result or "error" in result:
+            return None, result.get("error", "Unknown error") if result else "No response from Whoop"
+
+        records.extend(result.get("records", []))
+        next_token = result.get("next_token")
+        if not next_token:
+            return records, None
+
+        page_params = dict(params)
+        page_params["nextToken"] = next_token
+
+    return records, None
 
 
 def format_recovery_score(recovery: dict) -> str:
@@ -698,39 +728,40 @@ async def tool_get_weekly_summary(request: Request):
             "limit": 7
         }
 
-        # Fetch recovery, cycles, and sleep
-        recovery_result = whoop_api_request(uid, "GET", "/recovery", params=params)
-        cycle_result = whoop_api_request(uid, "GET", "/cycle", params=params)
-        sleep_result = whoop_api_request(uid, "GET", "/activity/sleep", params=params)
+        # Fetch recovery, cycles, sleep, and workouts, following pagination for each
+        recovery_records, recovery_error = whoop_fetch_all_records(uid, "/recovery", params)
+        cycle_records, cycle_error = whoop_fetch_all_records(uid, "/cycle", params)
+        sleep_records, sleep_error = whoop_fetch_all_records(uid, "/activity/sleep", params)
+        workout_records, workout_error = whoop_fetch_all_records(uid, "/activity/workout", params)
 
         # Calculate averages
         recovery_scores = []
-        if recovery_result and "records" in recovery_result:
-            for r in recovery_result["records"]:
-                score = r.get("score", {}).get("recovery_score")
-                if score is not None:
-                    recovery_scores.append(score)
+        for r in recovery_records or []:
+            score = r.get("score", {}).get("recovery_score")
+            if score is not None:
+                recovery_scores.append(score)
 
         strain_scores = []
-        if cycle_result and "records" in cycle_result:
-            for c in cycle_result["records"]:
-                strain = c.get("score", {}).get("strain")
-                if strain is not None:
-                    strain_scores.append(strain)
+        for c in cycle_records or []:
+            strain = c.get("score", {}).get("strain")
+            if strain is not None:
+                strain_scores.append(strain)
 
         sleep_hours = []
-        if sleep_result and "records" in sleep_result:
-            for s in sleep_result["records"]:
-                summary = s.get("score", {}).get("stage_summary", {})
-                total = summary.get("total_in_bed_time_milli", 0)
-                awake = summary.get("total_awake_time_milli", 0)
-                sleep_ms = total - awake
-                if sleep_ms > 0:
-                    sleep_hours.append(sleep_ms / (1000 * 60 * 60))
+        for s in sleep_records or []:
+            summary = s.get("score", {}).get("stage_summary", {})
+            total = summary.get("total_in_bed_time_milli", 0)
+            awake = summary.get("total_awake_time_milli", 0)
+            sleep_ms = total - awake
+            if sleep_ms > 0:
+                sleep_hours.append(sleep_ms / (1000 * 60 * 60))
 
         result_parts = ["**Weekly Summary (Last 7 Days)**", ""]
 
-        if recovery_scores:
+        if recovery_error:
+            log(f"Weekly summary: recovery fetch failed: {recovery_error}")
+            result_parts.append("**Recovery:** Temporarily unavailable")
+        elif recovery_scores:
             avg_recovery = sum(recovery_scores) / len(recovery_scores)
             min_recovery = min(recovery_scores)
             max_recovery = max(recovery_scores)
@@ -738,14 +769,20 @@ async def tool_get_weekly_summary(request: Request):
         else:
             result_parts.append("**Recovery:** No data")
 
-        if strain_scores:
+        if cycle_error:
+            log(f"Weekly summary: strain fetch failed: {cycle_error}")
+            result_parts.append("**Strain:** Temporarily unavailable")
+        elif strain_scores:
             avg_strain = sum(strain_scores) / len(strain_scores)
             total_strain = sum(strain_scores)
             result_parts.append(f"**Strain:** Avg {avg_strain:.1f} (Total: {total_strain:.1f})")
         else:
             result_parts.append("**Strain:** No data")
 
-        if sleep_hours:
+        if sleep_error:
+            log(f"Weekly summary: sleep fetch failed: {sleep_error}")
+            result_parts.append("**Sleep:** Temporarily unavailable")
+        elif sleep_hours:
             avg_sleep = sum(sleep_hours) / len(sleep_hours)
             min_sleep = min(sleep_hours)
             max_sleep = max(sleep_hours)
@@ -754,9 +791,11 @@ async def tool_get_weekly_summary(request: Request):
             result_parts.append("**Sleep:** No data")
 
         # Add workout count
-        workout_result = whoop_api_request(uid, "GET", "/activity/workout", params=params)
-        workout_count = len(workout_result.get("records", [])) if workout_result else 0
-        result_parts.append(f"**Workouts:** {workout_count}")
+        if workout_error:
+            log(f"Weekly summary: workout fetch failed: {workout_error}")
+            result_parts.append("**Workouts:** Temporarily unavailable")
+        else:
+            result_parts.append(f"**Workouts:** {len(workout_records)}")
 
         return ChatToolResponse(result="\n".join(result_parts))
 

--- a/plugins/omi-whoop-app/test_weekly_summary.py
+++ b/plugins/omi-whoop-app/test_weekly_summary.py
@@ -1,0 +1,110 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:
+    TestClient = None
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+if TestClient is not None:
+    from main import app
+
+
+def _page(records, next_token=None):
+    body = {"records": records}
+    if next_token:
+        body["next_token"] = next_token
+    return body
+
+
+def _record(value_path, value):
+    """Build a minimal Whoop record with a nested score value at value_path."""
+    record = {"score": {}}
+    node = record["score"]
+    for key in value_path[:-1]:
+        node = node.setdefault(key, {})
+    node[value_path[-1]] = value
+    return record
+
+
+@unittest.skipIf(TestClient is None, "fastapi/httpx test dependencies are not installed")
+class WeeklySummaryPaginationTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+        patcher = patch("main.get_valid_access_token", return_value="test-token")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def _mock_responses(self, by_endpoint):
+        """by_endpoint: endpoint -> list of pages (each a dict body) to return in order."""
+        calls = {endpoint: iter(pages) for endpoint, pages in by_endpoint.items()}
+
+        def fake_request(uid, method, endpoint, params=None):
+            return next(calls[endpoint])
+
+        return fake_request
+
+    def test_follows_continuation_pages_for_all_four_collections(self):
+        pages = {
+            "/recovery": [
+                _page([_record(["recovery_score"], 50)], next_token="r2"),
+                _page([_record(["recovery_score"], 70)]),
+            ],
+            "/cycle": [_page([_record(["strain"], 10.0)])],
+            "/activity/sleep": [_page([])],
+            "/activity/workout": [
+                _page([{} for _ in range(7)], next_token="w2"),
+                _page([{} for _ in range(3)]),
+            ],
+        }
+        with patch("main.whoop_api_request", side_effect=self._mock_responses(pages)):
+            response = self.client.post("/tools/get_weekly_summary", json={"uid": "u1"})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()["result"]
+        # Regression: before the fix, only the first page was fetched, so this
+        # read "Workouts: 7" and averaged recovery over one record instead of two.
+        self.assertIn("**Workouts:** 10", result)
+        self.assertIn("Avg 60%", result)
+
+    def test_no_continuation_token_stops_after_one_page(self):
+        pages = {
+            "/recovery": [_page([_record(["recovery_score"], 80)])],
+            "/cycle": [_page([])],
+            "/activity/sleep": [_page([])],
+            "/activity/workout": [_page([{}])],
+        }
+        with patch("main.whoop_api_request", side_effect=self._mock_responses(pages)):
+            response = self.client.post("/tools/get_weekly_summary", json={"uid": "u1"})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()["result"]
+        self.assertIn("**Workouts:** 1", result)
+
+    def test_page_failure_reports_unavailable_instead_of_partial_total(self):
+        pages = {
+            "/recovery": [_page([])],
+            "/cycle": [_page([])],
+            "/activity/sleep": [_page([])],
+            "/activity/workout": [
+                _page([{} for _ in range(7)], next_token="w2"),
+                {"error": "upstream failure", "status_code": 500},
+            ],
+        }
+        with patch("main.whoop_api_request", side_effect=self._mock_responses(pages)):
+            response = self.client.post("/tools/get_weekly_summary", json={"uid": "u1"})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()["result"]
+        # Regression: before the fix, a failed later page was never reachable
+        # (only page one was ever fetched) so a partial count could read as final.
+        self.assertIn("**Workouts:** Temporarily unavailable", result)
+        self.assertNotIn("**Workouts:** 7", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`tool_get_weekly_summary` in the WHOOP integration fetched exactly one page
(`limit=7`) per collection (recovery, cycle, sleep, workout) and never
followed WHOOP's `next_token` continuation contract. A week with more than 7
records in any collection silently reported an incomplete count as final —
e.g. "Workouts: 7" when 10 workouts existed for the week.

This adds `whoop_fetch_all_records`, which follows `next_token`/`nextToken`
across pages for a collection, and switches all four weekly-summary fetches
to use it. If a later page fails, the summary now reports "Temporarily
unavailable" for that section instead of presenting the partial total
gathered so far as complete.

## Why

Reported in #13174: WHOOP's pagination contract requires following
`next_token` until it's empty; the existing code made exactly one request per
collection regardless of how many records existed.

## Evidence / testing

Added `plugins/omi-whoop-app/test_weekly_summary.py` (no existing tests for
this plugin) exercising `/tools/get_weekly_summary` through the real FastAPI
route, with only `whoop_api_request` mocked at the network boundary:

- Multi-page recovery/workout collections are fully aggregated (10 workouts
  across 2 pages, recovery averaged over both pages) — fails on unfixed code
  (`Workouts: 7`, `Avg 50%`).
- A single-page collection with no `next_token` still returns the correct
  count (no regression for the common case).
- A failure on a later page reports "Temporarily unavailable" instead of the
  partial count gathered before the failure — fails on unfixed code (only
  page one was ever reachable, so a mid-fetch failure could never surface).

Ran via a local venv (`pip install -r requirements.txt pytest httpx==0.27.2`):
`pytest test_weekly_summary.py` → 3 passed. Confirmed 2 of 3 fail against the
pre-fix code. No live WHOOP account or credentials used.

Failure-Class: none

fixes #13174

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

