### PR TITLE
fix(desktop): make completed task undo atomic and identity-safe (#13259)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2743,13 +2743,13 @@ class TasksViewModel: ObservableObject {
   func undoLastDelete() async {
     guard let lastAction = undoStack.popLast() else { return }
 
-    await store.restoreTask(lastAction.task)
+    guard let restoredTask = await store.restoreTask(lastAction.task) else { return }
 
     // Re-insert into display
-    displayTasks.insert(lastAction.task, at: 0)
+    displayTasks.insert(restoredTask, at: 0)
     let cat = TaskCategory.today  // Default; will be recategorized on next recompute
     if categorizedTasks[cat] != nil {
-      categorizedTasks[cat]?.insert(lastAction.task, at: 0)
+      categorizedTasks[cat]?.insert(restoredTask, at: 0)
     }
 
     // Hide toast if stack is now empty

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -3287,15 +3287,15 @@ class TasksStore: ObservableObject {
   func restoreTask(
     _ task: TaskActionItem,
     expectedOwnerID: String? = nil
-  ) async {
-    guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return }
+  ) async -> TaskActionItem? {
+    guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return nil }
     // Undo of a tombstoned delete: the row still exists locally (deleted, whether or not
     // the backend acked). Purge it before the re-insert below or undo would duplicate it.
     try? await ActionItemStorage.shared.deleteActionItemByBackendId(
       task.id,
       authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
     )
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
 
     // A local-only task never had a backend row (deleteTask skipped the backend
     // delete). Restoring it through the backend-recreate path below is wrong on
@@ -3305,29 +3305,36 @@ class TasksStore: ObservableObject {
     // re-insert it as an UNSYNCED local row so the pending create-sync pushes it
     // exactly once (carrying completion via retryUnsyncedItems).
     if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
-      await restoreLocalOnlyTask(task, lease: lease)
-      return
+      return await restoreLocalOnlyTask(task, lease: lease)
     }
 
-    // 1. Re-insert into SQLite from the in-memory task object
+    // Stage the restore as a fresh unsynced local row. The old backend ID was
+    // hard-deleted, so persisting it again as synced would leave an identity
+    // that no longer exists remotely. It would also make the successful create
+    // below insert a second SQLite row under the replacement backend ID.
+    let restoreRecord = Self.backendTaskRestoreRecord(from: task)
+    let inserted: ActionItemRecord
     do {
-      try await ActionItemStorage.shared.syncTaskActionItems(
-        [task],
+      inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+        restoreRecord,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
     } catch {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-insert task locally for undo", error: error)
       }
-      return
+      return nil
     }
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
+    let localTask = inserted.toTaskActionItem()
 
-    // 2. Re-insert into the appropriate in-memory array
-    if task.completed {
-      completedTasks.insert(task, at: 0)
+    // Re-insert into the appropriate in-memory array immediately. If the
+    // network create fails, this local_<rowid> task stays pending and the
+    // normal durable retry path will create it later.
+    if localTask.completed {
+      completedTasks.insert(localTask, at: 0)
     } else {
-      incompleteTasks.insert(task, at: 0)
+      incompleteTasks.insert(localTask, at: 0)
     }
 
     // 3. Re-create on backend (hard-delete already removed it). Pass the full
@@ -3357,35 +3364,44 @@ class TasksStore: ObservableObject {
         recurrenceParentId: task.recurrenceParentId,
         goalId: task.goalId,
         workstreamId: task.workstreamId,
+        completed: task.completed,
         expectedOwnerId: lease.ownerID,
         authorizationSnapshot: lease.authorizationSnapshot
       )
-      guard isCurrent(lease) else { return }
-      // createActionItem cannot set completion; restore the completed state of
-      // a task that was done when it was deleted via a follow-up update.
-      var resolved = created
-      if task.completed, !created.completed {
-        resolved =
-          (try? await APIClient.shared.updateActionItem(
-            id: created.id,
-            completed: true,
-            expectedOwnerId: lease.ownerID,
-            authorizationSnapshot: lease.authorizationSnapshot
-          )) ?? created
-        guard isCurrent(lease) else { return }
-      }
-      // Update local record with new backend ID
-      try await ActionItemStorage.shared.syncTaskActionItems(
-        [resolved],
+      guard isCurrent(lease) else { return nil }
+      guard let localId = inserted.id else { return localTask }
+      try await ActionItemStorage.shared.markSynced(
+        id: localId,
+        backendId: created.id,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
-      guard isCurrent(lease) else { return }
-      log("TasksStore: Restored task via undo (new backend ID: \(resolved.id))")
+      guard isCurrent(lease) else { return nil }
+      replaceTaskInMemory(created, originalTask: localTask)
+      log("TasksStore: Restored task via undo (new backend ID: \(created.id))")
+      return created
     } catch {
       if isCurrent(lease) {
-        logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)
+        logError(
+          "TasksStore: Failed to re-create task on backend (local restore queued for retry)",
+          error: error
+        )
       }
+      return localTask
     }
+  }
+
+  /// A restored backend task starts a new local identity because its former
+  /// backend row was hard-deleted. Keeping it unsynced makes a failed recreate
+  /// durable, while the successful create can bind this row to its new ID
+  /// without leaving the stale pre-delete ID or inserting a duplicate.
+  static func backendTaskRestoreRecord(from task: TaskActionItem) -> ActionItemRecord {
+    var record = ActionItemRecord.from(task)
+    record.id = nil
+    record.backendId = nil
+    record.backendSynced = false
+    record.deleted = false
+    record.deletedBy = nil
+    return record
   }
 
   /// Build the SQLite record for restoring a local-only task: an UNSYNCED row
@@ -3410,10 +3426,14 @@ class TasksStore: ObservableObject {
   /// its original rowid so the surfaced "local_<rowid>" id is stable. No backend
   /// recreate: the task never had a backend row, and the pending create-sync
   /// (retryUnsyncedItems) is the single writer that pushes it to the backend.
-  private func restoreLocalOnlyTask(_ task: TaskActionItem, lease: OwnerOperationLease) async {
+  private func restoreLocalOnlyTask(
+    _ task: TaskActionItem,
+    lease: OwnerOperationLease
+  ) async -> TaskActionItem? {
     let record = Self.localOnlyRestoreRecord(from: task)
+    let inserted: ActionItemRecord
     do {
-      try await ActionItemStorage.shared.insertLocalActionItem(
+      inserted = try await ActionItemStorage.shared.insertLocalActionItem(
         record,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
@@ -3421,16 +3441,18 @@ class TasksStore: ObservableObject {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-insert local-only task for undo", error: error)
       }
-      return
+      return nil
     }
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
+    let restored = inserted.toTaskActionItem()
 
-    if task.completed {
-      completedTasks.insert(task, at: 0)
+    if restored.completed {
+      completedTasks.insert(restored, at: 0)
     } else {
-      incompleteTasks.insert(task, at: 0)
+      incompleteTasks.insert(restored, at: 0)
     }
-    log("TasksStore: Restored local-only task via undo (unsynced, id: \(task.id))")
+    log("TasksStore: Restored local-only task via undo (unsynced, id: \(restored.id))")
+    return restored
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -148,4 +148,47 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
       matches[0].id.hasPrefix("local_"),
       "restored task stays an unsynced local_ task, not a fabricated backend id")
   }
+
+  func testRestoreBackendTaskRebindsOnePendingRowToTheReplacementIdentity() async throws {
+    let deletedTask = TaskActionItem(
+      id: "deleted-backend-id",
+      description: "completed task restored with undo",
+      completed: true,
+      createdAt: Date(timeIntervalSince1970: 10),
+      updatedAt: Date(timeIntervalSince1970: 20),
+      source: "manual",
+      priority: "high"
+    )
+
+    let stagedRecord = await TasksStore.backendTaskRestoreRecord(from: deletedTask)
+    XCTAssertNil(stagedRecord.id)
+    XCTAssertNil(stagedRecord.backendId, "the deleted backend identity must not be resurrected")
+    XCTAssertFalse(stagedRecord.backendSynced, "a failed recreate must remain eligible for retry")
+    XCTAssertTrue(stagedRecord.completed, "completion must survive the local restore boundary")
+
+    let inserted = try await ActionItemStorage.shared.insertLocalActionItem(
+      stagedRecord,
+      authorization: .unrestricted
+    )
+    let localId = try XCTUnwrap(inserted.id)
+    try await ActionItemStorage.shared.markSynced(
+      id: localId,
+      backendId: "replacement-backend-id",
+      authorization: .unrestricted
+    )
+
+    let restored = try await ActionItemStorage.shared.getLocalActionItems(
+      limit: 100,
+      offset: 0,
+      completed: true
+    )
+    let matches = restored.filter { $0.description == deletedTask.description }
+    XCTAssertEqual(matches.count, 1, "undo must rebind one row instead of inserting a duplicate")
+    XCTAssertEqual(matches.first?.id, "replacement-backend-id")
+    XCTAssertTrue(matches.first?.completed == true)
+    let staleIdentity = try await ActionItemStorage.shared.getLocalActionItem(
+      byBackendId: "deleted-backend-id"
+    )
+    XCTAssertNil(staleIdentity)
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260909-completed-task-undo.json
+++ b/desktop/macos/changelog/unreleased/20260909-completed-task-undo.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed task undo creating duplicate copies or restoring completed tasks as incomplete"
+}


### PR DESCRIPTION
## What changed and why

Fixes #13259.

Undoing a deleted cloud-backed task crossed two independent mutation paths: SQLite was first repopulated with the deleted backend identity, then the create response was synced as a second row. Completed tasks also depended on a separate best-effort completion PATCH after the recreate POST.

This change stages undo as one fresh unsynced local row, recreates the task with its completion state in the same POST, and binds that row to the replacement backend ID. If the create fails, the single local row remains eligible for the existing durable retry path. The view model now displays the canonical task returned by the restore operation instead of the stale pre-delete identity.

## Product invariants affected

- INV-NAV-1
- INV-TASK-1

The change keeps the existing Tasks destination and dated-bucket behavior intact; it only corrects the identity and completion state of the item inserted by Undo.

Line-Count-Exception: desktop/macos/Desktop/Sources/Stores/TasksStore.swift | 3700 -> 3722 | the identity-safe restore transaction must stay beside the task store's owner-lease, in-memory projection, and durable retry operations

## How it was verified

- Reproduced the pre-fix failure in an isolated named bundle: one deleted task reappeared locally under both the deleted ID and replacement ID.
- Repeated the exact delete/undo path in a fresh named bundle (`com.omi.omi-13259-completed-task-undo-clean`) against a fresh local synthetic backend.
- The final task dump contained exactly one matching row: replacement ID `issue-13259-remote-2`, `completed: true`.
- The HTTP trace was `DELETE issue-13259-remote-1` followed by one `POST /v1/action-items` containing `"completed": true`; there was no completion PATCH after the restore POST.
- The app log showed the pending local row being inserted once and rebound to `issue-13259-remote-2`.

## Tests

- `xcrun swift test --package-path desktop/macos/Desktop --filter 'APIClientCreateActionItemCompletedTests|ActionItemLocalIdentityMutationTests'` — 9 passed, 0 failed.
- `xcrun swift test --package-path desktop/macos/Desktop --filter SubscriptionEntitlementServiceTests` — 11 passed, 0 failed.
- Full serial `xcrun swift test --package-path desktop/macos/Desktop` advanced through the catalog but the XCTest process exited with signal 5 when entering `SubscriptionEntitlementServiceTests`; that unchanged suite passes in isolation as recorded above. This is the same environment/global-state runner failure reproduced before this patch.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed.
- Pinned Swift formatter lint on all changed Swift files — passed.
- `git diff --check` and changelog JSON validation — passed.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

