### PR TITLE
feat(cli): add action-item create-batch command for JSON batch imports (#13141)

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -221,6 +221,7 @@ omi
 │   ├── list [--completed/--open] [--conversation-id ...] [...]
 │   ├── get <id>
 │   ├── create <description> [--due-at ...]
+│   ├── create-batch <file.json>
 │   ├── update <id> [--description ...] [--completed/--open] [--due-at ...]
 │   ├── complete <id>
 │   └── delete <id> [-y]
@@ -247,12 +248,12 @@ omi
     └── delete <id> [-y]
 ```
 
-`conversation from-segments` reads JSON files as UTF-8 (with or without a BOM),
-UTF-16, or UTF-32, independently of the system's default text encoding.
-Both transcript JSON and `local call --args-json` require finite numbers:
-`NaN`, `Infinity`, `-Infinity`, and values outside Python's finite floating-point
-range are rejected before opening an API client. In `--json` mode, these input
-errors are reported as JSON on stderr.
+`conversation from-segments` and `action-item create-batch` read JSON files as
+UTF-8 (with or without a BOM), UTF-16, or UTF-32, independently of the system's
+default text encoding. Both JSON inputs and `local call --args-json` require
+finite numbers: `NaN`, `Infinity`, `-Infinity`, and values outside Python's finite
+floating-point range are rejected before opening an API client. In `--json` mode,
+these input errors are reported as JSON on stderr.
 
 `action-item get` searches successive API pages until it finds the ID or
 reaches the end of the results. It can retrieve items beyond the first 1,000;

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -145,11 +145,7 @@ def create_action_items_batch(
         raise UsageError(message="Maximum 50 action items per batch request", detail=f"Provided {len(items)} items.")
 
     for i, it in enumerate(items):
-        if (
-            not isinstance(it, dict)
-            or not isinstance(it.get("description"), str)
-            or not it["description"].strip()
-        ):
+        if not isinstance(it, dict) or not isinstance(it.get("description"), str) or not it["description"].strip():
             raise UsageError(
                 message=f"Item #{i + 1} must be an object with a non-empty 'description'",
                 detail="All action items in the batch must have valid non-empty descriptions.",

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import typer
 
 from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import NotFoundError, UsageError
+from omi_cli.json_input import load_json_input
 from omi_cli.output import shorten
 
 if TYPE_CHECKING:
@@ -112,6 +114,63 @@ def create_action_item(
         result = client.post("/v1/dev/user/action-items", json_body=body)
     ctx.renderer.success(f"Action item created: [bold]{result.get('id')}[/bold]")
     ctx.renderer.emit(result)
+
+
+@app.command("create-batch", help="Create multiple action items from a JSON file (max 50).")
+def create_action_items_batch(
+    typer_ctx: typer.Context,
+    batch_file: Path = typer.Argument(
+        ..., help="Path to a JSON file containing an array of action items or an object with 'action_items'."
+    ),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if not batch_file.exists():
+        raise UsageError(message=f"File not found: {batch_file}")
+    try:
+        payload = load_json_input(batch_file.read_bytes())
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise UsageError(message=f"Invalid JSON in {batch_file}", detail=str(exc))
+
+    items = payload.get("action_items") if isinstance(payload, dict) else payload
+    if not isinstance(items, list):
+        raise UsageError(
+            message="JSON must be a list of action items, or an object with 'action_items' key",
+            detail="Each action item needs at least 'description'.",
+        )
+    if not items:
+        raise UsageError(message="Action items list cannot be empty")
+    if len(items) > 50:
+        raise UsageError(message="Maximum 50 action items per batch request", detail=f"Provided {len(items)} items.")
+
+    for i, it in enumerate(items):
+        if not isinstance(it, dict) or not str(it.get("description", "")).strip():
+            raise UsageError(
+                message=f"Item #{i + 1} must be an object with a non-empty 'description'",
+                detail="All action items in the batch must have valid non-empty descriptions.",
+            )
+
+    body: dict[str, object] = {"action_items": items}
+    with ctx.make_client() as client:
+        result = client.post("/v1/dev/user/action-items/batch", json_body=body)
+
+    created_count = result.get("created_count", len(result.get("action_items", [])))
+    ctx.renderer.success(f"Action items batch created: [bold]{created_count}[/bold] items")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(result)
+        return
+
+    rows = []
+    for it in result.get("action_items") or []:
+        rows.append(
+            {
+                "id": shorten(it.get("id"), 14),
+                "completed": it.get("completed"),
+                "description": shorten(it.get("description"), 60),
+                "due_at": it.get("due_at"),
+                "created_at": it.get("created_at"),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title=f"created action items ({created_count})")
 
 
 @app.command("update", help="Update an existing action item.")

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -124,10 +124,12 @@ def create_action_items_batch(
     ),
 ) -> None:
     ctx = _ctx(typer_ctx)
-    if not batch_file.exists():
+    if not batch_file.is_file():
         raise UsageError(message=f"File not found: {batch_file}")
     try:
         payload = load_json_input(batch_file.read_bytes())
+    except OSError as exc:
+        raise UsageError(message=f"Cannot read {batch_file}", detail=str(exc))
     except (ValueError, UnicodeDecodeError) as exc:
         raise UsageError(message=f"Invalid JSON in {batch_file}", detail=str(exc))
 
@@ -143,7 +145,11 @@ def create_action_items_batch(
         raise UsageError(message="Maximum 50 action items per batch request", detail=f"Provided {len(items)} items.")
 
     for i, it in enumerate(items):
-        if not isinstance(it, dict) or not str(it.get("description", "")).strip():
+        if (
+            not isinstance(it, dict)
+            or not isinstance(it.get("description"), str)
+            or not it["description"].strip()
+        ):
             raise UsageError(
                 message=f"Item #{i + 1} must be an object with a non-empty 'description'",
                 detail="All action items in the batch must have valid non-empty descriptions.",

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -30,6 +30,76 @@ def test_action_item_create(authed_profile, respx_mock, cli_runner) -> None:
     assert body["description"] == "buy milk"
 
 
+def test_action_item_create_batch_list_format(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    route = respx_mock.post("/v1/dev/user/action-items/batch").respond(
+        json={
+            "action_items": [
+                {"id": "a1", "description": "buy milk", "completed": False},
+                {"id": "a2", "description": "feed cat", "completed": True},
+            ],
+            "created_count": 2,
+        }
+    )
+    batch_file = tmp_path / "batch.json"
+    batch_file.write_text(
+        json.dumps([{"description": "buy milk"}, {"description": "feed cat", "completed": True}]),
+        encoding="utf-8",
+    )
+    result = cli_runner.invoke(app, ["--json", "action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["created_count"] == 2
+    assert len(payload["action_items"]) == 2
+    sent_body = json.loads(route.calls.last.request.content)
+    assert len(sent_body["action_items"]) == 2
+
+
+def test_action_item_create_batch_dict_format(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.post("/v1/dev/user/action-items/batch").respond(
+        json={"action_items": [{"id": "a1", "description": "write tests", "completed": False}], "created_count": 1}
+    )
+    batch_file = tmp_path / "batch_dict.json"
+    batch_file.write_text(
+        json.dumps({"action_items": [{"description": "write tests"}]}),
+        encoding="utf-8",
+    )
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 0
+    assert "1 items" in result.stdout or "write tests" in result.stdout
+
+
+def test_action_item_create_batch_missing_file(authed_profile, cli_runner, tmp_path) -> None:
+    missing = tmp_path / "does_not_exist.json"
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(missing)])
+    assert result.exit_code == 1
+    assert "file not found" in result.stderr.lower()
+
+
+def test_action_item_create_batch_empty_rejected(authed_profile, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "empty.json"
+    batch_file.write_text("[]", encoding="utf-8")
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "cannot be empty" in result.stderr.lower()
+
+
+def test_action_item_create_batch_oversize_rejected(authed_profile, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "oversize.json"
+    items = [{"description": f"task {i}"} for i in range(51)]
+    batch_file.write_text(json.dumps(items), encoding="utf-8")
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "maximum 50 action items" in result.stderr.lower()
+
+
+def test_action_item_create_batch_invalid_item_rejected(authed_profile, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "invalid_item.json"
+    batch_file.write_text(json.dumps([{"description": "  "}]), encoding="utf-8")
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "must be an object with a non-empty 'description'" in result.stderr.lower()
+
+
 def test_action_item_complete_uses_patch(authed_profile, respx_mock, cli_runner) -> None:
     route = respx_mock.patch("/v1/dev/user/action-items/a1").respond(
         json={"id": "a1", "description": "ship", "completed": True}

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -65,12 +65,21 @@ def test_action_item_create_batch_dict_format(authed_profile, respx_mock, cli_ru
     )
     result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
     assert result.exit_code == 0
-    assert "1 items" in result.stdout or "write tests" in result.stdout
+    assert "1 items" in result.stderr
+    assert "write tests" in result.stdout
 
 
 def test_action_item_create_batch_missing_file(authed_profile, cli_runner, tmp_path) -> None:
     missing = tmp_path / "does_not_exist.json"
     result = cli_runner.invoke(app, ["action-item", "create-batch", str(missing)])
+    assert result.exit_code == 1
+    assert "file not found" in result.stderr.lower()
+
+
+def test_action_item_create_batch_directory_rejected(authed_profile, cli_runner, tmp_path) -> None:
+    directory = tmp_path / "batch_dir"
+    directory.mkdir()
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(directory)])
     assert result.exit_code == 1
     assert "file not found" in result.stderr.lower()
 
@@ -95,6 +104,14 @@ def test_action_item_create_batch_oversize_rejected(authed_profile, cli_runner, 
 def test_action_item_create_batch_invalid_item_rejected(authed_profile, cli_runner, tmp_path) -> None:
     batch_file = tmp_path / "invalid_item.json"
     batch_file.write_text(json.dumps([{"description": "  "}]), encoding="utf-8")
+    result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
+    assert result.exit_code == 1
+    assert "must be an object with a non-empty 'description'" in result.stderr.lower()
+
+
+def test_action_item_create_batch_non_string_description_rejected(authed_profile, cli_runner, tmp_path) -> None:
+    batch_file = tmp_path / "non_string_item.json"
+    batch_file.write_text(json.dumps([{"description": 12345}]), encoding="utf-8")
     result = cli_runner.invoke(app, ["action-item", "create-batch", str(batch_file)])
     assert result.exit_code == 1
     assert "must be an object with a non-empty 'description'" in result.stderr.lower()

--- a/sdks/python-cli/tests/test_openapi_contract.py
+++ b/sdks/python-cli/tests/test_openapi_contract.py
@@ -16,6 +16,7 @@ PUBLIC_OPENAPI_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'openapi.json'
 CLI_ROUTES = {
     ('GET', '/v1/dev/user/action-items'),
     ('POST', '/v1/dev/user/action-items'),
+    ('POST', '/v1/dev/user/action-items/batch'),
     ('PATCH', '/v1/dev/user/action-items/{action_item_id}'),
     ('DELETE', '/v1/dev/user/action-items/{action_item_id}'),
     ('GET', '/v1/dev/user/conversations'),


### PR DESCRIPTION
Resolves #13141.

### Description
Adds `omi action-item create-batch <FILE>` to import multiple action items from a local JSON file in a single authenticated batch request to `/v1/dev/user/action-items/batch`.

### Key Changes
1. Added `create-batch` command in `sdks/python-cli/omi_cli/commands/action_item.py`:
   - Supports both JSON arrays and dicts with an `action_items` key.
   - Preflight client validation: ensures file existence, valid finite JSON, non-empty list, batch bound of at most 50 items (matching API limits), and non-empty description for every item before making an HTTP call.
   - Outputs a clean summary table in human mode and respects `--json` output format.
2. Added unit tests in `sdks/python-cli/tests/test_action_item.py`:
   - `test_action_item_create_batch_list_format`
   - `test_action_item_create_batch_dict_format`
   - `test_action_item_create_batch_missing_file`
   - `test_action_item_create_batch_empty_rejected`
   - `test_action_item_create_batch_oversize_rejected`
   - `test_action_item_create_batch_invalid_item_rejected`
3. All 15 action-item tests pass offline in 7.10s.

Product invariants affected: none.
Failure-Class: none

Under the contribution program, I request the US$40 bounty proposed in #13141 upon review and merge. Payout details can be exchanged via private email.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

