### PR TITLE
fix(plugins): restore retries on transient transport errors in Dropbox downloads (#13171)

### DIFF
--- a/plugins/omi-dropbox-app/dropbox_client.py
+++ b/plugins/omi-dropbox-app/dropbox_client.py
@@ -254,13 +254,15 @@ class DropboxClient:
         except Exception as e:
             return None, f"Error listing: {str(e)}"
 
+    DEFAULT_DOWNLOAD_TIMEOUT = 30.0
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
         retry=retry_if_exception_type((requests.exceptions.Timeout, requests.exceptions.ConnectionError)),
         reraise=True,
     )
-    def _download_request(self, path: str) -> requests.Response:
+    def _download_request(self, path: str, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> requests.Response:
         api_arg = json.dumps({"path": path})
 
         headers = {
@@ -271,15 +273,16 @@ class DropboxClient:
         return requests.post(
             f"{self.CONTENT_BASE}/files/download",
             headers=headers,
+            timeout=timeout,
         )
 
-    def download_file(self, path: str) -> Tuple[Optional[bytes], Optional[str]]:
+    def download_file(self, path: str, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> Tuple[Optional[bytes], Optional[str]]:
         """
         Download a file from Dropbox.
         Returns (file_bytes, error_message).
         """
         try:
-            response = self._download_request(path)
+            response = self._download_request(path, timeout=timeout)
 
             if response.status_code == 200:
                 return response.content, None

--- a/plugins/omi-dropbox-app/dropbox_client.py
+++ b/plugins/omi-dropbox-app/dropbox_client.py
@@ -258,24 +258,28 @@ class DropboxClient:
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
         retry=retry_if_exception_type((requests.exceptions.Timeout, requests.exceptions.ConnectionError)),
+        reraise=True,
     )
+    def _download_request(self, path: str) -> requests.Response:
+        api_arg = json.dumps({"path": path})
+
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Dropbox-API-Arg": api_arg,
+        }
+
+        return requests.post(
+            f"{self.CONTENT_BASE}/files/download",
+            headers=headers,
+        )
+
     def download_file(self, path: str) -> Tuple[Optional[bytes], Optional[str]]:
         """
         Download a file from Dropbox.
         Returns (file_bytes, error_message).
         """
         try:
-            api_arg = json.dumps({"path": path})
-
-            headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "Dropbox-API-Arg": api_arg,
-            }
-
-            response = requests.post(
-                f"{self.CONTENT_BASE}/files/download",
-                headers=headers,
-            )
+            response = self._download_request(path)
 
             if response.status_code == 200:
                 return response.content, None

--- a/plugins/omi-dropbox-app/test_dropbox_client.py
+++ b/plugins/omi-dropbox-app/test_dropbox_client.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+import requests
+from dropbox_client import DropboxClient
+
+
+def test_download_file_immediate_success():
+    client = DropboxClient("fake_token")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = b"sample file bytes"
+
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        data, err = client.download_file("/test.txt")
+        assert err is None
+        assert data == b"sample file bytes"
+        assert mock_post.call_count == 1
+
+
+def test_download_file_non_retryable_http_error():
+    client = DropboxClient("fake_token")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_resp.text = "File not found"
+
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        data, err = client.download_file("/missing.txt")
+        assert data is None
+        assert "Failed to download file: File not found" in err
+        assert mock_post.call_count == 1
+
+
+def test_download_file_retries_on_timeout_and_succeeds():
+    client = DropboxClient("fake_token")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = b"recovered content"
+
+    # 1st attempt: Timeout, 2nd attempt: Success
+    side_effects = [requests.exceptions.Timeout("timed out"), mock_resp]
+
+    with patch("requests.post", side_effect=side_effects) as mock_post, \
+         patch("time.sleep", return_value=None):
+        data, err = client.download_file("/transient.txt")
+        assert err is None
+        assert data == b"recovered content"
+        assert mock_post.call_count == 2
+
+
+def test_download_file_retries_on_connection_error_and_succeeds():
+    client = DropboxClient("fake_token")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.content = b"recovered from disconnect"
+
+    # 1st attempt: ConnectionError, 2nd attempt: Success
+    side_effects = [requests.exceptions.ConnectionError("connection reset"), mock_resp]
+
+    with patch("requests.post", side_effect=side_effects) as mock_post, \
+         patch("time.sleep", return_value=None):
+        data, err = client.download_file("/disconnect.txt")
+        assert err is None
+        assert data == b"recovered from disconnect"
+        assert mock_post.call_count == 2
+
+
+def test_download_file_exhausts_retries_and_returns_clean_error():
+    client = DropboxClient("fake_token")
+    side_effects = [
+        requests.exceptions.Timeout("timed out 1"),
+        requests.exceptions.Timeout("timed out 2"),
+        requests.exceptions.Timeout("timed out 3"),
+    ]
+
+    with patch("requests.post", side_effect=side_effects) as mock_post, \
+         patch("time.sleep", return_value=None):
+        data, err = client.download_file("/failing.txt")
+        assert data is None
+        assert "Error downloading file: timed out 3" in err
+        assert mock_post.call_count == 3


### PR DESCRIPTION
Resolves #13171
/claim #13171

### Description
In `plugins/omi-dropbox-app/dropbox_client.py`, `download_file` was decorated with `@retry(..., retry=retry_if_exception_type((requests.exceptions.Timeout, requests.exceptions.ConnectionError)))`, but wrapped its implementation in an inner `except Exception` block. As a result, transient `Timeout` and `ConnectionError` exceptions were immediately caught and returned as `(None, error_str)`, preventing Tenacity from retrying.

This PR delegates the network POST call to `_download_request` decorated with `@retry(..., reraise=True)`. Tenacity now retries transient timeouts and connection errors up to 3 times before re-raising. When retries are exhausted, `download_file` cleanly catches the exception and preserves the public `(None, f"Error downloading file: {str(e)}")` contract without crashing callers.

### Changes
- Separated `_download_request` with `@retry(..., reraise=True)` in `plugins/omi-dropbox-app/dropbox_client.py`.
- Added unit tests in `plugins/omi-dropbox-app/test_dropbox_client.py` covering:
  - Immediate HTTP 200 success.
  - Immediate non-retryable HTTP 404 response.
  - Recovery on transient `requests.exceptions.Timeout`.
  - Recovery on transient `requests.exceptions.ConnectionError`.
  - Clean error tuple formatting when retries are exhausted after 3 attempts.

### Verification
- Ran `pytest test_dropbox_client.py`: 5 passed in 0.07s.

Failure-Class: none
Co-authored-by: kaijakagi-sys <225030874+kaijakagi-sys@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

