### PR TITLE
fix(sdks/python-cli): define UTF-8 pipe support for conversation create (#13170)

### DIFF
--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -90,7 +90,7 @@ Visibility: `public` or `private`.
 | `omi conversation update ID [--title ... --discarded/--no-discarded]` | `PATCH /v1/dev/user/conversations/{id}` |
 | `omi conversation delete ID [-y]`             | `DELETE /v1/dev/user/conversations/{id}`                       |
 
-The `--text` flag accepts `-` to read from stdin:
+The `--text` flag accepts `-` to read UTF-8 content from stdin:
 
 ```bash
 cat meeting_notes.md | omi conversation create --text - --text-source message

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -96,7 +95,7 @@ def get_conversation(
 @app.command("create", help="Create a conversation from raw text.")
 def create_conversation(
     typer_ctx: typer.Context,
-    text: Optional[str] = typer.Option(None, "--text", help="Text body. Use '-' to read from stdin."),
+    text: Optional[str] = typer.Option(None, "--text", help="Text body. Use '-' to read UTF-8 from stdin."),
     text_source: ConversationTextSource = typer.Option(
         ConversationTextSource.other_text,
         "--text-source",
@@ -119,7 +118,17 @@ def create_conversation(
                 message="No --text provided",
                 detail="Pass --text 'your text' or pipe content via stdin and use --text -.",
             )
-        text = sys.stdin.read()
+        buffer = getattr(sys.stdin, "buffer", None)
+        try:
+            if buffer is not None:
+                text = buffer.read().decode("utf-8")
+            else:
+                text = sys.stdin.read()
+        except UnicodeDecodeError as exc:
+            raise UsageError(
+                message="Invalid UTF-8 in piped input",
+                detail=f"Piped conversation text must be valid UTF-8: {exc}",
+            ) from exc
 
     body: dict[str, object] = {
         "text": text,

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -106,3 +106,31 @@ def test_conversation_from_segments_rejects_invalid_unicode(config_path, respx_m
     assert result.exit_code == 1
     assert "Invalid JSON" in result.stderr
     assert not respx_mock.calls
+
+
+def test_conversation_create_reads_utf8_stdin(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/conversations").respond(
+        json={"id": "c1", "status": "completed", "discarded": False}
+    )
+    raw_text = "Caf\u00e9, \u65e5\u672c\u8a9e \U0001f642"
+    result = cli_runner.invoke(
+        app,
+        ["--json", "conversation", "create", "--text", "-", "--language", "ja"],
+        input=raw_text.encode("utf-8"),
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body["text"] == raw_text
+    assert body["language"] == "ja"
+
+
+def test_conversation_create_rejects_invalid_utf8_stdin(authed_profile, respx_mock, cli_runner) -> None:
+    result = cli_runner.invoke(
+        app,
+        ["--json", "conversation", "create", "--text", "-"],
+        input=b"invalid \xff\xfe bytes",
+    )
+    assert result.exit_code == 1
+    assert "UTF-8" in result.stderr
+    assert not respx_mock.calls
+

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -133,4 +133,3 @@ def test_conversation_create_rejects_invalid_utf8_stdin(authed_profile, respx_mo
     assert result.exit_code == 1
     assert "UTF-8" in result.stderr
     assert not respx_mock.calls
-


### PR DESCRIPTION
Resolves #13170

### Summary
- Read raw stdin bytes via sys.stdin.buffer and decode explicitly as UTF-8 when piping into omi conversation create --text -, preventing encoding corruption on platforms with non-UTF-8 default encodings (e.g. Windows cp1252).
- Raise a clear structured UsageError before making any network requests if undecodable UTF-8 bytes are piped.
- Update --text help option and CLI documentation to clarify UTF-8 piped stdin support.
- Add regression unit tests for UTF-8 piped stdin preservation and invalid byte rejection.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

