### PR TITLE
feat(sdks/python-cli): add config profile rename command (#13195)

### DIFF
--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -63,6 +63,7 @@ hand. The refresh token rotates if Firebase decides to.
 | `omi config set api_base URL`      | Override the API base for the active profile.        |
 | `omi config profile list`          | Tabular list of profiles.                            |
 | `omi config profile use NAME`      | Switch the active profile. Creates it if missing.    |
+| `omi config profile rename OLD NEW` | Rename an existing profile, preserving credentials. |
 | `omi config profile delete NAME`   | Wipe a profile (prompts unless `--yes`).             |
 
 ## `omi memory`

--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -151,3 +151,31 @@ def profile_delete(
     config.delete_profile(name)
     cfg.save(config)
     ctx.renderer.success(f"Deleted profile [bold]{escape(name)}[/bold].")
+
+
+@profile_app.command("rename", help="Rename an existing profile.")
+def profile_rename(
+    typer_ctx: typer.Context,
+    old_name: str = typer.Argument(..., help="Current name of the profile."),
+    new_name: str = typer.Argument(..., help="New name for the profile."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    clean_new = new_name.strip()
+    if not clean_new:
+        raise UsageError(message="New profile name cannot be blank")
+    if old_name not in config.profiles:
+        raise UsageError(message=f"No such profile: '{old_name}'")
+    if clean_new != old_name and clean_new in config.profiles:
+        raise UsageError(message=f"Profile '{clean_new}' already exists")
+
+    config.rename_profile(old_name, clean_new)
+    cfg.save(config)
+    ctx.renderer.success(f"Renamed profile [bold]{escape(old_name)}[/bold] to [bold]{escape(clean_new)}[/bold].")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(
+            {
+                "active_profile": config.active_profile,
+                "profiles": config.list_profiles(),
+            }
+        )

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -163,6 +163,23 @@ class Config:
         if self.active_profile == name:
             self.active_profile = DEFAULT_PROFILE_NAME
 
+    def rename_profile(self, old_name: str, new_name: str) -> None:
+        """Rename an existing profile, updating active_profile if needed."""
+        if not new_name or not new_name.strip():
+            raise ValueError("New profile name cannot be blank")
+        clean_new = new_name.strip()
+        if old_name not in self.profiles:
+            raise KeyError(f"No such profile: '{old_name}'")
+        if clean_new == old_name:
+            return
+        if clean_new in self.profiles:
+            raise ValueError(f"Profile '{clean_new}' already exists")
+        profile = self.profiles.pop(old_name)
+        profile.name = clean_new
+        self.profiles[clean_new] = profile
+        if self.active_profile == old_name:
+            self.active_profile = clean_new
+
     def list_profiles(self) -> list[str]:
         return sorted(self.profiles.keys())
 

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -468,7 +468,15 @@ def test_config_profile_rename_cli_command(config_path: Path, cli_runner) -> Non
     assert res_missing.exit_code != 0
     assert "No such profile" in res_missing.stderr
 
-    # Test CLI error on existing collision
-    res_collision = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "final-profile"])
-    assert res_collision.exit_code == 0  # no-op succeeds
+    # Test rename to self is a no-op that succeeds
+    res_self = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "final-profile"])
+    assert res_self.exit_code == 0
 
+    # Test CLI error on collision with another existing profile
+    config_with_two = cfg.load()
+    p2 = config_with_two.get_profile("other-profile")
+    config_with_two.set_profile(p2)
+    cfg.save(config_with_two)
+    res_collision = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "other-profile"])
+    assert res_collision.exit_code != 0
+    assert "already exists" in res_collision.stderr

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -380,3 +380,95 @@ def test_is_authenticated_states() -> None:
     p.id_token = None
     p.refresh_token = "refr..."
     assert p.is_authenticated()
+
+
+def test_rename_profile_dataclass_contract(tmp_path: Path) -> None:
+    config = cfg.Config(path=tmp_path / "config.toml")
+    p1 = cfg.Profile(
+        name="work",
+        auth_method="api_key",
+        api_key="omi_dev_secret123",
+        api_base="https://api.work.omi.local",
+        extra={"custom_key": "val"},
+    )
+    p2 = cfg.Profile(name="personal", auth_method="oauth", id_token="tok123")
+    config.set_profile(p1)
+    config.set_profile(p2)
+    config.active_profile = "work"
+
+    # 1. Rename active profile
+    config.rename_profile("work", "work-new")
+    assert "work" not in config.profiles
+    assert "work-new" in config.profiles
+    assert config.active_profile == "work-new"
+    renamed = config.profiles["work-new"]
+    assert renamed.name == "work-new"
+    assert renamed.api_key == "omi_dev_secret123"
+    assert renamed.api_base == "https://api.work.omi.local"
+    assert renamed.extra == {"custom_key": "val"}
+
+    # 2. Rename inactive profile
+    config.rename_profile("personal", "personal-renamed")
+    assert "personal" not in config.profiles
+    assert "personal-renamed" in config.profiles
+    assert config.active_profile == "work-new"  # unchanged
+
+    # 3. Missing source profile raises KeyError
+    with pytest.raises(KeyError, match="No such profile: 'missing'"):
+        config.rename_profile("missing", "target")
+
+    # 4. Blank destination raises ValueError
+    with pytest.raises(ValueError, match="cannot be blank"):
+        config.rename_profile("work-new", "   ")
+
+    # 5. Collision raises ValueError
+    with pytest.raises(ValueError, match="already exists"):
+        config.rename_profile("work-new", "personal-renamed")
+
+    # 6. Identical name is a no-op
+    config.rename_profile("work-new", "work-new")
+    assert "work-new" in config.profiles
+
+    # 7. Unicode names
+    config.rename_profile("work-new", "\u0440\u0430\u0431\u043e\u0447\u0438\u0439")
+    assert "\u0440\u0430\u0431\u043e\u0447\u0438\u0439" in config.profiles
+    assert config.active_profile == "\u0440\u0430\u0431\u043e\u0447\u0438\u0439"
+
+
+def test_config_profile_rename_cli_command(config_path: Path, cli_runner) -> None:
+    config = cfg.load()
+    p = config.get_profile("old-profile")
+    p.auth_method = "api_key"
+    p.api_key = "omi_dev_testkey"
+    config.set_profile(p)
+    config.active_profile = "old-profile"
+    cfg.save(config)
+
+    # Test CLI rename in text mode
+    res = cli_runner.invoke(app, ["config", "profile", "rename", "old-profile", "new-profile"])
+    assert res.exit_code == 0, res.output
+    assert "Renamed profile" in res.stderr
+
+    reloaded = cfg.load()
+    assert "old-profile" not in reloaded.profiles
+    assert "new-profile" in reloaded.profiles
+    assert reloaded.active_profile == "new-profile"
+    assert reloaded.profiles["new-profile"].api_key == "omi_dev_testkey"
+
+    # Test CLI rename in JSON mode
+    res_json = cli_runner.invoke(app, ["--json", "config", "profile", "rename", "new-profile", "final-profile"])
+    assert res_json.exit_code == 0, res_json.output
+    data = json.loads(res_json.stdout)
+    assert data["active_profile"] == "final-profile"
+    assert "final-profile" in data["profiles"]
+    assert "new-profile" not in data["profiles"]
+
+    # Test CLI error on non-existent profile
+    res_missing = cli_runner.invoke(app, ["config", "profile", "rename", "does-not-exist", "foo"])
+    assert res_missing.exit_code != 0
+    assert "No such profile" in res_missing.stderr
+
+    # Test CLI error on existing collision
+    res_collision = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "final-profile"])
+    assert res_collision.exit_code == 0  # no-op succeeds
+


### PR DESCRIPTION
Resolves #13195

### Summary
- Adds 
ename_profile method to Config in omi_cli/config.py which preserves all credentials and settings, updates the ctive_profile pointer when renaming the active profile, and guards against blank names or collisions.
- Adds omi config profile rename OLD NEW command under omi config profile in omi_cli/commands/config.py, supporting both human-readable and --json outputs.
- Adds CLI documentation for the new command in docs/doc/developer/cli/commands.mdx.
- Adds unit tests verifying dataclass contract (preservation of credentials, active/inactive handling, collision/blank error handling, Unicode support) and end-to-end CLI execution.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

