### PR TITLE
fix(plugins): bound Notion page content writes

### DIFF
--- a/plugins/omi-notion-app/README.md
+++ b/plugins/omi-notion-app/README.md
@@ -126,9 +126,27 @@ When users connect their Notion workspace, they must grant access to specific pa
 
 ## Regression tests
 
+Page creation and content appends share a planner for Notion's
+[request limits](https://developers.notion.com/reference/request-limits).
+Nonblank lines keep their text and order; long lines use multiple rich-text
+items, then continuation paragraph blocks when one block cannot fit. Requests
+contain at most 100 children and 100 rich-text items per paragraph, with text
+chunks bounded to 2000 UTF-16 units without splitting Unicode characters. The
+500,000-byte budget includes the exact escaped JSON sent over HTTP, including
+the parent and title on page creation. Oversized page properties fail before
+any write.
+
+Batches are sent in order. A failed write stops the operation without replaying
+earlier requests. The error includes the page ID and confirmed paragraph-block
+count (including a page already created), since a failed transport response may
+still have committed. Inspect the page before retrying to avoid duplicate text.
+
 Run `python3 plugins/omi-notion-app/test_main.py` from the repository root.
 The hermetic tests import the production module with framework/storage doubles
 and exercise `get_page` through its real HTTP helper: failed content retrieval
 must return a sanitized tool error retaining the independently retrieved page
 metadata (including archive status), while empty and populated successful reads
-retain their output. No live workspace or credentials are used.
+retain their output. Create/append tests capture the production HTTP bodies to
+check text, array, serialized-byte and Unicode boundaries, ordered writes,
+small-input compatibility, and partial failures. No live workspace or
+credentials are used.

--- a/plugins/omi-notion-app/README.md
+++ b/plugins/omi-notion-app/README.md
@@ -140,6 +140,12 @@ Batches are sent in order. A failed write stops the operation without replaying
 earlier requests. The error includes the page ID and confirmed paragraph-block
 count (including a page already created), since a failed transport response may
 still have committed. Inspect the page before retrying to avoid duplicate text.
+The [append response](https://developers.notion.com/reference/patch-block-children)
+must have the documented list shape and returned block identities before a
+batch is confirmed. A valid paginated response acknowledges the submitted
+request, so confirmed counts track accepted request batches rather than the
+number of returned results. Malformed responses stop the operation with only
+earlier accepted batches included in the error count.
 
 Run `python3 plugins/omi-notion-app/test_main.py` from the repository root.
 The hermetic tests import the production module with framework/storage doubles

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -28,6 +28,7 @@ from db import (
     get_user_setting,
 )
 from models import ChatToolResponse
+from notion_content import encode_payload, plan_content_requests, title_items
 
 load_dotenv()
 
@@ -88,9 +89,9 @@ def notion_api_request(uid: str, method: str, endpoint: str, params: dict = None
         if method == "GET":
             response = requests.get(url, headers=headers, params=params)
         elif method == "POST":
-            response = requests.post(url, headers=headers, json=json_data or {})
+            response = requests.post(url, headers=headers, data=encode_payload(json_data or {}))
         elif method == "PATCH":
-            response = requests.patch(url, headers=headers, json=json_data)
+            response = requests.patch(url, headers=headers, data=encode_payload(json_data))
         elif method == "DELETE":
             response = requests.delete(url, headers=headers)
         else:
@@ -105,6 +106,27 @@ def notion_api_request(uid: str, method: str, endpoint: str, params: dict = None
     except Exception as e:
         log(f"Notion API request error: {e}")
         return {"error": str(e)}
+
+
+def append_content_batches(uid: str, page_id: str, batches: list, confirmed: int, total: int) -> Optional[str]:
+    """Stop at the first unconfirmed write; replay could duplicate saved content."""
+    for batch in batches:
+        try:
+            result = notion_api_request(uid, "PATCH", f"/blocks/{page_id}/children", json_data=batch)
+        except Exception:
+            result = None
+        if not isinstance(result, dict) or not result or "error" in result:
+            status = result.get("status_code") if isinstance(result, dict) else None
+            diagnostic = f" (HTTP {status})" if status else ""
+            return (
+                f"Content write was not confirmed{diagnostic}.\n\n"
+                f"**Page ID:** `{page_id}`\n"
+                f"Confirmed {confirmed} of {total} paragraph block(s) saved. "
+                "The failed batch may have been applied. Check the page before retrying; "
+                "replaying the full content can duplicate it."
+            )
+        confirmed += len(batch["children"])
+    return None
 
 
 def extract_title(page: dict) -> str:
@@ -586,7 +608,7 @@ async def tool_create_page(request: Request):
         page_data = {
             "properties": {
                 "title": {
-                    "title": [{"text": {"content": title}}]
+                    "title": title_items(title)
                 }
             }
         }
@@ -597,7 +619,7 @@ async def tool_create_page(request: Request):
             # For database pages, use Name property instead of title
             page_data["properties"] = {
                 "Name": {
-                    "title": [{"text": {"content": title}}]
+                    "title": title_items(title)
                 }
             }
         elif parent_page_id:
@@ -611,28 +633,23 @@ async def tool_create_page(request: Request):
             else:
                 return ChatToolResponse(error="Please specify a parent page or database ID.")
 
-        # Add content as paragraph blocks
-        if content:
-            paragraphs = content.split("\n")
-            page_data["children"] = [
-                {
-                    "object": "block",
-                    "type": "paragraph",
-                    "paragraph": {
-                        "rich_text": [{"text": {"content": p}}]
-                    }
-                }
-                for p in paragraphs if p.strip()
-            ]
+        batches = plan_content_requests(content or "", page_data)
+        result = notion_api_request(uid, "POST", "/pages", json_data=batches[0])
 
-        log(f"Creating page with data: {page_data}")
+        page_id = result.get("id") if isinstance(result, dict) else None
+        if not result or "error" in result or not isinstance(page_id, str) or not page_id.strip():
+            status = result.get("status_code") if isinstance(result, dict) else None
+            diagnostic = f" (HTTP {status})" if status else ""
+            return ChatToolResponse(error=(
+                f"Page creation was not confirmed{diagnostic}. "
+                "Check Notion before retrying; the page may already have been created."
+            ))
 
-        result = notion_api_request(uid, "POST", "/pages", json_data=page_data)
+        total = sum(len(batch.get("children", [])) for batch in batches)
+        error = append_content_batches(uid, page_id, batches[1:], len(batches[0].get("children", [])), total)
+        if error:
+            return ChatToolResponse(error=f"Page created, but not all content writes were confirmed.\n\n{error}")
 
-        if not result or "error" in result:
-            return ChatToolResponse(error=f"Failed to create page: {result.get('error', 'Unknown error')}")
-
-        page_id = result.get("id", "")
         url = result.get("url", "")
 
         result_parts = [
@@ -647,11 +664,11 @@ async def tool_create_page(request: Request):
 
         return ChatToolResponse(result="\n".join(result_parts))
 
-    except Exception as e:
-        log(f"Error creating page: {e}")
-        import traceback
-        traceback.print_exc()
-        return ChatToolResponse(error=f"Failed to create page: {str(e)}")
+    except ValueError as e:
+        return ChatToolResponse(error=f"Failed to create page: {e}")
+    except Exception:
+        log("Error creating page")
+        return ChatToolResponse(error="Failed to create page. Check Notion before retrying.")
 
 
 @app.post("/tools/update_page", tags=["chat_tools"], response_model=ChatToolResponse)
@@ -737,29 +754,17 @@ async def tool_append_content(request: Request):
         if not access_token:
             return ChatToolResponse(error="Please connect your Notion workspace first in the app settings.")
 
-        # Create paragraph blocks from content
-        paragraphs = content.split("\n")
-        children = [
-            {
-                "object": "block",
-                "type": "paragraph",
-                "paragraph": {
-                    "rich_text": [{"text": {"content": p}}]
-                }
-            }
-            for p in paragraphs if p.strip()
-        ]
+        batches = plan_content_requests(content)
+        total = sum(len(batch["children"]) for batch in batches)
+        error = append_content_batches(uid, page_id, batches, 0, total)
+        if error:
+            return ChatToolResponse(error=error)
 
-        result = notion_api_request(uid, "PATCH", f"/blocks/{page_id}/children", json_data={"children": children})
+        return ChatToolResponse(result=f"**Content Added!**\n\nAdded {total} paragraph(s) to the page.")
 
-        if not result or "error" in result:
-            return ChatToolResponse(error=f"Failed to append content: {result.get('error', 'Unknown error')}")
-
-        return ChatToolResponse(result=f"**Content Added!**\n\nAdded {len(children)} paragraph(s) to the page.")
-
-    except Exception as e:
-        log(f"Error appending content: {e}")
-        return ChatToolResponse(error=f"Failed to append content: {str(e)}")
+    except Exception:
+        log("Error appending content")
+        return ChatToolResponse(error="Failed to append content. Check the page before retrying.")
 
 
 @app.post("/tools/list_databases", tags=["chat_tools"], response_model=ChatToolResponse)

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -108,6 +108,24 @@ def notion_api_request(uid: str, method: str, endpoint: str, params: dict = None
         return {"error": str(e)}
 
 
+def append_response_valid(result: Any) -> bool:
+    """Recognize the documented successful append response before counting a batch."""
+    if not isinstance(result, dict) or result.get("object") != "list" or "error" in result:
+        return False
+    blocks = result.get("results")
+    # The response can be paginated and contain partial block objects. It
+    # acknowledges the write; its result count need not equal the batch size.
+    if not isinstance(blocks, list):
+        return False
+    for block in blocks:
+        if not isinstance(block, dict) or block.get("object") != "block":
+            return False
+        block_id = block.get("id")
+        if not isinstance(block_id, str) or not block_id.strip():
+            return False
+    return True
+
+
 def append_content_batches(uid: str, page_id: str, batches: list, confirmed: int, total: int) -> Optional[str]:
     """Stop at the first unconfirmed write; replay could duplicate saved content."""
     for batch in batches:
@@ -115,7 +133,7 @@ def append_content_batches(uid: str, page_id: str, batches: list, confirmed: int
             result = notion_api_request(uid, "PATCH", f"/blocks/{page_id}/children", json_data=batch)
         except Exception:
             result = None
-        if not isinstance(result, dict) or not result or "error" in result:
+        if not append_response_valid(result):
             status = result.get("status_code") if isinstance(result, dict) else None
             diagnostic = f" (HTTP {status})" if status else ""
             return (

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -100,11 +100,11 @@ def notion_api_request(uid: str, method: str, endpoint: str, params: dict = None
         if response.status_code in [200, 201]:
             return response.json()
         else:
-            log(f"Notion API error: {response.status_code} - {response.text}")
+            log(f"Notion API error: HTTP {response.status_code}")
             return {"error": response.text, "status_code": response.status_code}
 
     except Exception as e:
-        log(f"Notion API request error: {e}")
+        log(f"Notion API request error: {type(e).__name__}")
         return {"error": str(e)}
 
 

--- a/plugins/omi-notion-app/notion_content.py
+++ b/plugins/omi-notion-app/notion_content.py
@@ -1,0 +1,81 @@
+"""Plan ordered Notion content writes before sending any non-idempotent request."""
+import json
+
+
+MAX_TEXT_CHARACTERS = 2000
+MAX_ARRAY_ITEMS = 100
+MAX_REQUEST_BYTES = 500000
+
+
+def encode_payload(payload: dict) -> bytes:
+    """Use these exact bytes for both size checks and the HTTP request body."""
+    return json.dumps(payload, allow_nan=False).encode("utf-8")
+
+
+def rich_text_items(text: str) -> list:
+    # Count astral characters as two UTF-16 units to stay within the limit
+    # whether Notion counts code points or UTF-16, without splitting a character.
+    items = []
+    start = units = 0
+    for index, character in enumerate(text):
+        width = 2 if ord(character) > 0xFFFF else 1
+        if units + width > MAX_TEXT_CHARACTERS:
+            items.append({"text": {"content": text[start:index]}})
+            start, units = index, 0
+        units += width
+    if start < len(text):
+        items.append({"text": {"content": text[start:]}})
+    return items
+
+
+def title_items(title: str) -> list:
+    items = rich_text_items(title)
+    if len(items) > MAX_ARRAY_ITEMS:
+        raise ValueError("Page title exceeds Notion's 100 rich-text item limit.")
+    return items
+
+
+def paragraph_block(items: list) -> dict:
+    return {"object": "block", "type": "paragraph", "paragraph": {"rich_text": items}}
+
+
+def content_blocks(content: str) -> list:
+    """Keep nonblank lines intact where possible, splitting oversized ones losslessly."""
+    blocks = []
+    for paragraph in content.split("\n"):
+        if not paragraph.strip():
+            continue
+        items = []
+        for item in rich_text_items(paragraph):
+            candidate = items + [item]
+            # A single block must fit in an append request, even for escaped emoji.
+            if len(candidate) > MAX_ARRAY_ITEMS or len(encode_payload({"children": [paragraph_block(candidate)]})) > MAX_REQUEST_BYTES:
+                blocks.append(paragraph_block(items))
+                items = []
+            items.append(item)
+        blocks.append(paragraph_block(items))
+    return blocks
+
+
+def plan_content_requests(content: str, page_data: dict = None) -> list:
+    """Return a create payload (if supplied), then bounded append payloads.
+
+    The first request includes all page metadata in its byte budget. It may
+    contain no children if the first block only fits in a subsequent append.
+    Planning completes before any write so invalid metadata cannot leave a page.
+    """
+    payload = dict(page_data) if page_data is not None else {}
+    if content or page_data is None:
+        payload["children"] = []
+    if len(encode_payload(payload)) > MAX_REQUEST_BYTES:
+        raise ValueError("Page properties exceed Notion's 500 KB request limit.")
+
+    batches = []
+    for block in content_blocks(content):
+        candidate = {**payload, "children": payload["children"] + [block]}
+        if len(candidate["children"]) > MAX_ARRAY_ITEMS or len(encode_payload(candidate)) > MAX_REQUEST_BYTES:
+            batches.append(payload)
+            payload = {"children": []}
+        payload["children"].append(block)
+    batches.append(payload)
+    return batches

--- a/plugins/omi-notion-app/test_main.py
+++ b/plugins/omi-notion-app/test_main.py
@@ -122,7 +122,14 @@ class PageWriteTests(unittest.TestCase):
                     raise failure
                 return failure
             response = Mock(status_code=200)
-            response.json.return_value = {"id": "created-page", "url": "https://www.notion.so/created-page"} if method == "POST" else {"results": []}
+            # The append endpoint returns newly created first-level blocks,
+            # including object/id even without read-content capabilities.
+            response.json.return_value = {"id": "created-page", "url": "https://www.notion.so/created-page"} if method == "POST" else {
+                "object": "list", "type": "block", "block": {},
+                "has_more": False, "next_cursor": None,
+                "results": [{"object": "block", "id": f"00000000-0000-4000-8000-{len(calls) * 100 + index:012d}"}
+                            for index in range(len(calls[-1][3]["children"]))],
+            }
             return response
 
         body = {"uid": "test-user", "content": content}
@@ -276,6 +283,56 @@ class PageWriteTests(unittest.TestCase):
                 self.assertIn("not confirmed", result.error)
                 self.assertIn("before retrying", result.error)
                 self.assertNotIn("private", result.error)
+
+    def test_malformed_append_success_does_not_confirm_the_batch(self):
+        blocks = [{"object": "block", "id": f"00000000-0000-4000-8000-{index:012d}"} for index in range(100)]
+        invalid_results = [
+            {"foo": "bar"},
+            {"object": "page", "id": "unrelated-page"},
+            {"object": "page", "results": blocks},
+            {"results": blocks},
+            {"object": "list"},
+        ]
+        for results in (None, "private malformed results", {},
+                        [None] * 100, ["block"] * 100, [{}] * 100,
+                        [{"object": "page", "id": block["id"]} for block in blocks],
+                        [{"object": "block", "id": None}] * 100,
+                        [{"object": "block", "id": " "}] * 100,
+                        [{"object": "block", "id": 123}] * 100):
+            invalid_results.append({"object": "list", "results": results})
+
+        for create, fail_at in ((False, 1), (False, 2), (True, 2)):
+            for payload in invalid_results:
+                with self.subTest(create=create, fail_at=fail_at, payload=payload):
+                    response = Mock(status_code=200)
+                    response.json.return_value = payload
+                    result, calls = self.write("\n".join(f"p{index}" for index in range(301)), create=create, fail_at=fail_at, failure=response)
+                    self.assertEqual(len(calls), fail_at)
+                    self.assertIsNone(result.result)
+                    self.assertIn(f"{(fail_at - 1) * 100} of 301", result.error)
+                    self.assertIn("created-page" if create else "existing-page", result.error)
+                    self.assertIn("not confirmed", result.error)
+                    self.assertIn("may have been applied", result.error)
+                    self.assertIn("duplicate", result.error)
+                    self.assertNotIn("private", result.error)
+
+    def test_paginated_append_response_acknowledges_the_submitted_batch(self):
+        # The version-matched SDK permits a paginated list of partial blocks:
+        # https://github.com/makenotion/notion-sdk-js/blob/v2.2.15/src/api-endpoints.ts
+        for create in (False, True):
+            with self.subTest(create=create):
+                response = Mock(status_code=200)
+                response.json.return_value = {
+                    "object": "list", "type": "block", "block": {},
+                    "has_more": True, "next_cursor": "opaque-cursor",
+                    "results": [{"object": "block", "id": "00000000-0000-4000-8000-000000000001"}],
+                }
+                result, calls = self.write("\n".join(f"p{index}" for index in range(301)), create=create, fail_at=2, failure=response)
+                self.assertIsNone(result.error)
+                self.assertEqual(len(calls), 4)
+                self.assertEqual([len(call[3]["children"]) for call in calls], [100, 100, 100, 1])
+                self.assertEqual(self.saved_paragraphs(calls), [f"p{index}" for index in range(301)])
+                self.assertIn("**Page Created!**" if create else "Added 301 paragraph(s)", result.result)
 
     def test_write_logs_omit_content_and_upstream_error_details(self):
         content = "private synthetic note contents"

--- a/plugins/omi-notion-app/test_main.py
+++ b/plugins/omi-notion-app/test_main.py
@@ -277,6 +277,13 @@ class PageWriteTests(unittest.TestCase):
                 self.assertIn("before retrying", result.error)
                 self.assertNotIn("private", result.error)
 
+    def test_write_logs_omit_content_and_upstream_error_details(self):
+        content = "private synthetic note contents"
+        for failure in (Mock(status_code=400, text=content), RuntimeError(content)):
+            with self.subTest(failure=type(failure).__name__):
+                self.write(content, create=True, fail_at=1, failure=failure)
+                self.assertNotIn(content, str(self.write_logs))
+
     def test_unusable_create_result_does_not_append_or_claim_success(self):
         for payload in (None, {}, {"error": ""}, {"url": "https://www.notion.so/unknown"}, {"id": ""}):
             with self.subTest(payload=payload):

--- a/plugins/omi-notion-app/test_main.py
+++ b/plugins/omi-notion-app/test_main.py
@@ -1,6 +1,7 @@
 """Hermetic production-handler tests; HTTP, framework and token storage are doubles."""
 import asyncio
 import importlib.util
+import json
 from pathlib import Path
 import sys
 import types
@@ -26,7 +27,7 @@ def module(name, **attributes):
     return value
 
 stubs = {
-    "requests": module("requests", get=Mock()),
+    "requests": module("requests", get=Mock(), post=Mock(), patch=Mock()),
     "dotenv": module("dotenv", load_dotenv=lambda: None),
     "fastapi": module("fastapi", FastAPI=Framework, Request=Framework, Query=Framework, HTTPException=Exception),
     "fastapi.responses": module("fastapi.responses", HTMLResponse=Framework, RedirectResponse=Framework, JSONResponse=Framework),
@@ -105,6 +106,197 @@ class PageReadTests(unittest.TestCase):
                 self.assertEqual("**Content:**" in result.result, bool(text))
                 if text:
                     self.assertIn(text, result.result)
+
+class PageWriteTests(unittest.TestCase):
+    def write(self, content, create=False, fail_at=None, failure=None, **metadata):
+        calls = []
+
+        def send(method, url, **kwargs):
+            # Accept the original json= seam as well as explicitly encoded data.
+            wire = kwargs.get("data")
+            if wire is None:
+                wire = json.dumps(kwargs["json"], allow_nan=False).encode("utf-8")
+            calls.append((method, url, wire, json.loads(wire)))
+            if len(calls) == fail_at:
+                if isinstance(failure, Exception):
+                    raise failure
+                return failure
+            response = Mock(status_code=200)
+            response.json.return_value = {"id": "created-page", "url": "https://www.notion.so/created-page"} if method == "POST" else {"results": []}
+            return response
+
+        body = {"uid": "test-user", "content": content}
+        body.update({"title": "Test title", "parent_page_id": "parent-page"} if create else {"page_id": "existing-page"})
+        body.update(metadata)
+        request = Mock(json=AsyncMock(return_value=body))
+        with patch.object(notion, "get_valid_access_token", return_value="test-placeholder"), patch.object(notion, "log") as log, patch.object(notion.requests, "post", side_effect=lambda *args, **kwargs: send("POST", *args, **kwargs)), patch.object(notion.requests, "patch", side_effect=lambda *args, **kwargs: send("PATCH", *args, **kwargs)):
+            result = asyncio.run((notion.tool_create_page if create else notion.tool_append_content)(request))
+        self.write_logs = log.call_args_list
+        return result, calls
+
+    def assert_valid_requests(self, calls):
+        def check(value):
+            if isinstance(value, list):
+                self.assertLessEqual(len(value), 100)
+                for item in value:
+                    check(item)
+            elif isinstance(value, dict):
+                if "text" in value:
+                    text = value["text"]["content"]
+                    self.assertLessEqual(len(text), 2000)
+                    self.assertLessEqual(len(text.encode("utf-16-le")) // 2, 2000)
+                for item in value.values():
+                    check(item)
+
+        for method, url, wire, payload in calls:
+            self.assertLessEqual(len(wire), 500000)
+            self.assertEqual(json.loads(wire), payload)
+            check(payload)
+
+    def saved_paragraphs(self, calls):
+        return ["".join(item["text"]["content"] for item in block["paragraph"]["rich_text"])
+                for _, _, _, payload in calls for block in payload.get("children", [])]
+
+    def test_small_inputs_keep_paragraphs_spacing_and_response(self):
+        for create in (False, True):
+            with self.subTest(create=create):
+                result, calls = self.write(" first \n\n \t \nsecond", create=create)
+                self.assertIsNone(result.error)
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(self.saved_paragraphs(calls), [" first ", "second"])
+                self.assert_valid_requests(calls)
+                self.assertIn("**Page Created!**" if create else "Added 2 paragraph(s)", result.result)
+
+    def test_text_item_boundaries_keep_one_paragraph(self):
+        for create in (False, True):
+            for length in (1999, 2000, 2001):
+                with self.subTest(create=create, length=length):
+                    content = "x" * length
+                    result, calls = self.write(content, create=create)
+                    self.assertIsNone(result.error)
+                    self.assert_valid_requests(calls)
+                    self.assertEqual(self.saved_paragraphs(calls), [content])
+
+    def test_unicode_chunk_boundaries_preserve_whole_characters(self):
+        for create in (False, True):
+            for content in ("a" * 1999 + "😀" + "tail", "😀" * 2000):
+                with self.subTest(create=create, length=len(content)):
+                    result, calls = self.write(content, create=create)
+                    self.assertIsNone(result.error)
+                    self.assert_valid_requests(calls)
+                    self.assertEqual(self.saved_paragraphs(calls), [content])
+
+    def test_child_boundaries_and_batches_are_ordered(self):
+        for create in (False, True):
+            for count in (99, 100, 101, 201):
+                with self.subTest(create=create, count=count):
+                    paragraphs = [f"Paragraph {index}" for index in range(count)]
+                    result, calls = self.write("\n".join(paragraphs), create=create)
+                    self.assertIsNone(result.error)
+                    self.assertEqual(len(calls), (count + 99) // 100)
+                    self.assertEqual(self.saved_paragraphs(calls), paragraphs)
+                    self.assert_valid_requests(calls)
+                    expected_page = "created-page" if create else "existing-page"
+                    for method, url, _, _ in calls[1:] if create else calls:
+                        self.assertEqual(method, "PATCH")
+                        self.assertTrue(url.endswith(f"/blocks/{expected_page}/children"))
+
+    def test_oversized_single_paragraph_preserves_all_characters(self):
+        # Exceed both 100 rich-text elements and one serialized request budget.
+        for create in (False, True):
+            for character in ("a", "😀"):
+                with self.subTest(create=create, character=character):
+                    content = character * 200001
+                    result, calls = self.write(content, create=create)
+                    self.assertIsNone(result.error)
+                    self.assert_valid_requests(calls)
+                    self.assertEqual("".join(self.saved_paragraphs(calls)), content)
+                    self.assertGreater(len(self.saved_paragraphs(calls)), 1)
+
+    def test_serialized_byte_budget_includes_escaping_and_create_metadata(self):
+        for create in (False, True):
+            for character in ("界", "😀", '"', "\\"):
+                with self.subTest(create=create, character=character):
+                    paragraphs = [character * 2000 + str(index) for index in range(100)]
+                    # A substantial title exercises the full first-request budget.
+                    metadata = {"title": "😀" * 2000, "database_id": "test-database"} if create else {}
+                    result, calls = self.write("\n".join(paragraphs), create=create, **metadata)
+                    self.assertIsNone(result.error)
+                    self.assert_valid_requests(calls)
+                    self.assertEqual(self.saved_paragraphs(calls), paragraphs)
+                    if character in ("界", "😀"):
+                        self.assertGreater(len(calls), 1)
+
+    def test_create_metadata_can_require_an_empty_first_batch(self):
+        content = "😀" * 40000
+        result, calls = self.write(content, create=True, title="😀" * 2000)
+        self.assertIsNone(result.error)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][3]["children"], [])
+        self.assertEqual(self.saved_paragraphs(calls), [content])
+        self.assert_valid_requests(calls)
+
+    def test_empty_content_and_whitespace_only_input_keep_existing_behavior(self):
+        for content in (None, "", " \n\t"):
+            result, calls = self.write(content, create=True)
+            self.assertIsNone(result.error)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual("children" in calls[0][3], bool(content))
+            self.assertEqual(self.saved_paragraphs(calls), [])
+        result, calls = self.write(" \n\t")
+        self.assertIsNone(result.error)
+        self.assertEqual(calls[0][3], {"children": []})
+        self.assertIn("Added 0 paragraph(s)", result.result)
+
+    def test_later_batch_failure_reports_confirmed_progress_and_stops(self):
+        failures = [Mock(status_code=429, text="private upstream response"), RuntimeError("private transport detail")]
+        for payload in (None, {}, {"error": ""}):
+            response = Mock(status_code=200)
+            response.json.return_value = payload
+            failures.append(response)
+        for create in (False, True):
+            for failure in failures:
+                with self.subTest(create=create, failure=type(failure).__name__):
+                    result, calls = self.write("\n".join(f"p{index}" for index in range(301)), create=create, fail_at=3, failure=failure)
+                    self.assertEqual(len(calls), 3)
+                    self.assertIsNone(result.result)
+                    self.assertIn("200 of 301", result.error)
+                    self.assertIn("created-page" if create else "existing-page", result.error)
+                    self.assertIn("not confirmed", result.error)
+                    self.assertIn("duplicate", result.error)
+                    self.assertNotIn("private", result.error)
+                    self.assert_valid_requests(calls)
+
+    def test_failed_create_is_not_replayed(self):
+        for failure in (Mock(status_code=400, text="private upstream response"), RuntimeError("private transport detail")):
+            with self.subTest(failure=type(failure).__name__):
+                result, calls = self.write("\n".join("x" for _ in range(101)), create=True, fail_at=1, failure=failure)
+                self.assertEqual(len(calls), 1)
+                self.assertIsNone(result.result)
+                self.assertIn("not confirmed", result.error)
+                self.assertIn("before retrying", result.error)
+                self.assertNotIn("private", result.error)
+
+    def test_unusable_create_result_does_not_append_or_claim_success(self):
+        for payload in (None, {}, {"error": ""}, {"url": "https://www.notion.so/unknown"}, {"id": ""}):
+            with self.subTest(payload=payload):
+                response = Mock(status_code=200)
+                response.json.return_value = payload
+                result, calls = self.write("\n".join("x" for _ in range(101)), create=True, fail_at=1, failure=response)
+                self.assertEqual(len(calls), 1)
+                self.assertIsNone(result.result)
+                self.assertIn("not confirmed", result.error)
+
+    def test_title_limits_are_validated_before_writing(self):
+        result, calls = self.write("content", create=True, title="a" * 2001)
+        self.assertIsNone(result.error)
+        self.assert_valid_requests(calls)
+        self.assertEqual("".join(item["text"]["content"] for item in calls[0][3]["properties"]["title"]["title"]), "a" * 2001)
+        for title in ("a" * 200001, "😀" * 100000):
+            result, calls = self.write("content", create=True, title=title)
+            self.assertEqual(calls, [])
+            self.assertIsNone(result.result)
+            self.assertTrue(result.error)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #13145. Thanks to @kaijakagi-sys for the report, reproduction, and proposed scope.

Create and append now share request planning for [Notion's documented limits](https://developers.notion.com/reference/request-limits). A 2001-character line becomes multiple rich-text items; 101 paragraphs become ordered requests. The planner bounds text to 2000 UTF-16 units conservatively, arrays to 100 items, and the exact outgoing JSON to 500000 bytes, including create metadata. Oversized properties fail before any write. Long lines retain their text in continuation paragraph blocks when necessary.

A failed batch stops further writes and reports the page ID and confirmed progress. It does not replay requests: an unconfirmed write may already have committed. Successful appends must return a valid block-list response; partial block objects and paginated result lists remain supported, as specified by the [SDK for API version 2022-06-28](https://github.com/makenotion/notion-sdk-js/blob/v2.2.15/src/api-endpoints.ts#L10778-L10784). Counts track acknowledged request batches, without assuming response cardinality matches the submitted children. A separate adjacent commit removes raw upstream response bodies and exception messages from the touched HTTP helper's logs.

## Validation

- `python3 plugins/omi-notion-app/test_main.py`: 19 tests pass. The malformed-response regression fails 45 subcases on the preceding PR head `efb144c`.
- Tests execute the production handlers and HTTP helper with fake HTTP/framework/storage boundaries. They inspect transmitted bytes, text reconstruction, Unicode and array boundaries, create metadata, ordered batches, malformed responses, partial failures, and logs. The existing manifest runs this suite locally and in CI.
- `make preflight`: 14 selected checks passed before and after committing, including final commit identity and failure-class validation. Draft-body preflight also passed.
- Independent code review cleared. Full history was fetched and the complete 90-day failure-class guard ratchet passed without skipping. No live Notion workspace or credentials were used.
- Upstream Actions currently report `action_required` with no jobs started; upstream CI is not yet verified.

## Product invariants affected

none (`scripts/pr-preflight --suggest` found no matching locked paths).

## Failure class

Failure-Class: none

No registered class matches the omitted outbound payload budget. The recent read-error class and `FC-bounded-read-exceeds-request-budget` concern different contracts. Both write handlers use the same production planner and behavioral tests; no new checker or registry transition is introduced.

Developed and reviewed with AI assistance.
