### PR TITLE
perf(backend): stop three GPT-5.6 features paying for unreadable cache writes

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -30,6 +30,7 @@ from utils.llm.desktop_llm_stub import (
     stub_chat_completions_json,
     stub_chat_completions_stream,
 )
+from utils.llm.prompt_cache import apply_cache_write_opt_out
 from utils.llm.gateway_client import (
     CHAT_AGENT_AUTO_LANE_ID,
     CHAT_STRUCTURED_AUTO_LANE_ID,
@@ -740,6 +741,10 @@ def _gateway_body(body: Mapping[str, object], lane_id: str = CHAT_AGENT_AUTO_LAN
         result.pop('tool_choice', None)
         result.pop('reasoning_effort', None)
         result['reasoning_effort'] = _thinking_escalation_effort(body)
+    if lane_id == CHAT_STRUCTURED_AUTO_LANE_ID:
+        # Single-shot planner/local-agent prompts, unique from the first token: the
+        # ledger billed 2.6M of 3.0M prompt tok/day as cache writes against 0.01M reads.
+        apply_cache_write_opt_out(result)
     return result
 
 

--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -744,7 +744,9 @@ def _gateway_body(body: Mapping[str, object], lane_id: str = CHAT_AGENT_AUTO_LAN
     if lane_id == CHAT_STRUCTURED_AUTO_LANE_ID:
         # Single-shot planner/local-agent prompts, unique from the first token: the
         # ledger billed 2.6M of 3.0M prompt tok/day as cache writes against 0.01M reads.
-        apply_cache_write_opt_out(result)
+        # Scan the CLIENT's messages for a breakpoint, not the translated copy:
+        # _gateway_user_content rebuilds user blocks as {type, text} and drops it.
+        apply_cache_write_opt_out(result, marked_messages=messages)
     return result
 
 

--- a/backend/tests/unit/test_conversation_features_prompt_cache.py
+++ b/backend/tests/unit/test_conversation_features_prompt_cache.py
@@ -309,31 +309,59 @@ def test_chat_agent_lane_is_untouched(gateway_on):
 
 
 def test_a_client_that_marked_its_own_prefix_keeps_its_own_options(gateway_on):
-    """The opt-out is a default, not an override: a client that did the work keeps it.
+    """The opt-out is a default, not an override.
 
-    The breakpoint has to ride a non-user message: ``_gateway_user_content``
-    rebuilds user blocks as ``{type, text}`` and drops every other key, so a
-    user-role breakpoint never reaches the gateway in the first place.
+    The client's options use a ttl the default never produces, so this
+    distinguishes "preserved theirs" from "we wrote ours on top".
     """
+    client_options = {'mode': 'explicit', 'ttl': '5m'}
     marked = {
         'model': 'omi-structured',
-        'prompt_cache_options': {'mode': 'explicit', 'ttl': '30m'},
-        'messages': [
-            {
-                'role': 'system',
-                'content': [
-                    {'type': 'text', 'text': 'stable', 'prompt_cache_breakpoint': {'mode': 'explicit'}},
-                ],
-            },
-            {'role': 'user', 'content': 'plan this'},
-        ],
+        'prompt_cache_options': client_options,
+        'messages': [{'role': 'user', 'content': 'plan this'}],
     }
     result = desktop_chat._gateway_body(marked, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
-    assert result['prompt_cache_options'] == {'mode': 'explicit', 'ttl': '30m'}
+    assert result['prompt_cache_options'] == client_options
 
-    without_options = {key: value for key, value in marked.items() if key != 'prompt_cache_options'}
-    result = desktop_chat._gateway_body(without_options, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
-    assert 'prompt_cache_options' not in result, 'a client breakpoint must not be paired with our opt-out'
+
+def test_a_client_breakpoint_on_a_user_message_still_suppresses_the_opt_out(gateway_on):
+    """_gateway_user_content drops the breakpoint, so the guard must read the ORIGINAL messages.
+
+    Reading the translated copy would strip the client's marking and then write
+    our opt-out on top of it — that client could never cache at all.
+    """
+    body = {
+        'model': 'omi-structured',
+        'messages': [
+            {
+                'role': 'user',
+                'content': [
+                    {'type': 'text', 'text': 'stable', 'prompt_cache_breakpoint': {'mode': 'explicit'}},
+                    {'type': 'text', 'text': 'volatile'},
+                ],
+            }
+        ],
+    }
+    result = desktop_chat._gateway_body(body, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
+    assert 'prompt_cache_options' not in result
+
+
+def test_a_client_routing_key_alone_is_never_turned_into_a_non_cache_request(gateway_on):
+    """A bare prompt_cache_key is how a pre-5.6 caller asks for implicit caching.
+
+    Adding explicit-mode options with no breakpoint on top would flip
+    cache_requested_for_openai_request from True to False for that caller.
+    """
+    from llm_gateway.gateway.accounting import cache_requested_for_openai_request
+
+    body = {
+        'model': 'omi-structured',
+        'prompt_cache_key': 'client-key-1',
+        'messages': [{'role': 'user', 'content': 'plan this'}],
+    }
+    result = desktop_chat._gateway_body(body, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
+    assert 'prompt_cache_options' not in result
+    assert cache_requested_for_openai_request(result) is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_conversation_features_prompt_cache.py
+++ b/backend/tests/unit/test_conversation_features_prompt_cache.py
@@ -140,18 +140,25 @@ def test_app_result_cache_key_is_content_derived_stable_and_versioned():
 
 
 @pytest.mark.parametrize(
-    'kwargs',
+    ('kwargs', 'expected_options'),
     [
-        {'memory_prompt': SHORT_TASK},  # prefix under the provider floor
-        {'byok': True},  # a BYOK key can route this feature off GPT-5.6
-        {'explicit': False},  # kill switch
+        # Prefix under the provider floor: no breakpoint is bought, but the request
+        # still carries the explicit-mode opt-out so the provider cannot bill an
+        # unreadable automatic cache write.
+        ({'memory_prompt': SHORT_TASK}, EXPLICIT_CACHE_OPTIONS),
+        # A BYOK key can route this feature off GPT-5.6, where a typed cache field
+        # is not a valid content part: no cache field at all.
+        ({'byok': True}, None),
+        # Kill switch: the field disappears with the feature.
+        ({'explicit': False}, None),
     ],
 )
-def test_app_result_falls_back_to_the_unmarked_request(kwargs):
-    """Every guard must land on a plain request, never on an unreadable cache write."""
+def test_app_result_falls_back_to_the_unmarked_request(kwargs, expected_options):
+    """Every guard must land on an unmarked request, never on an unreadable cache write."""
     captured = _run_app_result(**kwargs)
     assert isinstance(captured['payload'], str)
     assert captured['llm_kwargs']['cache_key'] is None
+    assert captured['llm_kwargs']['prompt_cache_options'] == expected_options
 
 
 def test_app_result_keeps_the_legacy_routing_key_off_gateway_mode():

--- a/backend/tests/unit/test_conversation_features_prompt_cache.py
+++ b/backend/tests/unit/test_conversation_features_prompt_cache.py
@@ -1,0 +1,386 @@
+"""Three GPT-5.6 features were paying the cache-write premium for writes nobody reads.
+
+The provider serves a cache READ only from a prefix that ends on a message
+boundary or an explicit ``prompt_cache_breakpoint`` (utils/llm/prompt_cache),
+but it still WRITES a long prompt automatically when the request carries no
+``prompt_cache_options`` at all — and bills those tokens at the write rate
+rather than plain input. The 2026-09-06 gateway ledger shows exactly that
+shape:
+
+  conversation_processing  15.70M prompt   0.00M read   9.93M written
+  chat_structured           3.02M prompt   0.01M read   2.63M written
+  conv_apps                63.09M prompt   0.86M read   0.08M written
+
+The first two are pure premium: unique prompts, so the write can never be read.
+They now send explicit mode with **no** breakpoint, the documented opt-out.
+``conv_apps``' legacy app-result prompt does have a genuinely repeating head —
+the app framing, identical for every conversation the same app summarizes — so
+it gets a real breakpoint once it clears the provider's floor, and keeps the
+opt-out shape below it.
+
+These tests pin the request shape and the prompt bytes, not the wording.
+"""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+import pytest
+
+from routers import desktop_chat
+from utils.llm import chat as chat_module
+from utils.llm import conversation_processing as conv_proc
+from utils.llm.prompt_cache import (
+    EXPLICIT_CACHE_BREAKPOINT,
+    EXPLICIT_CACHE_MINIMUM_CHARACTERS,
+    EXPLICIT_CACHE_OPTIONS,
+    GPT56_EXPLICIT_CACHE_ENABLED_ENV,
+    explicit_cache_switch_enabled,
+    gpt56_explicit_cache_enabled,
+)
+
+
+class _Extracted(BaseModel):
+    people: list[str] = []
+
+
+LONG_TASK = 'summarize the meeting and list every decision. ' * 120  # well past the floor
+SHORT_TASK = 'summarize it'
+
+
+@pytest.fixture
+def gateway_on(monkeypatch):
+    """The explicit contract is gateway-lane-only; pin the route for lane tests."""
+    monkeypatch.delenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    monkeypatch.setattr('utils.llm.gateway_client.should_route_features_through_gateway', lambda: True)
+
+
+def _app(memory_prompt):
+    return SimpleNamespace(id='app-123', name='Meeting Notes', description='notes', memory_prompt=memory_prompt)
+
+
+def _run_app_result(memory_prompt=LONG_TASK, *, byok=False, gateway=True, explicit=True, language_code='en'):
+    """Call get_app_result with the LLM mocked; return (get_llm kwargs, invoke arg)."""
+    captured = {}
+
+    llm = MagicMock()
+    llm.invoke.side_effect = lambda payload: captured.__setitem__('payload', payload) or SimpleNamespace(
+        content='summary'
+    )
+
+    def _get_llm(feature, **kwargs):
+        captured['feature'] = feature
+        captured['llm_kwargs'] = kwargs
+        return llm
+
+    with (
+        patch.object(conv_proc, 'get_llm', side_effect=_get_llm),
+        patch.object(conv_proc, 'should_route_features_through_gateway', lambda: gateway),
+        patch.object(conv_proc, '_gpt56_explicit_cache_enabled', lambda: explicit),
+        patch.object(conv_proc, 'has_byok_keys', lambda: byok),
+    ):
+        conv_proc.get_app_result('a real transcript', [], _app(memory_prompt), language_code=language_code)
+    return captured
+
+
+def _expected_prompt(memory_prompt, language_code='en'):
+    """The single string this prompt was before the split, rebuilt independently."""
+    app = _app(memory_prompt)
+    full_context = 'Transcript: ```a real transcript```'
+    return f'''
+    You are an AI with the following characteristics:
+    Name: {app.name},
+    Description: {app.description},
+    Task: ${app.memory_prompt}
+
+    Language: The conversation language is {language_code}. Use the same language {language_code} for your response.
+
+    Conversation:
+    {full_context}
+    '''
+
+
+# ---------------------------------------------------------------------------
+# conv_apps — the model reads exactly what it read before
+# ---------------------------------------------------------------------------
+
+
+def test_app_result_wire_text_is_byte_identical_to_the_single_string_prompt():
+    parts = _run_app_result()['payload'][0]['content']
+    assert isinstance(parts, list), 'a bare string has no boundary to place the break on'
+    assert ''.join(part['text'] for part in parts) == _expected_prompt(LONG_TASK)
+
+
+def test_app_result_uncached_path_still_sends_the_identical_single_string():
+    captured = _run_app_result(memory_prompt=SHORT_TASK)
+    assert captured['payload'] == _expected_prompt(SHORT_TASK)
+
+
+def test_app_result_breakpoint_is_on_the_stable_half_only():
+    parts = _run_app_result()['payload'][0]['content']
+    stable, volatile = parts[0], parts[1]
+    assert stable['prompt_cache_breakpoint'] == EXPLICIT_CACHE_BREAKPOINT
+    assert 'prompt_cache_breakpoint' not in volatile, 'a break after volatile text can never be read'
+    assert 'a real transcript' in volatile['text']
+    assert 'a real transcript' not in stable['text']
+    assert LONG_TASK.strip() in stable['text']
+
+
+def test_app_result_cache_key_is_content_derived_stable_and_versioned():
+    key = _run_app_result()['llm_kwargs']['cache_key']
+    assert key.startswith(conv_proc.APP_RESULT_CACHE_NAMESPACE)
+    assert key == _run_app_result()['llm_kwargs']['cache_key']
+    # Different framing bytes must not route onto the same prefix.
+    assert key != _run_app_result(language_code='fr')['llm_kwargs']['cache_key']
+    assert 'Meeting Notes' not in key and 'app-123' not in key
+    assert _run_app_result()['llm_kwargs']['prompt_cache_options'] == conv_proc.GPT56_EXPLICIT_CACHE_OPTIONS
+    assert _run_app_result()['feature'] == 'conv_app_result'
+
+
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {'memory_prompt': SHORT_TASK},  # prefix under the provider floor
+        {'byok': True},  # a BYOK key can route this feature off GPT-5.6
+        {'explicit': False},  # kill switch
+    ],
+)
+def test_app_result_falls_back_to_the_unmarked_request(kwargs):
+    """Every guard must land on a plain request, never on an unreadable cache write."""
+    captured = _run_app_result(**kwargs)
+    assert isinstance(captured['payload'], str)
+    assert captured['llm_kwargs']['cache_key'] is None
+
+
+def test_app_result_keeps_the_legacy_routing_key_off_gateway_mode():
+    captured = _run_app_result(memory_prompt=SHORT_TASK, gateway=False, explicit=False)
+    assert captured['llm_kwargs']['cache_key'] == 'omi-app-result'
+    assert captured['llm_kwargs']['prompt_cache_options'] is None
+
+
+def test_app_framing_floor_is_the_shared_provider_floor():
+    below = _run_app_result(memory_prompt='x' * 10)
+    assert isinstance(below['payload'], str)
+    above = _run_app_result(memory_prompt='x' * (EXPLICIT_CACHE_MINIMUM_CHARACTERS + 1))
+    assert isinstance(above['payload'], list)
+
+
+# ---------------------------------------------------------------------------
+# conversation_processing — opt out of an unreadable automatic write
+# ---------------------------------------------------------------------------
+
+
+class _FakeStructured:
+    """The parser-wrapped runnable. Remembers only the kwargs bound to IT."""
+
+    def __init__(self, captured, kwargs):
+        self._captured = captured
+        self.kwargs = dict(kwargs)
+
+    def bind(self, **kwargs):
+        return _FakeStructured(self._captured, {**self.kwargs, **kwargs})
+
+    def invoke(self, prompt):
+        self._captured['invoked_kwargs'] = self.kwargs
+        return SimpleNamespace(people=[], topics=[], entities=[], dates=[])
+
+
+class _FakeModel:
+    def __init__(self, captured):
+        self._captured = captured
+
+    def with_structured_output(self, schema):
+        return _FakeStructured(self._captured, {})
+
+    def bind(self, **kwargs):
+        return _FakeBinding(self, kwargs)
+
+
+class _FakeBinding:
+    """Mirrors langchain's RunnableBinding, trap included.
+
+    ``RunnableBinding`` defines no ``with_structured_output`` of its own, so the
+    attribute lookup forwards to the unbound model and every bound kwarg is
+    silently dropped. Reproducing that here is the point: a MagicMock answers
+    ``with_structured_output`` itself and hides the whole failure — an earlier
+    draft of this change bound first, shipped a request with no cache options at
+    all, and every mock-based assertion still passed.
+    """
+
+    def __init__(self, bound, kwargs):
+        self.bound = bound
+        self.kwargs = dict(kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self.bound, name)
+
+
+def _run_metadata_extraction(monkeypatch, *, gateway=True, byok=False):
+    """Drive the real conversation_processing extraction path with the LLM faked."""
+    captured = {}
+
+    def _get_llm(feature, **kwargs):
+        captured['feature'] = feature
+        captured['get_llm_kwargs'] = kwargs
+        model = _FakeModel(captured)
+        return model.bind(**kwargs) if kwargs else model
+
+    monkeypatch.delenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    monkeypatch.setattr('utils.llm.gateway_client.should_route_features_through_gateway', lambda: gateway)
+    monkeypatch.setattr('utils.byok.has_byok_keys', lambda: byok)
+    monkeypatch.setattr(chat_module, 'get_llm', _get_llm)
+    monkeypatch.setattr(chat_module, 'track_usage', lambda *a, **k: nullcontext())
+    monkeypatch.setattr(chat_module, 'add_filter_category_item', lambda *a, **k: None)
+    chat_module._process_extracted_metadata('uid-1', 'one unique prompt', '2026-09-09')
+    return captured
+
+
+def test_metadata_extraction_sends_explicit_mode_with_no_breakpoint(monkeypatch):
+    captured = _run_metadata_extraction(monkeypatch)
+    assert captured['feature'] == 'chat_extraction'
+    # Asserted on what the INVOKED runnable carried, not on what get_llm was handed:
+    # binding before with_structured_output would drop it and this is the only
+    # assertion that notices.
+    assert captured['invoked_kwargs'] == {'extra_body': {'prompt_cache_options': EXPLICIT_CACHE_OPTIONS}}
+    # No routing key: a key without a breakpoint opts this unique prompt back into
+    # the provider's implicit, billable cache.
+    assert captured['get_llm_kwargs'] == {}
+
+
+@pytest.fixture(scope='module')
+def real_langchain_runnables():
+    """Real langchain objects, built once: constructing them is the expensive part."""
+    from langchain_openai import ChatOpenAI
+
+    model = ChatOpenAI(model='gpt-5.6-luna', api_key='sk-not-used')
+    return (
+        model,
+        model.bind(extra_body={'prompt_cache_options': dict(EXPLICIT_CACHE_OPTIONS)}),
+        (model.with_structured_output(_Extracted)),
+    )
+
+
+def test_langchain_really_drops_kwargs_bound_before_with_structured_output(real_langchain_runnables):
+    """The reason with_cache_write_opt_out binds last, pinned against real langchain."""
+    from utils.llm.prompt_cache import with_cache_write_opt_out
+
+    _model, bound_first, structured = real_langchain_runnables
+    # RunnableBinding has no with_structured_output of its own; the lookup forwards
+    # to the unbound model and the bound kwargs are silently dropped.
+    assert 'with_structured_output' not in type(bound_first).__dict__
+    with patch('utils.llm.gateway_client.should_route_features_through_gateway', lambda: True):
+        with patch('utils.byok.has_byok_keys', lambda: False):
+            bound_last = with_cache_write_opt_out(structured)
+    assert bound_last.kwargs['extra_body'] == {'prompt_cache_options': dict(EXPLICIT_CACHE_OPTIONS)}
+
+
+@pytest.mark.parametrize('kwargs', [{'gateway': False}, {'byok': True}])
+def test_metadata_extraction_sends_nothing_when_a_guard_declines(monkeypatch, kwargs):
+    assert _run_metadata_extraction(monkeypatch, **kwargs)['invoked_kwargs'] == {}
+
+
+def test_metadata_extraction_honours_the_kill_switch(monkeypatch):
+    monkeypatch.setenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, 'false')
+    monkeypatch.setattr('utils.llm.gateway_client.should_route_features_through_gateway', lambda: True)
+    from utils.llm.prompt_cache import cache_write_opt_out_options
+
+    assert cache_write_opt_out_options() is None
+
+
+# ---------------------------------------------------------------------------
+# chat_structured — same opt-out, applied at the forwarding seam
+# ---------------------------------------------------------------------------
+
+
+def test_structured_lane_body_opts_out_of_automatic_cache_writes(gateway_on):
+    body = {'model': 'omi-structured', 'messages': [{'role': 'user', 'content': 'plan this'}]}
+    result = desktop_chat._gateway_body(body, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
+    assert result['prompt_cache_options'] == EXPLICIT_CACHE_OPTIONS
+    assert result['messages'][0]['role'] == 'user'
+    assert 'prompt_cache_breakpoint' not in str(result['messages'])
+
+
+def test_chat_agent_lane_is_untouched(gateway_on):
+    body = {'model': 'omi-luna', 'messages': [{'role': 'user', 'content': 'hi'}]}
+    result = desktop_chat._gateway_body(body, desktop_chat.CHAT_AGENT_AUTO_LANE_ID)
+    assert 'prompt_cache_options' not in result
+
+
+def test_a_client_that_marked_its_own_prefix_keeps_its_own_options(gateway_on):
+    """The opt-out is a default, not an override: a client that did the work keeps it.
+
+    The breakpoint has to ride a non-user message: ``_gateway_user_content``
+    rebuilds user blocks as ``{type, text}`` and drops every other key, so a
+    user-role breakpoint never reaches the gateway in the first place.
+    """
+    marked = {
+        'model': 'omi-structured',
+        'prompt_cache_options': {'mode': 'explicit', 'ttl': '30m'},
+        'messages': [
+            {
+                'role': 'system',
+                'content': [
+                    {'type': 'text', 'text': 'stable', 'prompt_cache_breakpoint': {'mode': 'explicit'}},
+                ],
+            },
+            {'role': 'user', 'content': 'plan this'},
+        ],
+    }
+    result = desktop_chat._gateway_body(marked, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
+    assert result['prompt_cache_options'] == {'mode': 'explicit', 'ttl': '30m'}
+
+    without_options = {key: value for key, value in marked.items() if key != 'prompt_cache_options'}
+    result = desktop_chat._gateway_body(without_options, desktop_chat.CHAT_STRUCTURED_AUTO_LANE_ID)
+    assert 'prompt_cache_options' not in result, 'a client breakpoint must not be paired with our opt-out'
+
+
+# ---------------------------------------------------------------------------
+# The switch itself
+# ---------------------------------------------------------------------------
+
+
+def test_kill_switch_semantics(monkeypatch):
+    monkeypatch.delenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    assert explicit_cache_switch_enabled()
+    for off in ('false', '0', 'off', 'no'):
+        monkeypatch.setenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, off)
+        assert not explicit_cache_switch_enabled()
+    monkeypatch.setenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, 'true')
+    assert explicit_cache_switch_enabled()
+
+
+def test_explicit_cache_requires_the_gateway_route(monkeypatch):
+    monkeypatch.delenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    with patch('utils.llm.gateway_client.should_route_features_through_gateway', lambda: False):
+        assert not gpt56_explicit_cache_enabled()
+    with patch('utils.llm.gateway_client.should_route_features_through_gateway', lambda: True):
+        assert gpt56_explicit_cache_enabled()
+
+
+def test_the_gateway_prices_each_new_shape_the_way_we_expect():
+    """The ledger's cache accounting keys off exactly these shapes."""
+    from llm_gateway.gateway.accounting import cache_requested_for_openai_request
+
+    parts = _run_app_result()['payload'][0]['content']
+    assert (
+        cache_requested_for_openai_request(
+            {
+                'prompt_cache_key': _run_app_result()['llm_kwargs']['cache_key'],
+                'prompt_cache_options': dict(EXPLICIT_CACHE_OPTIONS),
+                'messages': [{'role': 'user', 'content': parts}],
+            }
+        )
+        is True
+    )
+    # The opt-out shape must NOT read as a cache request: no key, no breakpoint.
+    assert (
+        cache_requested_for_openai_request(
+            {
+                'prompt_cache_options': dict(EXPLICIT_CACHE_OPTIONS),
+                'messages': [{'role': 'user', 'content': 'one unique prompt'}],
+            }
+        )
+        is False
+    )

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -27,6 +27,7 @@ from utils.llm.usage_tracker import track_usage, Features
 from utils.llm.temporal import MAX_EXTRACTED_DATE_LOOKAHEAD_DAYS, date_in_tz, normalize_extracted_dates
 
 from .clients import get_llm
+from utils.llm.prompt_cache import with_cache_write_opt_out
 import logging
 
 logger = logging.getLogger(__name__)
@@ -241,7 +242,6 @@ def retrieve_context_dates_by_question(question: str, tz: str) -> List[datetime]
     '''.replace('    ', '').strip()
 
     # print(prompt)
-    # print(get_llm('chat_extraction').invoke(prompt).content)
     with_parser = get_llm('chat_extraction').with_structured_output(DatesContext)
     response = cast(DatesContext, with_parser.invoke(prompt))
     return response.dates_range
@@ -1249,10 +1249,8 @@ def retrieve_metadata_fields_from_transcript(
     '''.replace('    ', '')
     try:
         with track_usage(uid, Features.CONVERSATION_PROCESSING):
-            result = cast(
-                ExtractedInformation,
-                get_llm('chat_extraction').with_structured_output(ExtractedInformation).invoke(prompt),
-            )
+            structured = get_llm('chat_extraction').with_structured_output(ExtractedInformation)
+            result = cast(ExtractedInformation, with_cache_write_opt_out(structured).invoke(prompt))
     except Exception as e:
         logger.error(f'e {e}')
         return {'people': [], 'topics': [], 'entities': [], 'dates': []}
@@ -1367,10 +1365,8 @@ def _process_extracted_metadata(uid: str, prompt: str, reference_date: str) -> d
     """Process the extracted metadata from any source"""
     try:
         with track_usage(uid, Features.CONVERSATION_PROCESSING):
-            result = cast(
-                ExtractedInformation,
-                get_llm('chat_extraction').with_structured_output(ExtractedInformation).invoke(prompt),
-            )
+            structured = get_llm('chat_extraction').with_structured_output(ExtractedInformation)
+            result = cast(ExtractedInformation, with_cache_write_opt_out(structured).invoke(prompt))
     except Exception as e:
         logger.error(f'Error extracting metadata: {e}')
         return {'people': [], 'topics': [], 'entities': [], 'dates': []}

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -35,7 +35,10 @@ from utils.llm.model_config import FOREGROUND_REQUEST_TIMEOUT_SECONDS
 from utils.llm.prompt_cache import (
     EXPLICIT_CACHE_MINIMUM_TOKENS,
     EXPLICIT_CACHE_OPTIONS,
+    GPT56_EXPLICIT_CACHE_ENABLED_ENV,
+    explicit_cache_switch_enabled,
     has_cacheable_prefix,
+    marked_prefix_request,
 )
 from utils.llm.conversation_prompt_prefix import ConversationPromptPrefix, shared_conversation_cache_supported
 
@@ -54,10 +57,10 @@ CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ST
 CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE = 'conversation_action_items.extract.shadow'
 CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED'
 CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE'
-GPT56_EXPLICIT_CACHE_ENABLED_ENV = 'OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED'
 GPT56_EXPLICIT_CACHE_OPTIONS = EXPLICIT_CACHE_OPTIONS
 TRANSCRIPT_STRUCTURE_CACHE_KEY = 'omi-transcript-structure-v1'
 ACTION_ITEMS_CACHE_KEY = 'omi-extract-actions-v1'
+APP_RESULT_CACHE_NAMESPACE = 'omi-app-result-v1'
 GPT56_CACHE_MINIMUM_TOKENS = EXPLICIT_CACHE_MINIMUM_TOKENS
 
 
@@ -167,7 +170,9 @@ def _env_flag_enabled(name: str, *, default: bool = False) -> bool:
 
 
 def _gpt56_explicit_cache_enabled() -> bool:
-    return should_route_features_through_gateway() and _env_flag_enabled(GPT56_EXPLICIT_CACHE_ENABLED_ENV, default=True)
+    # The route half stays local so this module's gateway seam remains patchable;
+    # the kill-switch half is owned once, in prompt_cache, for every caller.
+    return should_route_features_through_gateway() and explicit_cache_switch_enabled()
 
 
 def _env_sample_rate(name: str, *, default: float = 0.0) -> float:
@@ -1589,7 +1594,10 @@ def get_app_result(
 
     full_context = "\n\n".join(context_parts)
 
-    prompt = f'''
+    # Split, not rewritten: the framing is stable for an app+language and repeats on
+    # every conversation that app summarizes. The two halves concatenate to exactly
+    # the string this prompt was (test_app_result_wire_text_is_byte_identical_...).
+    app_framing = f'''
     You are an AI with the following characteristics:
     Name: {app.name},
     Description: {app.description},
@@ -1598,8 +1606,10 @@ def get_app_result(
     Language: The conversation language is {language_code}. Use the same language {language_code} for your response.
 
     Conversation:
-    {full_context}
     '''
+    app_conversation_block = f'''{full_context}
+    '''
+    prompt = f'{app_framing}{app_conversation_block}'
 
     # Both branches run a user-authored prompt over a whole conversation while the user waits, so
     # they need the foreground deadline get_llm gives the conv_app_result feature (see model_config);
@@ -1625,14 +1635,23 @@ Respond in {language_code}.'''
 
     gateway_mode_enabled = should_route_features_through_gateway()
     explicit_cache_enabled = _gpt56_explicit_cache_enabled()
-    # App-specific instructions vary at the start of the prompt. Explicit mode
-    # without a breakpoint keeps this route out of GPT-5.6's billable cache.
-    # The None/legacy split keys on gateway mode (like get_transcript_structure)
-    # so gateway-on requests never fall back to a legacy implicit routing key.
-    cache_key = None if gateway_mode_enabled else 'omi-app-result'
+    # Above the provider's floor the leading framing is a readable prefix: one write,
+    # then a read on every later conversation this app summarizes inside the TTL.
+    # Below it, marked_prefix_request declines and the request keeps its previous
+    # shape — explicit mode, no breakpoint, no routing key — which is how a unique
+    # prompt opts out of billable writes. BYOK is excluded: a BYOK key can route
+    # this feature off GPT-5.6, where a typed cache field is not a valid content part.
+    marked_key, marked_messages = (
+        marked_prefix_request(APP_RESULT_CACHE_NAMESPACE, app_framing, app_conversation_block)
+        if explicit_cache_enabled and not has_byok_keys()
+        else (None, None)
+    )
+    # The None/legacy split keys on gateway mode (like get_transcript_structure) so
+    # gateway-on requests never fall back to a legacy implicit routing key.
+    cache_key = marked_key or (None if gateway_mode_enabled else 'omi-app-result')
     cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if explicit_cache_enabled else None
     app_result_llm = get_llm('conv_app_result', cache_key=cache_key, prompt_cache_options=cache_options)
-    response = app_result_llm.invoke(prompt)
+    response = app_result_llm.invoke(marked_messages or prompt)
     content = strip_speaker_placeholders(_content_str(response).replace('```json', '').replace('```', ''))
     return content
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -35,7 +35,7 @@ from utils.llm.model_config import FOREGROUND_REQUEST_TIMEOUT_SECONDS
 from utils.llm.prompt_cache import (
     EXPLICIT_CACHE_MINIMUM_TOKENS,
     EXPLICIT_CACHE_OPTIONS,
-    GPT56_EXPLICIT_CACHE_ENABLED_ENV,
+    GPT56_EXPLICIT_CACHE_ENABLED_ENV,  # noqa: F401  — compatibility re-export; test_conversation_structure_timezone reads it via this module
     explicit_cache_switch_enabled,
     has_cacheable_prefix,
     marked_prefix_request,
@@ -1649,7 +1649,7 @@ Respond in {language_code}.'''
     # The None/legacy split keys on gateway mode (like get_transcript_structure) so
     # gateway-on requests never fall back to a legacy implicit routing key.
     cache_key = marked_key or (None if gateway_mode_enabled else 'omi-app-result')
-    cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if explicit_cache_enabled else None
+    cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if explicit_cache_enabled and not has_byok_keys() else None
     app_result_llm = get_llm('conv_app_result', cache_key=cache_key, prompt_cache_options=cache_options)
     response = app_result_llm.invoke(marked_messages or prompt)
     content = strip_speaker_placeholders(_content_str(response).replace('```json', '').replace('```', ''))

--- a/backend/utils/llm/prompt_cache.py
+++ b/backend/utils/llm/prompt_cache.py
@@ -161,14 +161,24 @@ def has_explicit_breakpoint(messages: object) -> bool:
     return False
 
 
-def apply_cache_write_opt_out(body: dict[str, Any]) -> None:
+def apply_cache_write_opt_out(body: dict[str, Any], *, marked_messages: object = None) -> None:
     """Default an outbound request body to the opt-out, without overriding a caller.
 
-    A body that already carries its own ``prompt_cache_options``, or whose
-    messages already mark a prefix, has made a deliberate choice; only an
-    unmarked one gets the default.
+    Three ways a caller can have made a deliberate choice, all of which win:
+    its own ``prompt_cache_options``; a ``prompt_cache_key``, which is how a
+    pre-5.6 caller asks for implicit caching (adding explicit-mode options on
+    top would silently turn that request into a non-cache one — see
+    ``accounting.cache_requested_for_openai_request``); or a breakpoint in its
+    messages.
+
+    ``marked_messages`` is the message list to scan for that breakpoint. Pass the
+    caller's ORIGINAL messages when ``body`` holds a translated copy: a
+    translation that normalizes content parts drops the breakpoint, and scanning
+    the copy would then miss a marking the caller really made.
     """
-    if body.get('prompt_cache_options') is not None or has_explicit_breakpoint(body.get('messages')):
+    if body.get('prompt_cache_options') is not None or body.get('prompt_cache_key') is not None:
+        return
+    if has_explicit_breakpoint(marked_messages if marked_messages is not None else body.get('messages')):
         return
     options = cache_write_opt_out_options()
     if options is not None:

--- a/backend/utils/llm/prompt_cache.py
+++ b/backend/utils/llm/prompt_cache.py
@@ -15,6 +15,11 @@ nothing, so callers preflight with :func:`has_cacheable_prefix` first.
 
 from __future__ import annotations
 
+import hashlib
+import os
+from collections.abc import Mapping
+from typing import Any
+
 # Below this, the provider never serves a read, so a breakpoint is pure noise.
 EXPLICIT_CACHE_MINIMUM_TOKENS = 1024
 
@@ -31,6 +36,155 @@ EXPLICIT_CACHE_OPTIONS = {'mode': 'explicit', 'ttl': '30m'}
 EXPLICIT_CACHE_BREAKPOINT = {'mode': 'explicit'}
 
 
+# One kill switch for every explicit-cache caller. Unset means enabled.
+GPT56_EXPLICIT_CACHE_ENABLED_ENV = 'OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED'
+
+
 def has_cacheable_prefix(content: str) -> bool:
     """Conservative preflight: is this block worth marking for a cache write?"""
     return len(content) >= EXPLICIT_CACHE_MINIMUM_CHARACTERS
+
+
+def explicit_cache_switch_enabled() -> bool:
+    """The operator kill switch shared by every explicit-cache caller.
+
+    Callers still add their own route condition (the explicit contract is
+    GPT-5.6-only); this owns just the env semantics so a rollback is one
+    variable everywhere rather than one per feature.
+    """
+    value = os.getenv(GPT56_EXPLICIT_CACHE_ENABLED_ENV)
+    if value is None:
+        return True
+    return value.strip().casefold() in {'1', 'true', 'yes', 'on'}
+
+
+def gpt56_explicit_cache_enabled() -> bool:
+    """May this process put ``prompt_cache_options`` on a request at all?
+
+    True when the gateway lanes (which pin the GPT-5.6 family) are the route and
+    the kill switch is not off. Whether a given prefix earns a breakpoint is a
+    separate, per-caller question.
+
+    Sending :data:`EXPLICIT_CACHE_OPTIONS` with *no* breakpoint is not a no-op:
+    it is how a request whose prompt has no reusable prefix opts out of the
+    provider's automatic caching, which otherwise bills much of the prompt at
+    the cache-write premium for a write nothing can ever read back.
+    """
+    try:
+        from utils.llm.gateway_client import should_route_features_through_gateway
+    except ImportError:  # pragma: no cover - isolated suites import this module alone
+        return False
+    return should_route_features_through_gateway() and explicit_cache_switch_enabled()
+
+
+def cache_write_opt_out_options() -> dict[str, str] | None:
+    """Options for a prompt with no reusable prefix: explicit mode, no breakpoint.
+
+    Not a no-op and not the same as sending nothing. A GPT-5.6 request that
+    carries no ``prompt_cache_options`` gets the provider's automatic caching,
+    which writes a long prompt on every call and bills those tokens at the
+    write premium — and when the prompt's stable head is under
+    ``EXPLICIT_CACHE_MINIMUM_TOKENS`` no later call can ever read that write
+    back. Explicit mode without a breakpoint declares "cache nothing here" and
+    returns the request to the plain input rate. It adds no field to the
+    messages and changes no prompt bytes.
+
+    None under BYOK: a BYOK key can route a feature off GPT-5.6 entirely, where
+    this is not a field the provider accepts.
+    """
+    if not gpt56_explicit_cache_enabled() or _byok_request():
+        return None
+    return dict(EXPLICIT_CACHE_OPTIONS)
+
+
+def _byok_request() -> bool:
+    try:
+        from utils.byok import has_byok_keys
+    except ImportError:  # pragma: no cover - isolated suites import this module alone
+        return False
+    return has_byok_keys()
+
+
+def with_cache_write_opt_out(runnable: Any) -> Any:
+    """Bind the opt-out to an already-structured runnable, which is the only order that works.
+
+    ``BaseChatModel.bind`` returns a ``RunnableBinding``, and ``RunnableBinding``
+    defines no ``with_structured_output`` of its own: the attribute lookup
+    forwards to the unbound model and every bound kwarg is silently dropped.
+    Binding first therefore produces a request with no cache options at all, and
+    nothing raises — measured against langchain_openai, ``_generate`` receives
+    ``{'response_format': ...}`` and no ``extra_body``. Bind last and it arrives.
+    Callers that invoke the model directly, or pipe it into a chain, keep the
+    binding either way and do not need this.
+    """
+    options = cache_write_opt_out_options()
+    if options is None:
+        return runnable
+    return runnable.bind(extra_body={'prompt_cache_options': options})
+
+
+def prefix_cache_key(namespace: str, stable_text: str) -> str:
+    """Routing key derived from the prefix bytes themselves.
+
+    Same bytes -> same key, so two callers that build an identical prefix land
+    on the same cache entry, and an edit to the prefix can never route onto the
+    entry its previous wording wrote. Carries no prompt content.
+    """
+    return f'{namespace}-{hashlib.sha256(stable_text.encode("utf-8")).hexdigest()[:32]}'
+
+
+def content_parts_with_breakpoint(stable_text: str, volatile_text: str) -> list[dict[str, Any]]:
+    """One message's text as two parts, with the readable break between them.
+
+    The concatenation is the caller's original prompt byte-for-byte; only where
+    the cache boundary sits is new. A breakpoint on the volatile part could
+    never be read, so there is deliberately only one.
+    """
+    return [
+        {'type': 'text', 'text': stable_text, 'prompt_cache_breakpoint': EXPLICIT_CACHE_BREAKPOINT},
+        {'type': 'text', 'text': volatile_text},
+    ]
+
+
+def has_explicit_breakpoint(messages: object) -> bool:
+    """Has some caller already marked its own prefix in these messages?"""
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get('content')
+        if not isinstance(content, list):
+            continue
+        if any(isinstance(part, Mapping) and 'prompt_cache_breakpoint' in part for part in content):
+            return True
+    return False
+
+
+def apply_cache_write_opt_out(body: dict[str, Any]) -> None:
+    """Default an outbound request body to the opt-out, without overriding a caller.
+
+    A body that already carries its own ``prompt_cache_options``, or whose
+    messages already mark a prefix, has made a deliberate choice; only an
+    unmarked one gets the default.
+    """
+    if body.get('prompt_cache_options') is not None or has_explicit_breakpoint(body.get('messages')):
+        return
+    options = cache_write_opt_out_options()
+    if options is not None:
+        body['prompt_cache_options'] = options
+
+
+def marked_prefix_request(namespace: str, stable_text: str, volatile_text: str) -> tuple[str | None, list[Any] | None]:
+    """``(cache_key, messages)`` for a two-part prompt, or ``(None, None)``.
+
+    ``(None, None)`` whenever the stable head is under the provider's floor: a
+    breakpoint there buys a write no later call can read, which costs more than
+    not caching at all. The returned messages are one user turn whose parts
+    concatenate to ``stable_text + volatile_text`` — the caller's original
+    prompt, unchanged.
+    """
+    if not has_cacheable_prefix(stable_text):
+        return None, None
+    parts = content_parts_with_breakpoint(stable_text, volatile_text)
+    return prefix_cache_key(namespace, stable_text), [{'role': 'user', 'content': parts}]


### PR DESCRIPTION
## What

Three GPT-5.6 features send request shapes that make the provider write a prompt cache nothing can
ever read, and pay the cache-write premium ($0.25/M vs $0.20/M input) for it. This changes the
**request shape only** — no prompt bytes, no model, no routing, no output.

| feature (ledger name) | before | after |
|---|---|---|
| `conversation_processing` — the two `chat_extraction` calls under `track_usage(CONVERSATION_PROCESSING)` in `utils/llm/chat.py` | no `prompt_cache_options` at all, so GPT-5.6's automatic caching writes the prompt every call | explicit mode, **no** breakpoint, no routing key — the documented opt-out from billable writes, bound **after** `with_structured_output` |
| `chat_structured` — the desktop structured lane, `routers/desktop_chat.py::_gateway_body` | same: client-built single-shot body forwarded with no cache options | the structured lane **defaults** to the same opt-out; a client that supplied its own options, or marked its own prefix, keeps them untouched |
| `conv_apps` — `get_app_result`'s legacy branch, `utils/llm/conversation_processing.py` | one string: app framing then the conversation, explicit mode with no breakpoint | the **same bytes** split into two content parts of the same user message, with the breakpoint on the app framing and a content-derived routing key — but only when that framing clears the shared `has_cacheable_prefix` floor |

The app framing (name / description / `memory_prompt` / language) is byte-identical on every
conversation the same app summarizes, so above the provider's 1,024-token floor it is a genuinely
readable prefix: one write, then a read on every later conversation that runs the app inside the TTL.
Below the floor the provider never serves it back, so nothing is marked and the request keeps exactly
today's shape.

All three shapes are now built by one owner, `utils/llm/prompt_cache.py`, instead of being
re-derived per caller: the kill switch (`explicit_cache_switch_enabled` /
`gpt56_explicit_cache_enabled`), the opt-out options (`cache_write_opt_out_options`,
`apply_cache_write_opt_out`, `with_cache_write_opt_out`), the content-derived routing key
(`prefix_cache_key`) and the two-part message (`content_parts_with_breakpoint`,
`marked_prefix_request`). `conversation_processing` keeps
its own gateway-route half so its existing monkeypatch seam is unchanged.

## Why

2026-09-06 gateway ledger, `provider=openai`, `payer=omi`, all tiers
(rate card `openai.gpt-5.6-luna.2026-07-30`: input $0.20/M, cached $0.02/M, **write $0.25/M**):

```
feature                    prompt      cached     WRITTEN
conversation_processing    15.70M      0.00M       9.93M   (63% of the prompt, zero reads)
chat_structured             3.02M      0.01M       2.63M   (87% of the prompt, zero reads)
conv_apps                  63.09M      0.86M       0.08M
```

`conversation_processing` and `chat_structured` are pure premium: each prompt is unique from its first
tokens (the stable framing above the content is ~400 tokens, under the 1,024-token floor), so the
write can never be read back. **Expected: −$0.50/day and −$0.13/day**, purely from moving 12.56M
tok/day off the write rate onto plain input.

`conv_apps` already opts out of writes (0.08M on 63.09M) — this PR does **not** claim the −$10/day the
work was scoped against. That estimate assumed `conv_apps` could read a transcript prefix cached by
`conv_structure` / `conv_action_items`; those two cache their *static instruction* blocks
(`omi-extract-actions-v1` returns 71.40M reads against 0.68M writes), never the transcript. The
app-framing prefix is the real repeat in this prompt, and its value is bounded and **not
unconditionally positive**, so state the bet plainly:

- **Who qualifies.** The framing scaffold with an empty `memory_prompt` is 231 chars, so an app needs
  ~3,865 chars of `description` + `memory_prompt` to clear the 4,096-char floor. That is a minority of
  apps; the ledger carries no per-app split, so the qualifying share is unmeasured.
- **Break-even.** For a qualifying app the first call pays $0.25/M instead of $0.20/M on the prefix
  (+$0.05/M) and every later read pays $0.02/M instead of $0.20/M (−$0.18/M), so it wins at
  **≥ 0.28 reads per write** — i.e. the same (app, language) summarizing a second conversation inside
  the 30-minute TTL. A long-prompt app that runs a few times an hour clears that comfortably; one that
  runs hourly does not, and loses cents.
- Claimed as **−$0 .. −$0.5/day**, with the kill switch as the exit if the ledger shows writes without
  reads. **If the coordinator would rather not take an unmeasured bet for cents, dropping this arm and
  keeping the two opt-outs is a clean cut** — the arms are independent.

Full derivation, plus the larger levers this deliberately does not take, in
`data/run-2026-09-09-overnight-margins/evidence/conv-cache.md`.

### Binding order is load-bearing

`get_llm(feature, prompt_cache_options=...)` returns `model.bind(extra_body=...)`, and
`RunnableBinding` defines no `with_structured_output` of its own — the attribute lookup forwards to the
**unbound** model and every bound kwarg is silently dropped. The first draft of the
`conversation_processing` change did exactly that and was a **no-op in production** while every
mock-based assertion still passed. Measured against `langchain_openai`: bind-then-structured reaches
`_generate` with `{'response_format': ...}` and no `extra_body`; structured-then-bind reaches it with
both. So `with_cache_write_opt_out` binds last, the harness in the new test file reproduces
`RunnableBinding`'s forwarding trap instead of using a `MagicMock` that answers
`with_structured_output` itself, and
`test_langchain_really_drops_kwargs_bound_before_with_structured_output` pins the behaviour against
real langchain objects. `conv_apps` and the untouched chain-based callers
(`conv_structure`, `conv_action_items`) invoke the bound model directly or pipe it, so they keep the
binding either way.

## Invariants

`scripts/pr-preflight --suggest`: **no product invariants** match the changed paths. The invariants
this change is written to hold, each with a test:

- **The model reads what it read before.** `app_framing + app_conversation_block` is byte-identical to
  the single string this prompt was, pinned by
  `test_app_result_wire_text_is_byte_identical_to_the_single_string_prompt`. Two content parts of one
  user message, not two messages, so the role framing is unchanged too.
- **A breakpoint is never bought below the provider's floor.** Guarded by the shared
  `has_cacheable_prefix`; `test_app_framing_floor_is_the_shared_provider_floor` pins both sides.
- **Every guard falls back to a plain request, never to an unreadable write.** Kill switch, sub-floor
  prefix, and BYOK each land on today's exact shape
  (`test_app_result_falls_back_to_the_unmarked_request`). BYOK is excluded because a BYOK key can
  route the feature off GPT-5.6, where a typed cache field is not a valid content part.
- **The opt-out really is an opt-out.** `cache_requested_for_openai_request` must return `False` for
  the new `conversation_processing` / `chat_structured` shape and `True` for the marked `conv_apps`
  shape — asserted against the gateway's own accounting code, not a copy of it.
- **The routing key carries no app text and cannot outlive an edit.**
  `omi-app-result-v1-<sha256(framing)[:32]>`, versioned.
- **The structured-lane default never overrides a client**, in all three ways a client can have made
  a choice: its own `prompt_cache_options` (pinned with a `ttl` the default never produces, so the
  assertion can tell "preserved" from "overwritten"); a bare `prompt_cache_key`, which is how a
  pre-5.6 caller asks for implicit caching and which our options would have flipped from a cache
  request to a non-cache one; and a breakpoint in its **original** messages — scanned before
  `_gateway_user_content` rebuilds user blocks and drops it, so a client marking cannot be stripped
  and then overwritten.

## Verification

- New: `backend/tests/unit/test_conversation_features_prompt_cache.py` — 20 tests, all passing under
  `test.sh`'s runner (which adds the fast-unit CPU-time guard bare pytest omits).
- Re-run green after the change (per-file, the repo's isolation partitioning):
  `test_conversation_structure_timezone` (16), `test_wake_word` (34), `test_desktop_chat` (93),
  `test_prompt_cache_wire_payload` (5), `test_compact_speaker_transcript` (7),
  `test_llm_gateway_accounting` (28), `test_client_processing_finalize` (55), plus the full set of 74
  test files that reference any changed module.
- `make preflight`: **passed, 27 checks.**
- Not run: any live provider call. This lane made none.

**After merge (dev auto-deploys)** — one ledger query, two independent pass conditions:

```sql
SELECT DATE(created_at) AS d, feature,
       SUM(prompt_tokens) AS prompt_tok,
       SUM(cached_input_tokens) AS cached_tok,
       SUM(cache_write_tokens) AS cache_write_tok,
       SAFE_DIVIDE(SUM(cache_write_tokens), SUM(prompt_tokens)) AS write_share
FROM   llm_gateway_attempts
WHERE  feature IN ('conversation_processing','chat_structured','conv_apps')
  AND  created_at >= TIMESTAMP('2026-09-06')
GROUP BY d, feature ORDER BY d, feature;
```

`write_share` must fall from **0.63** (`conversation_processing`) and **0.87** (`chat_structured`) to
≈ 0.00 within 24h, with `prompt_tok/attempt` unchanged. For `conv_apps`, writes and reads may both
rise from ~0; it is a regression only if `cached_tok/cache_write_tok` stays under 0.28 for a full day.

### Two honest caveats

- **The opt-out mechanism is inferred, not experimentally proven.** `cache_write_tokens` is
  provider-reported (`accounting.py`), and the evidence is the contrast in this same ledger:
  `conv_apps`, which already sends explicit-mode-with-no-breakpoint, writes 0.13% of its prompt
  tokens, while `conversation_processing`, which sends nothing, writes 63%. That is observational.
  The verification query above is what settles it.
- **`conv_apps`' wire shape does change**, from a content string to a two-element text array. The
  bytes the model reads are identical; the request is not literally identical.

## Automatic-or-dead check

Every claim in this PR is enforced by a test that fails without the change, not by review:

- byte-identical prompt → `test_app_result_wire_text_is_byte_identical_to_the_single_string_prompt`
  and `test_app_result_uncached_path_still_sends_the_identical_single_string`
- `conversation_processing` really sends it **on the invoked runnable**, driven through the real
  `_process_extracted_metadata` path → `test_metadata_extraction_sends_explicit_mode_with_no_breakpoint`
  (asserts `invoked_kwargs`, the only assertion that notices the binding-order no-op) and
  `test_langchain_really_drops_kwargs_bound_before_with_structured_output`
- the breakpoint sits only on the stable half → `test_app_result_breakpoint_is_on_the_stable_half_only`
- the shapes bill the way this body says → `test_the_gateway_prices_each_new_shape_the_way_we_expect`,
  asserted against `llm_gateway.gateway.accounting.cache_requested_for_openai_request` itself
- the kill switch really disables it → `test_kill_switch_semantics`,
  `test_explicit_cache_requires_the_gateway_route`, `test_app_result_falls_back_to_the_unmarked_request`,
  `test_metadata_extraction_honours_the_kill_switch`,
  `test_metadata_extraction_sends_nothing_when_a_guard_declines` (off-gateway and BYOK)

**Kill switch:** `OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED=false` reverts all three features to their
previous request shape with no deploy on a runtime-env host. It is now one variable for every
explicit-cache caller rather than one per feature.

## Cut list

- **The −$10/day `conv_apps` transcript-prefix change was not made, because the prefix it would read
  does not exist.** `conv_structure` / `conv_action_items` cache static instructions, not the
  transcript. Evidence record has the numbers.
- **Sharing one conversation-context prefix across the legacy finalize features: rejected, worked
  through.** It forfeits static-instruction caches already returning 94.7M reads/day
  (≈ +$17/day lost) to buy ≈ −$21/day of transcript reads — net ≈ −$4/day for a prompt reorder on the
  two biggest finalize features. Not worth the behaviour risk.
- **`get_app_result`'s notes-v2 branch, `conv_structure`, `conv_action_items`, and
  `process_conversation.py`: untouched.** The ledger says production is on the legacy finalize path
  (`conv_action_items` at 44,679 attempts/day, and ~39% of `conv_apps` cost on gpt-5-nano, i.e.
  `conv_app_select` still running — both impossible under notes v2). That is an env-drift finding for
  the coordinator, not a code change, and that file belongs to another lane.
- **The other `get_llm('chat_extraction')` call sites** (features `chat`, `rag`) have the identical
  unreadable-write shape at smaller volume. Left alone: one lane should not silently re-price four
  features it is not measuring.
- **`conv_apps`' output line** — 12.30M tok/day at $1.20/M = $14.8/day, larger than its whole input
  line — is a prompt-length/product question, out of scope for a "nothing the user sees" change.

## Line-count ratchet

Both exceptions are the code this change is, after moving every reusable piece out to
`utils/llm/prompt_cache.py` (which is not an oversized file) and trimming the comments to what is
load-bearing. `utils/llm/chat.py` **shrinks** (1514 -> 1510). Splitting a 1,900-line chat router or a
1,900-line conversation-processing module is real work with real merge risk and does not belong in a
request-shape change measured in cents per day.

Line-Count-Exception: backend/routers/desktop_chat.py | 1952 -> 1959 | +7: one import and a four-line
guarded call to the shared `apply_cache_write_opt_out` inside `_gateway_body`; the helper itself and
its breakpoint scan live in `utils/llm/prompt_cache.py`, not here
Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1854 -> 1873 | +19: the app-result
prompt split plus its cache decision in `get_app_result`; the key derivation, the two-part message and
the floor check are all in `utils/llm/prompt_cache.py`

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
