### PR TITLE
fix(cli): handle non-table profile configuration

### DIFF
--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -170,7 +170,8 @@ class Config:
 def load(path: Optional[Path] = None) -> Config:
     """Load the config from disk, returning an empty Config if the file is missing.
 
-    A malformed or undecodable TOML file also yields an empty Config rather
+    A malformed or undecodable TOML file, or non-table profile containers,
+    also yield an empty Config rather
     than raising, so read-only diagnostics such as ``omi version`` and
     ``omi config path`` keep working precisely when the config needs repair.
     The parse failure is recorded on :attr:`Config.load_error`, and
@@ -201,6 +202,13 @@ def load(path: Optional[Path] = None) -> Config:
 
     active = data.get("active_profile", DEFAULT_PROFILE_NAME)
     profiles_data = data.get("profiles", {})
+    if not isinstance(profiles_data, dict) or any(not isinstance(raw, dict) for raw in profiles_data.values()):
+        return Config(
+            path=p,
+            active_profile=DEFAULT_PROFILE_NAME,
+            profiles={},
+            load_error="config profiles and each named profile must be TOML tables",
+        )
     profiles = {name: Profile.from_toml_dict(name, raw) for name, raw in profiles_data.items()}
 
     extra = {key: value for key, value in data.items() if key not in {"active_profile", "profiles"}}

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -70,6 +70,34 @@ def test_load_invalid_utf8_records_unicode_error(config_path: Path) -> None:
     assert "not valid UTF-8" in config.load_error
 
 
+@pytest.mark.parametrize(
+    "document",
+    [
+        'profiles = "mistake"\n',
+        'profiles = ["mistake"]\n',
+        '[profiles]\ndefault = "mistake"\n',
+        '[profiles]\ndefault = 12\n',
+        '[profiles]\ndefault = ["mistake"]\n',
+    ],
+)
+def test_non_table_profiles_keep_diagnostics_and_refuse_writes(config_path: Path, cli_runner, document: str) -> None:
+    config_path.write_text(document, encoding="utf-8")
+    original = config_path.read_bytes()
+    config = cfg.load()
+    assert config.was_load_error
+    assert config.profiles == {}
+    with pytest.raises(PermissionError, match="refusing to overwrite"):
+        cfg.save(config)
+
+    result = cli_runner.invoke(app, ["--json", "config", "path"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["path"] == str(config_path)
+
+    result = cli_runner.invoke(app, ["config", "set", "api_base", "https://example.test"])
+    assert result.exit_code != 0
+    assert config_path.read_bytes() == original
+
+
 def test_save_refuses_to_overwrite_malformed_config(config_path: Path) -> None:
     """save() must refuse to overwrite a file that failed to parse on load:
     a write command would otherwise silently destroy profiles/credentials the


### PR DESCRIPTION
## What changed and why

Fixes #13340. Valid TOML such as `profiles = "mistake"` or `[profiles] default = "mistake"` crashes the configuration loader before diagnostic commands can inspect the file. Validate profile containers at the loader boundary and return the existing load-error state, keeping path diagnostics available while refusing to overwrite the original configuration.

## Product invariants affected

none

## How it was verified

Windows, Python 3.12.14, pytest 8.4.2:
- All five added regression cases fail on the original code with AttributeError.
- `python -m pytest sdks/python-cli/tests/test_config.py`: 29 passed with the fix.
- Installed `omi.exe --json config path` returns the synthetic malformed file path; `omi.exe config set api_base https://example.test` refuses the write and leaves its bytes unchanged.
- Full CLI test run exposed one auth transport failure, independently reproduced on the unmodified base: `test_transport_failure_during_login_leaves_saved_config_unchanged`. Four OpenAPI tests initially lacked the sparse checkout docs file; after completing the checkout all four pass. Other tests in the full run passed. The full suite is not claimed green.
- `python .github/scripts/pr_preflight.py --lane local --pr-body-file <body>` passed 12 checks both before and after commit. The history-based failure-class guard reports a skip in this shallow clone; full-history CI still needs to enforce it.
- `git diff --check` passed.

## Tests

`test_non_table_profiles_keep_diagnostics_and_refuse_writes` covers scalar/list top-level profiles and scalar/list named profiles through the production loader and CLI commands, including original-byte preservation after a refused write. Existing round-trip tests cover valid profiles and unknown fields.

This extends the existing malformed-config boundary; it adds no new check or fallback subsystem. Backend hermetic gate: not applicable (Python CLI only). All regression data is synthetic; no live account or API calls. Prepared with Codex assistance.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

