### PR TITLE
chore(finops): load omi_finops as dataset-scoped writer SA

### DIFF
--- a/backend/scripts/finops/README.md
+++ b/backend/scripts/finops/README.md
@@ -53,8 +53,10 @@ Firestore reads bill under service `App Engine`, so Firestore is matched by SKU,
   sourcing and refuses to pull under any other account.
 * The **BigQuery load** runs as `finops-writer@based-hardware.iam.gserviceaccount.com`
   (dataset `omi_finops` WRITER + project `roles/bigquery.jobUser`) and refuses to run
-  under any other account (`gcpauth.assert_writer_identity()`). The read-only bot stays
-  read-only. Human ADC is not the cron writer.
+  under any other account (`gcpauth.assert_writer_identity()`): it verifies the
+  key's `client_email` directly (ADC's credential) and activates the key into the
+  dedicated `WRITER_GCLOUD` config so `bq` uses the same identity. The read-only bot
+  stays read-only. Human ADC is not the cron writer.
 * No token, key or secret is ever printed or written to disk.
 * **No raw uid ever reaches disk.** Uids are hashed `sha256(uid)[:16]` in flight, and
   `run_unit_cost.validate()` scans the outputs for any hex run of 20+ characters before a load.

--- a/backend/scripts/finops/README.md
+++ b/backend/scripts/finops/README.md
@@ -51,8 +51,10 @@ Firestore reads bill under service `App Engine`, so Firestore is matched by SKU,
   path does not exist on this host and falls through **silently** to owner credentials, so
   `gcpauth.assert_readonly_identity()` re-checks `gcloud config get-value account` after
   sourcing and refuses to pull under any other account.
-* The **BigQuery load** runs as the interactive owner `david@scalingforever.com` and refuses
-  to run under any other account (`gcpauth.assert_writer_identity()`).
+* The **BigQuery load** runs as `finops-writer@based-hardware.iam.gserviceaccount.com`
+  (dataset `omi_finops` WRITER + project `roles/bigquery.jobUser`) and refuses to run
+  under any other account (`gcpauth.assert_writer_identity()`). The read-only bot stays
+  read-only. Human ADC is not the cron writer.
 * No token, key or secret is ever printed or written to disk.
 * **No raw uid ever reaches disk.** Uids are hashed `sha256(uid)[:16]` in flight, and
   `run_unit_cost.validate()` scans the outputs for any hex run of 20+ characters before a load.

--- a/backend/scripts/finops/gcpauth.py
+++ b/backend/scripts/finops/gcpauth.py
@@ -17,6 +17,7 @@ Nothing here prints or persists a token.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -67,22 +68,52 @@ def apply_writer_env() -> None:
     os.environ.pop("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", None)
 
 
-def assert_writer_identity() -> str:
-    """The finops-writer SA, which is what `bq load` will use."""
-    apply_writer_env()
-    p = subprocess.run(
-        ["gcloud", "config", "get-value", "account"],
-        capture_output=True,
-        text=True,
-        env=os.environ,
-    )
-    acct = (p.stdout or "").strip()
-    if p.returncode != 0 or acct != WRITER_ACCOUNT:
+def writer_key_email() -> str:
+    """The identity the writer key itself authenticates as.
+
+    This is the credential ADC (``GOOGLE_APPLICATION_CREDENTIALS``) actually presents.
+    A gcloud config account can drift independently of the key file (e.g. after key
+    rotation), so the key's ``client_email`` is the authoritative thing to verify.
+    """
+    try:
+        with open(WRITER_KEY) as f:
+            key = json.load(f)
+    except (OSError, ValueError) as e:
+        raise SystemExit("writer key unreadable: %s (%s)" % (WRITER_KEY, e))
+    email = str(key.get("client_email", "")).strip()
+    if email != WRITER_ACCOUNT:
         raise SystemExit(
-            "BigQuery writer identity check failed: got %r, expected %r. "
+            "BigQuery writer key is for %r, expected %r. Refusing to write to omi_finops." % (email, WRITER_ACCOUNT)
+        )
+    return email
+
+
+def activate_writer_gcloud() -> None:
+    """Activate the writer key in the dedicated ``WRITER_GCLOUD`` config.
+
+    ``GOOGLE_APPLICATION_CREDENTIALS`` does not authenticate the gcloud CLI: on a
+    new or uninitialized config, ``gcloud config get-value account`` is unset and
+    ``bq`` (which reads the config credential store) has no credentials at all.
+    Activating the key is idempotent and keeps the config store pinned to the
+    same key ADC uses, so neither credential source can drift to another identity.
+    """
+    acct = _sh("gcloud config get-value account 2>/dev/null")
+    if acct != WRITER_ACCOUNT:
+        _sh('gcloud auth activate-service-account --key-file="%s"' % WRITER_KEY)
+        acct = _sh("gcloud config get-value account 2>/dev/null")
+    if acct != WRITER_ACCOUNT:
+        raise SystemExit(
+            "BigQuery writer identity check failed: gcloud config account is %r, expected %r. "
             "Refusing to write to omi_finops." % (acct, WRITER_ACCOUNT)
         )
-    return acct
+
+
+def assert_writer_identity() -> str:
+    """The finops-writer SA: verified from the key itself and active in ``WRITER_GCLOUD``."""
+    apply_writer_env()
+    email = writer_key_email()
+    activate_writer_gcloud()
+    return email
 
 
 class Token:

--- a/backend/scripts/finops/gcpauth.py
+++ b/backend/scripts/finops/gcpauth.py
@@ -7,8 +7,10 @@ Two identities are used, on purpose:
     ``~/.hermes/scripts/omi-prod-gcp-read-only-env.sh``. The documented
     ``~/.hermes/profiles`` path does not exist on this host and falls through
     silently to owner credentials, so the account is verified after sourcing.
-  * the interactive owner account for BigQuery WRITES into ``omi_finops``
-    (dataset/table create, partition replace). Verified by name before any write.
+  * ``finops-writer@based-hardware.iam.gserviceaccount.com`` for BigQuery WRITES
+    into ``omi_finops`` only. Key at
+    ``~/.hermes/credentials/omi-gcp/prod/finops-writer-key.json``. Human ADC
+    expires; the read-only bot must stay read-only.
 
 Nothing here prints or persists a token.
 """
@@ -22,7 +24,9 @@ import time
 
 READONLY_ENV = os.path.expanduser("~/.hermes/scripts/omi-prod-gcp-read-only-env.sh")
 READONLY_ACCOUNT = "read-only-bot-account@based-hardware.iam.gserviceaccount.com"
-WRITER_ACCOUNT = "david@scalingforever.com"
+WRITER_KEY = os.path.expanduser("~/.hermes/credentials/omi-gcp/prod/finops-writer-key.json")
+WRITER_GCLOUD = os.path.expanduser("~/.hermes/gcloud/omi-finops-writer")
+WRITER_ACCOUNT = "finops-writer@based-hardware.iam.gserviceaccount.com"
 PROJECT = "based-hardware"
 
 
@@ -48,10 +52,32 @@ def assert_readonly_identity() -> str:
     return acct
 
 
+def apply_writer_env() -> None:
+    """Point this process at the finops-writer key so subsequent `bq` calls use it."""
+    if not os.path.isfile(WRITER_KEY):
+        raise SystemExit("writer key missing: %s" % WRITER_KEY)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = WRITER_KEY
+    os.environ["CLOUDSDK_CONFIG"] = WRITER_GCLOUD
+    os.environ["GOOGLE_CLOUD_PROJECT"] = PROJECT
+    os.environ["GCLOUD_PROJECT"] = PROJECT
+    os.environ["CLOUDSDK_CORE_PROJECT"] = PROJECT
+    os.environ["CLOUDSDK_PROJECT"] = PROJECT
+    os.environ["CLOUDSDK_PYTHON"] = os.environ.get("CLOUDSDK_PYTHON") or os.path.expanduser("~/.local/bin/python3.11")
+    os.environ["PYTHONPATH"] = ""
+    os.environ.pop("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT", None)
+
+
 def assert_writer_identity() -> str:
-    """The active (non-sourced) gcloud account, which is what `bq load` will use."""
-    acct = _sh("gcloud config get-value account 2>/dev/null")
-    if acct != WRITER_ACCOUNT:
+    """The finops-writer SA, which is what `bq load` will use."""
+    apply_writer_env()
+    p = subprocess.run(
+        ["gcloud", "config", "get-value", "account"],
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    acct = (p.stdout or "").strip()
+    if p.returncode != 0 or acct != WRITER_ACCOUNT:
         raise SystemExit(
             "BigQuery writer identity check failed: got %r, expected %r. "
             "Refusing to write to omi_finops." % (acct, WRITER_ACCOUNT)

--- a/backend/scripts/finops/load_bigquery.py
+++ b/backend/scripts/finops/load_bigquery.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Load an assembled run into `based-hardware.omi_finops`.
 
-Writes run as the interactive owner account (verified by name first); every read in the
+Writes run as finops-writer@based-hardware (verified by name first); every read in the
 pipeline runs as the read-only bot. Loads are IDEMPOTENT per date: rows for the dates in
 this run are deleted and re-inserted inside one BigQuery transaction, so re-running a date
 replaces it rather than doubling it.

--- a/backend/scripts/finops/run_unit_cost.py
+++ b/backend/scripts/finops/run_unit_cost.py
@@ -14,7 +14,7 @@ What it does, in order:
   5. optionally loads BigQuery `based-hardware.omi_finops`, idempotently per date
 
 Identities: every READ runs as read-only-bot-account@based-hardware; only the BigQuery load
-runs as the interactive owner, and it refuses to run under any other account.
+runs as finops-writer@based-hardware, and it refuses to run under any other account.
 
 Settlement: the GCP billing export lands a usage day over the following ~48 h, so a date is
 only treated as settled at D-2. `--date` defaults to today-2. Unsettled dates can still be
@@ -159,7 +159,7 @@ def main() -> None:
         help="last usage day, inclusive. Default: today-%d (the settlement frontier)." % SETTLEMENT_LAG_DAYS,
     )
     ap.add_argument("--backfill-from", default=None, help="first usage day, inclusive. Default: --date.")
-    ap.add_argument("--load", action="store_true", help="load BigQuery omi_finops (owner identity)")
+    ap.add_argument("--load", action="store_true", help="load BigQuery omi_finops (finops-writer SA)")
     ap.add_argument("--run-dir", default=None)
     ap.add_argument(
         "--cohort-window-start",

--- a/backend/tests/unit/test_finops_unit_cost.py
+++ b/backend/tests/unit/test_finops_unit_cost.py
@@ -5,6 +5,7 @@ They are deliberately hermetic: no GCP, no Firestore, no network.
 """
 
 import importlib.util
+import json
 import pathlib
 
 import pytest
@@ -23,6 +24,52 @@ def test_writer_is_finops_sa_not_human_or_readonly_bot():
     assert gcpauth.READONLY_ACCOUNT == "read-only-bot-account@based-hardware.iam.gserviceaccount.com"
     assert "david@" not in gcpauth.WRITER_ACCOUNT
     assert gcpauth.WRITER_ACCOUNT != gcpauth.READONLY_ACCOUNT
+
+
+def _write_key(tmp_path, email):
+    p = tmp_path / "writer-key.json"
+    p.write_text(json.dumps({"type": "service_account", "client_email": email}))
+    return str(p)
+
+
+def test_writer_key_email_verifies_the_key_itself(tmp_path, monkeypatch):
+    """ADC presents the key file, so client_email is the authoritative identity check."""
+    monkeypatch.setattr(gcpauth, "WRITER_KEY", _write_key(tmp_path, gcpauth.WRITER_ACCOUNT))
+    assert gcpauth.writer_key_email() == gcpauth.WRITER_ACCOUNT
+
+
+def test_writer_key_email_refuses_a_key_for_another_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        gcpauth, "WRITER_KEY", _write_key(tmp_path, "someone-else@based-hardware.iam.gserviceaccount.com")
+    )
+    with pytest.raises(SystemExit, match="someone-else"):
+        gcpauth.writer_key_email()
+
+
+def test_writer_gcloud_activates_the_key_when_config_account_is_unset(monkeypatch):
+    """A fresh WRITER_GCLOUD has no account; GOOGLE_APPLICATION_CREDENTIALS does not
+    authenticate the gcloud CLI, so the key must be activated before the account check."""
+    calls = []
+
+    def fake_sh(cmd, timeout=180):
+        calls.append(cmd)
+        if "get-value" in cmd:
+            return gcpauth.WRITER_ACCOUNT if any("activate-service-account" in c for c in calls) else ""
+        assert "activate-service-account" in cmd and gcpauth.WRITER_KEY in cmd
+        return ""
+
+    monkeypatch.setattr(gcpauth, "_sh", fake_sh)
+    gcpauth.activate_writer_gcloud()
+    assert any("activate-service-account" in c for c in calls)
+
+
+def test_writer_gcloud_refuses_when_activation_does_not_pin_the_writer(monkeypatch):
+    def fake_sh(cmd, timeout=180):
+        return "owner@scalingforever.com"
+
+    monkeypatch.setattr(gcpauth, "_sh", fake_sh)
+    with pytest.raises(SystemExit, match="owner@scalingforever.com"):
+        gcpauth.activate_writer_gcloud()
 
 
 # ---------------------------------------------------------------- fnum / is_one_time

--- a/backend/tests/unit/test_finops_unit_cost.py
+++ b/backend/tests/unit/test_finops_unit_cost.py
@@ -9,12 +9,20 @@ import pathlib
 
 import pytest
 
-_SPEC = importlib.util.spec_from_file_location(
-    "finops_assemble",
-    pathlib.Path(__file__).resolve().parents[2] / "scripts" / "finops" / "assemble_unit_cost.py",
-)
+_FINOPS = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "finops"
+_SPEC = importlib.util.spec_from_file_location("finops_assemble", _FINOPS / "assemble_unit_cost.py")
 alloc = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(alloc)
+_AUTH_SPEC = importlib.util.spec_from_file_location("finops_gcpauth", _FINOPS / "gcpauth.py")
+gcpauth = importlib.util.module_from_spec(_AUTH_SPEC)
+_AUTH_SPEC.loader.exec_module(gcpauth)
+
+
+def test_writer_is_finops_sa_not_human_or_readonly_bot():
+    assert gcpauth.WRITER_ACCOUNT == "finops-writer@based-hardware.iam.gserviceaccount.com"
+    assert gcpauth.READONLY_ACCOUNT == "read-only-bot-account@based-hardware.iam.gserviceaccount.com"
+    assert "david@" not in gcpauth.WRITER_ACCOUNT
+    assert gcpauth.WRITER_ACCOUNT != gcpauth.READONLY_ACCOUNT
 
 
 # ---------------------------------------------------------------- fnum / is_one_time


### PR DESCRIPTION
## Failure-Class
Failure-Class: none

## Summary
- Point the offline finops BigQuery load at `finops-writer@based-hardware` instead of interactive human ADC.
- Reads stay on `read-only-bot-account`. The RO bot is not granted write.
- Hermetic unit test pins the writer to the dataset-scoped SA.

No product runtime path. `backend/scripts/finops/` is still imported by nothing in the backend.

## Test plan
- [x] `pytest backend/tests/unit/test_finops_unit_cost.py` (35 passed)
- [x] Live load of 2026-09-07 as `finops-writer` into `based-hardware.omi_finops`
- [x] Writer denied on `gcp_billing_export`; RO bot denied `tables.create` on `omi_finops`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

