### PR TITLE
feat(sdks/python-cli): add folder list command (#13138)

### DIFF
--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -96,6 +96,12 @@ The `--text` flag accepts `-` to read from stdin:
 cat meeting_notes.md | omi conversation create --text - --text-source message
 ```
 
+## `omi folder`
+
+| Command             | Endpoint                     |
+| ------------------- | ---------------------------- |
+| `omi folder list`   | `GET /v1/dev/user/folders`   |
+
 ## `omi action-item`
 
 | Command                                       | Endpoint                                                    |

--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -12,6 +12,7 @@ omi
 ├── config        show | set <k> <v> | path | profile {list, use <name>, delete <name>}
 ├── memory        list | get | create | update | delete
 ├── conversation  list | get | create | from-segments | update | delete
+├── folder        list
 ├── action-item   list | get | create | update | complete | delete
 └── goal          list | get | create | update | progress | history | delete
 ```

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -217,6 +217,8 @@ omi
 │   ├── from-segments <file.json> [--source ...]
 │   ├── update <id> [--title ...] [--discarded/--no-discarded]
 │   └── delete <id> [-y]
+├── folder
+│   └── list
 ├── action-item
 │   ├── list [--completed/--open] [--conversation-id ...] [...]
 │   ├── get <id>

--- a/sdks/python-cli/omi_cli/commands/folder.py
+++ b/sdks/python-cli/omi_cli/commands/folder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import typer
 

--- a/sdks/python-cli/omi_cli/commands/folder.py
+++ b/sdks/python-cli/omi_cli/commands/folder.py
@@ -1,0 +1,50 @@
+"""``omi folder`` — organize conversations into groups."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> "AppContext":
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+_LIST_COLUMNS = ["id", "name", "conversation_count", "color", "icon", "is_system"]
+
+
+@app.command("list", help="List existing conversation folders.")
+def list_folders(typer_ctx: typer.Context) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        folders = client.get("/v1/dev/user/folders")
+
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(folders)
+        return
+
+    rows = []
+    for f in folders or []:
+        rows.append(
+            {
+                "id": shorten(f.get("id"), 14),
+                "name": shorten(f.get("name"), 30),
+                "conversation_count": f.get("conversation_count", 0),
+                "color": f.get("color", ""),
+                "icon": f.get("icon", ""),
+                "is_system": f.get("is_system", False),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title="folders")

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -31,6 +31,7 @@ from omi_cli.commands import action_item as action_item_cmd
 from omi_cli.commands import auth as auth_cmd
 from omi_cli.commands import config as config_cmd
 from omi_cli.commands import conversation as conversation_cmd
+from omi_cli.commands import folder as folder_cmd
 from omi_cli.commands import goal as goal_cmd
 from omi_cli.commands import local as local_cmd
 from omi_cli.commands import memory as memory_cmd
@@ -192,6 +193,7 @@ app.add_typer(memory_cmd.app, name="memory", help="Memories — facts and learni
 app.add_typer(conversation_cmd.app, name="conversation", help="Conversations — captured & processed audio + text.")
 app.add_typer(action_item_cmd.app, name="action-item", help="Action items — tasks and follow-ups.")
 app.add_typer(goal_cmd.app, name="goal", help="Goals — tracked progress metrics.")
+app.add_typer(folder_cmd.app, name="folder", help="Folders — organize conversations into groups.")
 app.add_typer(local_cmd.app, name="local", help="Local Omi Desktop API tools.")
 
 

--- a/sdks/python-cli/tests/test_folder.py
+++ b/sdks/python-cli/tests/test_folder.py
@@ -1,0 +1,77 @@
+"""Tests for ``omi folder`` commands."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from omi_cli.main import app
+
+
+def test_folder_list_json(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/folders").respond(
+        json=[
+            {
+                "id": "fld_work_1",
+                "name": "Work",
+                "description": "Work conversations",
+                "color": "#FF5733",
+                "icon": "briefcase",
+                "created_at": "2026-09-01T12:00:00Z",
+                "updated_at": "2026-09-01T12:00:00Z",
+                "order": 0,
+                "is_default": False,
+                "is_system": True,
+                "conversation_count": 5,
+            }
+        ]
+    )
+    result = cli_runner.invoke(app, ["--json", "folder", "list"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["id"] == "fld_work_1"
+    assert payload[0]["name"] == "Work"
+    assert payload[0]["conversation_count"] == 5
+
+
+def test_folder_list_text(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/folders").respond(
+        json=[
+            {
+                "id": "fld_personal",
+                "name": "Personal",
+                "description": None,
+                "color": "#33FF57",
+                "icon": "user",
+                "created_at": "2026-09-01T12:00:00Z",
+                "updated_at": "2026-09-01T12:00:00Z",
+                "order": 1,
+                "is_default": False,
+                "is_system": False,
+                "conversation_count": 12,
+            }
+        ]
+    )
+    result = cli_runner.invoke(app, ["folder", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Personal" in result.output
+    assert "fld_personal" in result.output
+
+
+def test_folder_list_empty(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/folders").respond(json=[])
+    result = cli_runner.invoke(app, ["--json", "folder", "list"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == []
+
+
+def test_folder_list_error(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/folders").respond(
+        status_code=403,
+        json={"detail": "Forbidden: requires conversations:read scope"},
+    )
+    result = cli_runner.invoke(app, ["folder", "list"])
+    assert result.exit_code != 0

--- a/sdks/python-cli/tests/test_folder.py
+++ b/sdks/python-cli/tests/test_folder.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 import json
 
-import httpx
-import pytest
-
 from omi_cli.main import app
 
 
@@ -59,6 +56,10 @@ def test_folder_list_text(authed_profile, respx_mock, cli_runner) -> None:
     assert result.exit_code == 0, result.output
     assert "Personal" in result.output
     assert "fld_personal" in result.output
+    assert "#33FF57" in result.output
+    assert "user" in result.output
+    assert "12" in result.output
+    assert "✗" in result.output
 
 
 def test_folder_list_empty(authed_profile, respx_mock, cli_runner) -> None:
@@ -74,4 +75,5 @@ def test_folder_list_error(authed_profile, respx_mock, cli_runner) -> None:
         json={"detail": "Forbidden: requires conversations:read scope"},
     )
     result = cli_runner.invoke(app, ["folder", "list"])
-    assert result.exit_code != 0
+    assert result.exit_code == 2
+    assert "Insufficient permissions" in result.output


### PR DESCRIPTION
Resolves #13138

### Feature
Adds `omi folder list` to discover existing conversation folder IDs, names, metadata, and conversation counts via the Developer API (`GET /v1/dev/user/folders`).

### Implementation Details
- Added `omi_cli.commands.folder` with `list_folders` command.
- Registered `folder` command group in `omi_cli.main`.
- Supports both rich table output (showing id, name, count, color, icon, is_system) and machine-readable `--json` output.
- Documented in `sdks/python-cli/README.md` and `docs/doc/developer/cli/commands.mdx`.
- Added unit tests in `sdks/python-cli/tests/test_folder.py` covering JSON mode, text table rendering, empty folder list, and error handling.

Failure-Class: none

Co-authored-by: Kgruben0133 <326547184+Kgruben0133@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

