### PR TITLE
feat(sdks/python-cli): allow setting and clearing goal horizon in update

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -241,7 +241,7 @@ omi
     ├── list [--limit N] [--include-inactive]
     ├── get <id>
     ├── create <title> --target N [--type ...] [--current N] [--unit ...]
-    ├── update <id> [--unit ... | --clear-unit] [...]
+    ├── update <id> [--unit ... | --clear-unit] [--horizon-at ISO | --clear-horizon] [...]
     ├── progress <id> <value>
     ├── history <id> [--days N]
     └── delete <id> [-y]

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 import typer
 
+from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import UsageError
 from omi_cli.models import GoalType
 from omi_cli.output import shorten
@@ -133,10 +134,11 @@ def update_goal(
     max_value: Optional[float] = typer.Option(None, "--max"),
     unit: Optional[str] = typer.Option(None, "--unit"),
     clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
-    horizon_at: Optional[str] = typer.Option(
+    horizon_at: Optional[datetime] = typer.Option(
         None,
         "--horizon-at",
-        help="Target horizon datetime with explicit timezone (ISO-8601).",
+        formats=ISO_DATETIME_FORMATS,
+        help="Target horizon datetime with explicit timezone.",
     ),
     clear_horizon: bool = typer.Option(
         False,
@@ -170,22 +172,12 @@ def update_goal(
     if clear_horizon:
         body["horizon_at"] = None
     elif horizon_at is not None:
-        iso_str = horizon_at
-        if iso_str.endswith("Z") or iso_str.endswith("z"):
-            iso_str = iso_str[:-1] + "+00:00"
-        try:
-            dt = datetime.fromisoformat(iso_str)
-        except Exception as exc:
-            raise UsageError(
-                message="Invalid datetime",
-                detail=f"Invalid ISO datetime for --horizon-at: {exc}",
-            ) from exc
-        if dt.tzinfo is None:
+        if horizon_at.tzinfo is None:
             raise UsageError(
                 message="Missing timezone",
                 detail="--horizon-at requires an explicit timezone (e.g. +00:00 or Z).",
             )
-        body["horizon_at"] = dt.isoformat()
+        body["horizon_at"] = horizon_at.isoformat()
     if not body:
         raise UsageError(
             message="No fields to update",

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 import typer
@@ -132,10 +133,25 @@ def update_goal(
     max_value: Optional[float] = typer.Option(None, "--max"),
     unit: Optional[str] = typer.Option(None, "--unit"),
     clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
+    horizon_at: Optional[str] = typer.Option(
+        None,
+        "--horizon-at",
+        help="Target horizon datetime with explicit timezone (ISO-8601).",
+    ),
+    clear_horizon: bool = typer.Option(
+        False,
+        "--clear-horizon",
+        help="Remove the target horizon datetime.",
+    ),
 ) -> None:
     ctx = _ctx(typer_ctx)
     if clear_unit and unit is not None:
         raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
+    if clear_horizon and horizon_at is not None:
+        raise UsageError(
+            message="Conflicting options",
+            detail="--horizon-at and --clear-horizon are mutually exclusive.",
+        )
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -151,10 +167,29 @@ def update_goal(
         body["unit"] = None
     elif unit is not None:
         body["unit"] = unit
+    if clear_horizon:
+        body["horizon_at"] = None
+    elif horizon_at is not None:
+        iso_str = horizon_at
+        if iso_str.endswith("Z") or iso_str.endswith("z"):
+            iso_str = iso_str[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(iso_str)
+        except Exception as exc:
+            raise UsageError(
+                message="Invalid datetime",
+                detail=f"Invalid ISO datetime for --horizon-at: {exc}",
+            ) from exc
+        if dt.tzinfo is None:
+            raise UsageError(
+                message="Missing timezone",
+                detail="--horizon-at requires an explicit timezone (e.g. +00:00 or Z).",
+            )
+        body["horizon_at"] = dt.isoformat()
     if not body:
         raise UsageError(
             message="No fields to update",
-            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit.",
+            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit/--horizon-at/--clear-horizon.",
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -259,9 +259,7 @@ def test_goal_update_rejects_invalid_horizon(authed_profile, respx_mock, monkeyp
     monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", "--horizon-at", "not-a-datetime"])
     with pytest.raises(SystemExit) as exc:
         main()
-    assert exc.value.code == 1
+    assert exc.value.code == 2
     output = capsys.readouterr()
-    assert output.out == ""
-    error = json.loads(output.err)
-    assert "invalid iso datetime" in error["detail"].lower()
+    assert "Invalid value for '--horizon-at'" in output.err
     assert not respx_mock.calls

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -207,3 +207,61 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
     assert not respx_mock.calls
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        (["--horizon-at", "2026-12-31T23:59:59Z"], {"horizon_at": "2026-12-31T23:59:59+00:00"}),
+        (["--horizon-at", "2026-12-31T23:59:59+02:00"], {"horizon_at": "2026-12-31T23:59:59+02:00"}),
+        (["--clear-horizon"], {"horizon_at": None}),
+        (["--clear-horizon", "--current", "5"], {"horizon_at": None, "current_value": 5.0}),
+    ],
+)
+def test_goal_update_horizon_patch(authed_profile, respx_mock, cli_runner, options, expected) -> None:
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1", **expected})
+    result = cli_runner.invoke(app, ["--json", "goal", "update", "g1", *options])
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content) == expected
+    assert json.loads(result.stdout) == {"id": "g1", **expected}
+
+
+def test_goal_update_rejects_set_and_clear_horizon(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["omi", "--json", "goal", "update", "g1", "--horizon-at", "2026-12-31T23:59:59Z", "--clear-horizon"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert "--horizon-at" in error["detail"]
+    assert "--clear-horizon" in error["detail"]
+    assert not respx_mock.calls
+
+
+@pytest.mark.parametrize("value", ["2026-12-31T23:59:59", "2026-12-31"])
+def test_goal_update_rejects_naive_horizon(authed_profile, respx_mock, monkeypatch, capsys, value) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", "--horizon-at", value])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert "timezone" in error["detail"].lower()
+    assert not respx_mock.calls
+
+
+def test_goal_update_rejects_invalid_horizon(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", "--horizon-at", "not-a-datetime"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert "invalid iso datetime" in error["detail"].lower()
+    assert not respx_mock.calls


### PR DESCRIPTION
## Summary
Implements `--horizon-at` and `--clear-horizon` options on `omi goal update`, mapping directly to the Developer API's `UpdateGoalRequest.horizon_at` field.
- `--horizon-at <ISO-8601>`: Sets the target completion timestamp. Requires an explicit timezone offset (e.g. `+00:00` or `Z`) to prevent silent UTC/local timestamp ambiguity.
- `--clear-horizon`: Removes the target completion timestamp by sending `{"horizon_at": null}`.
- Mutually exclusive checks prevent specifying both options at once.
- Invalid dates and naive datetimes lacking timezones are rejected before HTTP dispatch.

Resolves #13111

## Changes
- `sdks/python-cli/omi_cli/commands/goal.py`: Add `--horizon-at` and `--clear-horizon` parameters, validation, and payload serialization in `update_goal`.
- `sdks/python-cli/README.md`: Update command reference overview for `omi goal update`.
- `sdks/python-cli/tests/test_goal.py`: Add comprehensive test coverage for setting, clearing, mutual exclusivity, naive datetimes, and invalid timestamps.

## Verification
- Unit tests in `sdks/python-cli/tests/test_goal.py` pass (25/25).
- Clean code formatting verified with `ruff check`.
- Verified diff hygiene with `git diff --check HEAD` (clean).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

