### PR TITLE
feat(sdks/python-cli): add daily-summary list and get commands

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -3,7 +3,7 @@
 > Talk to Omi from your terminal. Designed for humans **and** agents.
 
 `omi-cli` is the command-line interface to the [Omi](https://omi.me) developer
-API. It exposes scoped, agent-friendly verbs for the four primary nouns Omi
+API. It exposes scoped, agent-friendly verbs for the five primary nouns Omi
 maintains about you:
 
 * **memories** — facts and learnings the system knows about you

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -9,6 +9,7 @@ maintains about you:
 * **memories** — facts and learnings the system knows about you
 * **conversations** — captured & processed audio/text exchanges
 * **action items** — tasks and follow-ups
+* **daily summaries** — stored daily recaps
 * **goals** — tracked progress metrics
 
 It's intentionally small, scriptable, and JSON-first — everything you need to
@@ -224,6 +225,9 @@ omi
 │   ├── update <id> [--description ...] [--completed/--open] [--due-at ...]
 │   ├── complete <id>
 │   └── delete <id> [-y]
+├── daily-summary
+│   ├── list [--limit N] [--offset N] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]
+│   └── get <id>
 ├── local
 │   ├── configure --url URL --token TOKEN
 │   ├── status

--- a/sdks/python-cli/omi_cli/commands/daily_summary.py
+++ b/sdks/python-cli/omi_cli/commands/daily_summary.py
@@ -48,8 +48,12 @@ def list_daily_summaries(
     typer_ctx: typer.Context,
     limit: int = typer.Option(30, "--limit", min=1, max=100, help="Number of daily summaries to return (1-100)."),
     offset: int = typer.Option(0, "--offset", min=0, help="Number of daily summaries to skip (>=0)."),
-    start_date: Optional[str] = typer.Option(None, "--start-date", help="Filter summaries on or after date (YYYY-MM-DD)."),
-    end_date: Optional[str] = typer.Option(None, "--end-date", help="Filter summaries on or before date (YYYY-MM-DD)."),
+    start_date: Optional[str] = typer.Option(
+        None, "--start-date", help="Filter summaries on or after date (YYYY-MM-DD)."
+    ),
+    end_date: Optional[str] = typer.Option(
+        None, "--end-date", help="Filter summaries on or before date (YYYY-MM-DD)."
+    ),
 ) -> None:
     ctx = _ctx(typer_ctx)
     if start_date is not None:

--- a/sdks/python-cli/omi_cli/commands/daily_summary.py
+++ b/sdks/python-cli/omi_cli/commands/daily_summary.py
@@ -1,0 +1,96 @@
+"""``omi daily-summary`` — stored daily recaps."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import TYPE_CHECKING, Optional
+
+import typer
+
+from omi_cli.errors import UsageError
+from omi_cli.output import shorten
+
+if TYPE_CHECKING:
+    from omi_cli.main import AppContext
+
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def _ctx(typer_ctx: typer.Context) -> AppContext:
+    obj = typer_ctx.obj
+    if obj is None:  # pragma: no cover
+        raise RuntimeError("AppContext not initialized")
+    return obj  # type: ignore[no-any-return]
+
+
+def _validate_date(value: str, flag: str) -> None:
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        raise UsageError(
+            message="Invalid date format",
+            detail=f"{flag} must be in YYYY-MM-DD format (got '{value}').",
+        )
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        raise UsageError(
+            message="Invalid calendar date",
+            detail=f"{flag} is not a valid calendar date: {exc}",
+        ) from exc
+
+
+_LIST_COLUMNS = ["id", "date", "day_emoji", "headline", "created_at"]
+
+
+@app.command("list", help="List stored daily summaries.")
+def list_daily_summaries(
+    typer_ctx: typer.Context,
+    limit: int = typer.Option(30, "--limit", min=1, max=100, help="Number of daily summaries to return (1-100)."),
+    offset: int = typer.Option(0, "--offset", min=0, help="Number of daily summaries to skip (>=0)."),
+    start_date: Optional[str] = typer.Option(None, "--start-date", help="Filter summaries on or after date (YYYY-MM-DD)."),
+    end_date: Optional[str] = typer.Option(None, "--end-date", help="Filter summaries on or before date (YYYY-MM-DD)."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if start_date is not None:
+        _validate_date(start_date, "--start-date")
+    if end_date is not None:
+        _validate_date(end_date, "--end-date")
+
+    params: dict[str, object] = {"limit": limit, "offset": offset}
+    if start_date is not None:
+        params["start_date"] = start_date
+    if end_date is not None:
+        params["end_date"] = end_date
+
+    with ctx.make_client() as client:
+        data = client.get("/v1/dev/user/daily-summaries", params=params)
+
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(data)
+        return
+
+    items = data.get("summaries", []) if isinstance(data, dict) else (data or [])
+    rows = []
+    for s in items:
+        rows.append(
+            {
+                "id": shorten(s.get("id"), 14),
+                "date": s.get("date") or "",
+                "day_emoji": s.get("day_emoji") or "",
+                "headline": shorten(s.get("headline") or s.get("overview") or "", 45),
+                "created_at": shorten(str(s.get("created_at") or ""), 19),
+            }
+        )
+    ctx.renderer.emit(rows, columns=_LIST_COLUMNS, title="daily summaries")
+
+
+@app.command("get", help="Fetch a single stored daily summary by ID.")
+def get_daily_summary(
+    typer_ctx: typer.Context,
+    summary_id: str = typer.Argument(..., help="Daily summary ID."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    with ctx.make_client() as client:
+        result = client.get(f"/v1/dev/user/daily-summaries/{summary_id}")
+    ctx.renderer.emit(result, title="daily summary")

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -31,6 +31,7 @@ from omi_cli.commands import action_item as action_item_cmd
 from omi_cli.commands import auth as auth_cmd
 from omi_cli.commands import config as config_cmd
 from omi_cli.commands import conversation as conversation_cmd
+from omi_cli.commands import daily_summary as daily_summary_cmd
 from omi_cli.commands import goal as goal_cmd
 from omi_cli.commands import local as local_cmd
 from omi_cli.commands import memory as memory_cmd
@@ -191,6 +192,7 @@ app.add_typer(config_cmd.app, name="config", help="View and modify CLI configura
 app.add_typer(memory_cmd.app, name="memory", help="Memories — facts and learnings about the user.")
 app.add_typer(conversation_cmd.app, name="conversation", help="Conversations — captured & processed audio + text.")
 app.add_typer(action_item_cmd.app, name="action-item", help="Action items — tasks and follow-ups.")
+app.add_typer(daily_summary_cmd.app, name="daily-summary", help="Daily summaries — stored daily recaps.")
 app.add_typer(goal_cmd.app, name="goal", help="Goals — tracked progress metrics.")
 app.add_typer(local_cmd.app, name="local", help="Local Omi Desktop API tools.")
 

--- a/sdks/python-cli/tests/test_daily_summary.py
+++ b/sdks/python-cli/tests/test_daily_summary.py
@@ -1,0 +1,133 @@
+"""Tests for ``omi daily-summary`` commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+import pytest
+
+from omi_cli.main import app, main
+
+
+_SAMPLE_SUMMARIES = {
+    "summaries": [
+        {
+            "id": "ds_01",
+            "date": "2026-04-25",
+            "day_emoji": "🚀",
+            "headline": "Launched the new Omi CLI daily summaries feature",
+            "overview": "Detailed overview of the launch activities and discussions.",
+            "created_at": "2026-04-25T20:00:00Z",
+            "stats": {
+                "total_conversations": 5,
+                "action_items_count": 2,
+            },
+        },
+        {
+            "id": "ds_02",
+            "date": "2026-04-26",
+            "day_emoji": "☕",
+            "headline": "Sprint planning and review",
+            "overview": "Reviewed user feedback and roadmap priorities.",
+            "created_at": "2026-04-26T18:30:00Z",
+        },
+    ]
+}
+
+
+def test_daily_summary_list_table(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/daily-summaries").respond(json=_SAMPLE_SUMMARIES)
+    result = cli_runner.invoke(app, ["daily-summary", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Launched the new Omi CLI" in result.stdout
+    assert "ds_01" in result.stdout
+
+
+def test_daily_summary_list_json_retains_shape(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.get("/v1/dev/user/daily-summaries").respond(json=_SAMPLE_SUMMARIES)
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "daily-summary",
+            "list",
+            "--limit",
+            "10",
+            "--offset",
+            "5",
+            "--start-date",
+            "2026-04-01",
+            "--end-date",
+            "2026-04-26",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    request = route.calls.last.request
+    assert request.url.params["limit"] == "10"
+    assert request.url.params["offset"] == "5"
+    assert request.url.params["start_date"] == "2026-04-01"
+    assert request.url.params["end_date"] == "2026-04-26"
+
+    payload = json.loads(result.stdout)
+    assert "summaries" in payload
+    assert len(payload["summaries"]) == 2
+    assert payload["summaries"][0]["id"] == "ds_01"
+
+
+def test_daily_summary_list_invalid_date_format(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["daily-summary", "list", "--start-date", "2026/04/25"])
+    assert result.exit_code == 1
+    assert "Invalid date format" in result.output
+
+
+def test_daily_summary_list_invalid_calendar_date(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["daily-summary", "list", "--end-date", "2026-02-30"])
+    assert result.exit_code == 1
+    assert "Invalid calendar date" in result.output
+
+
+def test_daily_summary_list_json_error(authed_profile, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["omi", "--json", "daily-summary", "list", "--start-date", "not-a-date"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    err = json.loads(output.err)
+    assert "Invalid date format" in err["error"]
+    assert "--start-date" in err["detail"]
+
+
+def test_daily_summary_get(authed_profile, respx_mock, cli_runner) -> None:
+    summary_data = _SAMPLE_SUMMARIES["summaries"][0]
+    respx_mock.get("/v1/dev/user/daily-summaries/ds_01").respond(json=summary_data)
+    result = cli_runner.invoke(app, ["--json", "daily-summary", "get", "ds_01"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["id"] == "ds_01"
+    assert payload["day_emoji"] == "🚀"
+
+
+def test_daily_summary_get_not_found(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/daily-summaries/missing_id").respond(
+        status_code=404, json={"detail": "Daily summary not found"}
+    )
+    result = cli_runner.invoke(app, ["daily-summary", "get", "missing_id"])
+    assert result.exit_code == 5
+    assert "not found" in result.output.lower()
+
+
+def test_daily_summary_get_not_found_json(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    respx_mock.get("/v1/dev/user/daily-summaries/missing_id").respond(
+        status_code=404, json={"detail": "Daily summary not found"}
+    )
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "daily-summary", "get", "missing_id"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 5
+    output = capsys.readouterr()
+    err = json.loads(output.err)
+    assert "not found" in err["error"].lower() or "not found" in err.get("detail", "").lower()

--- a/sdks/python-cli/tests/test_daily_summary.py
+++ b/sdks/python-cli/tests/test_daily_summary.py
@@ -77,13 +77,13 @@ def test_daily_summary_list_json_retains_shape(authed_profile, respx_mock, cli_r
 def test_daily_summary_list_invalid_date_format(authed_profile, cli_runner) -> None:
     result = cli_runner.invoke(app, ["daily-summary", "list", "--start-date", "2026/04/25"])
     assert result.exit_code == 1
-    assert "Invalid date format" in result.output
+    assert "Invalid date format" in result.stderr
 
 
 def test_daily_summary_list_invalid_calendar_date(authed_profile, cli_runner) -> None:
     result = cli_runner.invoke(app, ["daily-summary", "list", "--end-date", "2026-02-30"])
     assert result.exit_code == 1
-    assert "Invalid calendar date" in result.output
+    assert "Invalid calendar date" in result.stderr
 
 
 def test_daily_summary_list_json_error(authed_profile, monkeypatch, capsys) -> None:
@@ -102,13 +102,33 @@ def test_daily_summary_list_json_error(authed_profile, monkeypatch, capsys) -> N
 
 
 def test_daily_summary_get(authed_profile, respx_mock, cli_runner) -> None:
-    summary_data = _SAMPLE_SUMMARIES["summaries"][0]
+    summary_data = {
+        "id": "ds_01",
+        "date": "2026-04-25",
+        "day_emoji": "🚀",
+        "headline": "Launched the new Omi CLI daily summaries feature",
+        "overview": "Detailed overview of the launch activities and discussions.",
+        "created_at": "2026-04-25T20:00:00Z",
+        "highlights": ["Shipped CLI release", "Team demo went smoothly"],
+        "action_items": [{"description": "Write release notes", "completed": True}],
+        "knowledge_nuggets": ["Typer options formatting rules"],
+        "stats": {
+            "total_conversations": 5,
+            "action_items_count": 2,
+            "words_spoken": 1200,
+        },
+    }
     respx_mock.get("/v1/dev/user/daily-summaries/ds_01").respond(json=summary_data)
     result = cli_runner.invoke(app, ["--json", "daily-summary", "get", "ds_01"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     assert payload["id"] == "ds_01"
     assert payload["day_emoji"] == "🚀"
+    assert payload["highlights"] == ["Shipped CLI release", "Team demo went smoothly"]
+    assert payload["action_items"] == [{"description": "Write release notes", "completed": True}]
+    assert payload["knowledge_nuggets"] == ["Typer options formatting rules"]
+    assert payload["stats"]["total_conversations"] == 5
+    assert payload["stats"]["words_spoken"] == 1200
 
 
 def test_daily_summary_get_not_found(authed_profile, respx_mock, cli_runner) -> None:
@@ -117,7 +137,7 @@ def test_daily_summary_get_not_found(authed_profile, respx_mock, cli_runner) -> 
     )
     result = cli_runner.invoke(app, ["daily-summary", "get", "missing_id"])
     assert result.exit_code == 5
-    assert "not found" in result.output.lower()
+    assert "not found" in result.stderr.lower()
 
 
 def test_daily_summary_get_not_found_json(authed_profile, respx_mock, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
Implements `omi daily-summary list` and `omi daily-summary get <id>` commands in `omi-cli`, exposing the stored daily recap endpoints from the Developer API (`GET /v1/dev/user/daily-summaries` and `GET /v1/dev/user/daily-summaries/{summary_id}`).

- `omi daily-summary list`:
  - Supports `--limit` (1–100, default 30) and `--offset` (≥0, default 0) pagination.
  - Supports `--start-date` and `--end-date` filters validated as `YYYY-MM-DD` calendar dates before dispatching HTTP.
  - Formats tabular output with ID, date, day emoji, headline/overview, and created timestamp.
  - In `--json` mode, preserves the API's native `{"summaries": [...]}` envelope shape for scripting and agent consumption.
- `omi daily-summary get <id>`:
  - Fetches the full structured recap object including day stats, highlights, action items, and knowledge nuggets.
  - Translates 404 responses to clean CLI not-found errors (`exit_code = 5`).

Resolves #13139

## Changes
- `sdks/python-cli/omi_cli/commands/daily_summary.py`: Subcommand module implementing `list` and `get`.
- `sdks/python-cli/omi_cli/main.py`: Register `daily-summary` command group on the root Typer app.
- `sdks/python-cli/README.md`: Document `daily-summary` commands in resource overview and command tree.
- `sdks/python-cli/tests/test_daily_summary.py`: Full test suite covering tabular rendering, JSON shape retention, pagination/date parameters, date validation, and not-found error handling.

## Verification
- Unit tests in `sdks/python-cli/tests/test_daily_summary.py` pass (8/8).
- Linter checks verified clean with `ruff check`.
- Verified diff hygiene with `git diff --check HEAD` (clean).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

