### PR TITLE
fix(sdks/python-cli): preserve structured JSON errors for unreadable and directory paths in from-segments

### DIFF
--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -151,8 +150,18 @@ def from_segments(
     ctx = _ctx(typer_ctx)
     if not segments_file.exists():
         raise UsageError(message=f"File not found: {segments_file}")
+    if segments_file.is_dir():
+        raise UsageError(
+            message=f"Expected a file, but found a directory: {segments_file}",
+            detail="Provide the path to a JSON file containing transcript_segments.",
+        )
     try:
-        payload = load_json_input(segments_file.read_bytes())
+        data = segments_file.read_bytes()
+    except OSError as exc:
+        raise UsageError(message=f"Cannot read file {segments_file}", detail=str(exc))
+
+    try:
+        payload = load_json_input(data)
     except (ValueError, UnicodeDecodeError) as exc:
         raise UsageError(message=f"Invalid JSON in {segments_file}", detail=str(exc))
 

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 
 import pytest
 
-from omi_cli.main import app
+from omi_cli.main import app, main
 
 
 def test_conversation_list_renders(authed_profile, respx_mock, cli_runner) -> None:
@@ -105,4 +107,34 @@ def test_conversation_from_segments_rejects_invalid_unicode(config_path, respx_m
 
     assert result.exit_code == 1
     assert "Invalid JSON" in result.stderr
+    assert not respx_mock.calls
+
+def test_conversation_from_segments_rejects_directory(config_path, respx_mock, monkeypatch, capsys, tmp_path) -> None:
+    test_dir = tmp_path / "somedir"
+    test_dir.mkdir()
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "conversation", "from-segments", str(test_dir)])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    err = json.loads(output.err)
+    assert "Expected a file, but found a directory" in err["error"]
+    assert not respx_mock.calls
+
+
+def test_conversation_from_segments_rejects_unreadable_file(config_path, respx_mock, monkeypatch, capsys, tmp_path) -> None:
+    f = tmp_path / "unreadable.json"
+    f.write_text("{}")
+
+    def fail_read(*args, **kwargs):
+        raise PermissionError("Access denied")
+
+    monkeypatch.setattr(Path, "read_bytes", fail_read)
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "conversation", "from-segments", str(f)])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    err = json.loads(output.err)
+    assert "Cannot read file" in err["error"]
     assert not respx_mock.calls


### PR DESCRIPTION
## Summary
Fixes `omi conversation from-segments` crashing with unhandled `unexpected error: ...` when passed a directory or an unreadable file.
- Checks `segments_file.is_dir()` and emits a structured `UsageError` before attempting file reads.
- Catches `OSError` (such as `PermissionError`) on reading the file and routes it to `UsageError`.
- Preserves the machine-readable JSON error contract in `--json` mode with stable `exit_code = 1`.

Resolves #13013

## Changes
- `sdks/python-cli/omi_cli/commands/conversation.py`: Validate file vs directory and catch `OSError` in `from_segments`.
- `sdks/python-cli/tests/test_conversation.py`: Add unit tests asserting JSON error output when targeting a directory or unreadable file.

## Verification
- Unit tests in `sdks/python-cli/tests/test_conversation.py` pass (13/13).
- Clean code formatting verified with `ruff check`.
- Verified diff hygiene with `git diff --check HEAD` (clean).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

