### PR TITLE
fix(backend): fail-closed wear FCM on job-lock miss

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -1448,6 +1448,12 @@ def try_acquire_daily_summary_lock(uid: str, date: str, ttl: int = 60 * 60 * 2) 
     return result is not None
 
 
+def try_acquire_daily_wear_lock(uid: str, date: str, ttl: int = 60 * 60 * 24) -> bool:
+    """At most one wear FCM per uid per UTC day. True iff this caller may send."""
+    result = r.set(f'users:{uid}:daily_wear_lock:{date}', '1', ex=ttl, nx=True)
+    return result is not None
+
+
 def release_daily_summary_lock(uid: str, date: str) -> None:
     """Release a day lock this process took but did not spend on generation.
 

--- a/backend/tests/unit/test_daily_summary_selection_mode.py
+++ b/backend/tests/unit/test_daily_summary_selection_mode.py
@@ -52,12 +52,14 @@ def _loaded_notifications() -> Iterator[Tuple[ModuleType, ModuleType, ModuleType
         get_users_for_daily_summary=no_db_work,
         get_users_for_daily_summary_indexed=no_db_work,
         get_users_token_in_timezones=no_db_work,
+        get_users_id_in_timezones=no_db_work,
     )
     redis_db = _module(
         'database.redis_db',
         try_acquire_daily_summary_lock=lambda *_args: True,
         release_daily_summary_lock=lambda *_args: None,
         try_acquire_notifications_job_run_lock=lambda *_args, **_kwargs: True,
+        try_acquire_daily_wear_lock=lambda *_args, **_kwargs: True,
         release_notifications_job_run_lock=lambda *_args, **_kwargs: None,
     )
     notification_message = type(
@@ -365,7 +367,55 @@ def test_start_cron_job_fails_open_when_acquire_raises(caplog) -> None:
         with caplog.at_level(logging.WARNING):
             asyncio.run(notifications.start_cron_job())
 
-        assert calls == ['daily', 'summary']
+        assert calls == ['summary']
         assert released == []
         assert 'notifications_job_run_lock_acquire_failed' in caplog.text
         assert 'redis down' in caplog.text
+
+
+def test_send_daily_wear_disabled_does_not_bulk_send() -> None:
+    with _loaded_notifications() as (notifications, _db, _redis):
+        sent: list[object] = []
+
+        async def fake_bulk(*_a: Any, **_k: Any) -> None:
+            sent.append(1)
+
+        notifications.send_bulk_notification = fake_bulk
+        asyncio.run(notifications.send_daily_notification())
+        assert sent == []
+
+
+def test_send_daily_wear_caps_one_send_per_uid(caplog) -> None:
+    with _loaded_notifications() as (notifications, db, redis_db):
+        notifications.should_send_wear_device_reminder = lambda: True
+        notifications._get_timezones_at_time = lambda _t: ['America/New_York']
+        db.get_users_id_in_timezones = lambda _chunk: [
+            ('u1', ['t1'], 'America/New_York'),
+            ('u2', [], 'America/New_York'),
+            ('u3', ['t3a', 't3b'], 'America/New_York'),
+        ]
+        held: list[str] = []
+
+        def wear_lock(uid: str, _date: str, ttl: int = 60 * 60 * 24) -> bool:
+            assert ttl == 60 * 60 * 24
+            if uid in held:
+                return False
+            held.append(uid)
+            return True
+
+        redis_db.try_acquire_daily_wear_lock = wear_lock
+        sent: list[list[str]] = []
+
+        async def fake_bulk(tokens: list[str], title: str, body: str) -> None:
+            sent.append(list(tokens))
+            assert title == 'omi says'
+
+        notifications.send_bulk_notification = fake_bulk
+
+        with caplog.at_level(logging.INFO):
+            asyncio.run(notifications.send_daily_notification())
+            asyncio.run(notifications.send_daily_notification())
+
+        assert sent == [['t1', 't3a', 't3b']]
+        assert held == ['u1', 'u3']
+        assert 'notification_blast kind=wear users=2 tokens=3' in caplog.text

--- a/backend/tests/unit/test_other_notifications_async_boundaries.py
+++ b/backend/tests/unit/test_other_notifications_async_boundaries.py
@@ -35,6 +35,7 @@ def _loaded_other_notifications() -> Iterator[tuple[ModuleType, ModuleType]]:
         'database.notifications',
         get_users_for_daily_summary=no_db_work,
         get_users_token_in_timezones=no_db_work,
+        get_users_id_in_timezones=no_db_work,
     )
     notification_message = type(
         'NotificationMessage',
@@ -56,6 +57,7 @@ def _loaded_other_notifications() -> Iterator[tuple[ModuleType, ModuleType]]:
             # Declines before the LLM call hand the day back instead of sitting on the 2h key.
             release_daily_summary_lock=lambda *_args: None,
             try_acquire_notifications_job_run_lock=lambda *_args, **_kwargs: True,
+            try_acquire_daily_wear_lock=lambda *_args, **_kwargs: True,
             release_notifications_job_run_lock=lambda *_args, **_kwargs: None,
         ),
         'models.notification_message': _module(
@@ -154,21 +156,21 @@ def test_timezone_token_read_runs_off_loop_and_returns_tokens() -> None:
             loop = asyncio.get_running_loop()
             calls: list[list[str]] = []
 
-            def blocking_read(timezones: list[str]) -> list[str]:
+            def blocking_read(timezones: list[str]) -> list[Any]:
                 calls.append(timezones)
                 loop.call_soon_threadsafe(entered.set)
                 assert release.wait(timeout=2)
-                return ['token-a', 'token-b']
+                return [('u1', ['token-a', 'token-b'], 'Asia/Kolkata')]
 
             notifications._get_timezones_at_time = lambda _target: ['Asia/Kolkata']
-            notification_db.get_users_token_in_timezones = blocking_read
+            notification_db.get_users_id_in_timezones = blocking_read
 
             result = await _assert_loop_responsive_while_worker_waits(
-                notifications._get_users_in_timezone('08:00'),
+                notifications._get_wear_recipients('08:00'),
                 entered,
                 release,
             )
-            assert result == ['token-a', 'token-b']
+            assert result == [('u1', ['token-a', 'token-b'], 'Asia/Kolkata')]
             assert calls == [['Asia/Kolkata']]
 
         asyncio.run(exercise())

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -396,7 +396,10 @@ async def start_cron_job() -> None:
                 )
                 return
 
-        await send_daily_notification()
+        # Wear FCM has no per-send idempotency on the bulk path. Never ride
+        # job-lock fail-open (Redis maxmemory). Summaries still fail-open.
+        if acquired:
+            await send_daily_notification()
         summary_outcome = await send_daily_summary_notification()
         if not summary_outcome.ok:
             logger.error('Daily summary cron run failed: %s', summary_outcome.error_text)
@@ -911,8 +914,8 @@ def should_send_wear_device_reminder() -> bool:
     Issue #3328: current devices record onboard when BLE drops, so a morning
     wear/disconnect nag does not recover lost audio and causes notification
     fatigue. Keep the helper so the cron can be re-enabled without hunting
-    copy. Max 1/day was already true of the 08:00 cron; the product ask is
-    to stop sending them.
+    copy. Wear FCM is skipped unless the job run lock was acquired, and
+    capped at one send per uid per UTC day even if this flag is re-enabled.
     """
     return False
 
@@ -926,8 +929,23 @@ async def send_daily_notification() -> None:
         morning_alert_title = "omi says"
         morning_alert_body = "Wear your omi and capture your conversations today."
         morning_target_time = "08:00"
+        date_str = datetime.now(pytz.utc).strftime('%Y-%m-%d')
 
-        await _send_notification_for_time(morning_target_time, morning_alert_title, morning_alert_body)
+        recipients = await _get_wear_recipients(morning_target_time)
+        send_tokens: List[str] = []
+        locked_users = 0
+        for uid, tokens, _tz in recipients:
+            if not tokens:
+                continue
+            got = await run_blocking(db_executor, redis_db.try_acquire_daily_wear_lock, uid, date_str)
+            if not got:
+                continue
+            locked_users += 1
+            send_tokens.extend(tokens)
+
+        logger.info('notification_blast kind=wear users=%s tokens=%s', locked_users, len(send_tokens))
+        if send_tokens:
+            await send_bulk_notification(send_tokens, morning_alert_title, morning_alert_body)
 
     except Exception as e:
         logger.error(e)
@@ -935,22 +953,16 @@ async def send_daily_notification() -> None:
         return None
 
 
-async def _send_notification_for_time(target_time: str, title: str, body: str) -> Any:
-    user_in_time_zone = await _get_users_in_timezone(target_time)
-    if not user_in_time_zone:
-        logger.info("No users found in time zone")
-        return None
-    await send_bulk_notification(user_in_time_zone, title, body)
-    return user_in_time_zone
-
-
-async def _get_users_in_timezone(target_time: str) -> Any:
+async def _get_wear_recipients(target_time: str) -> List[Any]:
     timezones_in_time = _get_timezones_at_time(target_time)
     timezone_chunks = [timezones_in_time[i : i + 30] for i in range(0, len(timezones_in_time), 30)]
     chunk_results = await asyncio.gather(
-        *[run_blocking(db_executor, notification_db.get_users_token_in_timezones, chunk) for chunk in timezone_chunks]
+        *[run_blocking(db_executor, notification_db.get_users_id_in_timezones, chunk) for chunk in timezone_chunks]
     )
-    return [token for chunk in chunk_results for token in chunk]
+    users: List[Any] = []
+    for chunk in chunk_results:
+        users.extend(chunk)
+    return users
 
 
 def _get_timezones_at_time(target_time: str) -> List[str]:


### PR DESCRIPTION
## What changed and why

Wear FCM (`omi says` / Wear your omi…) rode `notifications-job` Redis run-lock **fail-open** (maxmemory) and had no per-user daily cap, so a minute-cadence job could spam the local-08 cohort.

- Call `send_daily_notification()` only when the job run lock was **acquired**. Summaries still fail-open (#13213).
- Cap wear at one FCM per uid per UTC day (`try_acquire_daily_wear_lock`).
- Log `notification_blast kind=wear users= tokens=` (no uid). Flag stays off (#3328).

Related: #3328 (already closed — not Closes).

Line-Count-Exception: backend/database/redis_db.py | 1605 -> 1611 | six-line wear daily lock next to daily_summary_lock; splitting redis_db is out of scope

## Product invariants affected

none

## How it was verified

`cd backend && python -m pytest tests/unit/test_wear_device_reminder.py tests/unit/test_daily_summary_selection_mode.py -m "not integration and not slow" -q` → 16 passed

## Failure-Class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

