### PR TITLE
feat(sdks/python-cli): add planning context options to goal create (#13172)

### DIFF
--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -126,6 +126,8 @@ exclusive. Omitting both leaves the unit unchanged.
 Goal types: `boolean`, `scale`, `numeric`. Up to **3 active goals per user**;
 the oldest is deactivated automatically when you create a fourth.
 
+Planning context options: `--desired-outcome`, `--why-it-matters`, repeatable `--success-criterion`, and `--horizon-at` (ISO datetime) can be specified when creating goals.
+
 ---
 
 ## Environment variables

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 import typer
 
+from omi_cli.datetime_options import ISO_DATETIME_FORMATS
 from omi_cli.errors import UsageError
 from omi_cli.models import GoalType
 from omi_cli.output import shorten
@@ -87,6 +89,12 @@ def create_goal(
     unit: Optional[str] = typer.Option(
         None, "--unit", help="Unit label (e.g. 'users', 'points'). Requires a metric option such as --target."
     ),
+    desired_outcome: Optional[str] = typer.Option(None, "--desired-outcome", help="Desired outcome."),
+    why_it_matters: Optional[str] = typer.Option(None, "--why-it-matters", help="Why this goal matters."),
+    success_criterion: list[str] = typer.Option([], "--success-criterion", help="Success criterion (repeatable)."),
+    horizon_at: Optional[datetime] = typer.Option(
+        None, "--horizon-at", formats=ISO_DATETIME_FORMATS, help="Target horizon datetime (ISO format)."
+    ),
 ) -> None:
     ctx = _ctx(typer_ctx)
     has_metrics = any(value is not None for value in (target_value, goal_type, current_value, min_value, max_value))
@@ -105,6 +113,14 @@ def create_goal(
             detail="Pass --target, or omit --type/--current/--min/--max/--unit to create a qualitative goal.",
         )
     body: dict[str, object] = {"title": title}
+    if desired_outcome is not None:
+        body["desired_outcome"] = desired_outcome
+    if why_it_matters is not None:
+        body["why_it_matters"] = why_it_matters
+    if success_criterion:
+        body["success_criteria"] = list(success_criterion)
+    if horizon_at is not None:
+        body["horizon_at"] = horizon_at.isoformat()
     if unit is not None:
         body["unit"] = unit
     if has_metrics:

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -207,3 +207,110 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
     assert not respx_mock.calls
+
+
+def test_goal_create_with_planning_context_qualitative(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g5",
+            "title": "Learn Rust",
+            "desired_outcome": "Build CLI tools",
+            "why_it_matters": "Performance and safety",
+            "success_criteria": ["Finish book", "Write a parser"],
+            "horizon_at": "2026-12-31T00:00:00",
+            "goal_type": None,
+            "target_value": None,
+            "current_value": None,
+            "min_value": None,
+            "max_value": None,
+            "unit": None,
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "goal",
+            "create",
+            "Learn Rust",
+            "--desired-outcome",
+            "Build CLI tools",
+            "--why-it-matters",
+            "Performance and safety",
+            "--success-criterion",
+            "Finish book",
+            "--success-criterion",
+            "Write a parser",
+            "--horizon-at",
+            "2026-12-31",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(route.calls.last.request.content)
+    assert body == {
+        "title": "Learn Rust",
+        "desired_outcome": "Build CLI tools",
+        "why_it_matters": "Performance and safety",
+        "success_criteria": ["Finish book", "Write a parser"],
+        "horizon_at": "2026-12-31T00:00:00",
+    }
+
+
+def test_goal_create_with_planning_context_metric(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.post("/v1/dev/user/goals").respond(
+        json={
+            "id": "g6",
+            "title": "Read papers",
+            "goal_type": "numeric",
+            "target_value": 50.0,
+            "current_value": 0,
+            "min_value": 0,
+            "max_value": 10,
+            "unit": "papers",
+            "desired_outcome": "Deep ML understanding",
+            "why_it_matters": "Research mastery",
+            "success_criteria": ["50 papers read"],
+            "horizon_at": "2026-12-31T23:59:59",
+            "is_active": True,
+        }
+    )
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "goal",
+            "create",
+            "Read papers",
+            "--target",
+            "50",
+            "--type",
+            "numeric",
+            "--unit",
+            "papers",
+            "--desired-outcome",
+            "Deep ML understanding",
+            "--why-it-matters",
+            "Research mastery",
+            "--success-criterion",
+            "50 papers read",
+            "--horizon-at",
+            "2026-12-31T23:59:59",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    body = json.loads(route.calls.last.request.content)
+    assert body["desired_outcome"] == "Deep ML understanding"
+    assert body["why_it_matters"] == "Research mastery"
+    assert body["success_criteria"] == ["50 papers read"]
+    assert body["horizon_at"] == "2026-12-31T23:59:59"
+    assert body["target_value"] == 50.0
+    assert body["goal_type"] == "numeric"
+    assert body["unit"] == "papers"
+
+
+def test_goal_create_invalid_horizon_rejected(authed_profile, respx_mock, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["goal", "create", "Learn Rust", "--horizon-at", "not-a-date"])
+    assert result.exit_code != 0
+    assert "Invalid value" in result.stderr
+    assert len(respx_mock.calls) == 0


### PR DESCRIPTION
## Summary
Resolves #13172.

Adds planning context options to `omi goal create`:
- `--desired-outcome`: Desired outcome of the goal
- `--why-it-matters`: Rationale and significance
- `--success-criterion`: Repeatable option specifying success criteria
- `--horizon-at`: Target horizon timestamp validating against `ISO_DATETIME_FORMATS` without HTTP roundtrips

Preserves existing omitted-field behavior for qualitative and metric goals.

## Testing
- Added unit tests in `sdks/python-cli/tests/test_goal.py` verifying:
  - Qualitative goal creation with planning context options
  - Metric goal creation with planning context options and units
  - Pre-flight rejection of invalid ISO datetimes without API calls
- Verified all 20 tests pass in `test_goal.py`
- Code formatting and linting verified with `ruff`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

