### PR TITLE
fix(sdks/python-cli): preserve prior dev key until replacement mint succeeds in OAuth re-login (#13041)

### DIFF
--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -283,48 +283,56 @@ def _exchange_firebase_token_for_dev_key(api_base: str, id_token: str) -> str:
 
     The Firebase session authenticates ``/v1/dev/keys`` (backend
     ``get_current_user_id``); the returned dev key is what every other
-    ``/v1/dev/*`` endpoint requires. Re-login first deletes the CLI's own
-    prior keys — matched by our exact :func:`_cli_key_name` only, so a user's
-    other keys are never touched — then mints a fresh one.
+    ``/v1/dev/*`` endpoint requires. Re-login mints a fresh key first, and
+    only cleans up prior keys matching our exact :func:`_cli_key_name` after
+    the replacement key is successfully obtained.
     """
     base = api_base.rstrip("/")
     headers = {"Authorization": f"Bearer {id_token}"}
     key_name = _cli_key_name()
 
     with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
-        # Best-effort cleanup of our own stale keys. Non-critical: if listing
-        # or deleting fails, still try to create — a duplicate is recoverable,
-        # a failed login is not.
-        try:
-            listing = client.get(f"{base}{_DEV_KEYS_PATH}", headers=headers)
-            if listing.status_code == 200:
-                for key in listing.json():
-                    if isinstance(key, dict) and key.get("name") == key_name and key.get("id"):
-                        client.delete(f"{base}{_DEV_KEYS_PATH}/{key['id']}", headers=headers)
-        except httpx.HTTPError:
-            pass
-
         resp = client.post(
             f"{base}{_DEV_KEYS_PATH}",
             headers=headers,
             json={"name": key_name, "scopes": _CLI_KEY_SCOPES},
         )
 
-    if resp.status_code not in (200, 201):
-        raise AuthError(
-            message=f"Could not create an API key for the CLI ({resp.status_code})",
-            detail=(
-                "OAuth sign-in succeeded, but minting a developer API key failed. "
-                "Try again, or use `omi auth login --api-key`."
-            ),
-        )
+        if resp.status_code not in (200, 201):
+            raise AuthError(
+                message=f"Could not create an API key for the CLI ({resp.status_code})",
+                detail=(
+                    "OAuth sign-in succeeded, but minting a developer API key failed. "
+                    "Try again, or use `omi auth login --api-key`."
+                ),
+            )
 
-    raw_key = resp.json().get("key")
-    if not raw_key:
-        raise AuthError(
-            message="Key-mint response was missing the API key",
-            detail="The /v1/dev/keys response did not include a `key` field.",
-        )
+        resp_data = resp.json()
+        raw_key = resp_data.get("key") if isinstance(resp_data, dict) else None
+        if not raw_key:
+            raise AuthError(
+                message="Key-mint response was missing the API key",
+                detail="The /v1/dev/keys response did not include a `key` field.",
+            )
+
+        new_key_id = resp_data.get("id") if isinstance(resp_data, dict) else None
+
+        # Best-effort cleanup of our own stale keys after replacement mint succeeds.
+        # Non-critical: if listing or deleting fails, the newly minted key remains valid.
+        try:
+            listing = client.get(f"{base}{_DEV_KEYS_PATH}", headers=headers)
+            if listing.status_code == 200:
+                for key in listing.json():
+                    if (
+                        isinstance(key, dict)
+                        and key.get("name") == key_name
+                        and key.get("id")
+                        and key.get("id") != new_key_id
+                    ):
+                        client.delete(f"{base}{_DEV_KEYS_PATH}/{key['id']}", headers=headers)
+        except httpx.HTTPError:
+            pass
+
     return str(raw_key)
 
 

--- a/sdks/python-cli/omi_cli/auth/oauth.py
+++ b/sdks/python-cli/omi_cli/auth/oauth.py
@@ -292,6 +292,24 @@ def _exchange_firebase_token_for_dev_key(api_base: str, id_token: str) -> str:
     key_name = _cli_key_name()
 
     with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        # Snapshot existing CLI keys before minting so that:
+        # 1. Stale keys are known prior to creation, and
+        # 2. Overlapping concurrent logins on the same host do not inadvertently delete
+        #    each other's freshly minted keys.
+        stale_key_ids: set[str] = set()
+        try:
+            listing = client.get(f"{base}{_DEV_KEYS_PATH}", headers=headers)
+            if listing.status_code == 200:
+                raw_list = listing.json()
+                if isinstance(raw_list, list):
+                    for key in raw_list:
+                        if isinstance(key, dict) and key.get("name") == key_name:
+                            k_id = key.get("id")
+                            if isinstance(k_id, str) and k_id:
+                                stale_key_ids.add(k_id)
+        except httpx.HTTPError:
+            pass
+
         resp = client.post(
             f"{base}{_DEV_KEYS_PATH}",
             headers=headers,
@@ -316,22 +334,21 @@ def _exchange_firebase_token_for_dev_key(api_base: str, id_token: str) -> str:
             )
 
         new_key_id = resp_data.get("id") if isinstance(resp_data, dict) else None
+        if not isinstance(new_key_id, str) or not new_key_id:
+            # When the response omits an ID, return the minted key without risking
+            # accidental deletion of the fresh credential.
+            return str(raw_key)
 
-        # Best-effort cleanup of our own stale keys after replacement mint succeeds.
-        # Non-critical: if listing or deleting fails, the newly minted key remains valid.
-        try:
-            listing = client.get(f"{base}{_DEV_KEYS_PATH}", headers=headers)
-            if listing.status_code == 200:
-                for key in listing.json():
-                    if (
-                        isinstance(key, dict)
-                        and key.get("name") == key_name
-                        and key.get("id")
-                        and key.get("id") != new_key_id
-                    ):
-                        client.delete(f"{base}{_DEV_KEYS_PATH}/{key['id']}", headers=headers)
-        except httpx.HTTPError:
-            pass
+        # Discard the new key from stale candidates (in case the snapshot already had it)
+        stale_key_ids.discard(new_key_id)
+
+        # Best-effort cleanup of only pre-mint snapshot keys after replacement mint succeeds.
+        if stale_key_ids:
+            try:
+                for stale_id in stale_key_ids:
+                    client.delete(f"{base}{_DEV_KEYS_PATH}/{stale_id}", headers=headers)
+            except httpx.HTTPError:
+                pass
 
     return str(raw_key)
 

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -338,6 +338,9 @@ def test_exchange_firebase_token_raises_when_key_field_missing(monkeypatch) -> N
 def test_failed_mint_keeps_previous_key_on_server_error(monkeypatch) -> None:
     deleted_urls: list[str] = []
 
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json=[{"id": "stale-key-1", "name": oauth._cli_key_name()}])
+
     def fake_post(self, url, **kwargs):  # noqa: ANN001
         return httpx.Response(503, json={"detail": "synthetic failure"})
 
@@ -345,6 +348,7 @@ def test_failed_mint_keeps_previous_key_on_server_error(monkeypatch) -> None:
         deleted_urls.append(url)
         return httpx.Response(204)
 
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
     monkeypatch.setattr(httpx.Client, "post", fake_post)
     monkeypatch.setattr(httpx.Client, "delete", fake_delete)
 
@@ -357,6 +361,9 @@ def test_failed_mint_keeps_previous_key_on_server_error(monkeypatch) -> None:
 def test_failed_mint_keeps_previous_key_on_missing_key_field(monkeypatch) -> None:
     deleted_urls: list[str] = []
 
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json=[{"id": "stale-key-1", "name": oauth._cli_key_name()}])
+
     def fake_post(self, url, **kwargs):  # noqa: ANN001
         return httpx.Response(201, json={"id": "minted-no-key", "name": oauth._cli_key_name()})
 
@@ -364,6 +371,7 @@ def test_failed_mint_keeps_previous_key_on_missing_key_field(monkeypatch) -> Non
         deleted_urls.append(url)
         return httpx.Response(204)
 
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
     monkeypatch.setattr(httpx.Client, "post", fake_post)
     monkeypatch.setattr(httpx.Client, "delete", fake_delete)
 
@@ -376,6 +384,9 @@ def test_failed_mint_keeps_previous_key_on_missing_key_field(monkeypatch) -> Non
 def test_failed_mint_keeps_previous_key_on_connect_error(monkeypatch) -> None:
     deleted_urls: list[str] = []
 
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json=[{"id": "stale-key-1", "name": oauth._cli_key_name()}])
+
     def fake_post(self, url, **kwargs):  # noqa: ANN001
         raise httpx.ConnectError("network unreachable")
 
@@ -383,6 +394,7 @@ def test_failed_mint_keeps_previous_key_on_connect_error(monkeypatch) -> None:
         deleted_urls.append(url)
         return httpx.Response(204)
 
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
     monkeypatch.setattr(httpx.Client, "post", fake_post)
     monkeypatch.setattr(httpx.Client, "delete", fake_delete)
 
@@ -390,3 +402,47 @@ def test_failed_mint_keeps_previous_key_on_connect_error(monkeypatch) -> None:
         oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
 
     assert not deleted_urls, f"DELETE should not have been called on transport failure, called: {deleted_urls}"
+
+
+def test_successful_mint_deletes_only_premint_snapshot_keys(monkeypatch) -> None:
+    deleted_urls: list[str] = []
+
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json=[{"id": "stale-key-1", "name": oauth._cli_key_name()}])
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(201, json={"id": "new-key-123", "key": "omi_dev_new", "name": oauth._cli_key_name()})
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        deleted_urls.append(url)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+
+    key = oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+    assert key == "omi_dev_new"
+    assert deleted_urls == ["https://api.test.omi.local/v1/dev/keys/stale-key-1"]
+
+
+def test_successful_mint_skips_cleanup_when_key_id_missing_in_response(monkeypatch) -> None:
+    deleted_urls: list[str] = []
+
+    def fake_get(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(200, json=[{"id": "stale-key-1", "name": oauth._cli_key_name()}])
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(201, json={"key": "omi_dev_new", "name": oauth._cli_key_name()})
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        deleted_urls.append(url)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+
+    key = oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+    assert key == "omi_dev_new"
+    assert not deleted_urls, f"DELETE should be skipped when new key ID is missing, called: {deleted_urls}"

--- a/sdks/python-cli/tests/test_auth_oauth.py
+++ b/sdks/python-cli/tests/test_auth_oauth.py
@@ -333,3 +333,60 @@ def test_exchange_firebase_token_raises_when_key_field_missing(monkeypatch) -> N
     with pytest.raises(AuthError) as info:
         oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
     assert "missing the api key" in str(info.value).lower()
+
+
+def test_failed_mint_keeps_previous_key_on_server_error(monkeypatch) -> None:
+    deleted_urls: list[str] = []
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(503, json={"detail": "synthetic failure"})
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        deleted_urls.append(url)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+
+    with pytest.raises(AuthError):
+        oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+
+    assert not deleted_urls, f"DELETE should not have been called on failed mint, called: {deleted_urls}"
+
+
+def test_failed_mint_keeps_previous_key_on_missing_key_field(monkeypatch) -> None:
+    deleted_urls: list[str] = []
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        return httpx.Response(201, json={"id": "minted-no-key", "name": oauth._cli_key_name()})
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        deleted_urls.append(url)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+
+    with pytest.raises(AuthError):
+        oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+
+    assert not deleted_urls, f"DELETE should not have been called when key is missing, called: {deleted_urls}"
+
+
+def test_failed_mint_keeps_previous_key_on_connect_error(monkeypatch) -> None:
+    deleted_urls: list[str] = []
+
+    def fake_post(self, url, **kwargs):  # noqa: ANN001
+        raise httpx.ConnectError("network unreachable")
+
+    def fake_delete(self, url, **kwargs):  # noqa: ANN001
+        deleted_urls.append(url)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    monkeypatch.setattr(httpx.Client, "delete", fake_delete)
+
+    with pytest.raises(httpx.ConnectError):
+        oauth._exchange_firebase_token_for_dev_key("https://api.test.omi.local", "tok")
+
+    assert not deleted_urls, f"DELETE should not have been called on transport failure, called: {deleted_urls}"


### PR DESCRIPTION
## Summary
Resolves #13041.

In `_exchange_firebase_token_for_dev_key`, stale CLI developer keys matching `_cli_key_name()` were previously deleted before sending the `POST /v1/dev/keys` request to mint the replacement. If minting failed (due to upstream 5xx errors, missing key field, or transient transport drops), the user's prior working developer key was revoked before any replacement was secured.

This PR reorders operations to mint the replacement key first:
1. `POST /v1/dev/keys` is dispatched and verified to contain a non-empty `key`.
2. Only after minting succeeds, stale keys matching `_cli_key_name()` are cleaned up, explicitly protecting the newly minted key ID.
3. If minting fails or disconnects, the previous keys remain untouched on the server.

## Testing
- Added regression tests in `sdks/python-cli/tests/test_auth_oauth.py`:
  - `test_failed_mint_keeps_previous_key_on_server_error` (verifies 503 leaves prior keys untouched)
  - `test_failed_mint_keeps_previous_key_on_missing_key_field` (verifies 201 without `key` leaves prior keys untouched)
  - `test_failed_mint_keeps_previous_key_on_connect_error` (verifies transport failure leaves prior keys untouched)
- Verified all 23 tests pass in `test_auth_oauth.py`
- Linted with `ruff` and verified clean diff

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

