### PR TITLE
fix(backend): apply canonical NFC normalization in text containment and similarity (#12946)

### DIFF
--- a/backend/tests/unit/test_text_containment.py
+++ b/backend/tests/unit/test_text_containment.py
@@ -3,6 +3,7 @@ Unit tests for compute_text_containment function.
 Tests character trigram containment across multiple languages.
 """
 
+import unicodedata
 from utils.text_utils import compute_text_containment
 
 
@@ -52,3 +53,27 @@ class TestComputeTextContainment:
 
     def test_trigram_length_boundary_not_contained(self):
         assert compute_text_containment("hey", "oh he there") == 0.0
+
+    def test_canonical_equivalence_spanish_nfd_nfc(self):
+        expected = "El próximo miércoles hablaremos sobre la configuración y la información del proyecto."
+        transcript_nfd = unicodedata.normalize("NFD", expected)
+        transcript_nfc = unicodedata.normalize("NFC", expected)
+        assert compute_text_containment(transcript_nfd, transcript_nfc) == 1.0
+        assert compute_text_containment(transcript_nfc, transcript_nfd) == 1.0
+
+    def test_canonical_equivalence_short_string(self):
+        expected = "él habló de todo"
+        transcript_nfd = unicodedata.normalize("NFD", "él")
+        assert compute_text_containment(transcript_nfd, expected) == 1.0
+
+    def test_canonical_equivalence_korean_hangul(self):
+        composed = "안녕하세요 세계"
+        decomposed = unicodedata.normalize("NFD", composed)
+        assert compute_text_containment(decomposed, composed) == 1.0
+        assert compute_text_containment(composed, decomposed) == 1.0
+
+    def test_canonical_equivalence_japanese_kana(self):
+        composed = "がんばってください"
+        decomposed = unicodedata.normalize("NFD", composed)
+        assert compute_text_containment(decomposed, composed) == 1.0
+        assert compute_text_containment(composed, decomposed) == 1.0

--- a/backend/tests/unit/test_text_similarity.py
+++ b/backend/tests/unit/test_text_similarity.py
@@ -3,6 +3,7 @@ Unit tests for compute_text_similarity function.
 Tests character trigram Jaccard similarity across multiple languages.
 """
 
+import unicodedata
 from utils.text_utils import compute_text_similarity
 
 
@@ -205,3 +206,19 @@ class TestComputeTextSimilarity:
         similarity = compute_text_similarity(text1, text2)
         # Should have relatively high similarity
         assert similarity > 0.3
+
+    def test_canonical_equivalence_accented_latin(self):
+        """Canonically equivalent accented Latin strings should have 1.0 similarity."""
+        text_nfc = "El próximo miércoles hablaremos sobre la configuración."
+        text_nfd = unicodedata.normalize("NFD", text_nfc)
+        assert compute_text_similarity(text_nfd, text_nfc) == 1.0
+
+    def test_canonical_equivalence_cjk(self):
+        """Canonically equivalent Korean and Japanese strings should have 1.0 similarity."""
+        korean_nfc = "안녕하세요 세계"
+        korean_nfd = unicodedata.normalize("NFD", korean_nfc)
+        assert compute_text_similarity(korean_nfd, korean_nfc) == 1.0
+
+        japanese_nfc = "がんばってください"
+        japanese_nfd = unicodedata.normalize("NFD", japanese_nfc)
+        assert compute_text_similarity(japanese_nfd, japanese_nfc) == 1.0

--- a/backend/utils/text_utils.py
+++ b/backend/utils/text_utils.py
@@ -1,9 +1,10 @@
+import unicodedata
 from typing import Set
 
 
 def _normalize_text(text: str) -> str:
-    """Normalize text: lowercase and collapse whitespace."""
-    return ' '.join(text.lower().split())
+    """Normalize text: canonical NFC composition, lowercase, and collapse whitespace."""
+    return ' '.join(unicodedata.normalize('NFC', text).lower().split())
 
 
 def _get_trigrams(text: str) -> Set[str]:


### PR DESCRIPTION
## Summary
Resolves #12946.

In `utils.text_utils._normalize_text`, strings were previously lowercased and whitespace-collapsed without Unicode canonical normalization. When comparing decomposed Unicode forms (NFD) against precomposed forms (NFC), character trigrams diverged significantly despite representing identical text. For example, Spanish accented text scored ~0.855 containment, failing the `MIN_CONTAINMENT = 0.9` threshold during speaker sample verification.

This PR normalizes text using `unicodedata.normalize('NFC', text)` during `_normalize_text`, ensuring canonical equivalence across Latin accents, Korean Hangul, Japanese kana, and short strings.

## Testing
- Added canonical equivalence tests in `backend/tests/unit/test_text_containment.py` and `backend/tests/unit/test_text_similarity.py` covering:
  - Spanish NFD vs NFC sentence containment (scores 1.0)
  - Short string containment with accented characters
  - Korean Hangul composed vs decomposed containment and similarity
  - Japanese kana with dakuten/handakuten composed vs decomposed containment and similarity
- Ran all 44 unit tests in `test_text_containment.py` and `test_text_similarity.py` (all passed)
- Code linted cleanly with `ruff`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

