### PR TITLE
docs(sdks/python-cli): add Korean quickstart guide (#13365)

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -63,7 +63,7 @@ Pretty output displays returned text literally, including square brackets and
 emoji-like codes such as `:warning:`. Styling applies to the table layout, not
 to the contents of your memories or conversations.
 
-> Looking for localized guides? See the [🇯🇵 日本語クイックスタート (Japanese Quickstart)](examples/quickstart.ja.md).
+> Looking for localized guides? See the [🇯🇵 日本語クイックスタート (Japanese Quickstart)](examples/quickstart.ja.md) or [🇰🇷 한국어 퀵스타트 (Korean Quickstart)](examples/quickstart.ko.md).
 
 ## Auth
 

--- a/sdks/python-cli/examples/README.md
+++ b/sdks/python-cli/examples/README.md
@@ -5,3 +5,4 @@
 * [`shell_examples.sh`](shell_examples.sh) — runnable shell snippets covering
   the most common verbs.
 * [`quickstart.ja.md`](quickstart.ja.md) — 日本語クイックスタートガイド (Japanese Quickstart).
+* [`quickstart.ko.md`](quickstart.ko.md) — 한국어 퀵스타트 가이드 (Korean Quickstart).

--- a/sdks/python-cli/examples/quickstart.ko.md
+++ b/sdks/python-cli/examples/quickstart.ko.md
@@ -1,8 +1,8 @@
-# omi-cli 한국어 퀵스타트 가이드 (Quickstart Guide)
+# omi-cli 빠른 시작 가이드 (Korean Quickstart)
 
-> 터미널에서 Omi와 직접 상호작용하기 위한 실전 가이드 — 개발자 및 자율형 AI 에이전트를 위해 설계되었습니다.
+> 터미널에서 Omi와 직접 상호작용하기 위한 실용 가이드 — 개발자와 자율 AI 에이전트 모두를 위해 설계되었습니다.
 
-`omi-cli`는 [Omi](https://omi.me) 개발자 API를 제어하기 위한 공식 명령줄 인터페이스(CLI)입니다. Omi가 관리하는 4대 핵심 리소스인 기억(Memories), 대화(Conversations), 액션 아이템(Action Items), 목표(Goals)를 스크립트와 파이프라인으로 쉽게 자동화할 수 있습니다.
+`omi-cli`는 [Omi](https://omi.me) 개발자 API를 위한 공식 명령줄 인터페이스입니다. 시스템의 핵심 4대 리소스인 메모리(memories), 대화(conversations), 작업 항목(action items), 목표(goals)를 정형화되고 자동화 가능한 방식으로 관리할 수 있습니다.
 
 * **PyPI:** [pypi.org/project/omi-cli](https://pypi.org/project/omi-cli/)
 * **공식 문서:** [docs.omi.me/doc/developer/cli/introduction](https://docs.omi.me/doc/developer/cli/introduction)
@@ -10,23 +10,23 @@
 
 ---
 
-## 1. 설치 (Installation)
+## 1. 설치
 
-권장되는 설치 방식은 격리된 환경에서 독립적으로 실행하는 `pipx`를 사용하는 것입니다:
+시스템 의존성 충돌을 방지하고 독립된 가상 환경에서 실행할 수 있도록 `pipx`를 통한 설치를 권장합니다.
 
 ```bash
-# 권장: pipx를 통한 격리 설치
+# 권장: pipx를 통한 독립 설치
 pipx install omi-cli
 
-# 또는 pip를 통한 일반 설치
+# 또는 표준 pip 설치
 pip install omi-cli
 ```
 
-> **중요: 패키지명과 명령어명의 차이**
-> * PyPI에 등록된 패키지 이름은 **`omi-cli`**입니다 (`omi` 패키지는 다른 무관한 패키지입니다).
-> * 설치 후 터미널에서 실행하는 명령어는 **`omi`**입니다.
+> **주의: 패키지명 vs. 명령어 이름**
+> * PyPI 패키지명은 **`omi-cli`**입니다 (`omi`라는 이름은 관련 없는 다른 패키지입니다).
+> * 터미널에서 실행하는 명령어는 간단히 **`omi`**입니다.
 
-설치 후 버전 및 도움말을 확인합니다:
+설치가 정상적으로 완료되었는지 확인합니다:
 
 ```bash
 omi --version
@@ -39,120 +39,126 @@ omi --help
 
 `omi-cli`는 두 가지 인증 방식을 지원합니다:
 
-| 인증 방식 | 주요 용도 | 명령어 예시 |
+| 인증 방식 | 권장 사용 환경 | 예시 명령어 |
 | :--- | :--- | :--- |
-| **개발자 API 키 (`omi_dev_*`)** | CI/CD, 자동화 스크립트, AI 에이전트 | `omi auth login --api-key ...` 또는 `OMI_API_KEY` |
-| **브라우저 OAuth (Google/Apple)** | 개발자 로컬 노트북 / PC | `omi auth login --browser` |
+| **개발자 API 키 (`omi_dev_*`)** | 자동화, CI/CD, 헤드리스 서버, AI 에이전트 | `omi auth login --api-key ...` 또는 `OMI_API_KEY` |
+| **브라우저 OAuth (Google/Apple)** | 로컬 데스크톱 및 개발자 워크스테이션 | `omi auth login --browser` (Google) / `--provider apple` |
 
 ### 대화형 로그인
-옵션 없이 실행하면 방식을 선택하는 프롬프트가 표시됩니다:
+옵션 없이 명령어를 실행하면 사용할 방식을 선택할 수 있습니다:
 
 ```bash
 omi auth login
-# 1) Browser — 웹 브라우저에서 Google 또는 Apple 계정으로 로그인
-# 2) API key — app.omi.me에서 발급받은 개발자 API 키 붙여넣기
+# 1) Browser — 웹 브라우저를 통한 Google 로그인 (Apple 계정은 `--provider apple` 사용)
+# 2) API key — app.omi.me에서 생성한 개발자 API 키 입력
 ```
 
 ### 브라우저 직접 로그인
 ```bash
+# 기본 Google 로그인
 omi auth login --browser
+
+# Apple 계정 로그인
+omi auth login --browser --provider apple
 ```
 
 ### 개발자 API 키 사용
-[app.omi.me](https://app.omi.me)의 **Developer → API Keys**에서 키를 발급받아 설정합니다:
+[app.omi.me](https://app.omi.me)의 **Developer → API Keys** 메뉴에서 키를 발급받습니다:
 
 ```bash
-# CLI를 통해 로컬 설정에 저장
-omi auth login --api-key omi_dev_...
+# 로컬 프로필에 영구 저장 (대화형 프롬프트로 붙여넣어 셸 히스토리 보호)
+omi auth login --api-key
 
-# 또는 환경 변수로 설정 (컨테이너 및 CI/CD에 최적)
-export OMI_API_KEY="omi_dev_..."
+# 또는 환경 변수로 설정 (컨테이너 및 CI/CD 파이프라인에 최적)
+# 참고: 활성 로컬 프로필에 이미 저장된 키가 있는 경우 `omi auth logout`을 먼저 실행하세요.
+export OMI_API_KEY="omi_dev_your_actual_key_here"
 ```
 
 ### 인증 상태 확인
-* `omi auth status`: 로컬에 저장된 프로필, 마스킹된 토큰 및 만료 시간을 확인합니다 (오프라인 작동).
-* `omi auth whoami`: Omi 서버에 실제 검증 요청을 보내 키의 유효성을 확인합니다 (네트워크 연결 필요).
+* `omi auth status`: 활성 로컬 프로필과 마스킹된 인증 정보를 표시합니다. 만료일은 OAuth 프로필에 대해서만 표시됩니다 (오프라인 작동).
+* `omi auth whoami`: Omi 서버에 검증 요청을 보내 실시간 자격 증명의 유효성을 확인합니다 (네트워크 필요).
 
 ```bash
 omi auth status
 omi auth whoami
 ```
 
-로그아웃 시:
+세션 종료:
 ```bash
 omi auth logout
+# OMI_API_KEY가 환경 변수로 설정되어 있다면 세션에서도 해제합니다 (Bash/Zsh: `unset OMI_API_KEY`).
 ```
 
 ---
 
-## 3. 핵심 리소스 명령어
+## 3. 핵심 명령어
 
-### 기억 (Memories)
-시스템이 사용자에 대해 학습한 사실, 지식, 컨텍스트 관리:
+### 메모리 (Memories)
+Omi가 기록한 원자 단위의 맥락 정보:
 
 ```bash
-# 저장된 기억 목록 조회
+# 저장된 메모리 목록 조회
 omi memory list
 
-# 새로운 기억 생성
-omi memory create "백엔드 구현시 Python과 TypeScript를 선호함" --category work
+# 새 메모리 생성
+omi memory create "파이썬 예제를 포함한 기술적이고 간결한 답변을 선호함" --category work
 
-# 특정 기억 상세 조회
+# 특정 메모리 상세 조회
 omi memory get <MEMORY_ID>
 ```
 
 ### 대화 (Conversations)
-Omi 디바이스 또는 앱에서 녹음되고 전사된 대화 기록:
+Omi 디바이스를 통해 녹음된 대화 및 오디오 트랜스크립트:
 
 ```bash
-# 최근 대화 5개 조회
+# 최근 5개의 대화 목록 조회
 omi conversation list --limit 5
 
-# 대화의 전체 스크립트를 포함하여 상세 조회
+# 대화 상세 정보 및 전체 텍스트 트랜스크립트 가져오기
 omi conversation get <CONVERSATION_ID> --include-transcript
 ```
 
-### 액션 아이템 (Action Items)
-대화에서 자동 추출된 할 일 및 후속 조치 과제:
+### 할 일 및 작업 항목 (Action Items)
+대화에서 자동으로 추출된 실행 항목:
 
 ```bash
-# 미완료된 액션 아이템 목록 조회
+# 진행 중인 할 일 목록 조회
 omi action-item list --open
 
-# 액션 아이템을 완료 처리
+# 작업 완료 처리
 omi action-item complete <ACTION_ITEM_ID>
 ```
 
 ### 목표 (Goals)
-진척 도를 추적하는 정량적/정성적 목표 관리:
+진행률 지표 및 목표 추적:
 
 ```bash
 # 활성 목표 목록 조회
 omi goal list
 
-# 새로운 수치형 목표 생성
-omi goal create "매일 2L 물 마시기" --type numeric --target 2 --unit liters
+# 새 정량적 목표 생성
+omi goal create "매일 물 2리터 마시기" --type numeric --target 2 --unit liters
 ```
 
 ---
 
-## 4. 자동화 및 JSON 출력 (`--json`)
+## 4. 구조화된 자동화 및 JSON 출력 (`--json`)
 
-`omi-cli`는 스크립트 자동화와 파이프라인을 위해 완벽한 JSON 출력을 지원합니다. `--json` 플래그는 **하위 명령어 앞에 위치해야 하는 글로벌 옵션**입니다:
+`omi-cli`는 자동화 파이프라인을 위해 최우선으로 설계되었습니다. 전역 플래그 `--json`을 지정하면 유효한 JSON 형식으로 결과가 출력됩니다:
 
 ```bash
-# 기억 목록을 JSON으로 가져와 jq로 필요한 필드만 추출
+# 메모리를 JSON으로 출력하고 jq로 필드 추출
 omi --json memory list | jq '.[] | {id, content, category}'
 
-# 최근 대화 제목 목록 추출
+# 최근 대화 제목 추출
 omi --json conversation list --limit 5 | jq '.[] | {id, title: .structured.title, started_at}'
 
-# 열려있는 액션 아이템만 JSON으로 조회
+# 열려 있는 작업 항목 원시 데이터 확인
 omi --json action-item list --open | jq '.'
 ```
 
-> **옵션 위치 주의사항:**
-> `--json` 플래그는 반드시 하위 리소스 명령어 앞에 있어야 합니다:
+> **중요 구문 규칙:**
+> `--json`은 **전역 옵션**이므로 항상 하위 명령어 **앞에** 위치해야 합니다:
 > * 올바른 예: `omi --json memory list`
 > * 잘못된 예: `omi memory list --json`
 
@@ -160,30 +166,30 @@ omi --json action-item list --open | jq '.'
 
 ## 5. 종료 코드 (Exit Codes)
 
-CI/CD 파이프라인과 스크립트에서 안정적인 예외 처리를 위해 정의된 표준 종료 코드:
+셸 스크립트와 CI/CD 파이프라인의 안정적인 오류 처리를 위한 표준 종료 코드:
 
 | 종료 코드 | 의미 | 설명 |
 | :---: | :--- | :--- |
 | `0` | **성공 (Success)** | 명령어가 정상적으로 실행됨. |
-| `1` | **사용법 오류 (Usage Error)** | 잘못된 인자, 필수 플래그 누락, 구문 오류. |
-| `2` | **인증 오류 (Auth Error)** | 미로그인, 유효하지 않은 API 키 또는 만료된 토큰. |
-| `3` | **서버/네트워크 오류 (Server Error)** | HTTP 5xx 응답, 타임아웃, 네트워크 연결 실패. |
-| `4` | **요청 제한 (Rate Limited)** | HTTP 429 Too Many Requests — 재시도 로직 필요. |
-| `5` | **리소스 없음 (Not Found)** | HTTP 404 Not Found — 요청한 ID를 찾을 수 없음. |
+| `1` | **사용법 오류 (유효성 검사 오류)** | 잘못된 데이터 값 또는 애플리케이션 검증 실패; Click 파서 구문 오류(누락된 필수 플래그 등)는 코드 `2`를 반환합니다. |
+| `2` | **인증 오류 / CLI 구문 오류** | 미인증 상태, 만료된 토큰 또는 잘못된 Click CLI 파서 구문 오류. |
+| `3` | **서버/네트워크 오류 (Server Error)** | HTTP 5xx 응답, 연결 타임아웃 또는 서버 도달 불가. |
+| `4` | **요청 빈도 제한 (Rate Limited)** | HTTP 429 Too Many Requests — 지연 후 재시도 필요. |
+| `5` | **찾을 수 없음 (Not Found)** | HTTP 404 Not Found — 요청한 리소스가 존재하지 않음. |
 
 ---
 
-## 6. 쉘(Shell)별 실행 예시
+## 6. 환경별 셸 스크립트 예제
 
 ### Bash / Zsh (Linux / macOS)
 ```bash
-# API 키 설정
+# 세션에 API 키 설정
 export OMI_API_KEY="omi_dev_your_actual_key_here"
 
-# 명령어 실행 및 종료 코드 검증
+# 실행 후 종료 코드 검증
 omi --json memory list --limit 10
 if [ $? -ne 0 ]; then
-    echo "기억 목록 조회 실패" >&2
+    echo "사용자 메모리 조회 중 오류가 발생했습니다." >&2
 fi
 ```
 
@@ -192,54 +198,56 @@ fi
 # PowerShell 환경 변수 설정
 $env:OMI_API_KEY = "omi_dev_your_actual_key_here"
 
-# JSON 결과를 PowerShell 객체로 변환하여 필드 선택
+# JSON 출력을 PowerShell 객체로 직접 변환
 $memories = omi --json memory list | ConvertFrom-Json
 $memories | Select-Object id, content, category
 
-# $LASTEXITCODE를 통한 오류 처리
+# $LASTEXITCODE를 통한 오류 검사
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Omi CLI 실행 실패: 코드 $LASTEXITCODE"
+    Write-Error "Omi 명령어가 오류 코드 $LASTEXITCODE(으)로 실패했습니다."
 }
 ```
 
 ---
 
-## 7. 로컬 Desktop API 연동
+## 7. 로컬 데스크톱 API 연동
 
-Omi Desktop 앱이 로컬 컴퓨터에서 실행 중일 때, 클라우드를 거치지 않고 로컬 네트워크를 통해 직접 화면 기록 및 DB를 조회할 수 있습니다:
+Omi Desktop 애플리케이션이 머신에서 실행 중인 경우 클라우드 요청 없이 로컬 캡처 및 화면 기록을 조회할 수 있습니다:
 
 ```bash
-# 로컬 API 연결 정보 구성
-omi local configure --url http://127.0.0.1:47778 --token YOUR_DESKTOP_TOKEN
+# 로컬 엔드포인트 구성 (보안을 위해 환경 변수 사용 권장)
+export OMI_LOCAL_API_URL="http://127.0.0.1:47778"
+read -r -s -p "Desktop token: " OMI_LOCAL_TOKEN; echo
+export OMI_LOCAL_TOKEN
 
 # 로컬 연결 상태 확인
 omi --json local status
 
-# 로컬 화면 타임라인 검색
-omi --json local search-screen "프로젝트 보고서" --days 7 --app Safari
+# 최근 시각 타임라인 검색
+omi --json local search-screen "분기 보고서" --days 7 --app Safari
 ```
 
 ---
 
-## 8. 프로필 관리 (Profiles)
+## 8. 다중 프로필 관리 (Profiles)
 
-개인 계정과 업무 계정, 또는 테스트 환경과 운영 환경을 전환하면서 사용할 때는 `--profile` 옵션을 사용합니다. 설정은 `~/.omi/config.toml`에 저장됩니다:
+개인 계정과 업무용 계정 또는 테스트 환경을 전환할 때 `--profile` 옵션을 사용합니다. 설정은 `~/.omi/config.toml`에 안전하게 저장됩니다:
 
 ```bash
-# 개인 프로필로 로그인
+# 개인 프로필 생성 및 로그인
 omi --profile personal auth login
 
-# 업무 프로필로 로그인
+# 업무용 프로필 생성 및 로그인
 omi --profile work auth login
 
-# 특정 프로필 컨텍스트에서 명령어 실행
+# 특정 프로필로 명령어 실행
 omi --profile work memory list
 ```
 
 ---
 
-## 9. 보안 권장 사항
+## 9. 보안 모범 사례
 
-* **API 키 Git 커밋 금지:** 개발자 API 키를 소스 코드 리포지토리에 포함하지 마십시오. 환경 변수나 `.gitignore`에 등록된 설정 파일을 활용하십시오.
-* **터미널 히스토리 보호:** 명령줄에 키를 직접 노출하는 대신 환경 변수(`OMI_API_KEY`)나 대화형 프롬프트를 사용하십시오.
-* **즉각 폐기:** 키가 외부에 노출된 것으로 의심되면 [app.omi.me](https://app.omi.me)에서 즉시 키를 삭제 및 재발급하십시오.
+* **Git 저장소에 키 커밋 금지:** API 키는 버전 관리 시스템에 절대 커밋하지 마시고, 비밀 관리자나 `.gitignore` 처리된 `.env` 파일을 활용하세요.
+* **셸 히스토리 보호:** 공유 환경에서는 커맨드라인 플래그로 직접 키를 전달하지 말고 대화형 입력이나 `OMI_API_KEY` 환경 변수를 사용하세요.
+* **디렉터리 권한:** Unix 환경에서는 설정 디렉터리 `~/.omi/`의 권한을 엄격하게 제한하세요 (`chmod 700 ~/.omi`).

--- a/sdks/python-cli/examples/quickstart.ko.md
+++ b/sdks/python-cli/examples/quickstart.ko.md
@@ -1,0 +1,245 @@
+# omi-cli 한국어 퀵스타트 가이드 (Quickstart Guide)
+
+> 터미널에서 Omi와 직접 상호작용하기 위한 실전 가이드 — 개발자 및 자율형 AI 에이전트를 위해 설계되었습니다.
+
+`omi-cli`는 [Omi](https://omi.me) 개발자 API를 제어하기 위한 공식 명령줄 인터페이스(CLI)입니다. Omi가 관리하는 4대 핵심 리소스인 기억(Memories), 대화(Conversations), 액션 아이템(Action Items), 목표(Goals)를 스크립트와 파이프라인으로 쉽게 자동화할 수 있습니다.
+
+* **PyPI:** [pypi.org/project/omi-cli](https://pypi.org/project/omi-cli/)
+* **공식 문서:** [docs.omi.me/doc/developer/cli/introduction](https://docs.omi.me/doc/developer/cli/introduction)
+* **소스 코드:** [github.com/BasedHardware/omi/tree/main/sdks/python-cli](https://github.com/BasedHardware/omi/tree/main/sdks/python-cli)
+
+---
+
+## 1. 설치 (Installation)
+
+권장되는 설치 방식은 격리된 환경에서 독립적으로 실행하는 `pipx`를 사용하는 것입니다:
+
+```bash
+# 권장: pipx를 통한 격리 설치
+pipx install omi-cli
+
+# 또는 pip를 통한 일반 설치
+pip install omi-cli
+```
+
+> **중요: 패키지명과 명령어명의 차이**
+> * PyPI에 등록된 패키지 이름은 **`omi-cli`**입니다 (`omi` 패키지는 다른 무관한 패키지입니다).
+> * 설치 후 터미널에서 실행하는 명령어는 **`omi`**입니다.
+
+설치 후 버전 및 도움말을 확인합니다:
+
+```bash
+omi --version
+omi --help
+```
+
+---
+
+## 2. 인증 (Authentication)
+
+`omi-cli`는 두 가지 인증 방식을 지원합니다:
+
+| 인증 방식 | 주요 용도 | 명령어 예시 |
+| :--- | :--- | :--- |
+| **개발자 API 키 (`omi_dev_*`)** | CI/CD, 자동화 스크립트, AI 에이전트 | `omi auth login --api-key ...` 또는 `OMI_API_KEY` |
+| **브라우저 OAuth (Google/Apple)** | 개발자 로컬 노트북 / PC | `omi auth login --browser` |
+
+### 대화형 로그인
+옵션 없이 실행하면 방식을 선택하는 프롬프트가 표시됩니다:
+
+```bash
+omi auth login
+# 1) Browser — 웹 브라우저에서 Google 또는 Apple 계정으로 로그인
+# 2) API key — app.omi.me에서 발급받은 개발자 API 키 붙여넣기
+```
+
+### 브라우저 직접 로그인
+```bash
+omi auth login --browser
+```
+
+### 개발자 API 키 사용
+[app.omi.me](https://app.omi.me)의 **Developer → API Keys**에서 키를 발급받아 설정합니다:
+
+```bash
+# CLI를 통해 로컬 설정에 저장
+omi auth login --api-key omi_dev_...
+
+# 또는 환경 변수로 설정 (컨테이너 및 CI/CD에 최적)
+export OMI_API_KEY="omi_dev_..."
+```
+
+### 인증 상태 확인
+* `omi auth status`: 로컬에 저장된 프로필, 마스킹된 토큰 및 만료 시간을 확인합니다 (오프라인 작동).
+* `omi auth whoami`: Omi 서버에 실제 검증 요청을 보내 키의 유효성을 확인합니다 (네트워크 연결 필요).
+
+```bash
+omi auth status
+omi auth whoami
+```
+
+로그아웃 시:
+```bash
+omi auth logout
+```
+
+---
+
+## 3. 핵심 리소스 명령어
+
+### 기억 (Memories)
+시스템이 사용자에 대해 학습한 사실, 지식, 컨텍스트 관리:
+
+```bash
+# 저장된 기억 목록 조회
+omi memory list
+
+# 새로운 기억 생성
+omi memory create "백엔드 구현시 Python과 TypeScript를 선호함" --category work
+
+# 특정 기억 상세 조회
+omi memory get <MEMORY_ID>
+```
+
+### 대화 (Conversations)
+Omi 디바이스 또는 앱에서 녹음되고 전사된 대화 기록:
+
+```bash
+# 최근 대화 5개 조회
+omi conversation list --limit 5
+
+# 대화의 전체 스크립트를 포함하여 상세 조회
+omi conversation get <CONVERSATION_ID> --include-transcript
+```
+
+### 액션 아이템 (Action Items)
+대화에서 자동 추출된 할 일 및 후속 조치 과제:
+
+```bash
+# 미완료된 액션 아이템 목록 조회
+omi action-item list --open
+
+# 액션 아이템을 완료 처리
+omi action-item complete <ACTION_ITEM_ID>
+```
+
+### 목표 (Goals)
+진척 도를 추적하는 정량적/정성적 목표 관리:
+
+```bash
+# 활성 목표 목록 조회
+omi goal list
+
+# 새로운 수치형 목표 생성
+omi goal create "매일 2L 물 마시기" --type numeric --target 2 --unit liters
+```
+
+---
+
+## 4. 자동화 및 JSON 출력 (`--json`)
+
+`omi-cli`는 스크립트 자동화와 파이프라인을 위해 완벽한 JSON 출력을 지원합니다. `--json` 플래그는 **하위 명령어 앞에 위치해야 하는 글로벌 옵션**입니다:
+
+```bash
+# 기억 목록을 JSON으로 가져와 jq로 필요한 필드만 추출
+omi --json memory list | jq '.[] | {id, content, category}'
+
+# 최근 대화 제목 목록 추출
+omi --json conversation list --limit 5 | jq '.[] | {id, title: .structured.title, started_at}'
+
+# 열려있는 액션 아이템만 JSON으로 조회
+omi --json action-item list --open | jq '.'
+```
+
+> **옵션 위치 주의사항:**
+> `--json` 플래그는 반드시 하위 리소스 명령어 앞에 있어야 합니다:
+> * 올바른 예: `omi --json memory list`
+> * 잘못된 예: `omi memory list --json`
+
+---
+
+## 5. 종료 코드 (Exit Codes)
+
+CI/CD 파이프라인과 스크립트에서 안정적인 예외 처리를 위해 정의된 표준 종료 코드:
+
+| 종료 코드 | 의미 | 설명 |
+| :---: | :--- | :--- |
+| `0` | **성공 (Success)** | 명령어가 정상적으로 실행됨. |
+| `1` | **사용법 오류 (Usage Error)** | 잘못된 인자, 필수 플래그 누락, 구문 오류. |
+| `2` | **인증 오류 (Auth Error)** | 미로그인, 유효하지 않은 API 키 또는 만료된 토큰. |
+| `3` | **서버/네트워크 오류 (Server Error)** | HTTP 5xx 응답, 타임아웃, 네트워크 연결 실패. |
+| `4` | **요청 제한 (Rate Limited)** | HTTP 429 Too Many Requests — 재시도 로직 필요. |
+| `5` | **리소스 없음 (Not Found)** | HTTP 404 Not Found — 요청한 ID를 찾을 수 없음. |
+
+---
+
+## 6. 쉘(Shell)별 실행 예시
+
+### Bash / Zsh (Linux / macOS)
+```bash
+# API 키 설정
+export OMI_API_KEY="omi_dev_your_actual_key_here"
+
+# 명령어 실행 및 종료 코드 검증
+omi --json memory list --limit 10
+if [ $? -ne 0 ]; then
+    echo "기억 목록 조회 실패" >&2
+fi
+```
+
+### PowerShell (Windows)
+```powershell
+# PowerShell 환경 변수 설정
+$env:OMI_API_KEY = "omi_dev_your_actual_key_here"
+
+# JSON 결과를 PowerShell 객체로 변환하여 필드 선택
+$memories = omi --json memory list | ConvertFrom-Json
+$memories | Select-Object id, content, category
+
+# $LASTEXITCODE를 통한 오류 처리
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Omi CLI 실행 실패: 코드 $LASTEXITCODE"
+}
+```
+
+---
+
+## 7. 로컬 Desktop API 연동
+
+Omi Desktop 앱이 로컬 컴퓨터에서 실행 중일 때, 클라우드를 거치지 않고 로컬 네트워크를 통해 직접 화면 기록 및 DB를 조회할 수 있습니다:
+
+```bash
+# 로컬 API 연결 정보 구성
+omi local configure --url http://127.0.0.1:47778 --token YOUR_DESKTOP_TOKEN
+
+# 로컬 연결 상태 확인
+omi --json local status
+
+# 로컬 화면 타임라인 검색
+omi --json local search-screen "프로젝트 보고서" --days 7 --app Safari
+```
+
+---
+
+## 8. 프로필 관리 (Profiles)
+
+개인 계정과 업무 계정, 또는 테스트 환경과 운영 환경을 전환하면서 사용할 때는 `--profile` 옵션을 사용합니다. 설정은 `~/.omi/config.toml`에 저장됩니다:
+
+```bash
+# 개인 프로필로 로그인
+omi --profile personal auth login
+
+# 업무 프로필로 로그인
+omi --profile work auth login
+
+# 특정 프로필 컨텍스트에서 명령어 실행
+omi --profile work memory list
+```
+
+---
+
+## 9. 보안 권장 사항
+
+* **API 키 Git 커밋 금지:** 개발자 API 키를 소스 코드 리포지토리에 포함하지 마십시오. 환경 변수나 `.gitignore`에 등록된 설정 파일을 활용하십시오.
+* **터미널 히스토리 보호:** 명령줄에 키를 직접 노출하는 대신 환경 변수(`OMI_API_KEY`)나 대화형 프롬프트를 사용하십시오.
+* **즉각 폐기:** 키가 외부에 노출된 것으로 의심되면 [app.omi.me](https://app.omi.me)에서 즉시 키를 삭제 및 재발급하십시오.


### PR DESCRIPTION
## Summary
Resolves #13365.

Adds a comprehensive, idiomatic Korean quickstart guide (`sdks/python-cli/examples/quickstart.ko.md`) for `omi-cli`:
- Package name (`omi-cli`) vs binary executable (`omi`)
- Installation options via `pipx` (isolated environment) and `pip`
- Complete authentication walkthrough:
  - Interactive browser login (`omi auth login --browser`)
  - Headless API-key login (`omi auth login --api-key`) and environment variable (`OMI_API_KEY`)
  - Offline status inspection (`omi auth status`) vs live server verification (`omi auth whoami`)
- Primary resource workflows for memories, conversations, action items, and goals
- Structured automation guidelines with global `--json` option and `jq` recipes
- Detailed exit codes reference table (`0`, `1`, `2`, `3`, `4`, `5`)
- Cross-platform shell snippets for Linux/macOS (Bash/Zsh) and Windows (PowerShell with `$LASTEXITCODE` validation)
- Local Omi Desktop API integration (`omi local configure`, `omi local search-screen`)
- Multi-environment profile management (`--profile`, `~/.omi/config.toml`)
- Security recommendations for credentials and shell history
- Discovery links added in `sdks/python-cli/README.md` and `sdks/python-cli/examples/README.md`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

