### PR TITLE
fix(sdks/python-cli): emit machine-readable JSON object in version subcommand (#13362)

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -287,6 +287,9 @@ The CLI is built so an LLM can use it without a wrapper:
 
 * `--json` returns valid JSON to stdout. Nothing else writes to stdout in JSON
   mode (errors go to stderr as `{"error": "...", "detail": "..."}`).
+* Use `omi --json version` for a machine-readable version object
+  (`{"version": "..."}`). `omi version` and the eager `omi --version` flag
+  retain their plain-text output.
 * Stable exit codes (above) let an agent disambiguate retryable vs terminal
   errors.
 * Successful resource `delete --yes` commands preserve the API response in

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -153,8 +153,12 @@ def _root(
 
 
 @app.command(help="Print the omi-cli version.")
-def version() -> None:
-    typer.echo(f"omi-cli {__version__}")
+def version(typer_ctx: typer.Context) -> None:
+    ctx: AppContext = typer_ctx.obj
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"version": __version__})
+    else:
+        typer.echo(f"omi-cli {__version__}")
 
 
 @app.command(help="Ask a natural-language question, answered from your own Omi conversations.")

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -47,6 +47,14 @@ def test_version_subcommand(cli_runner) -> None:
     assert __version__ in result.stdout
 
 
+def test_version_subcommand_json(config_path, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "version"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"version": __version__}
+    assert result.stderr == ""
+    assert not config_path.exists()
+
+
 def test_help_lists_all_top_level_commands(cli_runner) -> None:
     result = cli_runner.invoke(app, ["--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
Resolves #13362.

When `--json` is supplied, `omi version` previously emitted plain-text `omi-cli <version>\n`, violating the documented JSON stdout contract for autonomous agents and machine automation scripts.

This change:
- Updates `version()` in `sdks/python-cli/omi_cli/main.py` to check `ctx.renderer.json_mode` and emit `{"version": __version__}`.
- Preserves plain-text output for standard `omi version` and the eager `omi --version` flag.
- Documents the behavior in `sdks/python-cli/README.md`.
- Adds regression test `test_version_subcommand_json` in `sdks/python-cli/tests/test_main.py` ensuring exit code 0, valid JSON payload `{"version": "..."}`, empty stderr, and no unintended config creation.

Co-authored-by: tamirpeled <tamirpeled@users.noreply.github.com>
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

