### PR TITLE
fix(mcp): propagate HTTP errors instead of returning error bodies as successful tool results (#13049)

### DIFF
--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -133,6 +133,18 @@ class SearchConversations(BaseModel):
     end_date: Optional[str] = Field(description="Filter conversations before this date (yyyy-mm-dd).", default=None)
 
 
+def _response_json(response: requests.Response):
+    """Reject failed API calls without exposing query strings or response bodies."""
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        raise requests.HTTPError(
+            f"Omi API request failed (HTTP {response.status_code})",
+            response=response,
+        ) from None
+    return response.json()
+
+
 def _parse_categories(categories, category_cls: type, logger: logging.Logger) -> list:
     if not isinstance(categories, list):
         raise ValueError(f"categories must be a list, got {type(categories)}")
@@ -163,8 +175,7 @@ def get_memories(
             params=params,
             headers={"Authorization": f"Bearer {api_key}"},
         )
-        logger.info(f"get_memories response: {response.json()}")
-        return response.json()
+        return _response_json(response)
     except Exception as e:
         logger.error(f"Error getting memories: {e}")
         raise e
@@ -176,7 +187,7 @@ def create_memory(api_key: str, content: str, category: MemoryCategory) -> dict:
         headers={"Authorization": f"Bearer {api_key}"},
         json={"content": content, "category": category},
     )
-    return response.json()
+    return _response_json(response)
 
 
 def delete_memory(api_key: str, memory_id: str) -> dict:
@@ -184,7 +195,7 @@ def delete_memory(api_key: str, memory_id: str) -> dict:
         f"{base_url}memories/{memory_id}",
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    return response.json()
+    return _response_json(response)
 
 
 def edit_memory(api_key: str, memory_id: str, content: str) -> dict:
@@ -193,7 +204,7 @@ def edit_memory(api_key: str, memory_id: str, content: str) -> dict:
         headers={"Authorization": f"Bearer {api_key}"},
         params={"value": content},
     )
-    return response.json()
+    return _response_json(response)
 
 
 def search_memories(
@@ -208,8 +219,7 @@ def search_memories(
         params={"query": query, "limit": limit},
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    response.raise_for_status()
-    return response.json()
+    return _response_json(response)
 
 
 def get_conversations(
@@ -242,7 +252,7 @@ def get_conversations(
         params=params,
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    return response.json()
+    return _response_json(response)
 
 
 def get_conversation_by_id(api_key: str, conversation_id: str) -> dict:
@@ -250,7 +260,7 @@ def get_conversation_by_id(api_key: str, conversation_id: str) -> dict:
         f"{base_url}conversations/{conversation_id}",
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    return response.json()
+    return _response_json(response)
 
 
 def search_conversations(
@@ -273,8 +283,7 @@ def search_conversations(
         params=params,
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    response.raise_for_status()
-    return response.json()
+    return _response_json(response)
 
 
 async def serve(uid: str | None) -> None:

--- a/mcp/tests/test_http_status.py
+++ b/mcp/tests/test_http_status.py
@@ -1,18 +1,6 @@
 """REST helpers must not return unsuccessful HTTP responses as tool results."""
 
 import logging
-import sys
-from unittest.mock import MagicMock
-
-if "mcp" not in sys.modules:
-    mcp = MagicMock()
-    mcp_server = MagicMock()
-    mcp_stdio = MagicMock()
-    mcp_types = MagicMock()
-    sys.modules["mcp"] = mcp
-    sys.modules["mcp.server"] = mcp_server
-    sys.modules["mcp.server.stdio"] = mcp_stdio
-    sys.modules["mcp.types"] = mcp_types
 
 import pytest
 import requests

--- a/mcp/tests/test_http_status.py
+++ b/mcp/tests/test_http_status.py
@@ -1,0 +1,56 @@
+"""REST helpers must not return unsuccessful HTTP responses as tool results."""
+
+import logging
+import sys
+from unittest.mock import MagicMock
+
+if "mcp" not in sys.modules:
+    mcp = MagicMock()
+    mcp_server = MagicMock()
+    mcp_stdio = MagicMock()
+    mcp_types = MagicMock()
+    sys.modules["mcp"] = mcp
+    sys.modules["mcp.server"] = mcp_server
+    sys.modules["mcp.server.stdio"] = mcp_stdio
+    sys.modules["mcp.types"] = mcp_types
+
+import pytest
+import requests
+
+from mcp_server_omi import server
+
+
+LOGGER = logging.getLogger(__name__)
+OPERATIONS = [
+    ("get", lambda: server.get_memories(LOGGER, "synthetic-key")),
+    ("post", lambda: server.create_memory("synthetic-key", "fixture", server.MemoryCategory.core)),
+    ("delete", lambda: server.delete_memory("synthetic-key", "fixture-id")),
+    ("patch", lambda: server.edit_memory("synthetic-key", "fixture-id", "fixture")),
+    ("get", lambda: server.get_conversations(LOGGER, "synthetic-key")),
+    ("get", lambda: server.get_conversation_by_id("synthetic-key", "fixture-id")),
+    ("get", lambda: server.search_memories(LOGGER, "synthetic-key", "fixture")),
+    ("get", lambda: server.search_conversations(LOGGER, "synthetic-key", "fixture")),
+]
+
+
+@pytest.mark.parametrize("method,operation", OPERATIONS)
+@pytest.mark.parametrize("status", [401, 429, 503])
+def test_http_errors_propagate(monkeypatch, method, operation, status):
+    response = requests.Response()
+    response.status_code = status
+    response.url = "https://example.invalid/fixture?value=private-memory"
+    response._content = b'{"detail":"request failed"}'
+    monkeypatch.setattr(server.requests, method, lambda *args, **kwargs: response)
+    with pytest.raises(requests.HTTPError) as caught:
+        operation()
+    assert caught.value.response is response
+    assert str(caught.value) == f"Omi API request failed (HTTP {status})"
+
+
+@pytest.mark.parametrize("method,operation", OPERATIONS)
+def test_successful_json_is_preserved(monkeypatch, method, operation):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b'{"id":"fixture-id"}'
+    monkeypatch.setattr(server.requests, method, lambda *args, **kwargs: response)
+    assert operation() == {"id": "fixture-id"}


### PR DESCRIPTION
## Summary
Resolves #13049.

In the standalone `mcp/` server, REST helpers previously returned JSON directly from `requests` without checking HTTP response status. Consequently, upstream failures (such as HTTP 401 Unauthorized, 429 Rate Limited, or 503 Service Unavailable) were delivered to the MCP client as `isError: false` with the error payload treated as ordinary content.

This change:
- Centralizes response validation into `_response_json(response: requests.Response)` in `mcp/src/mcp_server_omi/server.py`.
- Replaces raw `response.json()` calls across all 8 REST helpers (`get_memories`, `create_memory`, `delete_memory`, `edit_memory`, `search_memories`, `get_conversations`, `get_conversation_by_id`, and `search_conversations`).
- Formats `requests.HTTPError` with concise status messaging (`Omi API request failed (HTTP {status})`) while redacting URL query parameters that could leak memory content.
- Adds comprehensive unit test suite in `mcp/tests/test_http_status.py` covering error propagation on 401/429/503 and preserving successful JSON responses across all operations.

Co-authored-by: tarun753 <tarun753@users.noreply.github.com>
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

