### PR TITLE
SCA-464: stop MIC dead-letters amplifying a Modulate 5xx storm

### DIFF
--- a/.github/failure-classes/FC-session-handoff-counted-as-failed-attempt.json
+++ b/.github/failure-classes/FC-session-handoff-counted-as-failed-attempt.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "id": "FC-session-handoff-counted-as-failed-attempt",
+  "violated_contract": "A durable job's attempt budget counts failed processing attempts, not lease handoffs. Reclaiming an expired lease because a listen session reconnected is not evidence that the worker failed to process the job. Dead-lettering after N session handoffs turns a healthy reconnect into a terminal MIC failure while the upstream STT outage is still in progress.",
+  "canonical_prevention": "Increment the processing attempt counter only on a retryable processing failure. Inline (pusher) retryable failures must increment the same retries counter as the Cloud Tasks worker. Cover reclaim-without-failure, retryable increment, and dead-letter-only-after-N-failed-processing-attempts with behavioral tests.",
+  "canonical_prevention_artifact": [
+    "backend/database/conversation_finalization_jobs.py",
+    "backend/utils/pusher_finalization.py",
+    "backend/tests/unit/test_conversation_finalization_jobs.py",
+    "backend/tests/unit/test_listen_finalization_cloud_tasks.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/database/conversation_finalization_jobs.py",
+    "backend/utils/pusher_finalization.py",
+    "backend/utils/stt/**"
+  ],
+  "status": "open"
+}

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -269,7 +269,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: NO_SOCKET_TIMEOUT
     value: "true"
   - name: HOSTED_PUSHER_API_URL

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -337,7 +337,7 @@ env:
   - name: DEEPGRAM_SELF_HOSTED_ENABLED
     value: "false"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: HOSTED_TRANSLATION_API_URL
     value: "http://nllb.omi.me"
   - name: TRANSLATION_SERVICE_MODELS

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -289,7 +289,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
     value: "1000000"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -294,7 +294,7 @@ env:
   - name: STT_PRERECORDED_MODEL
     value: "parakeet,modulate-velma-2"
   - name: STT_SERVICE_MODELS
-    value: "modulate-velma-2,soniox,dg-nova-3,parakeet"
+    value: "modulate-velma-2,dg-nova-3,parakeet"
   - name: RAPID_API_KEY
     valueFrom:
       secretKeyRef:

--- a/backend/config/stt_provider_policy.py
+++ b/backend/config/stt_provider_policy.py
@@ -135,14 +135,11 @@ PROVIDER_SERVING_SURFACES: Final[Mapping[str, frozenset[STTServingSurface]]] = {
 # hard stream gate (see parakeet/admission.py), so every listener converges on
 # one cap per serving pod instead of listener-local counters.
 DEFAULT_MODELS_BY_SURFACE: Final[Mapping[STTServingSurface, tuple[str, ...]]] = {
-    # Velma-2 leads on cost, and its failures are now recoverable: a mid-session
-    # error frame hands the stream to Soniox rather than ending it (#12459), which
-    # is what the second slot is for. Deepgram stays last so a BYOK user still
-    # resolves a `dg-*` model — dropping it would strip them of Deepgram entirely.
-    # Parakeet stays last rather than being dropped: a client can ask for it by
-    # name (`?stt_service=parakeet`), and that preference is only honorable while
-    # the model is listed here.
-    STTServingSurface.STREAMING: ('modulate-velma-2', 'soniox', 'dg-nova-3', 'parakeet'),
+    # Velma-2 leads on cost. Soniox is streaming-capable but not a default hop:
+    # prod's SONIOX_API_KEY is empty, so listing it consumed a mental next slot
+    # while accepted=0. Deepgram is the overflow; Parakeet stays last (bounded
+    # GPU, English-only streaming) and is honorable when a client asks by name.
+    STTServingSurface.STREAMING: ('modulate-velma-2', 'dg-nova-3', 'parakeet'),
     # Batch work is queued, so Parakeet's bounded GPU means waiting rather than the
     # user-visible failure it causes on the streaming surface. Prefer the self-hosted
     # provider here and keep Velma as the overflow.

--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -618,7 +618,10 @@ def _claim_finalization_job_txn(
 
     lease_epoch = int(job.get('lease_epoch') or 0) + 1
     lease_expires_at = now + timedelta(seconds=lease_seconds)
-    attempt_count = int(job.get('attempt_count') or 0) + 1
+    # Failed-processing count only. Reconnect/session handoffs reclaim the
+    # same job; bumping here made the 5th lease (not the 5th processing
+    # failure) dead-letter the conversation. Increment in mark_finalization_retryable.
+    attempt_count = int(job.get('attempt_count') or 0)
 
     transaction.update(
         job_ref,
@@ -631,9 +634,6 @@ def _claim_finalization_job_txn(
             'lease_epoch': lease_epoch,
             'reconcile_after_at': (firestore.DELETE_FIELD if bool(job.get('requires_byok')) else lease_expires_at),
             'updated_at': now,
-            # The claimer owns the attempt budget: an inline (pusher) worker has
-            # no Cloud Tasks retry count to fence its terminal attempt with.
-            'attempt_count': attempt_count,
         },
     )
     if status == 'queued':
@@ -945,12 +945,14 @@ def _mark_finalization_retryable_txn(
     job = snapshot.to_dict() or {}
     if not _is_current_lease(job, dispatch_generation, lease_epoch):
         return False
+    attempt_count = int(job.get('attempt_count') or 0) + 1
     transaction.update(
         job_ref,
         {
             'status': 'queued',
             'updated_at': now,
             'lease_expires_at': now,
+            'attempt_count': attempt_count,
             'reconcile_after_at': (
                 firestore.DELETE_FIELD
                 if bool(job.get('requires_byok'))

--- a/backend/deploy/_generate_runtime_env_sources.py
+++ b/backend/deploy/_generate_runtime_env_sources.py
@@ -52,7 +52,7 @@ GKE_CONFIG_MAP_KEYS_PROD_ONLY = [
 
 STT_LITERALS = {
     'STT_PRERECORDED_MODEL': 'parakeet,modulate-velma-2',
-    'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet',
+    'STT_SERVICE_MODELS': 'modulate-velma-2,dg-nova-3,parakeet',
 }
 
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -61,7 +61,7 @@ environments:
             value: dev
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -298,7 +298,7 @@ environments:
             value: parakeet,modulate-velma-2
             category: stt_policy
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware-dev
@@ -376,7 +376,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,soniox,dg-nova-3,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:
@@ -1354,7 +1354,7 @@ environments:
             value: prod
             category: runtime_identity
           STT_SERVICE_MODELS:
-            value: modulate-velma-2,soniox,dg-nova-3,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
             category: stt_policy
           CONVERSATION_SUMMARIZED_APP_IDS:
             config_map:
@@ -1578,7 +1578,7 @@ environments:
             value: parakeet,modulate-velma-2
           STT_SERVICE_MODELS:
             source: literal
-            value: modulate-velma-2,soniox,dg-nova-3,parakeet
+            value: modulate-velma-2,dg-nova-3,parakeet
           TYPESENSE_HOST:
             source: environment
           TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -68,7 +68,7 @@ environment_shared:
           value: '{env}'
           category: runtime_identity
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,soniox,dg-nova-3,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
           category: stt_policy
         CONVERSATION_SUMMARIZED_APP_IDS:
           config_map:

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -138,7 +138,7 @@ overlay:
           value: parakeet,modulate-velma-2
           category: stt_policy
         STT_SERVICE_MODELS:
-          value: modulate-velma-2,soniox,dg-nova-3,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
           category: stt_policy
         GOOGLE_CLOUD_PROJECT:
           value: based-hardware-dev
@@ -216,7 +216,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,soniox,dg-nova-3,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -121,7 +121,7 @@ overlay:
           value: parakeet,modulate-velma-2
         STT_SERVICE_MODELS:
           source: literal
-          value: modulate-velma-2,soniox,dg-nova-3,parakeet
+          value: modulate-velma-2,dg-nova-3,parakeet
         TYPESENSE_HOST:
           source: environment
         TWILIO_ACCOUNT_SID:

--- a/backend/docs/operational/modulate-serve-error-deaths.md
+++ b/backend/docs/operational/modulate-serve-error-deaths.md
@@ -5,7 +5,7 @@ Incident window: 2026-08-31 → 09-01 (backend-listen, Loop S sensor).
 was the #3 error signature (×11/30m), with `Unable to complete the request.
 Please try again.` at #10 (×5/30m); the sensor logged 62 more over the
 following 6 hours. Modulate-Velma-2 is the streaming **primary**
-(`modulate-velma-2,soniox,dg-nova-3,parakeet`), so during such an outage
+(`modulate-velma-2,dg-nova-3,parakeet`), so during such an outage
 every new session is handed to Velma, serves briefly, takes the error frame
 mid-session, and fails over.
 
@@ -52,11 +52,14 @@ configured right behind it.
   `connection`) and `_CIRCUIT_OPENING_REASONS`, so both the failover seam
   (`note_typed_provider_death`) and the terminal funnel
   (`terminate_live_stt_session`) open `_modulate_circuit`.
-- Recovery is unchanged: one `record_serve_failure` opens the circuit for
-  one cooldown window (default 30s, `MODULATE_CIRCUIT_COOLDOWN_SECONDS`);
-  the half-open probe restores Velma as soon as one stream serves again.
-  Sessions already running fail over as before — close codes, client-visible
-  events, and the fallback chain are untouched.
+- Recovery: one `record_serve_failure` opens the circuit for the serve-error
+  cooldown (default 180s, `MODULATE_SERVE_ERROR_CIRCUIT_COOLDOWN_SECONDS`),
+  distinct from the connect-path 30s window. Re-admission requires three
+  consecutive half-open successes (`MODULATE_SERVE_ERROR_SUCCESSES_TO_CLOSE`)
+  so a 5xx storm that still accepts connects cannot flap every 30s. Connect-path
+  failures still close on the first probe success. Sessions already running fail
+  over as before — close codes, client-visible events, and the fallback chain
+  are untouched.
 
 ## Signals after the fix
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -125,6 +125,7 @@ from utils.executors import (
 )
 from utils.executors import start_background_task
 from utils.cloud_tasks import validate_account_deletion_dispatch_configuration
+from utils.stt.streaming import validate_streaming_stt_env
 from utils.llm.managed_spend_ledger import shutdown_managed_spend_ledger
 from services.conversation_finalization import reconcile_abandoned_byok_finalization_jobs
 from services.conversation_finalization import reconcile_listen_finalization_jobs
@@ -310,6 +311,7 @@ app.add_middleware(BYOKMiddleware)
 async def startup_event():
     start_metrics_sidecar_server()
     validate_account_deletion_dispatch_configuration()
+    validate_streaming_stt_env()
     asyncio.create_task(log_executor_health())
     # Drain account-deletion wipes orphaned by a previous deploy/restart. Offloaded
     # to db_executor so the blocking Firestore queries don't stall event-loop startup.

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -20,7 +20,7 @@ from routers import pusher, metrics
 from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from utils.http_client import close_all_clients
 from utils.executors import drain_background_tasks, log_executor_health, start_background_task
-from utils.readiness import ReadinessGate
+from utils.stt.streaming import validate_streaming_stt_env
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -45,6 +45,7 @@ def _validate_static_capabilities(env: Mapping[str, str] | None = None) -> None:
             'pusher static capability admission failed: '
             'conversation.finalize.persisted requires memory.canonical.mutate'
         )
+    validate_streaming_stt_env(env)
 
 
 async def startup_event() -> None:

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -20,6 +20,7 @@ from routers import pusher, metrics
 from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from utils.http_client import close_all_clients
 from utils.executors import drain_background_tasks, log_executor_health, start_background_task
+from utils.readiness import ReadinessGate
 from utils.stt.streaming import validate_streaming_stt_env
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -1082,8 +1082,8 @@ async def _inline_finalization_survives_source_close(stack: Stack) -> None:
     # The durable claim transitions the job to 'leased' (the only non-terminal
     # processing state); 'processing' is a conversation status, not a job status.
     claimed = _wait_for_job(stack, uid, conversation_id, 'leased')
-    if claimed.get('attempt_count') != 1:
-        raise StackFailure('source-close finalization was not claimed exactly once before disconnect')
+    if claimed.get('attempt_count') != 0:
+        raise StackFailure('source-close claim burned failed-processing attempts before work ran')
 
     await websocket.close(code=1000)
     _wait_until(
@@ -1094,7 +1094,7 @@ async def _inline_finalization_survives_source_close(stack: Stack) -> None:
 
     completed = _wait_for_job(stack, uid, conversation_id, 'completed')
     conversation = stack.conversation(uid, conversation_id)
-    if completed.get('attempt_count') != 1 or completed.get('fanout_status') != 'completed':
+    if completed.get('attempt_count') != 0 or completed.get('fanout_status') != 'completed':
         raise StackFailure('source-close finalization did not complete the original durable job')
     if not conversation or conversation.get('status') != 'completed':
         raise StackFailure('source-close finalization did not complete its conversation without a later session')
@@ -1159,9 +1159,9 @@ async def _pusher_restart_replay(stack: Stack) -> None:
         or replay.get('finalization_job_id') != job.get('id', replay.get('finalization_job_id'))
     ):
         raise StackFailure('pusher replay changed its durable finalization identity')
-    if job.get('attempt_count') != 1:
+    if job.get('attempt_count') != 0:
         raise StackFailure(
-            f'pusher restart processed the durable job more than once: attempts={job.get("attempt_count")}'
+            f'pusher restart burned failed-processing attempts on a successful replay: attempts={job.get("attempt_count")}'
         )
     _assert_local_provider_admission(stack, session_id)
     await websocket.close(code=1000)
@@ -1277,7 +1277,7 @@ async def _rest_finalization_survives_listener_restart(stack: Stack) -> None:
         raise StackFailure(f'restarted-listener task delivery did not complete: {delivered}')
 
     completed = _wait_for_job(stack, uid, conversation_id, 'completed')
-    if completed.get('attempt_count') != 1 or completed.get('fanout_status') != 'completed':
+    if completed.get('attempt_count') != 0 or completed.get('fanout_status') != 'completed':
         raise StackFailure('detached worker did not complete the exact REST-finalization job once')
     completed_status = await stack.finalization_status(uid, conversation_id)
     if (
@@ -1285,7 +1285,7 @@ async def _rest_finalization_survives_listener_restart(stack: Stack) -> None:
         or completed_status.get('status') != 'completed'
         or not completed_status.get('terminal')
         or completed_status.get('retryable')
-        or completed_status.get('attempt_count') != 1
+        or completed_status.get('attempt_count') != 0
     ):
         raise StackFailure(f'completed REST finalization projection was incorrect: {completed_status}')
 
@@ -1306,7 +1306,7 @@ async def _rest_finalization_survives_listener_restart(stack: Stack) -> None:
         raise StackFailure(f'duplicate REST task delivery was not safely acknowledged: {duplicate}')
     if (
         len(stack.finalization_tasks) != 1
-        or _wait_for_job(stack, uid, conversation_id, 'completed').get('attempt_count') != 1
+        or _wait_for_job(stack, uid, conversation_id, 'completed').get('attempt_count') != 0
         or len(stack.finalizer_events) != provider_event_count
     ):
         raise StackFailure('duplicate REST task delivery repeated durable work')
@@ -1362,7 +1362,7 @@ async def _shutdown_window_retries_through_cloud_tasks(stack: Stack) -> None:
     if (
         completed_job.get('status') != 'completed'
         or completed_job.get('terminal_outcome') != 'success'
-        or completed_job.get('attempt_count') != 2
+        or completed_job.get('attempt_count') != 1
     ):
         raise StackFailure('successful retry did not complete the exact durable job')
     if completed_job.get('fanout_status') != 'completed':
@@ -1399,7 +1399,7 @@ async def _terminal_cloud_tasks_failure_dead_letters(stack: Stack) -> None:
     if (
         dead_letter.get('status') != 'dead_letter'
         or dead_letter.get('terminal_outcome') != 'failure'
-        or dead_letter.get('attempt_count') != 2
+        or dead_letter.get('attempt_count') != 1
         or dead_letter.get('task_retry_count') != 2
     ):
         raise StackFailure('exhausted worker delivery did not record its terminal durable state')

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1160,7 +1160,7 @@ def test_deployment_stt_models_must_match_the_central_serving_policy():
         ),
         validator.ValidationError(
             'prod/gke/backend-listen',
-            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,soniox,dg-nova-3,parakeet', got 'modulate-velma-2'",
+            "STT_SERVICE_MODELS must match stt_provider_policy: expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'",
         ),
     ]
 

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -409,10 +409,10 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
     first = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(first, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1, 'created_at': None}
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 0, 'created_at': None}
     claim_update = first.updates[0][1]
     assert claim_update['status'] == 'leased'
-    assert claim_update['attempt_count'] == 1
+    assert 'attempt_count' not in claim_update
 
     ref.data = ref.data | claim_update
     duplicate = _Transaction()
@@ -462,9 +462,52 @@ def test_expired_worker_lease_can_be_safely_reclaimed():
     transaction = _Transaction()
 
     claim = jobs._claim_finalization_job_txn(transaction, ref, 2, False, 1500, now)
-    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 2, 'created_at': None}
-    assert transaction.updates[0][1]['attempt_count'] == 2
+    assert claim == {'status': 'claimed', 'lease_epoch': 1, 'attempt_count': 1, 'created_at': None}
+    assert 'attempt_count' not in transaction.updates[0][1]
     assert transaction.updates[0][1]['lease_epoch'] == 1
+
+
+def test_session_handoff_reclaim_does_not_burn_the_processing_attempt_budget():
+    """Reconnects reclaim an expired lease; that is not a failed processing try."""
+    now = _now()
+    ref = _Ref(
+        'job-1',
+        {
+            'status': 'leased',
+            'dispatch_generation': 2,
+            'attempt_count': 0,
+            'lease_epoch': 3,
+            'lease_expires_at': now - timedelta(seconds=1),
+        },
+    )
+
+    for _ in range(5):
+        transaction = _Transaction()
+        claim = jobs._claim_finalization_job_txn(transaction, ref, 2, False, 1500, now)
+        assert claim['status'] == 'claimed'
+        assert claim['attempt_count'] == 0
+        assert 'attempt_count' not in transaction.updates[0][1]
+        ref.data = ref.data | transaction.updates[0][1]
+        ref.data['lease_expires_at'] = now - timedelta(seconds=1)
+
+
+def test_retryable_processing_failure_increments_the_attempt_budget():
+    now = _now()
+    ref = _Ref(
+        'job-1',
+        {
+            'status': 'leased',
+            'dispatch_generation': 2,
+            'lease_epoch': 4,
+            'attempt_count': 0,
+            'requires_byok': False,
+        },
+    )
+    transaction = _Transaction()
+
+    assert jobs._mark_finalization_retryable_txn(transaction, ref, 2, 4, 'processing_failed', now) is True
+    assert transaction.updates[0][1]['attempt_count'] == 1
+    assert transaction.updates[0][1]['last_failure_code'] == 'processing_failed'
 
 
 def test_finalization_completion_requires_durable_fanout_completion():
@@ -810,7 +853,7 @@ def test_expired_lease_reclaim_fences_a_stale_worker_terminal_write():
 
     reclaim = _Transaction()
     new_claim = jobs._claim_finalization_job_txn(reclaim, ref, 3, False, 1500, now)
-    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 1, 'created_at': None}
+    assert new_claim == {'status': 'claimed', 'lease_epoch': 5, 'attempt_count': 0, 'created_at': None}
     ref.data = ref.data | reclaim.updates[0][1]
 
     stale_completion = _Transaction()

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -1012,13 +1012,15 @@ async def test_pusher_replays_a_terminal_fenced_job_without_completed_signal(mon
 async def test_pusher_requeues_an_unexpected_failure_after_claim(monkeypatch):
     websocket = _PusherWebSocket()
     retryable = MagicMock(return_value=True)
+    retries = MagicMock()
     monkeypatch.setattr(pusher_finalization, 'run_blocking', _inline_run_blocking)
     monkeypatch.setattr(
         jobs_db,
         'claim_finalization_job',
-        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 1},
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 0},
     )
     monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
+    monkeypatch.setattr(pusher_finalization.LISTEN_FINALIZATION_RETRIES_TOTAL, 'inc', retries)
     monkeypatch.setattr(pusher_finalization, 'get_listen_finalization_tasks_max_attempts', lambda: 5)
     monkeypatch.setattr(
         pusher_finalization, 'finalize_persisted_conversation', AsyncMock(side_effect=RuntimeError('raw transcript'))
@@ -1029,6 +1031,44 @@ async def test_pusher_requeues_an_unexpected_failure_after_claim(monkeypatch):
     )
 
     retryable.assert_called_once_with('job-1', 3, 4, 'worker_failed')
+    retries.assert_called_once_with()
+    assert json.loads(websocket.sent[0][4:]) == {
+        'conversation_id': 'conversation-1',
+        'error': 'processing_failed',
+        'terminal': False,
+    }
+
+
+@pytest.mark.anyio
+async def test_pusher_does_not_dead_letter_a_job_whose_only_claims_were_session_handoffs(monkeypatch):
+    """Reconnect re-claims must not consume the processing attempt budget.
+
+    Production MIC dead-letters tracked lease handoffs, not failed processing.
+    """
+    websocket = _PusherWebSocket()
+    retryable = MagicMock(return_value=True)
+    dead_letter = MagicMock(return_value=True)
+    monkeypatch.setattr(pusher_finalization, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(
+        jobs_db,
+        'claim_finalization_job',
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 9, 'attempt_count': 0},
+    )
+    monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
+    monkeypatch.setattr(pusher_finalization, 'final_attempt_failed', dead_letter)
+    monkeypatch.setattr(pusher_finalization, 'get_listen_finalization_tasks_max_attempts', lambda: 5)
+    monkeypatch.setattr(
+        pusher_finalization,
+        'finalize_persisted_conversation',
+        AsyncMock(side_effect=ConversationFinalizationError('processing_failed')),
+    )
+
+    await pusher_finalization.process_conversation_task(
+        'uid-1', 'conversation-1', 'en', websocket, finalization_job_id='job-1', dispatch_generation=3
+    )
+
+    retryable.assert_called_once_with('job-1', 3, 9, 'processing_failed')
+    dead_letter.assert_not_called()
     assert json.loads(websocket.sent[0][4:]) == {
         'conversation_id': 'conversation-1',
         'error': 'processing_failed',
@@ -1050,7 +1090,7 @@ async def test_pusher_dead_letters_a_job_that_exhausted_its_attempt_budget(monke
     monkeypatch.setattr(
         jobs_db,
         'claim_finalization_job',
-        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 5},
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 4},
     )
     monkeypatch.setattr(jobs_db, 'mark_finalization_retryable', retryable)
     monkeypatch.setattr(pusher_finalization, 'final_attempt_failed', dead_letter)
@@ -1082,7 +1122,7 @@ async def test_pusher_lease_loss_never_terminalizes_a_newer_finalization_owner(m
     monkeypatch.setattr(
         jobs_db,
         'claim_finalization_job',
-        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 5},
+        lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 4, 'attempt_count': 4},
     )
     monkeypatch.setattr(pusher_finalization, 'final_attempt_failed', dead_letter)
     monkeypatch.setattr(pusher_finalization, 'get_listen_finalization_tasks_max_attempts', lambda: 5)

--- a/backend/tests/unit/test_modulate_serve_error_deaths.py
+++ b/backend/tests/unit/test_modulate_serve_error_deaths.py
@@ -6,7 +6,7 @@ was the #3 error signature (×11/30m) with ``Unable to complete the request.
 Please try again.`` at #10 (×5/30m); over the following day the sensor
 recorded 62 and ~5 more per 6h window while every session was rescued by
 mid-session failover. Modulate-Velma-2 is the streaming PRIMARY
-(``modulate-velma-2,soniox,dg-nova-3,parakeet``), so during such an outage
+(``modulate-velma-2,dg-nova-3,parakeet``), so during such an outage
 every new session is handed to Velma, serves briefly, takes the error frame,
 and fails over — the session survives, which is exactly why nothing ever
 paged beyond the log line:
@@ -525,18 +525,34 @@ async def test_selection_skips_the_benched_modulate_primary_on_the_next_connect(
 
 
 def test_the_circuit_recovers_through_the_half_open_probe():
-    """Benching Velma must not brick it: after the cooldown exactly one probe
-    is offered, and a probe that serves closes the circuit again."""
+    """Benching Velma must not brick it: after the serve-error cooldown a
+    probe is offered, and enough consecutive probe successes close it again.
+    A single half-open connect is not recovery during a 5xx storm
+    (first transcript succeeds, then teardown fails)."""
     now = [0.0]
-    circuit = ProviderCircuitBreaker(failure_threshold=3, cooldown_seconds=30.0, clock=lambda: now[0])
+    circuit = ProviderCircuitBreaker(
+        failure_threshold=3,
+        cooldown_seconds=30.0,
+        clock=lambda: now[0],
+        serve_error_cooldown_seconds=180.0,
+        serve_error_successes_to_close=3,
+    )
 
     circuit.record_serve_failure()
     assert circuit.state == 'open'
     assert circuit.allow_request() is False
 
     now[0] = 31.0
+    assert circuit.allow_request() is False
+    now[0] = 181.0
     assert circuit.allow_request() is True  # the single half-open probe
     assert circuit.allow_request() is False
 
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
     circuit.record_success()
     assert circuit.state == 'closed'

--- a/backend/tests/unit/test_serve_death_feeds_provider_circuit.py
+++ b/backend/tests/unit/test_serve_death_feeds_provider_circuit.py
@@ -251,12 +251,18 @@ def test_open_provider_selection_circuit_opens_the_named_provider() -> None:
 def test_circuit_recovers_through_the_half_open_probe() -> None:
     """Opening on serve-death must not brick the provider forever.
 
-    After the cooldown the breaker offers exactly one probe; a successful
-    probe closes the circuit again. This pins the recovery half of the new
-    transition against future "safety" additions.
+    After the serve-error cooldown the breaker offers exactly one probe at a
+    time; a 5xx storm that still accepts connects must not fully re-admit on
+    the first half-open success (RCA 2026-09-09).
     """
     now: List[float] = [0.0]
-    circuit = ProviderCircuitBreaker(failure_threshold=3, cooldown_seconds=30.0, clock=lambda: now[0])
+    circuit = ProviderCircuitBreaker(
+        failure_threshold=3,
+        cooldown_seconds=30.0,
+        clock=lambda: now[0],
+        serve_error_cooldown_seconds=180.0,
+        serve_error_successes_to_close=3,
+    )
 
     circuit.record_serve_failure()
     assert circuit.state == 'open'
@@ -264,9 +270,17 @@ def test_circuit_recovers_through_the_half_open_probe() -> None:
 
     now[0] = 31.0
     assert circuit.state == 'open'
+    assert circuit.allow_request() is False
+    now[0] = 181.0
     assert circuit.allow_request() is True  # the single half-open probe
     assert circuit.allow_request() is False  # and only one
 
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
     circuit.record_success()
     assert circuit.state == 'closed'
     assert circuit.allow_request() is True

--- a/backend/tests/unit/test_soniox_streaming.py
+++ b/backend/tests/unit/test_soniox_streaming.py
@@ -21,7 +21,7 @@ from config.stt_provider_policy import (
     default_models_for_surface,
     provider_is_enabled,
 )
-from utils.stt.streaming import SafeSonioxSocket, process_audio_soniox
+from utils.stt.streaming import SafeSonioxSocket, process_audio_soniox, validate_streaming_stt_env
 
 
 class FakeWebSocket:
@@ -205,17 +205,36 @@ def _empty_stream():
     return gen()
 
 
-def test_soniox_serves_streaming_only_and_backs_velma_there():
-    """Soniox was opt-in while it was being trialled; it is now the streaming fallback.
+def test_soniox_serves_streaming_only_and_is_opt_in():
+    """Soniox stays streaming-capable but is not a default hop.
 
-    The batch path still has no Soniox client, so it must stay absent from the
-    non-streaming surfaces however the streaming chain is ordered.
+    Prod's key is empty, so listing it consumed a mental next slot while
+    accepted=0. A deployment that wants it must name it in STT_SERVICE_MODELS
+    and set SONIOX_API_KEY. The batch path still has no Soniox client.
     """
     assert provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.STREAMING)
     assert not provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.PRERECORDED)
     assert not provider_is_enabled(SONIOX_PROVIDER, STTServingSurface.PTT)
 
     streaming = default_models_for_surface(STTServingSurface.STREAMING)
-    assert streaming.index('soniox') == streaming.index('modulate-velma-2') + 1
+    assert 'soniox' not in streaming
+    assert streaming == ('modulate-velma-2', 'dg-nova-3', 'parakeet')
     for surface in (STTServingSurface.PRERECORDED, STTServingSurface.PTT):
         assert 'soniox' not in default_models_for_surface(surface)
+
+
+def test_soniox_listed_without_key_is_rejected_at_config_check():
+    with pytest.raises(RuntimeError, match='SONIOX_API_KEY is empty'):
+        validate_streaming_stt_env(
+            {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet', 'SONIOX_API_KEY': ''}
+        )
+
+
+def test_soniox_listed_with_key_is_accepted_at_config_check():
+    validate_streaming_stt_env(
+        {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet', 'SONIOX_API_KEY': 'k'}
+    )
+
+
+def test_default_chain_without_soniox_is_accepted_at_config_check():
+    validate_streaming_stt_env({'STT_SERVICE_MODELS': 'modulate-velma-2,dg-nova-3,parakeet'})

--- a/backend/tests/unit/test_stt_provider_policy.py
+++ b/backend/tests/unit/test_stt_provider_policy.py
@@ -53,7 +53,7 @@ def test_self_hosted_deepgram_is_explicitly_limited_to_streaming():
 
 def test_policy_owns_the_safe_model_order_for_every_serving_surface():
     expected = {
-        STTServingSurface.STREAMING: 'modulate-velma-2,soniox,dg-nova-3,parakeet',
+        STTServingSurface.STREAMING: 'modulate-velma-2,dg-nova-3,parakeet',
         STTServingSurface.PRERECORDED: 'parakeet,modulate-velma-2',
         STTServingSurface.PTT: 'modulate-velma-2,parakeet',
     }

--- a/backend/tests/unit/test_stt_provider_resilience.py
+++ b/backend/tests/unit/test_stt_provider_resilience.py
@@ -50,3 +50,49 @@ def test_expected_rejection_releases_a_half_open_probe():
 
     assert circuit.state == 'closed'
     assert circuit.allow_request() is True
+
+
+def test_serve_error_cooldown_is_longer_than_connect_path_and_needs_multiple_successes():
+    """RCA 2026-09-09: first transcript succeeds, then teardown fails ~1:1.
+
+    A 30s serve-error bench flaps. Connect-path still closes on the first
+    success; serve-error recovery must not re-admit on the first probe.
+    """
+    clock = Clock()
+    circuit = ProviderCircuitBreaker(
+        failure_threshold=2,
+        cooldown_seconds=30,
+        clock=clock,
+        serve_error_cooldown_seconds=180,
+        serve_error_successes_to_close=3,
+    )
+
+    circuit.record_serve_failure()
+    assert circuit.allow_request() is False
+    clock.now = 30
+    assert circuit.allow_request() is False
+    clock.now = 180
+    assert circuit.allow_request() is True
+    assert circuit.allow_request() is False
+
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
+    circuit.record_success()
+    assert circuit.state == 'half_open'
+    assert circuit.allow_request() is True
+    circuit.record_success()
+    assert circuit.state == 'closed'
+    assert circuit.allow_request() is True
+
+
+def test_connect_path_still_closes_on_the_first_half_open_success():
+    clock = Clock()
+    circuit = ProviderCircuitBreaker(failure_threshold=1, cooldown_seconds=30, clock=clock)
+
+    circuit.record_failure()
+    assert circuit.allow_request() is False
+    clock.now = 30
+    assert circuit.allow_request() is True
+    circuit.record_success()
+    assert circuit.state == 'closed'

--- a/backend/tests/unit/test_stt_session_failover.py
+++ b/backend/tests/unit/test_stt_session_failover.py
@@ -66,6 +66,19 @@ def test_excluding_the_dead_provider_selects_the_next_one():
         assert second == STTService.soniox
 
 
+def test_excluding_the_dead_provider_skips_soniox_without_a_key():
+    """An empty key must not consume a failover hop."""
+    with patch.dict(
+        'os.environ',
+        {'STT_SERVICE_MODELS': 'modulate-velma-2,soniox,dg-nova-3,parakeet', 'SONIOX_API_KEY': ''},
+        clear=False,
+    ), patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'soniox', 'dg-nova-3']), patch(
+        'utils.stt.streaming._deepgram_is_available', return_value=True
+    ):
+        second, _, _ = get_stt_service_for_language('en', exclude=frozenset({MODULATE_PROVIDER}))
+        assert second == STTService.deepgram
+
+
 def test_excluding_every_provider_selects_nothing():
     """Exhausting the chain must report no provider, not loop back to the first."""
     with patch('utils.stt.streaming.stt_service_models', ['modulate-velma-2', 'soniox']), patch.dict(

--- a/backend/tests/unit/test_verify_pusher_config_references.py
+++ b/backend/tests/unit/test_verify_pusher_config_references.py
@@ -192,7 +192,7 @@ def test_rendered_dev_pusher_direct_bindings_match_source_contract(preflight: Si
         "OMI_LLM_GATEWAY_FEATURE_MODE": "gateway",
         "OMI_LLM_GATEWAY_URL": "http://dev-omi-llm-gateway.dev-omi-backend.svc.cluster.local:8080",
         "STT_PRERECORDED_MODEL": "parakeet,modulate-velma-2",
-        "STT_SERVICE_MODELS": "modulate-velma-2,soniox,dg-nova-3,parakeet",
+        "STT_SERVICE_MODELS": "modulate-velma-2,dg-nova-3,parakeet",
     }
     assert clear_historical_secret == {"REDIS_DB_HOST", "GOOGLE_CLIENT_ID", "TYPESENSE_HOST"}
     assert preflight.validate_dev_pusher_binding_contract(deployment) == []
@@ -206,7 +206,7 @@ def test_prod_pusher_retains_the_explicit_self_hosted_deepgram_contract(prefligh
     assert bindings["DEEPGRAM_API_KEY"] == ("secret", "prod-omi-backend-secrets", "DEEPGRAM_API_KEY")
     assert literals["DEEPGRAM_SELF_HOSTED_ENABLED"] == "true"
     assert literals["DEEPGRAM_SELF_HOSTED_URL"] == "https://dg.omi.me"
-    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,soniox,dg-nova-3,parakeet"
+    assert literals["STT_SERVICE_MODELS"] == "modulate-velma-2,dg-nova-3,parakeet"
 
 
 def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: SimpleNamespace):
@@ -217,7 +217,7 @@ def test_dev_pusher_literal_policy_rejects_stale_deepgram_model(preflight: Simpl
 
     assert preflight.validate_dev_pusher_binding_contract(deployment) == [
         "dev pusher literal contract mismatch for STT_SERVICE_MODELS: "
-        "expected 'modulate-velma-2,soniox,dg-nova-3,parakeet', got 'modulate-velma-2'"
+        "expected 'modulate-velma-2,dg-nova-3,parakeet', got 'modulate-velma-2'"
     ]
 
 

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -10,6 +10,7 @@ from database import conversation_finalization_jobs as finalization_jobs_db
 from services.conversation_finalization import final_attempt_failed
 from utils.byok import set_validated_byok_keys
 from utils.cloud_tasks import get_listen_finalization_tasks_max_attempts
+from utils.metrics import LISTEN_FINALIZATION_RETRIES_TOTAL
 from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations.finalizer import (
     ConversationFinalizationDisposition,
@@ -29,9 +30,18 @@ FINALIZATION_RESULT_PROTOCOL_LEGACY = 1
 FINALIZATION_RESULT_PROTOCOL_V2 = 2
 
 
+def _processing_attempt_number(failed_processing_attempts: int) -> int:
+    """Return the 1-based attempt index for this processing try.
+
+    ``claim_finalization_job`` no longer burns the budget on lease handoffs;
+    ``attempt_count`` is failed processing so far. This try is the next one.
+    """
+    return max(int(failed_processing_attempts), 0) + 1
+
+
 def _finalization_attempt_decision(attempt_count: int, *, reason: str):
     return decide_attempt(
-        attempt_count=max(attempt_count, 1),
+        attempt_count=_processing_attempt_number(attempt_count),
         outcome=ProcessOutcome.retry(reason, reason=reason),
         policy=QueuePolicy(max_attempts=get_listen_finalization_tasks_max_attempts()),
         now=datetime.now(timezone.utc),
@@ -94,6 +104,7 @@ async def process_conversation_task(
         """
         if job_id is None or generation is None or lease_epoch is None:
             return False
+        this_try = _processing_attempt_number(attempt_count)
         terminal = _finalization_attempt_decision(attempt_count, reason=failure_code).terminal
         try:
             if terminal:
@@ -103,7 +114,7 @@ async def process_conversation_task(
                     job_id,
                     generation,
                     lease_epoch,
-                    attempt_count,
+                    this_try,
                 )
                 if not marked_dead_letter:
                     return False
@@ -116,6 +127,7 @@ async def process_conversation_task(
                 lease_epoch,
                 failure_code,
             )
+            LISTEN_FINALIZATION_RETRIES_TOTAL.inc()
         except Exception:
             logger.error(
                 'pusher finalization recovery update failed uid=%s conversation=%s failure=%s terminal=%s',

--- a/backend/utils/stt/live_failure.py
+++ b/backend/utils/stt/live_failure.py
@@ -79,8 +79,9 @@ _CIRCUIT_OPENING_REASONS = frozenset(
         # the death would otherwise stay invisible to selection: the surviving
         # session never runs the terminal funnel that feeds the circuit, and
         # the next session's successful connect resets the counter. One
-        # serve-error death opens the circuit for one cooldown window; the
-        # half-open probe restores Velma as soon as one stream serves again.
+        # serve-error death opens the circuit for the serve-error cooldown;
+        # re-admission needs more than one half-open success so a 5xx storm
+        # that still accepts connects cannot flap every 30s.
         # Session-scoped shapes (invalid input audio) stay untyped and do not
         # bench the provider.
         'modulate_serve_error',

--- a/backend/utils/stt/provider_resilience.py
+++ b/backend/utils/stt/provider_resilience.py
@@ -62,19 +62,37 @@ class ProviderCircuitBreaker:
         failure_threshold: int,
         cooldown_seconds: float,
         clock: Callable[[], float] = time.monotonic,
+        serve_error_cooldown_seconds: float | None = None,
+        serve_error_successes_to_close: int = 3,
     ) -> None:
         if failure_threshold < 1:
             raise ValueError('failure_threshold must be >= 1')
         if cooldown_seconds <= 0:
             raise ValueError('cooldown_seconds must be > 0')
+        if serve_error_successes_to_close < 1:
+            raise ValueError('serve_error_successes_to_close must be >= 1')
+        # Serve-error storms accept connects then die (~1:1). The connect-path
+        # 30s window flaps; default the serve-error bench to 180s.
+        serve_cooldown = 180.0 if serve_error_cooldown_seconds is None else serve_error_cooldown_seconds
+        if serve_cooldown <= 0:
+            raise ValueError('serve_error_cooldown_seconds must be > 0')
         self._failure_threshold = failure_threshold
         self._cooldown_seconds = cooldown_seconds
+        self._serve_error_cooldown_seconds = serve_cooldown
+        self._serve_error_successes_to_close = serve_error_successes_to_close
         self._clock = clock
         self._failures = 0
         self._opened_at = 0.0
         self._state = 'closed'
         self._probe_in_flight = False
+        self._opened_by_serve_error = False
+        self._remaining_successes_to_close = 1
         self._lock = threading.Lock()
+
+    def _active_cooldown(self) -> float:
+        if self._opened_by_serve_error:
+            return self._serve_error_cooldown_seconds
+        return self._cooldown_seconds
 
     @property
     def state(self) -> str:
@@ -92,14 +110,14 @@ class ProviderCircuitBreaker:
         with self._lock:
             if self._state != 'open':
                 return True
-            return self._clock() - self._opened_at >= self._cooldown_seconds
+            return self._clock() - self._opened_at >= self._active_cooldown()
 
     def allow_request(self) -> bool:
         with self._lock:
             if self._state == 'closed':
                 return True
             if self._state == 'open':
-                if self._clock() - self._opened_at < self._cooldown_seconds:
+                if self._clock() - self._opened_at < self._active_cooldown():
                     return False
                 self._state = 'half_open'
                 self._probe_in_flight = False
@@ -110,9 +128,18 @@ class ProviderCircuitBreaker:
 
     def record_success(self) -> None:
         with self._lock:
+            self._probe_in_flight = False
+            # Connect-path recovery still closes on the first probe success.
+            # After a serve-error storm a single half-open connect is not
+            # evidence of recovery (first transcript succeeds, then teardown
+            # fails ~1:1), so stay half-open until enough consecutive successes.
+            if self._opened_by_serve_error and self._remaining_successes_to_close > 1:
+                self._remaining_successes_to_close -= 1
+                return
             self._failures = 0
             self._state = 'closed'
-            self._probe_in_flight = False
+            self._opened_by_serve_error = False
+            self._remaining_successes_to_close = 1
 
     def record_failure(self) -> None:
         with self._lock:
@@ -120,11 +147,15 @@ class ProviderCircuitBreaker:
             if self._state == 'half_open':
                 self._state = 'open'
                 self._opened_at = self._clock()
+                if self._opened_by_serve_error:
+                    self._remaining_successes_to_close = self._serve_error_successes_to_close
                 return
             self._failures += 1
             if self._failures >= self._failure_threshold:
                 self._state = 'open'
                 self._opened_at = self._clock()
+                self._opened_by_serve_error = False
+                self._remaining_successes_to_close = 1
 
     def record_serve_failure(self) -> None:
         """Open the circuit after a provider died while serving a session.
@@ -137,13 +168,16 @@ class ProviderCircuitBreaker:
         die), the counter never reaches ``failure_threshold``, so selection
         keeps choosing the provider that stopped serving. A serve-time death
         is terminal evidence for the session it killed, so it opens the
-        circuit for the full cooldown; the half-open probe afterwards restores
-        the provider as soon as one probe serves again.
+        circuit for the serve-error cooldown. Re-admission requires more than
+        one half-open success so a 5xx storm that still accepts connects
+        cannot flap the breaker every 30s.
         """
         with self._lock:
             self._probe_in_flight = False
             self._state = 'open'
             self._opened_at = self._clock()
+            self._opened_by_serve_error = True
+            self._remaining_successes_to_close = self._serve_error_successes_to_close
 
     def record_rejection(self, reason: str) -> None:
         if reason in EXPECTED_REJECTIONS:

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -93,6 +93,8 @@ _deepgram_circuit = ProviderCircuitBreaker(
 _modulate_circuit = ProviderCircuitBreaker(
     failure_threshold=int(os.getenv('MODULATE_CIRCUIT_FAILURE_THRESHOLD', '3')),
     cooldown_seconds=float(os.getenv('MODULATE_CIRCUIT_COOLDOWN_SECONDS', '30')),
+    serve_error_cooldown_seconds=float(os.getenv('MODULATE_SERVE_ERROR_CIRCUIT_COOLDOWN_SECONDS', '180')),
+    serve_error_successes_to_close=int(os.getenv('MODULATE_SERVE_ERROR_SUCCESSES_TO_CLOSE', '3')),
 )
 _soniox_circuit = ProviderCircuitBreaker(
     failure_threshold=int(os.getenv('MODULATE_CIRCUIT_FAILURE_THRESHOLD', '3')),
@@ -449,6 +451,22 @@ deepgram_nova3_languages = {
 # Compatibility export for callers. Its value is owned by stt_provider_policy.
 DEFAULT_STT_SERVICE_MODELS = default_models_for_surface(STTServingSurface.STREAMING)
 stt_service_models = os.getenv('STT_SERVICE_MODELS', ','.join(DEFAULT_STT_SERVICE_MODELS)).split(',')
+
+
+def validate_streaming_stt_env(env: Any = None) -> None:
+    """Fail listen/pusher startup when soniox is listed without a key.
+
+    Selection already skips an empty key, but the listed slot still looks like
+    a next hop in the documented chain. Do not print secret values.
+    """
+    source = os.environ if env is None else env
+    models = source.get('STT_SERVICE_MODELS', ','.join(DEFAULT_STT_SERVICE_MODELS))
+    listed = [model.strip() for model in models.split(',') if model.strip()]
+    if 'soniox' in listed and not (source.get('SONIOX_API_KEY') or '').strip():
+        raise RuntimeError(
+            'STT_SERVICE_MODELS lists soniox but SONIOX_API_KEY is empty; '
+            'remove soniox from the serving chain or set the key'
+        )
 
 
 def modulate_is_configured_fallback(language: Optional[str]) -> bool:


### PR DESCRIPTION
SCA-464: stop MIC dead-letters amplifying a Modulate 5xx storm

This does **not** fix Modulate’s 5xx. It stops our MIC/dead-letter amplifier and the 30s circuit flap.

## Summary
- Pusher inline finalization now increments `LISTEN_FINALIZATION_RETRIES_TOTAL` on the retryable path, matching the Cloud Tasks worker.
- `attempt_count` is failed **processing** attempts, not listen reconnect re-claims. Dead-letter only after N failed processing attempts, not N session handoffs.
- Serve-error circuit: 180s cooldown (connect-path stays 30s) and three consecutive half-open successes before fully re-admitting Modulate. A single connect success during a teardown-fail storm no longer closes the breaker.
- Honest Soniox slot: default streaming chain is `modulate-velma-2,dg-nova-3,parakeet`. Listing `soniox` without `SONIOX_API_KEY` fails the listen/pusher env check. Does not print secret values. Does not send the storm to Parakeet as primary.

## Failure-Class
Failure-Class: new

New class: `FC-session-handoff-counted-as-failed-attempt`.

## Invariants
- INV-MEM-4 — path glob match only; this PR does not change Long-term admission authority.

## Line-count exceptions
Line-Count-Exception: backend/database/conversation_finalization_jobs.py | 2216 -> 2218 | Keep attempt budget increment on retryable processing, not on claim.
Line-Count-Exception: backend/utils/stt/streaming.py | 1836 -> 1854 | Add listed-without-key soniox env check and modulate serve-error circuit env.

## Test plan
- [x] `pytest tests/unit/test_conversation_finalization_jobs.py tests/unit/test_listen_finalization_cloud_tasks.py tests/unit/test_stt_provider_resilience.py tests/unit/test_modulate_serve_error_deaths.py tests/unit/test_serve_death_feeds_provider_circuit.py tests/unit/test_soniox_streaming.py tests/unit/test_stt_session_failover.py tests/unit/test_stt_provider_policy.py tests/unit/test_backend_runtime_env_validator.py tests/unit/test_verify_pusher_config_references.py tests/unit/test_pusher_static_capability_admission.py` — 384 passed
- [x] Additional: `test_modulate_connection_fallback.py`, `test_listen_helm_env_overrides.py`, `test_render_gke_backend_config.py`, `test_deepgram_connection_fallback.py` — 39 passed
- [x] `make preflight` after this body is attached
- Tests prove: pusher retryable path increments retries; reconnect re-claim does not dead-letter by itself; serve-error cooldown does not re-admit Modulate on the first half-open success; soniox-listed-without-key is rejected at config check.

## Out of scope
- No prod listen/pusher/Cloud Run rollback or redeploy.
- No policy flip of streaming primary off Modulate.
- Does not fix Modulate’s 5xx.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

