### PR TITLE
fix(cli): preserve fields from later table rows

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -62,6 +62,7 @@ omi --json memory list | jq '.[] | {id, content}'
 Pretty output displays returned text literally, including square brackets and
 emoji-like codes such as `:warning:`. Styling applies to the table layout, not
 to the contents of your memories or conversations.
+Tables without predefined columns include fields from every row, in first-seen order.
 
 > Looking for localized guides? See the [🇯🇵 日本語クイックスタート (Japanese Quickstart)](examples/quickstart.ja.md).
 

--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -96,8 +96,8 @@ class Renderer:
             self._stdout.print("[dim](no results)[/dim]")
             return
 
-        # Pick columns. Caller-supplied wins; otherwise use the keys of the first row.
-        cols = list(columns) if columns else list(rows[0].keys())
+        # Explicit columns win; inferred columns preserve keys from every row.
+        cols = list(columns) if columns else list(dict.fromkeys(key for row in rows for key in row))
 
         table = Table(title=title, show_lines=False, header_style="bold")
         for col in cols:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -103,6 +103,22 @@ def test_local_call_accepts_args_json(config_path: Path, cli_runner) -> None:
     assert json.loads(result.stdout) == {"ok": True}
 
 
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_local_call_preserves_fields_from_later_result_rows(config_path: Path, cli_runner, json_mode: bool) -> None:
+    _configure_local_profile(config_path)
+    rows = [{"id": "first"}, {"id": "second", "detail": "later-value"}]
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(rows)))
+        result = cli_runner.invoke(app, (["--json"] if json_mode else []) + ["local", "call", "test_tool"])
+
+    assert result.exit_code == 0, result.output
+    if json_mode:
+        assert json.loads(result.stdout) == rows
+    else:
+        assert "detail" in result.stdout
+        assert "later-value" in result.stdout
+
+
 def test_local_call_exits_nonzero_when_api_reports_error(config_path: Path, cli_runner) -> None:
     _configure_local_profile(config_path)
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -77,6 +77,24 @@ def test_pretty_mode_renders_no_results_for_empty_list(capsys) -> None:
     assert "no results" in captured.out
 
 
+@pytest.mark.parametrize("first_row", [{}, {"id": "first"}])
+def test_pretty_table_includes_fields_from_later_rows(capsys, first_row) -> None:
+    Renderer(no_color=True).emit([first_row, {"id": "second", "detail": "later-value"}])
+    output = capsys.readouterr().out
+    assert "second" in output
+    assert "detail" in output
+    assert "later-value" in output
+
+
+def test_pretty_table_respects_explicit_columns(capsys) -> None:
+    Renderer(no_color=True).emit([{"id": "first"}, {"id": "second", "detail": "hidden-value"}], columns=["id"])
+    output = capsys.readouterr().out
+    assert "first" in output
+    assert "second" in output
+    assert "detail" not in output
+    assert "hidden-value" not in output
+
+
 def test_shorten_basic() -> None:
     assert shorten("abcdef", 3) == "ab…"
     assert shorten("abcdef", 10) == "abcdef"


### PR DESCRIPTION
## What changed and why

Human-readable CLI tables silently omit fields that occur only in later rows. For example, a local tool returning `[{"id":"first"},{"id":"second","detail":"later-value"}]` displays both IDs but hides `detail`, while the command exits successfully.

Infer columns from all rows in first-seen order. Explicit column selections and JSON output keep their current behavior. The README describes inferred columns.

## Product invariants affected

none

## How it was verified

- Regression tests failed on the original renderer: a later field was absent, and an empty first row hid all data.
- The installed `python -m omi_cli local call fixture` command ran against a disposable loopback HTTP fixture. Before the fix, it exited 0 without `later-value`. After the fix, it exited 0 and displayed that field.
- Focused renderer and local-command tests passed. Tests cover an empty first row, later fields, explicit column selection, and JSON output.
- The wheel build and Black formatting check passed.
- All test credentials and response records were synthetic. No live Omi account or desktop data was used.

Full CLI suite: **342 passed, 1 skipped, 1 failed**. The failure is `test_transport_failure_during_login_leaves_saved_config_unchanged`; it also fails on unchanged upstream code. The skipped test requires Windows. Focused renderer/local-command/OpenAPI tests: **70 passed**. The two warnings are dependency deprecations. `make preflight` passed all 12 selected checks in the sparse checkout after materializing required verification sources. The bounded pre-push gate also passed. Full-checkout CI remains unverified.

## Tests

`test_pretty_table_includes_fields_from_later_rows`, `test_pretty_table_respects_explicit_columns`, and `test_local_call_preserves_fields_from_later_result_rows` exercise the renderer and command behavior.

## Failure class (fixes)

Failure-Class: none

## Proposed bounty

This is an AI-assisted contribution. Following the contribution guide, @josancamon19, would you consider a US$25 bounty for this fix and its regression tests if accepted and merged? No bounty approval or payment is assumed. Payment details would use the documented private process.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

