### PR TITLE
SCA-463: add a synthetic conversation-summary lab harness

### DIFF
--- a/backend/testing/summary_lab/README.md
+++ b/backend/testing/summary_lab/README.md
@@ -1,0 +1,17 @@
+# Conversation summary lab
+
+Offline matrix: synthetic transcript → named variant → judged note + estimated cost.
+
+Default seam is **recorded**. It never calls an LLM and never imports production
+summarizer modules. `--live` is the opt-in path that calls
+`get_conversation_notes`; keep that local and untracked if you point it at real
+transcripts.
+
+```bash
+cd backend
+python -m testing.summary_lab run --out /tmp/summary-lab
+python -m testing.summary_lab compare --left /tmp/a/run.json --right /tmp/b/run.json
+```
+
+Fixtures in `testing/summary_lab/fixtures/` are synthetic. Do not commit customer
+transcripts.

--- a/backend/testing/summary_lab/__init__.py
+++ b/backend/testing/summary_lab/__init__.py
@@ -1,0 +1,28 @@
+"""Offline conversation-summary lab.
+
+Transcription-in → pipeline → summary-out, comparable across variants.
+Production modules are not imported unless a live seam is opted into.
+"""
+
+from __future__ import annotations
+
+from testing.summary_lab.compare import compare_runs, compare_variants
+from testing.summary_lab.fixtures import Fixture, load_synthetic_fixtures
+from testing.summary_lab.judge import JudgeReport, score_note
+from testing.summary_lab.pricing import estimate_usd
+from testing.summary_lab.runner import LabRun, run_matrix
+from testing.summary_lab.variants import VARIANTS, Variant
+
+__all__ = [
+    'Fixture',
+    'JudgeReport',
+    'LabRun',
+    'VARIANTS',
+    'Variant',
+    'compare_runs',
+    'compare_variants',
+    'estimate_usd',
+    'load_synthetic_fixtures',
+    'run_matrix',
+    'score_note',
+]

--- a/backend/testing/summary_lab/__main__.py
+++ b/backend/testing/summary_lab/__main__.py
@@ -1,0 +1,3 @@
+from testing.summary_lab.cli import main
+
+raise SystemExit(main())

--- a/backend/testing/summary_lab/cli.py
+++ b/backend/testing/summary_lab/cli.py
@@ -1,0 +1,118 @@
+"""CLI: run the synthetic matrix or compare two run JSON files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from testing.summary_lab.compare import compare_runs
+from testing.summary_lab.fixtures import load_synthetic_fixtures
+from testing.summary_lab.judge import JudgeReport
+from testing.summary_lab.pricing import CostEstimate
+from testing.summary_lab.render import render_lab_html
+from testing.summary_lab.runner import CellResult, LabRun, run_matrix
+from testing.summary_lab.seams import recorded_seam
+from testing.summary_lab.variants import VARIANTS, VARIANTS_BY_ID, Variant
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+def _run_from_dict(payload: dict[str, object]) -> LabRun:
+    raw_cells = payload.get('cells')
+    if not isinstance(raw_cells, list):
+        raise ValueError('run JSON missing cells')
+    cells: list[CellResult] = []
+    for raw in raw_cells:
+        if not isinstance(raw, dict):
+            continue
+        judge_raw = raw.get('judge') or {}
+        cost_raw = raw.get('cost') or {}
+        if not isinstance(judge_raw, dict) or not isinstance(cost_raw, dict):
+            continue
+        note = raw.get('note') if isinstance(raw.get('note'), dict) else {}
+        cells.append(
+            CellResult(
+                fixture_id=str(raw.get('fixture_id') or ''),
+                variant_id=str(raw.get('variant_id') or ''),
+                note=note if isinstance(note, dict) else {},
+                judge=JudgeReport(
+                    usefulness=float(judge_raw.get('usefulness') or 0),
+                    defects=tuple(judge_raw.get('defects') or ()),
+                    missing_facts=tuple(judge_raw.get('missing_facts') or ()),
+                    filler_hits=int(judge_raw.get('filler_hits') or 0),
+                    playback_hits=int(judge_raw.get('playback_hits') or 0),
+                    speaker_leaks=int(judge_raw.get('speaker_leaks') or 0),
+                ),
+                cost=CostEstimate(
+                    model=str(cost_raw.get('model') or ''),
+                    input_tokens=int(cost_raw.get('input_tokens') or 0),
+                    output_tokens=int(cost_raw.get('output_tokens') or 0),
+                    usd=float(cost_raw.get('usd') or 0),
+                ),
+            )
+        )
+    return LabRun(cells=tuple(cells))
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    fixtures = load_synthetic_fixtures(Path(args.fixtures) if args.fixtures else None)
+    variant_ids = args.variant or [variant.id for variant in VARIANTS]
+    variants: list[Variant] = []
+    for variant_id in variant_ids:
+        variant = VARIANTS_BY_ID.get(variant_id)
+        if variant is None:
+            raise SystemExit(f'unknown variant {variant_id!r}')
+        variants.append(variant)
+    summarize = recorded_seam
+    if args.live:
+        from testing.summary_lab.seams import production_notes_v2_seam
+
+        summarize = production_notes_v2_seam
+    run = run_matrix(fixtures, tuple(variants), summarize=summarize)
+    out = Path(args.out)
+    _write(out / 'run.json', json.dumps(run.as_dict(), indent=2, ensure_ascii=True) + '\n')
+    _write(out / 'lab.html', render_lab_html(run))
+    summary = f'cells={len(run.cells)} mean_usefulness={run.mean_usefulness:.3f} ' f'est_usd={run.total_usd:.5f}\n'
+    _write(out / 'summary.txt', summary)
+    print(summary, end='')
+    return 0
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    left = _run_from_dict(json.loads(Path(args.left).read_text(encoding='utf-8')))
+    right = _run_from_dict(json.loads(Path(args.right).read_text(encoding='utf-8')))
+    report = compare_runs(left, right)
+    text = json.dumps(report.as_dict(), indent=2, ensure_ascii=True) + '\n'
+    if args.out:
+        _write(Path(args.out), text)
+    print(text, end='')
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog='summary_lab', description='Conversation summary quality lab')
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    run_parser = sub.add_parser('run', help='run the synthetic fixture matrix')
+    run_parser.add_argument('--fixtures', help='directory of synthetic JSON fixtures')
+    run_parser.add_argument('--variant', action='append', help='variant id (repeatable)')
+    run_parser.add_argument('--out', required=True, help='output directory')
+    run_parser.add_argument(
+        '--live',
+        action='store_true',
+        help='call production get_conversation_notes (needs LLM credentials; not the default)',
+    )
+    run_parser.set_defaults(func=_cmd_run)
+
+    compare_parser = sub.add_parser('compare', help='compare two run.json files')
+    compare_parser.add_argument('--left', required=True)
+    compare_parser.add_argument('--right', required=True)
+    compare_parser.add_argument('--out')
+    compare_parser.set_defaults(func=_cmd_compare)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))

--- a/backend/testing/summary_lab/compare.py
+++ b/backend/testing/summary_lab/compare.py
@@ -1,0 +1,89 @@
+"""Compare two lab runs cell-by-cell."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from testing.summary_lab.runner import CellResult, LabRun
+
+
+@dataclass(frozen=True)
+class CellDelta:
+    fixture_id: str
+    variant_id: str
+    usefulness_delta: float
+    usd_delta: float
+    left_defects: tuple[str, ...]
+    right_defects: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'fixture_id': self.fixture_id,
+            'variant_id': self.variant_id,
+            'usefulness_delta': round(self.usefulness_delta, 3),
+            'usd_delta': round(self.usd_delta, 6),
+            'left_defects': list(self.left_defects),
+            'right_defects': list(self.right_defects),
+        }
+
+
+@dataclass(frozen=True)
+class CompareReport:
+    deltas: tuple[CellDelta, ...]
+    mean_usefulness_delta: float
+    total_usd_delta: float
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'mean_usefulness_delta': round(self.mean_usefulness_delta, 3),
+            'total_usd_delta': round(self.total_usd_delta, 6),
+            'deltas': [delta.as_dict() for delta in self.deltas],
+        }
+
+
+def _index(run: LabRun) -> dict[tuple[str, str], CellResult]:
+    return {(cell.fixture_id, cell.variant_id): cell for cell in run.cells}
+
+
+def compare_variants(run: LabRun, left_variant: str, right_variant: str) -> CompareReport:
+    """Pair cells that share a fixture across two named variants of one run."""
+    left = LabRun(cells=tuple(cell for cell in run.cells if cell.variant_id == left_variant))
+    right = LabRun(cells=tuple(cell for cell in run.cells if cell.variant_id == right_variant))
+    return compare_runs(left, right, by_fixture_only=True)
+
+
+def compare_runs(left: LabRun, right: LabRun, *, by_fixture_only: bool = False) -> CompareReport:
+    if by_fixture_only:
+        left_index = {(cell.fixture_id,): cell for cell in left.cells}
+        right_index = {(cell.fixture_id,): cell for cell in right.cells}
+    else:
+        left_index = _index(left)
+        right_index = _index(right)
+    keys = sorted(set(left_index) | set(right_index))
+    deltas: list[CellDelta] = []
+    for key in keys:
+        left_cell = left_index.get(key)
+        right_cell = right_index.get(key)
+        left_score = left_cell.judge.usefulness if left_cell else 0.0
+        right_score = right_cell.judge.usefulness if right_cell else 0.0
+        left_usd = left_cell.cost.usd if left_cell else 0.0
+        right_usd = right_cell.cost.usd if right_cell else 0.0
+        left_variant = left_cell.variant_id if left_cell else '?'
+        right_variant = right_cell.variant_id if right_cell else '?'
+        variant_id = key[1] if len(key) > 1 else f'{left_variant}->{right_variant}'
+        deltas.append(
+            CellDelta(
+                fixture_id=key[0],
+                variant_id=variant_id,
+                usefulness_delta=right_score - left_score,
+                usd_delta=right_usd - left_usd,
+                left_defects=left_cell.judge.defects if left_cell else ('missing-left',),
+                right_defects=right_cell.judge.defects if right_cell else ('missing-right',),
+            )
+        )
+    mean = sum(delta.usefulness_delta for delta in deltas) / len(deltas) if deltas else 0.0
+    return CompareReport(
+        deltas=tuple(deltas),
+        mean_usefulness_delta=mean,
+        total_usd_delta=right.total_usd - left.total_usd,
+    )

--- a/backend/testing/summary_lab/fixtures.py
+++ b/backend/testing/summary_lab/fixtures.py
@@ -1,0 +1,82 @@
+"""Synthetic conversation fixtures. No customer transcripts, no PII."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+FIXTURE_DIR = Path(__file__).resolve().parent / 'fixtures'
+
+
+@dataclass(frozen=True)
+class Fixture:
+    id: str
+    kind: str
+    started_at: str
+    timezone: str
+    language: str
+    transcript: str
+    expected_facts: tuple[str, ...]
+    must_not_contain: tuple[str, ...]
+    owner_threads: tuple[str, ...]
+    recorded: dict[str, dict[str, Any]]
+    token_estimate: dict[str, int]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'id': self.id,
+            'kind': self.kind,
+            'started_at': self.started_at,
+            'timezone': self.timezone,
+            'language': self.language,
+            'transcript': self.transcript,
+            'expected_facts': list(self.expected_facts),
+            'must_not_contain': list(self.must_not_contain),
+            'owner_threads': list(self.owner_threads),
+            'recorded': self.recorded,
+            'token_estimate': dict(self.token_estimate),
+        }
+
+
+def _as_str_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def load_fixture(path: Path) -> Fixture:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict) or not payload.get('id'):
+        raise ValueError(f'invalid fixture: {path}')
+    recorded = payload.get('recorded') or {}
+    if not isinstance(recorded, dict):
+        raise ValueError(f'invalid recorded map: {path}')
+    token_estimate = payload.get('token_estimate') or {'input': 0, 'output': 0}
+    if not isinstance(token_estimate, dict):
+        raise ValueError(f'invalid token_estimate: {path}')
+    return Fixture(
+        id=str(payload['id']),
+        kind=str(payload.get('kind') or 'conversation'),
+        started_at=str(payload.get('started_at') or ''),
+        timezone=str(payload.get('timezone') or 'UTC'),
+        language=str(payload.get('language') or 'en'),
+        transcript=str(payload.get('transcript') or ''),
+        expected_facts=_as_str_tuple(payload.get('expected_facts')),
+        must_not_contain=_as_str_tuple(payload.get('must_not_contain')),
+        owner_threads=_as_str_tuple(payload.get('owner_threads')),
+        recorded={str(key): value for key, value in recorded.items() if isinstance(value, dict)},
+        token_estimate={
+            'input': int(token_estimate.get('input') or 0),
+            'output': int(token_estimate.get('output') or 0),
+        },
+    )
+
+
+def load_synthetic_fixtures(directory: Path | None = None) -> tuple[Fixture, ...]:
+    root = directory or FIXTURE_DIR
+    paths = sorted(root.glob('*.json'))
+    if not paths:
+        raise FileNotFoundError(f'no synthetic fixtures in {root}')
+    return tuple(load_fixture(path) for path in paths)

--- a/backend/testing/summary_lab/fixtures/filler-decision.json
+++ b/backend/testing/summary_lab/fixtures/filler-decision.json
@@ -1,0 +1,39 @@
+{
+  "id": "filler-decision",
+  "kind": "meeting",
+  "started_at": "2026-09-05T11:00:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] Um, so, like, I think we should, you know, drop the OCR flag until Beta bakes.\n[s2 1] Uh, yeah. Keep it dev-only.\n[s1 0] Okay. That's the call.",
+  "expected_facts": ["drop the OCR flag", "Keep it dev-only"],
+  "must_not_contain": ["Um, so", "you know"],
+  "owner_threads": ["OCR stays dark"],
+  "token_estimate": {"input": 480, "output": 140},
+  "recorded": {
+    "notes_v2": {
+      "title": "OCR Flag Stays Dev-Only",
+      "overview": "They decided to drop the OCR flag until Beta bakes and keep it dev-only.",
+      "sections": [
+        {
+          "heading": "Decision",
+          "body_markdown": "- Drop the OCR flag until Beta bakes.\n- Keep it dev-only."
+        }
+      ],
+      "action_items": []
+    },
+    "legacy": {
+      "title": "Flag talk",
+      "overview": "Unclear discussion about a flag.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Um Flag Chat",
+      "overview": "Um, so, like, you know, they kind of talked.",
+      "sections": [
+        {"heading": "Filler", "body_markdown": "- Um, so, like, you know, maybe a flag."}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/fixtures/greeting-only.json
+++ b/backend/testing/summary_lab/fixtures/greeting-only.json
@@ -1,0 +1,36 @@
+{
+  "id": "greeting-only",
+  "kind": "trivial",
+  "started_at": "2026-09-03T12:01:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] Hey.\n[s2 1] Hey.\n[s1 0] Okay bye.",
+  "expected_facts": [],
+  "must_not_contain": ["Speaker 1", "pause the song"],
+  "owner_threads": [],
+  "token_estimate": {"input": 120, "output": 40},
+  "recorded": {
+    "notes_v2": {
+      "title": "Brief Greeting",
+      "overview": "A short hello and goodbye with no decisions.",
+      "sections": [
+        {"heading": "Exchange", "body_markdown": "- Brief greeting, then goodbye."}
+      ],
+      "action_items": []
+    },
+    "legacy": {
+      "title": "Hi",
+      "overview": "Greeting.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Speaker 1 Hello",
+      "overview": "Speaker 1 said hey then pause the song.",
+      "sections": [
+        {"heading": "Noise", "body_markdown": "- Speaker 1\n- pause the song"}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/fixtures/playback-commute.json
+++ b/backend/testing/summary_lab/fixtures/playback-commute.json
@@ -1,0 +1,41 @@
+{
+  "id": "playback-commute",
+  "kind": "ambient",
+  "started_at": "2026-09-06T08:05:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] Pause the song.\n[s1 0] Skip this track.\n[s1 0] I need to call the dentist before noon about the crown.\n[s1 0] Volume down.\n[s1 0] Next song.",
+  "expected_facts": ["call the dentist before noon"],
+  "must_not_contain": ["Pause the song", "Skip this track", "Next song"],
+  "owner_threads": ["dentist"],
+  "token_estimate": {"input": 500, "output": 120},
+  "recorded": {
+    "notes_v2": {
+      "title": "Dentist Call Before Noon",
+      "overview": "The only useful thread is calling the dentist before noon about the crown.",
+      "sections": [
+        {
+          "heading": "Errand",
+          "body_markdown": "- Call the dentist before noon about the crown."
+        }
+      ],
+      "action_items": [
+        {"description": "Call the dentist before noon about the crown"}
+      ]
+    },
+    "legacy": {
+      "title": "Commute audio",
+      "overview": "Music and a phone reminder.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Playlist Session",
+      "overview": "Pause the song, skip this track, then next song, then maybe a dentist.",
+      "sections": [
+        {"heading": "Playback", "body_markdown": "- Pause the song.\n- Skip this track.\n- Next song."}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/fixtures/product-review.json
+++ b/backend/testing/summary_lab/fixtures/product-review.json
@@ -1,0 +1,39 @@
+{
+  "id": "product-review",
+  "kind": "meeting",
+  "started_at": "2026-09-04T15:45:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] The harness should refuse customer transcripts in git.\n[s2 1] Synthetic only. Judge filler and playback.\n[s3 2] Cost note after the matrix, no prompt change without a before/after.",
+  "expected_facts": ["refuse customer transcripts", "Judge filler and playback", "no prompt change without a before/after"],
+  "must_not_contain": ["Speaker 3", "rewind"],
+  "owner_threads": ["harness contract"],
+  "token_estimate": {"input": 820, "output": 200},
+  "recorded": {
+    "notes_v2": {
+      "title": "Summary Lab Stays Synthetic and Comparable",
+      "overview": "The harness must refuse customer transcripts in git, judge filler and playback, and withhold prompt changes until a before/after exists.",
+      "sections": [
+        {
+          "heading": "Contract",
+          "body_markdown": "- Refuse customer transcripts in git; synthetic only.\n- Judge filler and playback.\n- No prompt change without a before/after."
+        }
+      ],
+      "action_items": []
+    },
+    "legacy": {
+      "title": "Review",
+      "overview": "Talked about a harness.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Speaker 3 Review",
+      "overview": "Speaker 3 said rewind and then some process stuff.",
+      "sections": [
+        {"heading": "Noise", "body_markdown": "- Speaker 3 wants to rewind.\n- Something about git."}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/fixtures/social-dinner.json
+++ b/backend/testing/summary_lab/fixtures/social-dinner.json
@@ -1,0 +1,41 @@
+{
+  "id": "social-dinner",
+  "kind": "social",
+  "started_at": "2026-09-07T18:10:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] Want to do Thai on Thursday with Priya?\n[s2 1] Yes, 7pm in Brooklyn, not the place with the tasting menu.\n[s1 0] I'll book a table for three.\n[s2 1] Don't invite the work thread into this.",
+  "expected_facts": ["Thai on Thursday", "7pm in Brooklyn"],
+  "must_not_contain": ["hey google", "Speaker 0"],
+  "owner_threads": ["dinner plan"],
+  "token_estimate": {"input": 700, "output": 180},
+  "recorded": {
+    "notes_v2": {
+      "title": "Thursday Thai Dinner in Brooklyn",
+      "overview": "They planned Thai on Thursday at 7pm in Brooklyn, not the tasting-menu restaurant.",
+      "sections": [
+        {
+          "heading": "Dinner",
+          "body_markdown": "- Thai on Thursday at 7pm in Brooklyn.\n- Skip the tasting-menu place.\n- Book a table for three."
+        }
+      ],
+      "action_items": [
+        {"description": "Book a table for three"}
+      ]
+    },
+    "legacy": {
+      "title": "Chat",
+      "overview": "Talked about food.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Speaker 0 Food Talk",
+      "overview": "You know, hey google, they kind of mentioned dinner.",
+      "sections": [
+        {"heading": "Playback", "body_markdown": "- hey google set a timer\n- um maybe food"}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/fixtures/standup-roadmap.json
+++ b/backend/testing/summary_lab/fixtures/standup-roadmap.json
@@ -1,0 +1,41 @@
+{
+  "id": "standup-roadmap",
+  "kind": "meeting",
+  "started_at": "2026-09-08T09:30:00-04:00",
+  "timezone": "America/New_York",
+  "language": "en",
+  "transcript": "[s1 0] Morning. Let's lock Friday for the notes v2 flag on backend-sync.\n[s2 1] Agreed. Calendar context stays off in prod.\n[s1 0] I'll send the rollout note after standup.\n[s2 1] Ash is reviewing the harness this afternoon.",
+  "expected_facts": ["Friday for the notes v2 flag", "Calendar context stays off"],
+  "must_not_contain": ["pause the song", "Speaker 1"],
+  "owner_threads": ["flag rollout", "prod calendar off"],
+  "token_estimate": {"input": 900, "output": 220},
+  "recorded": {
+    "notes_v2": {
+      "title": "Team Locks Friday Notes v2 Rollout",
+      "overview": "The team agreed to enable notes v2 on backend-sync on Friday and keep calendar context off in prod.",
+      "sections": [
+        {
+          "heading": "Rollout",
+          "body_markdown": "- Friday is the date for the notes v2 flag on backend-sync.\n- Calendar context stays off in prod.\n- A rollout note goes out after standup."
+        }
+      ],
+      "action_items": [
+        {"description": "Send the rollout note after standup"}
+      ]
+    },
+    "legacy": {
+      "title": "Standup",
+      "overview": "Discussed flags and a review.",
+      "sections": [],
+      "action_items": []
+    },
+    "defective": {
+      "title": "Speaker 1 Morning Chat",
+      "overview": "Um, they like, yeah, talked about flags after pause the song.",
+      "sections": [
+        {"heading": "Noise", "body_markdown": "- Speaker 1 said um a lot.\n- Then skip this song and keep going."}
+      ],
+      "action_items": []
+    }
+  }
+}

--- a/backend/testing/summary_lab/judge.py
+++ b/backend/testing/summary_lab/judge.py
@@ -1,0 +1,117 @@
+"""Deterministic owner-usefulness judge.
+
+Scores a note for the defects that make David's own summaries unusable:
+playback/incidental device commands, filler surviving into the recap,
+speaker-cluster leaks, and missing owner threads. Heuristic, not an LLM.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+_FILLER = re.compile(
+    r"\b(?:um+|uh+|erm+|you know|i mean|like,? yeah|kind of|sort of)\b",
+    re.IGNORECASE,
+)
+_PLAYBACK = re.compile(
+    r"\b(?:pause(?:d|s| the)?|skip(?:ped|s)?(?: (?:this|that|the))? (?:song|track|episode)|"
+    r"next song|rewind|volume (?:up|down)|hey google|hey siri|ok google|"
+    r"play(?:ed)? (?:the )?(?:music|podcast))\b",
+    re.IGNORECASE,
+)
+_SPEAKER_LEAK = re.compile(
+    r"\b(?:speaker\s+\d+|spk[_ ]?\d+|speaker_\d+)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class JudgeReport:
+    usefulness: float
+    defects: tuple[str, ...]
+    missing_facts: tuple[str, ...]
+    filler_hits: int
+    playback_hits: int
+    speaker_leaks: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'usefulness': round(self.usefulness, 3),
+            'defects': list(self.defects),
+            'missing_facts': list(self.missing_facts),
+            'filler_hits': self.filler_hits,
+            'playback_hits': self.playback_hits,
+            'speaker_leaks': self.speaker_leaks,
+        }
+
+
+def _flatten_note(note: dict[str, object]) -> str:
+    parts: list[str] = []
+    for key in ('title', 'overview'):
+        value = note.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    sections = note.get('sections')
+    if isinstance(sections, list):
+        for section in sections:
+            if not isinstance(section, dict):
+                continue
+            heading = section.get('heading')
+            body = section.get('body_markdown') or section.get('body')
+            if isinstance(heading, str):
+                parts.append(heading)
+            if isinstance(body, str):
+                parts.append(body)
+    items = note.get('action_items')
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict):
+                description = item.get('description')
+                if isinstance(description, str):
+                    parts.append(description)
+            elif isinstance(item, str):
+                parts.append(item)
+    return '\n'.join(parts)
+
+
+def score_note(
+    note: dict[str, object],
+    *,
+    expected_facts: tuple[str, ...] = (),
+    must_not_contain: tuple[str, ...] = (),
+) -> JudgeReport:
+    text = _flatten_note(note)
+    lowered = text.lower()
+    defects: list[str] = []
+    filler_hits = len(_FILLER.findall(text))
+    playback_hits = len(_PLAYBACK.findall(text))
+    speaker_leaks = len(_SPEAKER_LEAK.findall(text))
+    if filler_hits:
+        defects.append(f'filler:{filler_hits}')
+    if playback_hits:
+        defects.append(f'playback:{playback_hits}')
+    if speaker_leaks:
+        defects.append(f'speaker-leak:{speaker_leaks}')
+
+    for phrase in must_not_contain:
+        if phrase.strip() and phrase.lower() in lowered:
+            defects.append(f'forbidden:{phrase}')
+
+    missing = tuple(fact for fact in expected_facts if fact.lower() not in lowered)
+
+    usefulness = 1.0
+    usefulness -= min(0.45, 0.15 * filler_hits)
+    usefulness -= min(0.50, 0.25 * playback_hits)
+    usefulness -= min(0.40, 0.20 * speaker_leaks)
+    usefulness -= 0.12 * len([d for d in defects if d.startswith('forbidden:')])
+    usefulness -= 0.20 * len(missing)
+    usefulness = max(0.0, min(1.0, usefulness))
+    return JudgeReport(
+        usefulness=usefulness,
+        defects=tuple(defects),
+        missing_facts=missing,
+        filler_hits=filler_hits,
+        playback_hits=playback_hits,
+        speaker_leaks=speaker_leaks,
+    )

--- a/backend/testing/summary_lab/pricing.py
+++ b/backend/testing/summary_lab/pricing.py
@@ -1,0 +1,49 @@
+"""Lab-local token pricing. Copied rates, not a production import.
+
+Uses the same Luna short-context list prices as the maintenance planner
+(``openai.gpt-5.6-luna.2026-07-30``) so harness cost notes stay comparable
+to other backend planning estimates without pulling production modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+LUNA_SHORT_INPUT_USD_PER_MILLION = 0.20
+LUNA_SHORT_OUTPUT_USD_PER_MILLION = 1.20
+DEFAULT_MODEL = 'omi:auto:conversation-notes'
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    model: str
+    input_tokens: int
+    output_tokens: int
+    usd: float
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'model': self.model,
+            'input_tokens': self.input_tokens,
+            'output_tokens': self.output_tokens,
+            'usd': round(self.usd, 6),
+        }
+
+
+def estimate_usd(
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    model: str = DEFAULT_MODEL,
+    input_usd_per_million: float = LUNA_SHORT_INPUT_USD_PER_MILLION,
+    output_usd_per_million: float = LUNA_SHORT_OUTPUT_USD_PER_MILLION,
+) -> CostEstimate:
+    if input_tokens < 0 or output_tokens < 0:
+        raise ValueError('token counts must be non-negative')
+    usd = input_tokens * input_usd_per_million / 1_000_000 + output_tokens * output_usd_per_million / 1_000_000
+    return CostEstimate(
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        usd=usd,
+    )

--- a/backend/testing/summary_lab/render.py
+++ b/backend/testing/summary_lab/render.py
@@ -1,0 +1,61 @@
+"""Render a lab run to a standalone HTML table."""
+
+from __future__ import annotations
+
+import html
+
+from testing.summary_lab.runner import LabRun
+
+
+def render_lab_html(run: LabRun) -> str:
+    rows: list[str] = []
+    for cell in run.cells:
+        defects = ', '.join(cell.judge.defects) or 'none'
+        title = ''
+        raw_title = cell.note.get('title')
+        if isinstance(raw_title, str):
+            title = raw_title
+        rows.append(
+            '<tr>'
+            f'<td>{html.escape(cell.fixture_id)}</td>'
+            f'<td>{html.escape(cell.variant_id)}</td>'
+            f'<td>{cell.judge.usefulness:.2f}</td>'
+            f'<td>${cell.cost.usd:.5f}</td>'
+            f'<td>{html.escape(defects)}</td>'
+            f'<td>{html.escape(title)}</td>'
+            '</tr>'
+        )
+    body = '\n'.join(rows)
+    return f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>summary lab</title>
+  <style>
+    body {{ font-family: sans-serif; margin: 24px; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border: 1px solid #ccc; padding: 6px 8px; text-align: left; }}
+    th {{ background: #f4f4f4; }}
+  </style>
+</head>
+<body>
+  <h1>summary lab</h1>
+  <p>mean usefulness {run.mean_usefulness:.3f} · estimated USD {run.total_usd:.5f}</p>
+  <table>
+    <thead>
+      <tr>
+        <th>fixture</th>
+        <th>variant</th>
+        <th>usefulness</th>
+        <th>est. USD</th>
+        <th>defects</th>
+        <th>title</th>
+      </tr>
+    </thead>
+    <tbody>
+{body}
+    </tbody>
+  </table>
+</body>
+</html>
+'''

--- a/backend/testing/summary_lab/runner.py
+++ b/backend/testing/summary_lab/runner.py
@@ -1,0 +1,79 @@
+"""Run fixture × variant matrix through a seam, then judge and price it."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from testing.summary_lab.fixtures import Fixture
+from testing.summary_lab.judge import JudgeReport, score_note
+from testing.summary_lab.pricing import CostEstimate, estimate_usd
+from testing.summary_lab.seams import SummarizeFn, recorded_seam
+from testing.summary_lab.variants import VARIANTS, Variant
+
+
+@dataclass(frozen=True)
+class CellResult:
+    fixture_id: str
+    variant_id: str
+    note: dict[str, object]
+    judge: JudgeReport
+    cost: CostEstimate
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'fixture_id': self.fixture_id,
+            'variant_id': self.variant_id,
+            'note': self.note,
+            'judge': self.judge.as_dict(),
+            'cost': self.cost.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class LabRun:
+    cells: tuple[CellResult, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {'cells': [cell.as_dict() for cell in self.cells]}
+
+    @property
+    def mean_usefulness(self) -> float:
+        if not self.cells:
+            return 0.0
+        return sum(cell.judge.usefulness for cell in self.cells) / len(self.cells)
+
+    @property
+    def total_usd(self) -> float:
+        return sum(cell.cost.usd for cell in self.cells)
+
+
+def run_matrix(
+    fixtures: tuple[Fixture, ...],
+    variants: tuple[Variant, ...] = VARIANTS,
+    *,
+    summarize: SummarizeFn | None = None,
+) -> LabRun:
+    seam = summarize or recorded_seam
+    cells: list[CellResult] = []
+    for fixture in fixtures:
+        for variant in variants:
+            note = seam(fixture, variant)
+            judge = score_note(
+                note,
+                expected_facts=fixture.expected_facts,
+                must_not_contain=fixture.must_not_contain,
+            )
+            cost = estimate_usd(
+                fixture.token_estimate.get('input', 0),
+                fixture.token_estimate.get('output', 0),
+            )
+            cells.append(
+                CellResult(
+                    fixture_id=fixture.id,
+                    variant_id=variant.id,
+                    note=note,
+                    judge=judge,
+                    cost=cost,
+                )
+            )
+    return LabRun(cells=tuple(cells))

--- a/backend/testing/summary_lab/seams.py
+++ b/backend/testing/summary_lab/seams.py
@@ -1,0 +1,49 @@
+"""Injectable summarize callables. Production code is never imported by default."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from testing.summary_lab.fixtures import Fixture
+from testing.summary_lab.variants import Variant
+
+Note = dict[str, object]
+SummarizeFn = Callable[[Fixture, Variant], Note]
+
+
+class MissingRecordedNote(KeyError):
+    """Fixture has no recorded note for this variant."""
+
+
+def recorded_seam(fixture: Fixture, variant: Variant) -> Note:
+    """Hermetic default: return the fixture's recorded note for the variant."""
+    note = fixture.recorded.get(variant.recorded_key)
+    if note is None:
+        raise MissingRecordedNote(f'{fixture.id} has no recorded note {variant.recorded_key!r}')
+    return dict(note)
+
+
+def production_notes_v2_seam(fixture: Fixture, variant: Variant) -> Note:
+    """Opt-in live path. Imports production only when this function is called."""
+    del variant
+    from utils.llm.conversation_processing import get_conversation_notes
+    from utils.llm.conversation_prompt_prefix import build_conversation_prompt_prefix
+    from datetime import datetime
+
+    started = datetime.fromisoformat(fixture.started_at)
+    prefix = build_conversation_prompt_prefix(
+        conversation_id=f'synthetic-{fixture.id}',
+        transcript=fixture.transcript,
+        started_at=started,
+        timezone_name=fixture.timezone,
+        language_code=fixture.language,
+    )
+    structured = get_conversation_notes(
+        prefix,
+        started_at=started,
+        language_code=fixture.language,
+        output_language_code=fixture.language,
+        tz=fixture.timezone,
+        task_intelligence_capture=False,
+    )
+    return structured.model_dump()

--- a/backend/testing/summary_lab/variants.py
+++ b/backend/testing/summary_lab/variants.py
@@ -1,0 +1,34 @@
+"""Named pipeline variants. Recorded keys are hermetic; live is opt-in."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Variant:
+    id: str
+    recorded_key: str
+    description: str
+    live: bool = False
+
+
+VARIANTS: tuple[Variant, ...] = (
+    Variant(
+        id='notes_v2_recorded',
+        recorded_key='notes_v2',
+        description='Current notes-v2 shape: sectioned recap, verb-led actions.',
+    ),
+    Variant(
+        id='legacy_recorded',
+        recorded_key='legacy',
+        description='Pre-v2 overview-primary note. Used as the cost/quality baseline.',
+    ),
+    Variant(
+        id='defective_recorded',
+        recorded_key='defective',
+        description='Calibration: filler, playback commands, and speaker leaks.',
+    ),
+)
+
+VARIANTS_BY_ID = {variant.id: variant for variant in VARIANTS}

--- a/backend/tests/unit/test_summary_lab.py
+++ b/backend/tests/unit/test_summary_lab.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from testing.summary_lab.cli import main as cli_main
+from testing.summary_lab.compare import compare_variants
+from testing.summary_lab.fixtures import load_synthetic_fixtures
+from testing.summary_lab.judge import score_note
+from testing.summary_lab.pricing import estimate_usd
+from testing.summary_lab.render import render_lab_html
+from testing.summary_lab.runner import run_matrix
+from testing.summary_lab.seams import MissingRecordedNote, recorded_seam
+from testing.summary_lab.variants import VARIANTS
+
+
+def test_synthetic_fixtures_are_committable_and_nonempty() -> None:
+    fixtures = load_synthetic_fixtures()
+    assert len(fixtures) >= 6
+    ids = {fixture.id for fixture in fixtures}
+    assert 'playback-commute' in ids
+    assert 'filler-decision' in ids
+    for fixture in fixtures:
+        assert fixture.transcript.strip()
+        assert 'notes_v2' in fixture.recorded
+        assert 'defective' in fixture.recorded
+        assert '@' not in fixture.transcript
+
+
+def test_judge_rewards_owner_useful_notes_and_penalizes_playback_filler() -> None:
+    fixtures = {fixture.id: fixture for fixture in load_synthetic_fixtures()}
+    commute = fixtures['playback-commute']
+    good = score_note(
+        commute.recorded['notes_v2'],
+        expected_facts=commute.expected_facts,
+        must_not_contain=commute.must_not_contain,
+    )
+    bad = score_note(
+        commute.recorded['defective'],
+        expected_facts=commute.expected_facts,
+        must_not_contain=commute.must_not_contain,
+    )
+    assert good.usefulness >= 0.8
+    assert good.playback_hits == 0
+    assert bad.usefulness < good.usefulness
+    assert bad.playback_hits >= 1
+    assert any(defect.startswith('playback:') or defect.startswith('forbidden:') for defect in bad.defects)
+
+
+def test_pricing_is_linear_and_non_negative() -> None:
+    cheap = estimate_usd(1_000, 200)
+    twice = estimate_usd(2_000, 400)
+    assert cheap.usd > 0
+    assert abs(twice.usd - 2 * cheap.usd) < 1e-9
+
+
+def test_recorded_matrix_scores_notes_v2_above_defective() -> None:
+    run = run_matrix(load_synthetic_fixtures())
+    by_variant: dict[str, list[float]] = {}
+    for cell in run.cells:
+        by_variant.setdefault(cell.variant_id, []).append(cell.judge.usefulness)
+    notes_mean = sum(by_variant['notes_v2_recorded']) / len(by_variant['notes_v2_recorded'])
+    defective_mean = sum(by_variant['defective_recorded']) / len(by_variant['defective_recorded'])
+    assert notes_mean > defective_mean
+    assert run.total_usd > 0
+
+
+def test_compare_reports_usefulness_gain_for_notes_v2_over_defective() -> None:
+    run = run_matrix(load_synthetic_fixtures())
+    report = compare_variants(run, 'defective_recorded', 'notes_v2_recorded')
+    assert report.mean_usefulness_delta > 0
+
+
+def test_html_renderer_includes_scores() -> None:
+    run = run_matrix(load_synthetic_fixtures(), (VARIANTS[0],))
+    page = render_lab_html(run)
+    assert '<table>' in page
+    assert 'usefulness' in page
+    assert run.cells[0].fixture_id in page
+
+
+def test_cli_run_writes_json_and_html(tmp_path: Path) -> None:
+    out = tmp_path / 'lab'
+    assert cli_main(['run', '--out', str(out)]) == 0
+    payload = json.loads((out / 'run.json').read_text(encoding='utf-8'))
+    assert payload['cells']
+    html = (out / 'lab.html').read_text(encoding='utf-8')
+    assert 'summary lab' in html
+    summary = (out / 'summary.txt').read_text(encoding='utf-8')
+    assert 'mean_usefulness=' in summary
+
+
+def test_recorded_seam_requires_variant_key() -> None:
+    fixture = load_synthetic_fixtures()[0]
+    missing = VARIANTS[0]
+    broken = type(missing)(id='x', recorded_key='not-a-key', description='x')
+    try:
+        recorded_seam(fixture, broken)
+        raise AssertionError('expected MissingRecordedNote')
+    except MissingRecordedNote:
+        pass
+
+
+def test_harness_import_does_not_load_production_summarizer() -> None:
+    loaded = {name for name in sys.modules if name.startswith('utils.llm.conversation_processing')}
+    assert not loaded


### PR DESCRIPTION
## Summary
- Adds `backend/testing/summary_lab/`: CLI, seams, synthetic fixtures, variants, runner, compare, judge, pricing, and an HTML renderer.
- Default seam is recorded and hermetic. It does not import production summarizer modules and does not call an LLM. `--live` is opt-in.
- Six committable synthetic fixtures. No customer transcripts.

This PR does not change production prompts or the summary pipeline. Prompt changes wait on a separate, evidence-backed PR.

## Lab run (synthetic, recorded seam)
- 6 fixtures × 3 variants = 18 cells
- `notes_v2_recorded` mean usefulness **0.967**, no playback/filler/speaker-leak defects
- `legacy_recorded` mean usefulness **0.667** (missing owner facts; +0.30 if moved to notes v2)
- `defective_recorded` mean usefulness **0.000** (judge calibration for playback/filler)
- Estimated Luna short-context cost for the matrix: **$0.00535** total (~$0.00178 per variant)

No production prompt change: notes v2 already wins on these fixtures, and the lab has not yet been pointed at a live model.

## Test plan
- [x] `backend/test.sh` on `tests/unit/test_summary_lab.py` (9 passed)
- [x] `python -m testing.summary_lab run --out <dir>` on synthetic fixtures
- [ ] Optional local `--live` run stays untracked and is not required to merge

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

