### PR TITLE
fix(python-cli): reject lone surrogates in JSON input before HTTP encoding

### DIFF
--- a/sdks/python-cli/omi_cli/json_input.py
+++ b/sdks/python-cli/omi_cli/json_input.py
@@ -1,4 +1,4 @@
-"""Decode user-provided JSON without numbers the HTTP serializer cannot send."""
+"""Decode user-provided JSON that the HTTP serializer can encode."""
 
 from __future__ import annotations
 
@@ -19,9 +19,20 @@ def _finite_float(value: str) -> float:
 
 
 def load_json_input(value: str | bytes) -> Any:
-    """Reject NaN, infinities, and exponents that overflow Python's float range.
+    """Reject non-finite numbers and strings that cannot be encoded as UTF-8.
 
     JSON strings are unchanged, and bytes retain json.loads' encoding detection.
-    Invalid input raises ValueError (including JSONDecodeError).
+    Invalid input raises ValueError (including JSONDecodeError and UnicodeError).
     """
-    return json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    parsed = json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    pending = [parsed]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, str):
+            item.encode("utf-8")
+        elif isinstance(item, list):
+            pending.extend(item)
+        elif isinstance(item, dict):
+            pending.extend(item)
+            pending.extend(item.values())
+    return parsed

--- a/sdks/python-cli/tests/test_json_input_unicode.py
+++ b/sdks/python-cli/tests/test_json_input_unicode.py
@@ -1,0 +1,45 @@
+"""JSON input must reach the HTTP encoder without losing Unicode data."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from omi_cli.json_input import load_json_input
+
+
+@pytest.mark.parametrize("surrogate", ["\ud800", "\udfff"])
+@pytest.mark.parametrize("location", ["root", "value", "key", "nested"])
+def test_rejects_surrogates_before_http_encoding(surrogate, location) -> None:
+    values = {
+        "root": surrogate,
+        "value": {"text": surrogate},
+        "key": {surrogate: "text"},
+        "nested": {"items": [{"text": surrogate}]},
+    }
+    with pytest.raises(ValueError, match="surrogates not allowed"):
+        load_json_input(json.dumps(values[location]))
+
+
+@pytest.mark.parametrize("encoding", [None, "utf-8", "utf-16", "utf-32"])
+def test_preserves_unicode_and_can_encode_http_request(encoding) -> None:
+    value = {"ș😀": ["日本語", "\\ud800", "", None, True, 42, -1.5e2, 1e300]}
+    raw = json.dumps(value, ensure_ascii=encoding is None)
+    decoded = load_json_input(raw if encoding is None else raw.encode(encoding))
+    assert decoded == value
+    request = httpx.Request("POST", "https://example.invalid", json=decoded)
+    assert json.loads(request.content) == value
+
+
+@pytest.mark.parametrize("raw", ['"\\ud800"', '{"\\udfff": 1}', '[{"text":"\\ud800"}]'])
+def test_byte_inputs_reject_surrogates(raw) -> None:
+    with pytest.raises(ValueError, match="surrogates not allowed"):
+        load_json_input(raw.encode("utf-16"))
+
+
+@pytest.mark.parametrize("number", ["NaN", "Infinity", "-Infinity", "1e400", "-1e400"])
+def test_preserves_non_finite_number_rejection(number) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        load_json_input('{"nested":[' + number + ']}')


### PR DESCRIPTION
- Validate strings and dictionary keys in `load_json_input()` to ensure UTF-8 encodability.
- Reject lone surrogates at input parsing rather than crashing with unhandled `UnicodeEncodeError` inside `httpx`.
- Add `tests/test_json_input_unicode.py` covering root values, dictionary keys, nested structures, and byte streams.

Fixes #13382

    ## What changed and why
    `load_json_input` previously accepted JSON containing lone surrogate escape sequences (e.g. `\ud800`). When later serialized by `httpx` for HTTP
  transmission, an unhandled `UnicodeEncodeError` was raised. Validating decoded strings ensures invalid Unicode is rejected as a `ValueError` at the CLI
  boundary.

    ## Product invariants affected
    none

    ## How it was verified
    Ran `pytest tests/test_json_input_unicode.py tests/test_json_input_commands.py`. 42/42 tests pass.

    ## Tests
    `sdks/python-cli/tests/test_json_input_unicode.py`

    ## Failure class (fixes)
    Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

