### PR TITLE
fix(pusher): install typesense so image smoke and auto-qual can pass

### DIFF
--- a/backend/pusher/pylock.toml
+++ b/backend/pusher/pylock.toml
@@ -839,6 +839,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/eb/a3/68d476e978930d6f1
 wheels = [{ url = "https://files.pythonhosted.org/packages/06/f0/0b875419fa7ddfa6c4a07954f4991e50b37dcc9922bc502f023b12be67e1/twilio-9.5.0-py2.py3-none-any.whl", upload-time = 2025-03-11T12:56:28Z, size = 1882103, hashes = { sha256 = "e6d0ccf9162a83acfa6d21a02e90a22fdbc53f4269be3402ba579f13b2a259fc" } }]
 
 [[packages]]
+name = "typesense"
+version = "0.21.0"
+sdist = { url = "https://files.pythonhosted.org/packages/73/c4/b9ee39e15503c7e284bdb8afb5f2b8d06ee06e7abc33ed56c17388ab24e6/typesense-0.21.0.tar.gz", upload-time = 2024-05-10T04:42:42Z, size = 14030, hashes = { sha256 = "24470525b577300bd81fe43029dddd9269b942b20b49236edf049f6ecead7c8e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/88/2c/e3f25e6e2c5ddb0c8b6e78115f6acd1be3167da1bbe361ae0bcff5c90512/typesense-0.21.0-py3-none-any.whl", upload-time = 2024-05-10T04:42:40Z, size = 21143, hashes = { sha256 = "e4330f103a40af98ba2b0ffd817392a84a537e04816221c9a283faadea7718f0" } }]
+
+[[packages]]
 name = "typing-extensions"
 version = "4.15.0"
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", upload-time = 2025-08-25T13:49:26Z, size = 109391, hashes = { sha256 = "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" } }

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -62,6 +62,8 @@ langsmith==0.8.5
 # Vector databases
 pinecone==7.3.0
 qdrant-client==1.11.0
+# Conversation search index (process_conversation → lifecycle → typesense_index)
+typesense==0.21.0
 
 # Knowledge graph
 neo4j==5.23.1

--- a/backend/tests/unit/test_runtime_image_contracts.py
+++ b/backend/tests/unit/test_runtime_image_contracts.py
@@ -400,3 +400,25 @@ def test_load_contracts_dockerfile_filter_skips_non_matching_entries(contracts_m
     filtered = contracts_module.load_contracts(staged_registry, dockerfile_filter=backend_filter)
 
     assert [c.name for c in filtered] == ['backend']
+
+
+def _requirement_pin(requirements_text: str, package: str) -> str:
+    prefix = f'{package}=='
+    for line in requirements_text.splitlines():
+        if line.startswith(prefix):
+            return line
+    raise AssertionError(f'{package} pin missing from requirements')
+
+
+def test_pusher_installs_typesense_because_finalization_indexes_conversations():
+    """process_conversation → lifecycle → typesense_index is reachable in the pusher image.
+
+    Auto-deploy smoke failed from 2026-09-01 onward with
+    missing installed dependency modules: typesense / typesense.exceptions.ObjectNotFound
+    because the module was on backend/requirements.txt but not the pusher subset.
+    """
+    pusher = (BACKEND_DIR / 'pusher' / 'requirements.txt').read_text(encoding='utf-8')
+    backend = (BACKEND_DIR / 'requirements.txt').read_text(encoding='utf-8')
+    assert _requirement_pin(pusher, 'typesense') == _requirement_pin(backend, 'typesense')
+    pylock = (BACKEND_DIR / 'pusher' / 'pylock.toml').read_text(encoding='utf-8')
+    assert 'name = "typesense"' in pylock


### PR DESCRIPTION
## Summary

Pusher image auto-deploy smoke has failed since 2026-09-01 because conversation finalization reaches Typesense (`process_conversation` → lifecycle → `typesense_index`) but `backend/pusher/requirements.txt` did not install the client. That blocked `pusher-dev-qualification`, so GKE pusher never received #12507/#13188 (Speaker N sanitizer / compact transcript).

Pin `typesense==0.21.0` on the pusher subset (same pin as `backend/requirements.txt`) and lock it in `pusher/pylock.toml`.

## Failure-Class
Failure-Class: none

## Tests
- `backend/tests/unit/test_runtime_image_contracts.py::test_pusher_installs_typesense_because_finalization_indexes_conversations`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

