### PR TITLE
fix(cli): treat empty HTTP error responses as failures

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -184,7 +184,7 @@ class OmiClient:
         raise RuntimeError("unreachable")
 
     def _handle_response(self, response: httpx.Response) -> Any:
-        if response.status_code == 204 or not response.content:
+        if 200 <= response.status_code < 300 and (response.status_code == 204 or not response.content):
             return None
         if 200 <= response.status_code < 300:
             return _safe_parse_json(response)


### PR DESCRIPTION
## Summary
- only treat empty bodies as success for 2xx responses
- preserve existing 204 and empty-2xx behavior
- let the existing error mapper handle empty 4xx/5xx responses

## Validation
- `git diff --check` passes
- Python test execution was attempted, but this environment does not have pytest installed

This addresses #13390. The proposed US$25 bounty remains unapproved and is not treated as guaranteed. AI assistance was used and the change is limited to the reported response-boundary bug.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

