### PR TITLE
fix(pusher): ignore terminating pods in live image receipt

### DIFF
--- a/backend/scripts/pusher_release_receipt.py
+++ b/backend/scripts/pusher_release_receipt.py
@@ -307,8 +307,15 @@ def validate_live_identity(
         if not isinstance(pod, dict):
             continue
         pod_metadata = pod.get("metadata") if isinstance(pod.get("metadata"), dict) else {}
+        # kubectl get pods includes terminating replicas. Helm rollout status can
+        # return success while an old replica is still pending deletion, which
+        # made auto-qual fail closed on a matching live Deployment (2026-09-10).
+        if pod_metadata.get("deletionTimestamp"):
+            continue
         pod_spec = pod.get("spec") if isinstance(pod.get("spec"), dict) else {}
         pod_status = pod.get("status") if isinstance(pod.get("status"), dict) else {}
+        if pod_status.get("phase") not in (None, "Running"):
+            continue
         spec_images = [
             image
             for item in pod_spec.get("containers", [])

--- a/backend/tests/unit/test_verify_pusher_promotion_evidence.py
+++ b/backend/tests/unit/test_verify_pusher_promotion_evidence.py
@@ -478,6 +478,53 @@ def test_rejects_contradictory_deployment_receipt(
     assert any("config_sha256 contradicts" in error for error in errors)
 
 
+def test_live_receipt_ignores_terminating_old_replica(receipt_builder: SimpleNamespace) -> None:
+    old_digest = "sha256:" + "f" * 64
+    deployment = {
+        "metadata": {"name": "dev-omi-pusher", "uid": "deploy", "generation": 4},
+        "spec": {"template": {"spec": {"containers": [{"name": "pusher", "image": f"{REPOSITORY}@{DIGEST}"}]}}},
+        "status": {"observedGeneration": 4, "replicas": 1, "readyReplicas": 1, "availableReplicas": 1},
+    }
+    pods = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "pusher-old",
+                    "uid": "pod-old",
+                    "deletionTimestamp": "2026-09-10T02:13:51Z",
+                },
+                "spec": {"containers": [{"name": "pusher", "image": f"{REPOSITORY}@{old_digest}"}]},
+                "status": {
+                    "phase": "Running",
+                    "containerStatuses": [
+                        {"name": "pusher", "ready": False, "imageID": f"docker-pullable://{REPOSITORY}@{old_digest}"}
+                    ],
+                },
+            },
+            {
+                "metadata": {"name": "pusher-new", "uid": "pod-new"},
+                "spec": {"containers": [{"name": "pusher", "image": f"{REPOSITORY}@{DIGEST}"}]},
+                "status": {
+                    "phase": "Running",
+                    "containerStatuses": [
+                        {"name": "pusher", "ready": True, "imageID": f"docker-pullable://{REPOSITORY}@{DIGEST}"}
+                    ],
+                },
+            },
+        ]
+    }
+
+    identity = receipt_builder.validate_live_identity(
+        deployment,
+        pods,
+        namespace="dev-omi-backend",
+        repository=REPOSITORY,
+        digest=DIGEST,
+    )
+    assert identity["replicas"] == 1
+    assert [pod["name"] for pod in identity["pods"]] == ["pusher-new"]
+
+
 def test_live_receipt_rejects_a_pod_running_another_digest(receipt_builder: SimpleNamespace) -> None:
     deployment = {
         "metadata": {"name": "dev-omi-pusher", "uid": "deploy", "generation": 4},


### PR DESCRIPTION
## Summary

Dev pusher auto-qual on `2a2171e661` built and rolled the new image twice (`sha256:38536ce7…`, then `sha256:29589591…`). Helm `rollout status` succeeded while one old replica was still terminating. The live-identity receipt then listed every pod with the instance label, including the terminating replica, and failed because that pod still had the previous digest.

This skips pods with `metadata.deletionTimestamp` so a rolling update with a draining old replica is not treated as a mixed-image cluster. A ready pod on a different digest still fails.

## Test plan

- [x] `pytest backend/tests/unit/test_verify_pusher_promotion_evidence.py::test_live_receipt_ignores_terminating_old_replica`
- [x] existing mixed-digest ready-pod rejection still fails closed
- [ ] Auto Deploy Backend Pusher (Development) succeeds on this SHA and uploads `pusher-dev-qualification`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

