### PR TITLE
fix(pusher): treat helm null env sources as absent in live receipts

### DIFF
--- a/backend/scripts/pusher_release_receipt.py
+++ b/backend/scripts/pusher_release_receipt.py
@@ -142,6 +142,15 @@ def rendered_chart_documents(
     return documents
 
 
+def _drop_null_fields(value: Any) -> Any:
+    """Drop YAML nulls so Helm `secretKeyRef: null` matches the API-omitted key."""
+    if isinstance(value, dict):
+        return {key: _drop_null_fields(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [_drop_null_fields(item) for item in value]
+    return value
+
+
 def pod_template_semantic_projection(template: dict[str, Any]) -> dict[str, Any]:
     """Project capability-relevant PodTemplate fields without API defaults."""
     spec = template.get("spec") if isinstance(template.get("spec"), dict) else {}
@@ -185,7 +194,8 @@ def pod_template_semantic_projection(template: dict[str, Any]) -> dict[str, Any]
     )
     projected_container = {field: copy.deepcopy(container[field]) for field in container_fields if field in container}
     projected_container["env"] = sorted(
-        (copy.deepcopy(item) for item in env if isinstance(item, dict)), key=lambda item: str(item.get("name", ""))
+        (_drop_null_fields(copy.deepcopy(item)) for item in env if isinstance(item, dict)),
+        key=lambda item: str(item.get("name", "")),
     )
     for probe_name in ("livenessProbe", "readinessProbe", "startupProbe"):
         probe = projected_container.get(probe_name)
@@ -206,9 +216,12 @@ def pod_template_semantic_projection(template: dict[str, Any]) -> dict[str, Any]
                 for resource_name in ("cpu", "memory"):
                     if resource_name in values:
                         values[resource_name] = _normalize_resource_quantity(resource_name, values[resource_name])
+    pod = {field: copy.deepcopy(spec[field]) for field in pod_fields if field in spec}
+    if pod.get("securityContext") == {}:
+        pod.pop("securityContext")
     return {
         "container": projected_container,
-        "pod": {field: copy.deepcopy(spec[field]) for field in pod_fields if field in spec},
+        "pod": pod,
     }
 
 

--- a/backend/tests/unit/test_verify_pusher_promotion_evidence.py
+++ b/backend/tests/unit/test_verify_pusher_promotion_evidence.py
@@ -679,6 +679,57 @@ def test_pusher_template_semantics_normalize_kubernetes_probe_defaults_and_quant
     )
 
 
+def test_live_receipt_treats_helm_null_secret_ref_and_empty_pod_security_as_absent(
+    receipt_builder: SimpleNamespace,
+) -> None:
+    expected = {
+        "spec": {
+            "serviceAccountName": "dev-omi-pusher",
+            "containers": [
+                {
+                    "name": "pusher",
+                    "image": f"repo@{DIGEST}",
+                    "env": [
+                        {"name": "MEMORY_ENABLED", "value": "on"},
+                        {
+                            "name": "TYPESENSE_HOST",
+                            "valueFrom": {
+                                "configMapKeyRef": {"name": "dev-omi-backend-config", "key": "TYPESENSE_HOST"},
+                                "secretKeyRef": None,
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+    live = {
+        "spec": {
+            "serviceAccountName": "dev-omi-pusher",
+            "securityContext": {},
+            "containers": [
+                {
+                    "name": "pusher",
+                    "image": f"repo@{DIGEST}",
+                    "env": [
+                        {"name": "MEMORY_ENABLED", "value": "on"},
+                        {
+                            "name": "TYPESENSE_HOST",
+                            "valueFrom": {
+                                "configMapKeyRef": {"name": "dev-omi-backend-config", "key": "TYPESENSE_HOST"},
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+
+    assert receipt_builder.pod_template_semantic_projection(expected) == (
+        receipt_builder.pod_template_semantic_projection(live)
+    )
+
+
 def test_isolated_canary_render_uses_one_proposed_config_map_for_every_reference(
     receipt_builder: SimpleNamespace,
 ) -> None:


### PR DESCRIPTION
## Summary

Dev pusher Helm already rolled `gcr.io/based-hardware-dev/pusher@sha256:789b2aa6…` (typesense image). Auto-qual then failed closed on PodTemplate semantic equality.

The mismatch is not a mixed image. Helm values keep `secretKeyRef: null` on `REDIS_DB_HOST`, `GOOGLE_CLIENT_ID`, and `TYPESENSE_HOST` so a 3-way upgrade drops a historical Secret source. `helm template` serializes that null; the API omits the key. The API also stores an empty pod `securityContext: {}`.

This projection drops YAML nulls and empty pod securityContext so the receipt compares applied semantics, not serialization. A live extra Secret source still fails closed.

## Test plan

- [x] unit: helm `secretKeyRef: null` + empty pod securityContext equals live omitted fields
- [x] live dev Deployment vs `helm template` now hash-equal under the new projection
- [ ] Auto Deploy Backend Pusher (Development) succeeds and uploads `pusher-dev-qualification`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

