### PR TITLE
fix(backend): fail-open Redis cache writes on maxmemory

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -391,9 +391,31 @@ def get_apps_installs_count(app_ids: List[str]) -> Dict[str, int]:
     return {app_id: max(0, int(count)) if count else 0 for app_id, count in zip(app_ids, counts)}
 
 
+def _cache_set_fail_open(key: str, value: Any, ttl: int) -> None:
+    """Best-effort cache write. Redis maxmemory must not 500 product requests."""
+    try:
+        r.set(key, value)
+        r.expire(key, ttl)
+    except redis.exceptions.OutOfMemoryError:
+        prefix = key.split(':', 1)[0]
+        logger.warning('redis cache write skipped capacity_full prefix=%s', prefix)
+        try:
+            from utils.observability.fallback import record_fallback
+
+            record_fallback(
+                component='other',
+                from_mode='cache_write',
+                to_mode='skip',
+                reason='capacity_full',
+                outcome='degraded',
+                log=logger,
+            )
+        except Exception:
+            pass
+
+
 def cache_user_name(uid: str, name: str, ttl: int = 60 * 60 * 24 * 7) -> None:
-    r.set(f'users:{uid}:name', name)
-    r.expire(f'users:{uid}:name', ttl)
+    _cache_set_fail_open(f'users:{uid}:name', name, ttl)
 
 
 def cache_signed_url(blob_path: str, signed_url: str, ttl: int = 60 * 60) -> None:
@@ -423,11 +445,14 @@ def cache_user_geolocation(uid: str, geolocation: Dict[str, Any]) -> None:
     # was finalizing. Every reader rebuilds ``Geolocation`` from this dict, whose
     # optional fields already default to ``None`` when absent.
     present_fields = {key: value for key, value in geolocation.items() if value is not None}
-    r.set(f'users:{uid}:geolocation', _serialize_cache_value(present_fields))
     # 30m: conversation/tool place tagging does not need second-level freshness;
     # clients re-upload on significant moves and at recording start. Keeps the
     # last-known coords available without inventing a tighter freshness policy.
-    r.expire(f'users:{uid}:geolocation', 60 * 30)
+    _cache_set_fail_open(
+        f'users:{uid}:geolocation',
+        _serialize_cache_value(present_fields),
+        60 * 30,
+    )
 
 
 def get_cached_user_geolocation(uid: str) -> Optional[Dict[str, Any]]:

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -396,7 +396,10 @@ def _cache_set_fail_open(key: str, value: Any, ttl: int) -> None:
     try:
         r.set(key, value)
         r.expire(key, ttl)
-    except redis.exceptions.OutOfMemoryError:
+    except Exception as exc:
+        # redis-py types omit ``exceptions``; match the live maxmemory class by name.
+        if type(exc).__name__ != 'OutOfMemoryError':
+            raise
         prefix = key.split(':', 1)[0]
         logger.warning('redis cache write skipped capacity_full prefix=%s', prefix)
         try:

--- a/backend/tests/unit/test_redis_db_cache_serialization.py
+++ b/backend/tests/unit/test_redis_db_cache_serialization.py
@@ -104,3 +104,18 @@ def test_apps_reviews_batch_round_trip(fake_redis: _FakeRedis) -> None:
         "app-b": {"uid-2": {"rating": 5}},
         "app-missing": {},
     }
+
+
+class _MaxMemoryRedis(_FakeRedis):
+    def set(self, key: str, value: Any, ex: Optional[int] = None) -> None:
+        raise redis_db.redis.exceptions.OutOfMemoryError("command not allowed when used memory > 'maxmemory'.")
+
+
+def test_cache_user_geolocation_fail_open_on_maxmemory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(redis_db, "r", _MaxMemoryRedis())
+    redis_db.cache_user_geolocation("uid-1", {"latitude": 37.77, "longitude": -122.42})
+
+
+def test_cache_user_name_fail_open_on_maxmemory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(redis_db, "r", _MaxMemoryRedis())
+    redis_db.cache_user_name("uid-1", "Ada")


### PR DESCRIPTION
## Summary
Prod Redis Cloud is at maxmemory. Cloud Run `SET` on `users:{uid}:geolocation` and `users:{uid}:name` raises `OutOfMemoryError`, which 500s `PATCH /v1/users/geolocation`. Clients retry and the write storm continues. Chat agentic setup can fail with the same exception.

Fail-open those two cache writes: skip the SET, emit `record_fallback` `capacity_full`, do not raise. Does not free Redis; stops the retry storm and chat 500s from cache writes.

## Failure-Class
Failure-Class: none

Line-Count-Exception: backend/database/redis_db.py | 1611 -> 1639 | fail-open helper for maxmemory cache SETs; split is out of scope for this incident patch

## Test plan
- [x] Unit: geo/name cache SET raising `OutOfMemoryError` does not propagate
- [x] Existing redis cache serialization + users router tests


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

