### PR TITLE
SCA-462: one notch layout snapshot and one frame-transition owner

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarFrameTransition.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarFrameTransition.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+
+/// One owner for every floating-bar frame snap and animation.
+///
+/// Starting a new transition invalidates the previous completion by construction:
+/// completions capture a token, and only the current token may land. Hover
+/// collapse and close-settle work that used to live on a hand-managed
+/// `DispatchWorkItem` or `asyncAfter` are scheduled through the same owner so a
+/// later snap cannot leave a stale resize behind.
+final class FloatingBarFrameTransition {
+  struct Token: Equatable {
+    fileprivate let id: UInt64
+  }
+
+  private var generation: UInt64 = 0
+  private(set) var pendingTarget: NSRect?
+  private var scheduledWork: DispatchWorkItem?
+
+  var currentGeneration: UInt64 { generation }
+  var isAnimating: Bool { pendingTarget != nil }
+
+  /// Begin a new snap or animation. Any in-flight completion or scheduled
+  /// settle from a previous `start`/`schedule` is stale.
+  @discardableResult
+  func start(pendingTarget: NSRect? = nil) -> Token {
+    generation &+= 1
+    scheduledWork?.cancel()
+    scheduledWork = nil
+    self.pendingTarget = pendingTarget
+    return Token(id: generation)
+  }
+
+  func isCurrent(_ token: Token) -> Bool {
+    token.id == generation
+  }
+
+  func clearPending(if token: Token) {
+    guard isCurrent(token) else { return }
+    pendingTarget = nil
+  }
+
+  func dropPendingWithoutInvalidating() {
+    pendingTarget = nil
+  }
+
+  /// Cancel in-flight completions without aiming at a new frame.
+  func invalidate() {
+    _ = start(pendingTarget: nil)
+    pendingTarget = nil
+  }
+
+  func cancelScheduled() {
+    scheduledWork?.cancel()
+    scheduledWork = nil
+  }
+  func scheduleOnNextTurn(_ work: @escaping () -> Void) {
+    let token = start()
+    let item = DispatchWorkItem { [weak self] in
+      guard let self, self.isCurrent(token) else { return }
+      work()
+    }
+    scheduledWork = item
+    DispatchQueue.main.async(execute: item)
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLayout.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLayout.swift
@@ -1,0 +1,167 @@
+import AppKit
+import VoiceTurnDomain
+
+/// Typed voice phase for floating-bar sizing and chrome.
+///
+/// `isVoiceListening` and `isVoicePresentationActive` overloaded several
+/// live states (capture, a failure hint, thinking, spoken response) into
+/// booleans. A layout reader that needs the capture waveform is not the same
+/// as one that needs the hold-longer banner, and treating them as one boolean
+/// is how the island settled at the wrong width.
+enum FloatingBarVoicePhase: Equatable, Sendable {
+  case idle
+  case listening
+  case thinking
+  case hint
+  case responding
+
+  static func from(_ projection: VoiceTurnUIProjection) -> Self {
+    if projection.isListening { return .listening }
+    if !projection.hint.isEmpty { return .hint }
+    if projection.isThinking { return .thinking }
+    if projection.isResponseActive || projection.isResponseWaiting { return .responding }
+    return .idle
+  }
+
+  /// Any phase that reserves the closed surface so hover/idle collapse cannot
+  /// steal the island.
+  var reservesSurface: Bool {
+    self != .idle
+  }
+
+  /// Capture is live. A failure hint is a different phase and must not reuse
+  /// this for waveform chrome.
+  var isCapturing: Bool {
+    self == .listening
+  }
+
+  /// The historical `isVoiceListening` boolean: capture *or* a hint that
+  /// kept that flag true. Prefer the typed cases at new call sites.
+  var isListeningOrHint: Bool {
+    self == .listening || self == .hint
+  }
+}
+
+/// One pure layout snapshot both the SwiftUI view and the window read.
+///
+/// Lobe width, chrome width, the drawn surface, and the closed surface are
+/// derived from the same inputs so a hover menu, a card, or a voice phase
+/// cannot paint one size and settle the window at another.
+struct FloatingBarLayout: Equatable {
+  var voicePhase: FloatingBarVoicePhase
+  var lobeWidth: CGFloat
+  var chromeWidth: CGFloat
+  var chromeHeight: CGFloat
+  var drawnSurface: NSSize
+  var closedSurface: NSSize
+
+  struct Metrics: Equatable {
+    var compactSideWidth: CGFloat
+    var activeSideWidth: CGFloat
+    var voiceSideWidth: CGFloat
+    var thinkingSideWidth: CGFloat
+    var hiddenCenterWidth: CGFloat
+    var chromeHeight: CGFloat
+    var expandedWidth: CGFloat
+    var hoverMenuHeight: CGFloat
+    var minBarSize: NSSize
+    var voiceBarSize: NSSize
+  }
+
+  /// Side width of one notch lobe. Capture uses the voice control; thinking
+  /// uses the thinking mark; everything else that is not compact idle uses
+  /// the active lobe.
+  static func lobeWidth(
+    phase: FloatingBarVoicePhase,
+    isChatPresented: Bool,
+    hasAgentPills: Bool,
+    metrics: Metrics
+  ) -> CGFloat {
+    if phase.isCapturing { return metrics.voiceSideWidth }
+    if isChatPresented {
+      return hasAgentPills ? metrics.activeSideWidth : metrics.compactSideWidth
+    }
+    if phase == .thinking { return metrics.thinkingSideWidth }
+    if !hasAgentPills && !phase.reservesSurface {
+      return metrics.compactSideWidth
+    }
+    return metrics.activeSideWidth
+  }
+
+  static func chromeWidth(lobeWidth: CGFloat, hiddenCenterWidth: CGFloat) -> CGFloat {
+    hiddenCenterWidth + lobeWidth * 2
+  }
+
+  /// The black chrome the view draws: idle island, or idle plus the hover
+  /// menu hanging under it. Cards, banners, and conversation are composed
+  /// on top of this by the window's closed-surface authority.
+  static func drawnSurface(
+    chromeWidth: CGFloat,
+    chromeHeight: CGFloat,
+    hoverMenuVisible: Bool,
+    hoverMenuHeight: CGFloat,
+    expandedWidth: CGFloat
+  ) -> NSSize {
+    if hoverMenuVisible {
+      return NSSize(
+        width: max(chromeWidth, expandedWidth),
+        height: chromeHeight + hoverMenuHeight
+      )
+    }
+    return NSSize(width: chromeWidth, height: chromeHeight)
+  }
+
+  static func make(
+    phase: FloatingBarVoicePhase,
+    isChatPresented: Bool,
+    hasAgentPills: Bool,
+    hoverMenuVisible: Bool,
+    metrics: Metrics,
+    closedSurface: NSSize
+  ) -> FloatingBarLayout {
+    let lobe = lobeWidth(
+      phase: phase,
+      isChatPresented: isChatPresented,
+      hasAgentPills: hasAgentPills,
+      metrics: metrics
+    )
+    let chrome = chromeWidth(lobeWidth: lobe, hiddenCenterWidth: metrics.hiddenCenterWidth)
+    return FloatingBarLayout(
+      voicePhase: phase,
+      lobeWidth: lobe,
+      chromeWidth: chrome,
+      chromeHeight: metrics.chromeHeight,
+      drawnSurface: drawnSurface(
+        chromeWidth: chrome,
+        chromeHeight: metrics.chromeHeight,
+        hoverMenuVisible: hoverMenuVisible,
+        hoverMenuHeight: metrics.hoverMenuHeight,
+        expandedWidth: metrics.expandedWidth
+      ),
+      closedSurface: closedSurface
+    )
+  }
+}
+
+extension FloatingControlBarGeometry {
+  /// Closed-conversation chrome size from a typed voice phase. A mounted
+  /// notification card still wins; listening/thinking may only grow it.
+  static func collapsedSurfaceSize(
+    hasMountedNotification: Bool,
+    phase: FloatingBarVoicePhase,
+    notificationSize: NSSize,
+    listeningSize: NSSize,
+    thinkingSize: NSSize,
+    idleSize: NSSize
+  ) -> NSSize {
+    collapsedSurfaceSize(
+      hasMountedNotification: hasMountedNotification,
+      isVoiceListening: phase.isListeningOrHint,
+      isThinking: phase == .thinking || phase == .responding,
+      notificationSize: notificationSize,
+      listeningSize: listeningSize,
+      thinkingSize: thinkingSize,
+      idleSize: idleSize
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -44,17 +44,13 @@ extension FloatingControlBarWindow {
   func beginNotchRetraction(then completion: @escaping () -> Void) {
     notchRetractionCancellation?.cancel()
     cancelInFlightNotchReveal()
-    // Cancel in-flight *frame* animations. Retract/reveal use dedicated
-    // generations so a later no-op resize cannot strand the island at 0.01.
-    frameAnimationToken += 1
-    notchRetractionGeneration &+= 1
-    let generation = notchRetractionGeneration
+    let token = frameTransition.start()
     OmiMotion.withGated(.easeIn(duration: 0.18)) {
       state.notchRevealProgress = FloatingBarNotchRevealPolicy.retractedProgress
     }
     notchRetractionCancellation = notchRetractionScheduler.schedule(after: 0.18) { [weak self] in
       guard let self else { return }
-      guard self.notchRetractionGeneration == generation else {
+      guard self.frameTransition.isCurrent(token) else {
         self.restoreNotchRevealProgressIfWindowStillVisible()
         return
       }
@@ -63,6 +59,7 @@ extension FloatingControlBarWindow {
       // reveal (e.g. showTemporarily) — the next reveal re-zeroes it.
       self.state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
       self.notchRetractionCancellation = nil
+      self.releaseSurfaceFloorDeferral(reason: "retract_settled")
     }
   }
 
@@ -76,21 +73,21 @@ extension FloatingControlBarWindow {
     state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
   }
 
-  func scheduleNotchRevealCompletion(generation: Int, after duration: TimeInterval) {
+  func scheduleNotchRevealCompletion(token: FloatingBarFrameTransition.Token, after duration: TimeInterval) {
     notchRevealCancellation?.cancel()
     notchRevealCancellation = notchRetractionScheduler.schedule(after: duration) { [weak self] in
       guard let self else { return }
-      guard self.notchRevealGeneration == generation else {
+      guard self.frameTransition.isCurrent(token) else {
         self.restoreNotchRevealProgressIfWindowStillVisible()
         return
       }
       self.state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
       self.notchRevealCancellation = nil
+      self.releaseSurfaceFloorDeferral(reason: "reveal_settled")
     }
   }
 
   func cancelInFlightNotchReveal() {
-    notchRevealGeneration &+= 1
     notchRevealCancellation?.cancel()
     notchRevealCancellation = nil
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -503,7 +503,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
   // partially applied voice state.
   @Published private(set) var voiceProjection = VoiceTurnUIProjection.idle
   var isVoiceListening: Bool {
-    voiceProjection.isListening || !voiceProjection.hint.isEmpty
+    voicePhase.isListeningOrHint
   }
   var isVoiceLocked: Bool { voiceProjection.isLocked }
   var voiceTranscript: String { voiceProjection.transcript }
@@ -520,9 +520,14 @@ class FloatingControlBarState: NSObject, ObservableObject {
   var isVoiceResponseGlowActive: Bool {
     isVoiceResponseActive || isVoiceResponseWaiting
   }
+  /// Typed voice phase for sizing. Prefer this over the boolean projections
+  /// when deciding lobe width or which closed surface is showing.
+  var voicePhase: FloatingBarVoicePhase {
+    FloatingBarVoicePhase.from(voiceProjection)
+  }
   /// Any reducer-owned voice phase that reserves the notch surface.
   var isVoicePresentationActive: Bool {
-    isVoiceListening || isThinking || isVoiceResponseGlowActive || !pttHintText.isEmpty
+    voicePhase.reservesSurface
   }
   /// True only when the notch-mode setting is enabled and the current display
   /// exposes a real camera housing safe area. External displays keep old pill UI.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -111,21 +111,23 @@ struct FloatingControlBarView: View {
       : FloatingControlBarWindow.pillSurfaceCenterGapWidth
   }
   private var notchSideWidth: CGFloat {
-    if showingNotchVoiceControl {
-      return NotchVoiceControlPresentation.activeSideWidth
-    }
-    if isChatChromePinned {
-      return agentPills.pills.isEmpty
-        ? FloatingControlBarWindow.notchCompactSideWidth
-        : FloatingControlBarWindow.notchActiveSideWidth
-    }
-    if showingNotchThinking {
-      return FloatingControlBarWindow.notchThinkingSideWidth
-    }
-    if agentPills.pills.isEmpty && !state.isVoiceListening {
-      return FloatingControlBarWindow.notchCompactSideWidth
-    }
-    return FloatingControlBarWindow.notchActiveSideWidth
+    FloatingBarLayout.lobeWidth(
+      phase: state.voicePhase,
+      isChatPresented: isChatChromePinned,
+      hasAgentPills: !agentPills.pills.isEmpty,
+      metrics: FloatingBarLayout.Metrics(
+        compactSideWidth: FloatingControlBarWindow.notchCompactSideWidth,
+        activeSideWidth: FloatingControlBarWindow.notchActiveSideWidth,
+        voiceSideWidth: FloatingControlBarWindow.notchVoiceSideWidth,
+        thinkingSideWidth: FloatingControlBarWindow.notchThinkingSideWidth,
+        hiddenCenterWidth: notchHiddenCenterWidth,
+        chromeHeight: 0,
+        expandedWidth: FloatingControlBarWindow.notchExpandedWidth,
+        hoverMenuHeight: notchHoverMenuHeight,
+        minBarSize: .zero,
+        voiceBarSize: .zero
+      )
+    )
   }
   private var notchChromeWidth: CGFloat {
     notchHiddenCenterWidth + notchSideWidth * 2

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -217,33 +217,29 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// produces into one check.
   private var surfaceFloorReconcileScheduled = false
   private var isEnforcingSurfaceFloor = false
+  /// A floor check ran while a deferral owned the frame, or while AppKit had
+  /// not yet assigned a screen. Cleared only when that deferral ends and the
+  /// dropped check is requeued — otherwise the bar can settle below the
+  /// surface the live state requires.
+  private var surfaceFloorCheckDropped = false
   var mouseInterceptionReconciler: FloatingBarMouseInterceptionReconciler?
   private var previousVoiceResponseGlowActive = false
-  private var resizeWorkItem: DispatchWorkItem?
+  let frameTransition = FloatingBarFrameTransition()
+  var frameTransitionGeneration: UInt64 { frameTransition.currentGeneration }
   var notchRetractionScheduler: DelayedActionScheduling = TaskDelayedActionScheduler()
   var notchRetractionCancellation: DelayedActionCancellation?
-  var notchRetractionGeneration = 0
-  var notchRevealGeneration = 0
   var notchRevealCancellation: DelayedActionCancellation?
   /// Saved center point from before chat opened, used to restore position on close.
   private var preChatCenter: NSPoint?
-  /// Token incremented each time a windowDidResignKey dismiss animation starts.
-  /// Checked in the completion block so a new PTT query can cancel a stale close.
-  private var resignKeyAnimationToken: Int = 0
-  /// The target origin of an in-progress close/restore animation, set in
-  /// closeAIConversation() and cleared when the animation settles.
-  /// Used by savePreChatCenterIfNeeded() to snap to the correct pill position
-  /// if a new PTT query fires while the restore animation is still running.
-  // Stores the FULL pending restore frame (origin AND size), not just the origin.
-  // The restore origin is computed for the glow-inflated window size; snapping to
-  // it with the bare collapsed size instead drifted the recorded center by one
-  // glow outset (~22pt left / 18pt down) on every rapid re-open cycle.
+  /// Full pending restore frame (origin and size) for an in-progress close.
+  /// The restore origin is computed for the glow-inflated window size; snapping
+  /// to it with the bare collapsed size instead drifted the recorded center by
+  /// one glow outset on every rapid re-open cycle.
   private var pendingRestoreFrame: NSRect?
   /// The idle pill frame captured just before morphing into the active island
   /// on a non-notch display, so the pill returns to the exact same spot.
   private var savedPillFrame: NSRect?
-  var frameAnimationToken: Int = 0
-  private var pendingFrameAnimationTarget: NSRect?
+  private var pendingFrameAnimationTarget: NSRect? { frameTransition.pendingTarget }
   private var startupDisplayRevalidationWorkItems: [DispatchWorkItem] = []
   /// In-process NSMenus (bar context menus, the model picker) render at
   /// .popUpMenu (101); while one is tracking, the bar drops to that level so
@@ -288,21 +284,45 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     Self.screenContainingCursor()
   }
   private var usesVoiceNotchControl: Bool {
-    state.voiceProjection.isListening
+    state.voicePhase.isCapturing
+  }
+  func layoutMetrics(screen: NSScreen? = nil) -> FloatingBarLayout.Metrics {
+    FloatingBarLayout.Metrics(
+      compactSideWidth: Self.notchCompactSideWidth,
+      activeSideWidth: Self.notchActiveSideWidth,
+      voiceSideWidth: Self.notchVoiceSideWidth,
+      thinkingSideWidth: Self.notchThinkingSideWidth,
+      hiddenCenterWidth: screen.map { Self.notchHiddenCenterWidth(for: $0) }
+        ?? notchHiddenCenterWidthForCurrentScreen,
+      chromeHeight: screen.map { Self.notchChromeHeight(for: $0) }
+        ?? notchChromeHeightForCurrentScreen,
+      expandedWidth: Self.notchExpandedWidth,
+      hoverMenuHeight: Self.notchHoverMenuHeight(agentCount: AgentPillsManager.shared.pills.count),
+      minBarSize: Self.minBarSize,
+      voiceBarSize: Self.voiceBarSize
+    )
+  }
+  /// The layout both the window and the SwiftUI view read for lobe/chrome
+  /// widths. Closed surface is the composed authority already used to size
+  /// the panel.
+  func currentLayout(usesNotchIsland: Bool? = nil, screen: NSScreen? = nil) -> FloatingBarLayout {
+    let island = usesNotchIsland ?? notchModeEnabled
+    return FloatingBarLayout.make(
+      phase: state.voicePhase,
+      isChatPresented: state.showingAIConversation || state.hasVisibleConversation,
+      hasAgentPills: !AgentPillsManager.shared.pills.isEmpty,
+      hoverMenuVisible: state.isNotchHoverMenuVisible,
+      metrics: layoutMetrics(screen: screen),
+      closedSurface: closedSurfaceSize(usesNotchIsland: island, screen: screen)
+    )
   }
   private var notchSideWidth: CGFloat {
-    if usesVoiceNotchControl {
-      return Self.notchVoiceSideWidth
-    }
-    if state.showingAIConversation {
-      return AgentPillsManager.shared.pills.isEmpty
-        ? Self.notchCompactSideWidth
-        : Self.notchActiveSideWidth
-    }
-    if AgentPillsManager.shared.pills.isEmpty && !state.isVoicePresentationActive {
-      return Self.notchCompactSideWidth
-    }
-    return Self.notchActiveSideWidth
+    FloatingBarLayout.lobeWidth(
+      phase: state.voicePhase,
+      isChatPresented: state.showingAIConversation || state.hasVisibleConversation,
+      hasAgentPills: !AgentPillsManager.shared.pills.isEmpty,
+      metrics: layoutMetrics()
+    )
   }
   private var notchHiddenCenterWidthForCurrentScreen: CGFloat {
     Self.notchHiddenCenterWidth(for: screenForPlacement)
@@ -544,9 +564,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   override func orderOut(_ sender: Any?) {
-    notchRetractionGeneration &+= 1
     notchRetractionCancellation?.cancel()
     notchRetractionCancellation = nil
+    frameTransition.invalidate()
     cancelInFlightNotchReveal()
     state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
     super.orderOut(sender)
@@ -829,8 +849,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       forName: .floatingBarDragDidStart, object: nil, queue: .main
     ) { [weak self] _ in
       Task { @MainActor in
-        self?.isUserDragging = true
-        self?.state.isDragging = true
+        self?.beginUserDrag()
       }
     }
 
@@ -838,8 +857,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       forName: .floatingBarDragDidEnd, object: nil, queue: .main
     ) { [weak self] _ in
       Task { @MainActor in
-        self?.isUserDragging = false
-        self?.state.isDragging = false
+        self?.endUserDrag()
       }
     }
 
@@ -849,6 +867,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     ) { [weak self] _ in
       Task { @MainActor in
         self?.validatePositionOnScreenChange(reason: "screen_parameters_changed")
+        self?.releaseSurfaceFloorDeferral(reason: "screen_assigned")
         self?.cursorScreenTracker.sync()
       }
     }
@@ -997,8 +1016,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
     return FloatingControlBarGeometry.collapsedSurfaceSize(
       hasMountedNotification: state.currentNotification != nil,
-      isVoiceListening: state.isVoiceListening,
-      isThinking: state.isThinking || state.isVoiceResponseWaiting,
+      phase: state.voicePhase,
       notificationSize: notificationSize,
       listeningSize: listeningSize,
       thinkingSize: thinkingSize,
@@ -1064,12 +1082,8 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   private func animateGrowOutFromNotch(to targetFrame: NSRect, duration: TimeInterval = 0.16) {
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
-    frameAnimationToken += 1
-    let token = frameAnimationToken
-    notchRevealGeneration &+= 1
-    let revealGeneration = notchRevealGeneration
+    frameTransition.cancelScheduled()
+    let token = frameTransition.start(pendingTarget: targetFrame)
     isResizingProgrammatically = true
     alphaValue = 1
     state.notchRevealProgress = 0.001
@@ -1081,13 +1095,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
       guard let self else { return }
-      if self.frameAnimationToken == token {
+      if self.frameTransition.isCurrent(token) {
         self.setFrame(targetFrame, display: true, animate: false)
         self.alphaValue = 1
         self.isResizingProgrammatically = false
+        self.frameTransition.clearPending(if: token)
       }
     }
-    scheduleNotchRevealCompletion(generation: revealGeneration, after: duration)
+    scheduleNotchRevealCompletion(token: token, after: duration)
   }
 
   // MARK: - Automation hover seam (non-production)
@@ -1354,6 +1369,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       state.$currentNotification.map { _ in () }.eraseToAnyPublisher(),
       state.$voiceProjection.map { _ in () }.eraseToAnyPublisher(),
       state.$notchHoverMenuOpen.map { _ in () }.eraseToAnyPublisher(),
+      state.$isHoveringBar.map { _ in () }.eraseToAnyPublisher(),
       state.$showingAIConversation.map { _ in () }.eraseToAnyPublisher(),
       state.$usesNotchIsland.map { _ in () }.eraseToAnyPublisher(),
       AgentPillsManager.shared.$pills.map { _ in () }.eraseToAnyPublisher(),
@@ -1369,7 +1385,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// and every state change calls this; the turn boundary is what makes it
   /// safe — transitions that resize *before* flipping state (chat open, hover
   /// expand) are consistent again by the time the check runs.
-  private func scheduleSurfaceFloorReconcile(reason: String) {
+  func scheduleSurfaceFloorReconcile(reason: String) {
     guard !surfaceFloorReconcileScheduled else { return }
     surfaceFloorReconcileScheduled = true
     DispatchQueue.main.async { [weak self] in
@@ -1412,7 +1428,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       isConversationOpen: state.showingAIConversation,
       isRevealOrRetractInFlight: notchRetractionCancellation != nil || notchRevealCancellation != nil
     )
-    guard deferral == nil else { return false }
+    guard deferral == nil else {
+      surfaceFloorCheckDropped = true
+      return false
+    }
+    // AppKit can report `screen == nil` during display reassignment. Using
+    // `screenForPlacement`'s fallback would move the bar to another display's
+    // top centre. Drop the check and requeue it when a screen is assigned.
+    guard screen != nil else {
+      surfaceFloorCheckDropped = true
+      return false
+    }
 
     let usesNotchIsland = notchModeEnabled
     let floorSize = surfaceFloorWindowSize()
@@ -1589,8 +1615,6 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
   func closeAIConversation(intent: FloatingConversationCloseIntent = .userDismissal) {
     AnalyticsManager.shared.floatingBarAskOmiClosed()
-    resignKeyAnimationToken += 1
-    let closeAnimationToken = resignKeyAnimationToken
 
     if intent.cancelsInFlightWork {
       // Collapsing the chat should not interrupt spoken playback. The voice
@@ -1654,52 +1678,31 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         center: NSPoint(x: frame.midX, y: frame.midY), size: size)
     }
 
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
+    frameTransition.cancelScheduled()
     styleMask.remove(.resizable)
     isResizingProgrammatically = true
     // Record the animation target so savePreChatCenterIfNeeded() can snap to it
     // if a new PTT query fires while this restore animation is still running.
     let targetFrame = NSRect(origin: restoreOrigin, size: size)
     pendingRestoreFrame = targetFrame
-    animateFrame(to: targetFrame, duration: Self.askOmiAnimationDuration)
-    preChatCenter = nil
-    DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
-      guard let self = self else { return }
-      guard self.resignKeyAnimationToken == closeAnimationToken else { return }
+    animateFrame(to: targetFrame, duration: Self.askOmiAnimationDuration) { [weak self] in
+      guard let self else { return }
       self.isResizingProgrammatically = false
       self.pendingRestoreFrame = nil
-      // Safety net: only snap if no new AI session was opened while the close settled.
-      // Without this guard, a rapid PTT query that fires while close settles gets collapsed
-      // back to the pill position by this stale completion block.
       guard !self.state.showingAIConversation else { return }
-      // A card or voice presentation that surfaced during the settle window
-      // now owns the composed surface; snapping to the precomputed close frame
-      // would crush it (the same substitution the close target above stopped
-      // making). The arrival path already resized correctly.
       let settledSize = self.responseGlowWindowSizeForCurrentScreen(
         forSurfaceSize: self.closedSurfaceSize(usesNotchIsland: self.notchModeEnabled))
       guard NSEqualSizes(size, settledSize) else { return }
       if !NSEqualRects(self.frame, targetFrame) {
         self.setFrame(targetFrame, display: true, animate: false)
       }
-    }
-
-    // Allow hover resizes again after the animation settles.
-    DispatchQueue.main.asyncAfter(deadline: .now() + Self.askOmiSettleDelay) { [weak self] in
-      guard let self = self else { return }
-      guard self.resignKeyAnimationToken == closeAnimationToken else { return }
       self.suppressHoverResize = false
       FloatingControlBarManager.shared.flushQueuedNotificationsIfPossible()
-
-      // If the user has the bar disabled, hide it completely after closing the
-      // AI conversation instead of leaving the compact pill visible — unless a
-      // queued notification was just flushed; hiding now would swallow it, and
-      // its dismissal re-hides the bar anyway.
       if self.shouldOrderOutAfterConversationClose {
         self.orderOut(nil)
       }
     }
+    preChatCenter = nil
   }
 
   private func hideBar() {
@@ -1721,8 +1724,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   func showAIConversation() {
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
+    frameTransition.cancelScheduled()
     makeKeyAndOrderFront(nil)
 
     let shouldRestoreVisibleConversation = state.canRestoreVisibleConversation
@@ -1834,15 +1836,14 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     let heightProgress = targetSize.height > 0 ? startHeight / targetSize.height : 1
     let startProgress = min(1, max(0.001, min(widthProgress, heightProgress)))
 
-    notchRevealGeneration &+= 1
-    let revealGeneration = notchRevealGeneration
+    let token = frameTransition.start()
     state.notchRevealProgress = startProgress
 
     OmiMotion.withGated(.easeOut(duration: duration)) {
       state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
     }
 
-    scheduleNotchRevealCompletion(generation: revealGeneration, after: duration)
+    scheduleNotchRevealCompletion(token: token, after: duration)
   }
 
   func clearVisibleConversationFromUI() {
@@ -1924,8 +1925,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     anchorTop: Bool = false
   ) {
     // Cancel any pending resizeToFixedHeight work item to prevent stale resizes
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
+    frameTransition.cancelScheduled()
     updateNotchIslandState()
     applySurfaceLevel()
 
@@ -1967,8 +1967,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     animated: Bool,
     animationDuration: TimeInterval
   ) {
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
+    frameTransition.cancelScheduled()
     updateNotchIslandState()
     applySurfaceLevel()
 
@@ -2018,10 +2017,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       } ?? false
 
     if alreadyAtTarget, wasResizable == makeResizable {
-      // Hover / Space / display revalidation often land here. Bumping
-      // frameAnimationToken cancelled in-flight retract/reveal completions
-      // and left the island scaled into the camera housing.
-      pendingFrameAnimationTarget = nil
+      // Hover / Space / display revalidation often land here. Starting a new
+      // frame transition would cancel in-flight retract/reveal completions and
+      // leave the island scaled into the camera housing.
+      frameTransition.dropPendingWithoutInvalidating()
       isResizingProgrammatically = false
       scheduleSurfaceFloorReconcile(reason: "resize_noop")
       return
@@ -2061,14 +2060,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
   private func animateFrame(to frame: NSRect, duration: TimeInterval, completion: (() -> Void)? = nil) {
     let completionBox = completion.map { AnimationCompletionBox(value: $0) }
-    frameAnimationToken += 1
-    let token = frameAnimationToken
-    pendingFrameAnimationTarget = frame
+    let token = frameTransition.start(pendingTarget: frame)
 
     // Reduce Motion (or zero duration): land on the final frame directly.
     guard duration > 0, !OmiMotion.reduceMotion else {
       setFrame(frame, display: true, animate: false)
-      pendingFrameAnimationTarget = nil
+      frameTransition.clearPending(if: token)
       completion?()
       return
     }
@@ -2088,9 +2085,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       },
       completionHandler: { [weak self] in
         MainActor.assumeIsolated {
-          guard let self, self.frameAnimationToken == token else { return }
+          guard let self, self.frameTransition.isCurrent(token) else { return }
           self.setFrame(frame, display: true, animate: false)
-          self.pendingFrameAnimationTarget = nil
+          self.frameTransition.clearPending(if: token)
           completionBox?.value()
           // The landed frame is a settle point: the state it was aimed at may
           // have moved on while it animated.
@@ -2100,14 +2097,10 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   private func resizeToFixedHeight(_ height: CGFloat, animated: Bool = false) {
-    resizeWorkItem?.cancel()
     let width = expandedContentWidth
     let size = NSSize(width: width, height: height)
-    resizeWorkItem = DispatchWorkItem { [weak self] in
+    frameTransition.scheduleOnNextTurn { [weak self] in
       self?.resizeAnchored(to: size, makeResizable: false, animated: animated, anchorTop: true)
-    }
-    if let workItem = resizeWorkItem {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: workItem)
     }
   }
 
@@ -2167,8 +2160,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       resizeForAgentSwitcher(visible: expanded)
       return true
     }
-    resizeWorkItem?.cancel()
-    resizeWorkItem = nil
+    frameTransition.cancelScheduled()
 
     let targetSize = expanded ? FloatingControlBarWindow.expandedBarSize : FloatingControlBarWindow.minBarSize
 
@@ -2203,11 +2195,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       // a flicker loop when hovering from the top or bottom edge.
       doResize()
     } else {
-      // Collapse async to avoid blocking SwiftUI body evaluation during unhover.
-      // Cancellable via resizeWorkItem so rapid hover in/out doesn't queue stale
-      // resizes. (OMI-COMPUTER-1PT)
-      resizeWorkItem = DispatchWorkItem(block: doResize)
-      DispatchQueue.main.async(execute: resizeWorkItem!)
+      // Collapse on the next turn so SwiftUI can finish evaluating unhover.
+      // A later snap/animation through the transition owner cancels this.
+      frameTransition.scheduleOnNextTurn(doResize)
     }
     return true
   }
@@ -2249,8 +2239,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     else { return }
 
     if notchModeEnabled {
-      resizeWorkItem?.cancel()
-      resizeWorkItem = nil
+      frameTransition.cancelScheduled()
       // The collapse lands on the composed closed surface (the guards above
       // exclude voice and cards, so this is the idle lobe today) rather than
       // a bare lobe size derived here.
@@ -2481,14 +2470,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
       return
     }
-    notchRevealCancellation?.cancel()
-    notchRevealGeneration &+= 1
-    let generation = notchRevealGeneration
+    let token = frameTransition.start()
     state.notchRevealProgress = FloatingBarNotchRevealPolicy.retractedProgress
     OmiMotion.withGated(.easeOut(duration: 0.24)) {
       state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
     }
-    scheduleNotchRevealCompletion(generation: generation, after: 0.24)
+    scheduleNotchRevealCompletion(token: token, after: 0.24)
   }
 
   /// Mirror of the reveal: shrink the island back into the camera housing,
@@ -2503,11 +2490,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   }
 
   private func cancelPendingRetraction() {
-    notchRetractionGeneration &+= 1
     notchRetractionCancellation?.cancel()
     notchRetractionCancellation = nil
+    frameTransition.invalidate()
     cancelInFlightNotchReveal()
     state.notchRevealProgress = FloatingBarNotchRevealPolicy.revealedProgress
+    releaseSurfaceFloorDeferral(reason: "retract_cancelled")
   }
 
   func showNotification(_ notification: FloatingBarNotification, animated: Bool = true) {
@@ -2557,12 +2545,11 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   /// on the surface the new state implies.
   func resizeToClosedSurface(animated: Bool = true) {
     // A nonanimated landing must win over any in-flight animated resize: the
-    // old animation's completion still holds a matching frameAnimationToken
+    // old animation's completion still holds a matching transition token
     // and would restore its obsolete target after this resize. Invalidate it
     // and drop the pending target so the direct setFrame below is final.
     if !animated {
-      frameAnimationToken += 1
-      pendingFrameAnimationTarget = nil
+      frameTransition.invalidate()
     }
     resizeAnchored(
       to: closedSurfaceSize(usesNotchIsland: notchModeEnabled),
@@ -2856,7 +2843,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     guard isMouseClick else { return }
 
     // Close in-place so the bar collapses smoothly instead of blinking out and back in.
-    resignKeyAnimationToken += 1
+    frameTransition.invalidate()
     closeAIConversation()
   }
 
@@ -2937,6 +2924,30 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     if state.conversationSurface.isResponseLike {
       persistCurrentResponseSurfaceSize()
     }
+    releaseSurfaceFloorDeferral(reason: "user_resize_end")
+  }
+
+  /// Starts a user drag. The floor defers while the pointer owns the frame.
+  func beginUserDrag() {
+    isUserDragging = true
+    state.isDragging = true
+  }
+
+  /// Ends a user drag and requeues any floor check that was dropped while the
+  /// pointer owned the frame.
+  func endUserDrag() {
+    isUserDragging = false
+    state.isDragging = false
+    releaseSurfaceFloorDeferral(reason: "drag_end")
+  }
+
+  /// Requeue a floor check that was dropped because a deferral owned the
+  /// frame. No-op when nothing was dropped, so ordinary drag-end and reveal
+  /// completion do not force an extra resize.
+  func releaseSurfaceFloorDeferral(reason: String) {
+    guard surfaceFloorCheckDropped else { return }
+    surfaceFloorCheckDropped = false
+    scheduleSurfaceFloorReconcile(reason: reason)
   }
 
   private func persistCurrentResponseSurfaceSize() {
@@ -6069,8 +6080,7 @@ extension FloatingControlBarWindow {
   /// Invalidates any in-flight windowDidResignKey dismiss animation so a new PTT
   /// query won't be immediately closed by a stale completion block.
   func cancelPendingDismiss() {
-    resignKeyAnimationToken += 1
-    frameAnimationToken += 1
+    frameTransition.invalidate()
     restoreNotchRevealProgressIfWindowStillVisible()
     if !ShortcutSettings.shared.draggableBarEnabled {
       pendingRestoreFrame = nil

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -2016,13 +2016,12 @@ import XCTest
     let source = try floatingControlBarWindowSource()
 
     XCTAssertTrue(source.contains("private static let frameNoopEpsilon: CGFloat = 0.5"))
-    XCTAssertTrue(source.contains("private var pendingFrameAnimationTarget: NSRect?"))
+    XCTAssertTrue(source.contains("private var pendingFrameAnimationTarget: NSRect? { frameTransition.pendingTarget }"))
     XCTAssertTrue(source.contains("let wasResizable = styleMask.contains(.resizable)"))
     XCTAssertTrue(source.contains("let alreadyAnimatingToTarget =\n      pendingFrameAnimationTarget.map"))
     XCTAssertTrue(source.contains("if alreadyAtTarget, wasResizable == makeResizable"))
     XCTAssertTrue(source.contains("if alreadyAnimatingToTarget, wasResizable == makeResizable"))
-    XCTAssertTrue(source.contains("frameAnimationToken += 1"))
-    XCTAssertTrue(source.contains("pendingFrameAnimationTarget = frame"))
+    XCTAssertTrue(source.contains("frameTransition.start(pendingTarget: frame)"))
     XCTAssertTrue(source.contains("private static func framesEquivalent(_ lhs: NSRect, _ rhs: NSRect) -> Bool"))
   }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -67,29 +67,24 @@ final class FloatingBarGeometryTests: XCTestCase {
       NSPoint(x: center.x - 22, y: center.y - 18))
   }
 
-  func testScreenChangeReconcilesTheFloatingBarPresentationAndFrame() throws {
-    // omi-test-quality: source-inspection -- static contract: AppKit delegate callback must retain the reconciliation wiring
-    let source = try String(
-      contentsOf: URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .appendingPathComponent("Sources/FloatingControlBar/FloatingControlBarWindow.swift"),
-      encoding: .utf8
+  func testScreenChangeReconcilesTheFloatingBarPresentationAndFrame() {
+    let window = FloatingControlBarWindow(
+      contentRect: .zero,
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
     )
-    guard let methodStart = source.range(of: "func windowDidChangeScreen(_ notification: Notification)") else {
-      return XCTFail("Expected the floating bar to reconcile direct window screen changes")
-    }
-    guard let nextMethod = source.range(of: "func windowDidResignKey", range: methodStart.upperBound..<source.endIndex)
-    else {
-      return XCTFail("Expected windowDidChangeScreen to precede the next window delegate method")
-    }
-
-    let method = String(source[methodStart.lowerBound..<nextMethod.lowerBound])
-    XCTAssertTrue(method.contains("let previousUsesNotchIsland = state.usesNotchIsland"))
-    XCTAssertTrue(method.contains("updateNotchIslandState()"))
-    XCTAssertTrue(method.contains("guard !state.showingAIConversation else { return }"))
-    XCTAssertTrue(method.contains("frameForCurrentState(on: screen, usesNotchIsland: state.usesNotchIsland)"))
-    XCTAssertTrue(method.contains("resizeToFrame("))
+    window.makeKeyAndOrderFront(nil)
+    defer { window.close() }
+    window.settlePendingSurfaceFloorReconcile()
+    let required = window.surfaceFloorWindowSize()
+    window.setFrame(NSRect(x: 10, y: 10, width: 120, height: 30), display: false)
+    window.windowDidChangeScreen(
+      Notification(name: NSWindow.didChangeScreenNotification, object: window))
+    XCTAssertGreaterThanOrEqual(
+      window.frame.width + 0.5, required.width,
+      "a screen change must restore the closed surface, not leave a scrunched frame")
+    XCTAssertGreaterThanOrEqual(window.frame.height + 0.5, required.height)
   }
 
   func testTopCenterExpansionKeepsTopEdgeAndHorizontalCenterFixed() {

--- a/desktop/macos/Desktop/Tests/FloatingBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarLayoutTests.swift
@@ -1,0 +1,77 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+@testable import VoiceTurnDomain
+
+@MainActor
+final class FloatingBarLayoutTests: XCTestCase {
+  private let metrics = FloatingBarLayout.Metrics(
+    compactSideWidth: 30,
+    activeSideWidth: 42,
+    voiceSideWidth: 86,
+    thinkingSideWidth: 42,
+    hiddenCenterWidth: 206,
+    chromeHeight: 58,
+    expandedWidth: 430,
+    hoverMenuHeight: 104,
+    minBarSize: NSSize(width: 40, height: 14),
+    voiceBarSize: NSSize(width: 224, height: 42)
+  )
+
+  func testVoicePhaseKeepsHintDistinctFromCapture() {
+    XCTAssertEqual(FloatingBarVoicePhase.from(VoiceTurnUIProjection(isListening: true)), .listening)
+    XCTAssertEqual(FloatingBarVoicePhase.from(VoiceTurnUIProjection(hint: "Hold longer")), .hint)
+    XCTAssertEqual(FloatingBarVoicePhase.from(VoiceTurnUIProjection(isThinking: true)), .thinking)
+    XCTAssertEqual(
+      FloatingBarVoicePhase.from(VoiceTurnUIProjection(isResponseActive: true)), .responding)
+    XCTAssertEqual(FloatingBarVoicePhase.from(.idle), .idle)
+    XCTAssertTrue(FloatingBarVoicePhase.hint.reservesSurface)
+    XCTAssertFalse(FloatingBarVoicePhase.hint.isCapturing)
+  }
+
+  func testLobeWidthUsesCaptureWidthOnlyWhileListening() {
+    XCTAssertEqual(
+      FloatingBarLayout.lobeWidth(
+        phase: .listening, isChatPresented: false, hasAgentPills: false, metrics: metrics),
+      86)
+    XCTAssertEqual(
+      FloatingBarLayout.lobeWidth(
+        phase: .hint, isChatPresented: false, hasAgentPills: false, metrics: metrics),
+      42,
+      "a failure hint must not reuse the capture waveform lobe")
+    XCTAssertEqual(
+      FloatingBarLayout.lobeWidth(
+        phase: .idle, isChatPresented: false, hasAgentPills: false, metrics: metrics),
+      30)
+  }
+
+  func testWindowAndViewReadTheSameLobeWidth() {
+    let window = FloatingControlBarWindow(
+      contentRect: .zero,
+      styleMask: [.borderless, .nonactivatingPanel],
+      backing: .buffered,
+      defer: false
+    )
+    window.makeKeyAndOrderFront(nil)
+    defer { window.close() }
+
+    let layout = window.currentLayout()
+    XCTAssertEqual(
+      layout.chromeWidth,
+      FloatingBarLayout.chromeWidth(
+        lobeWidth: layout.lobeWidth, hiddenCenterWidth: window.layoutMetrics().hiddenCenterWidth))
+    XCTAssertEqual(
+      layout.closedSurface,
+      window.closedSurfaceSize(usesNotchIsland: window.state.usesNotchIsland))
+  }
+
+  func testANewTransitionInvalidatesThePreviousCompletion() {
+    let owner = FloatingBarFrameTransition()
+    let first = owner.start(pendingTarget: NSRect(x: 0, y: 0, width: 10, height: 10))
+    let second = owner.start(pendingTarget: NSRect(x: 0, y: 0, width: 20, height: 10))
+    XCTAssertFalse(owner.isCurrent(first), "a later start must invalidate the previous token")
+    XCTAssertTrue(owner.isCurrent(second))
+    XCTAssertEqual(owner.pendingTarget?.width, 20)
+  }
+}

--- a/desktop/macos/Desktop/Tests/FloatingBarNotchPersistTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotchPersistTests.swift
@@ -20,7 +20,7 @@ final class FloatingBarNotchPersistTests: XCTestCase {
       var staleCompletionCount = 0
       window.beginNotchRetraction { staleCompletionCount += 1 }
       XCTAssertEqual(window.state.notchRevealProgress, FloatingBarNotchRevealPolicy.retractedProgress)
-      window.notchRetractionGeneration &+= 1
+      window.frameTransition.invalidate()
       window.notchRetractionCancellation = nil
 
       XCTAssertTrue(scheduler.fireNext())
@@ -48,7 +48,7 @@ final class FloatingBarNotchPersistTests: XCTestCase {
 
       window.playNotchRevealAnimation()
       window.state.notchRevealProgress = FloatingBarNotchRevealPolicy.retractedProgress
-      window.notchRevealGeneration &+= 1
+      window.frameTransition.invalidate()
       window.notchRevealCancellation = nil
       XCTAssertTrue(scheduler.fireNext())
       XCTAssertEqual(
@@ -90,14 +90,12 @@ final class FloatingBarNotchPersistTests: XCTestCase {
 
       var completionCount = 0
       window.beginNotchRetraction { completionCount += 1 }
-      let token = window.frameAnimationToken
-      let generation = window.notchRetractionGeneration
+      let generation = window.frameTransitionGeneration
       window.normalizeForTemporaryShow()
 
       XCTAssertEqual(
-        window.frameAnimationToken, token,
+        window.frameTransitionGeneration, generation,
         "a no-op resize must not share a cancellation token with retract/reveal")
-      XCTAssertEqual(window.notchRetractionGeneration, generation)
       XCTAssertTrue(scheduler.fireNext())
       XCTAssertEqual(completionCount, 1, "the retract still finishes; hover did not abort it")
     }

--- a/desktop/macos/Desktop/Tests/FloatingBarSurfaceFloorTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarSurfaceFloorTests.swift
@@ -59,26 +59,15 @@ final class FloatingBarSurfaceFloorTests: XCTestCase {
     )
   }
 
+  private func scrunchedFrame(for window: FloatingControlBarWindow) -> NSRect {
+    NSRect(x: window.frame.midX - 60, y: window.frame.maxY - 30, width: 120, height: 30)
+  }
+
   private func presenter(for window: FloatingControlBarWindow) -> FloatingControlBarState.PTTBarPresenter {
     FloatingControlBarState.PTTBarPresenter(
       barState: window.state,
       resizeForPTT: { [weak window] in window?.resizeForPTTState(expanded: $0) }
     )
-  }
-
-  /// A frame smaller than any closed surface, positioned where the island
-  /// hangs: the "regular notch width" a stale path lands on.
-  private func scrunchedFrame(for window: FloatingControlBarWindow) -> NSRect {
-    NSRect(x: window.frame.midX - 60, y: window.frame.maxY - 30, width: 120, height: 30)
-  }
-
-  /// Spins the main run loop until `condition` holds or `passes` turns have
-  /// elapsed. The floor's async triggers hop through `DispatchQueue.main`
-  /// exactly once, so the condition is a signal, not a timing guess.
-  private func drainMainQueue(passes: Int = 20, until condition: () -> Bool) {
-    for _ in 0..<passes where !condition() {
-      RunLoop.main.run(until: Date().addingTimeInterval(0.005))
-    }
   }
 
   // MARK: - The pure policy
@@ -196,7 +185,8 @@ final class FloatingBarSurfaceFloorTests: XCTestCase {
       let required = window.surfaceFloorWindowSize()
       XCTAssertGreaterThan(required.width, idle.width, "the card must require more than the idle lobe")
 
-      drainMainQueue { window.frame.width + 0.5 >= required.width }
+      window.scheduleSurfaceFloorReconcile(reason: "test_state_change")
+      window.settlePendingSurfaceFloorReconcile()
 
       XCTAssertEqual(window.frame.width, required.width, accuracy: 0.5)
       XCTAssertEqual(window.frame.height, required.height, accuracy: 0.5)
@@ -308,6 +298,28 @@ final class FloatingBarSurfaceFloorTests: XCTestCase {
       window.dismissNotification(animated: false)
       XCTAssertEqual(window.surfaceFloorWindowSize(), idle)
       XCTAssertFalse(window.enforceSurfaceFloor(reason: "test"), "the idle frame satisfies the idle floor")
+    }
+  }
+
+  /// A floor check that runs while the user is dragging must not be dropped
+  /// forever. Drag-end requeues the reconcile so the card surface is restored.
+  func testAFloorCheckDroppedDuringDragIsRequeuedWhenTheDragEnds() {
+    withNotchMode {
+      let window = makeWindow()
+      defer { window.close() }
+      window.showNotification(card(), animated: false)
+      let mounted = window.frame
+
+      window.beginUserDrag()
+      window.setFrame(scrunchedFrame(for: window), display: false)
+      XCTAssertFalse(window.enforceSurfaceFloor(reason: "drag"))
+      XCTAssertLessThan(window.frame.width, mounted.width)
+
+      window.endUserDrag()
+      window.settlePendingSurfaceFloorReconcile()
+
+      XCTAssertEqual(window.frame.width, mounted.width, accuracy: 0.5)
+      XCTAssertEqual(window.frame.height, mounted.height, accuracy: 0.5)
     }
   }
 }

--- a/desktop/macos/changelog/unreleased/20260910-notch-geometry-and-transitions.json
+++ b/desktop/macos/changelog/unreleased/20260910-notch-geometry-and-transitions.json
@@ -1,0 +1,3 @@
+{
+  "change": "The notch now sizes its lobes, chrome, and closed surface from one layout snapshot, and a later animation can no longer leave a stale resize behind"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -29,6 +29,8 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarMouseInterception.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarSurfaceFloor.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLayout.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarFrameTransition.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift


### PR DESCRIPTION
## What changed and why

Stacked on #13337. That PR is the settle floor: the window cannot land smaller than the surface live state requires. This follow-up is the missing width state machine so the floor is not the only thing keeping the island honest.

- **Geometry authority.** `FloatingBarLayout` is one pure snapshot for lobe width, chrome width, drawn surface, and closed surface. `FloatingBarVoicePhase` (`idle` / `listening` / `thinking` / `hint` / `responding`) replaces the overloaded `isVoiceListening` / `isVoicePresentationActive` booleans at the layout boundary. The window and the SwiftUI view read the same lobe policy, so a hover menu, a card, or a hint cannot paint one size and settle the panel at another. A failure hint no longer reuses the capture waveform lobe.
- **Frame-transition owner.** `FloatingBarFrameTransition` is one generation for every snap and animation. Starting a new transition invalidates the previous completion. The five hand-managed tokens (`frameAnimationToken`, reveal/retract generations, resign-key token, hover `DispatchWorkItem`) fold into it. Close-conversation settle is the animation completion, not a second `asyncAfter`. A no-op resize drops the pending target without bumping generation, so it cannot cancel an in-flight retract.
- **Floor review.** A floor check that ran during a user drag, a reveal/retract morph, or before AppKit assigned a screen is requeued when that deferral ends. The observer also watches `$isHoveringBar`. `drainMainQueue` wall-clock waits are gone from the floor tests.

A and B both edit `FloatingControlBarWindow.swift`, so they ship as one PR instead of two parallel merges.

## Product invariants affected

- INV-CHAT-1 — matched by the `FloatingControlBar/**` path only. This PR changes window frame sizing and the typed layout snapshot; it does not touch transcript ownership, journaling, or which surface renders which chat content.

## How it was verified

Repository `BasedHardware/omi`, branch `fix/desktop-notch-geometry-and-transitions`, Xcode toolchain locally (CI's pinned 16.4 is the authority for strict-concurrency).

- `xcrun swift test --package-path Desktop --filter 'FloatingBarSurfaceFloorTests|FloatingBarLayoutTests|FloatingBarNotchPersistTests|FloatingBarGeometryTests/testScreenChangeReconcilesTheFloatingBarPresentationAndFrame|FloatingBarNotchCardSizingTests'` — 39 passed (run before the `origin/main` merge into #13337; cherry-pick onto that merge was clean).
- `xcrun swift test --package-path Desktop --filter 'AgentPillLifecycleTests/testFloatingBarResizeCoalescesNoopFrames'` — passed.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — 53 source-reading files / 143 sites, 16 waits. Converted `testScreenChangeReconcilesTheFloatingBarPresentationAndFrame` to a behavioral window test; that site was already annotated, so the unannotated ratchet does not move.
- `./scripts/swift-format-wrapper.sh lint` on the changed Swift files — clean.

Not verified: live notch QA on a physical camera-housing display, and the e2e pool slot. I did not run a live harness against `api.omi.me` or `?rig=dev`.

## Tests

- `FloatingBarLayoutTests` (new): hint is distinct from capture for lobe width; window chrome width matches the snapshot; a later `start` invalidates the previous transition token.
- `FloatingBarSurfaceFloorTests.testAFloorCheckDroppedDuringDragIsRequeuedWhenTheDragEnds`.
- `FloatingBarGeometryTests.testScreenChangeReconcilesTheFloatingBarPresentationAndFrame` now drives the window instead of reading source.

## Failure class (fixes)

Failure-Class: FC-notch-resize-state-substitution

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5936 -> 6091 | the layout snapshot readers, frame-transition owner, and floor requeue-on-deferral-end sit beside the resize funnel they guard; moving them out would split the settle-point contract from the three places that must call it

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 3226 -> 3228 | the SwiftUI view now reads FloatingBarLayout.lobeWidth with the same metrics the window uses, replacing the previous inline lobe switch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

