### PR TITLE
ci(backend): shard the unit suite four ways with a literal-named gate

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -107,11 +107,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  backend-unit-tests:
-    name: Backend unit suite
+  # The suite's measured cost is per-file pytest process startup (2026-09-10,
+  # run 34430370667: 1126 files each in its own session, 19m18s of a 21m53s
+  # run, only two files above 4.5s of test time), and sharing processes
+  # across files is blocked by dense sys.modules contamination (see the
+  # BACKEND_PYTEST_PARALLEL_SESSION measurement in backend/test.sh). So the
+  # SAME selection fans out to four parallel shard jobs — standard runners
+  # on this public repository are free — each executing an interleaved slice
+  # of the sorted file list with the same per-file isolation. Union of the
+  # shards is exactly the full selection; ~5m of tests per shard replaces
+  # ~20m on one runner.
+  backend-unit-shard:
+    name: Backend unit shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -145,22 +158,91 @@ jobs:
 
       - name: Run authoritative backend unit contract
         working-directory: backend
+        env:
+          # Regression budget: a shard carries ~1/4 of the selection
+          # (measured ~5m of per-file sessions + ~1m preflight/typecheck
+          # + ~1.5m setup). 600s holds every legitimate shard shape with
+          # headroom and sits far below the unsharded 20m class this
+          # workflow existed at. Raise only with measured evidence.
+          BACKEND_UNIT_STEP_BUDGET_SECONDS: "600"
         run: |
+          step_started=$SECONDS
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Resolve the base live against the checkout (matching detect-changes)
             # rather than the event-payload base.sha, which can be stale for a
             # queued run (FC-stale-event-payload-diff-base, #10785).
             ../scripts/changed-files "origin/${{ github.base_ref }}"...HEAD > /tmp/backend-changed-files.txt
-            bash scripts/run-unit-ci.sh --changed-files /tmp/backend-changed-files.txt
+            bash scripts/run-unit-ci.sh --changed-files /tmp/backend-changed-files.txt --shard 4/${{ matrix.shard }}
           else
-            bash scripts/run-unit-ci.sh --all
+            bash scripts/run-unit-ci.sh --all --shard 4/${{ matrix.shard }}
+          fi
+          elapsed=$((SECONDS - step_started))
+          echo "backend unit shard wall: ${elapsed}s (budget ${BACKEND_UNIT_STEP_BUDGET_SECONDS}s)"
+          if [ "${BACKEND_UNIT_STEP_BUDGET_SECONDS}" -gt 0 ] && [ "$elapsed" -gt "${BACKEND_UNIT_STEP_BUDGET_SECONDS}" ]; then
+            echo "FAIL: backend unit shard ${{ matrix.shard }} took ${elapsed}s, over its ${BACKEND_UNIT_STEP_BUDGET_SECONDS}s regression budget. The per-file duration summary above names the slow tail; fix the regression or raise the budget with measured evidence." >&2
+            exit 1
           fi
 
-      # `run-unit-ci.sh` runs `not integration and not slow`, which is correct
-      # for PR latency but meant every `slow`-marked codebase guardrail in the
-      # repository executed nowhere. This step runs exactly those, unselected
-      # and unconditional: a guardrail whose job is to notice a change nobody
-      # anticipated cannot be gated on the change set that triggered the run.
+  # `run-unit-ci.sh` runs `not integration and not slow`, which is correct
+  # for PR latency but meant every `slow`-marked codebase guardrail in the
+  # repository executed nowhere. This job runs exactly those, unselected
+  # and unconditional: a guardrail whose job is to notice a change nobody
+  # anticipated cannot be gated on the change set that triggered the run.
+  backend-unit-guardrails:
+    name: Backend unit guardrails
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: backend/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@ecd24dd710f2fb0dca1693a67af11fc4a5c5ec84
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/pylock*.toml
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          uv venv .venv
+          uv pip sync pylock.toml --python .venv/bin/python
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
       - name: Run slow-marked backend guardrails
         working-directory: backend
         run: PYTHON=.venv/bin/python bash scripts/run-slow-guardrails-ci.sh
+
+  # Keep this name a literal and the sole required-check surface: GitHub
+  # publishes matrix job names as separate checks, so the shards must never
+  # carry the check name branch protection and humans watch. The gate fails
+  # closed on any non-success shard or guardrail result.
+  backend-unit-suite:
+    name: Backend unit suite
+    needs: [backend-unit-shard, backend-unit-guardrails]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every shard and the guardrails to pass
+        env:
+          # A matrix job's aggregate result is 'success' only when every
+          # shard instance succeeded, which is exactly the fail-closed
+          # verdict this gate exists to publish.
+          SHARD_RESULT: ${{ needs.backend-unit-shard.result }}
+          GUARDRAILS_RESULT: ${{ needs.backend-unit-guardrails.result }}
+        run: |
+          failed=0
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "FAIL: backend unit shards result was '$SHARD_RESULT'" >&2
+            failed=1
+          fi
+          if [ "$GUARDRAILS_RESULT" != "success" ]; then
+            echo "FAIL: backend unit guardrails result was '$GUARDRAILS_RESULT'" >&2
+            failed=1
+          fi
+          exit "$failed"

--- a/backend/scripts/run-unit-ci.sh
+++ b/backend/scripts/run-unit-ci.sh
@@ -87,9 +87,10 @@ shard_note=""
 if [ "$shard_total" -ge 2 ]; then
   full_count="$(wc -l < "$selected_tests" | tr -d ' ')"
   sliced="$(mktemp "${TMPDIR:-/tmp}/omi-backend-unit-tests-shard.XXXXXX")"
-  # NB: `index` is an awk builtin, so the shard variable must be named
-  # anything else; passing -v index=… is a syntax error on every awk.
-  awk -v total="$shard_total" -v shard="$shard_index" 'NR % total == (shard - 1) % total' \
+  # One-based mapping so shard labels match the files they carry: line i
+  # runs in shard ((i - 1) % total) + 1, i.e. shard 1 takes files 1, 5, 9…
+  # (`index` is an awk builtin; the shard variable must be named else.)
+  awk -v total="$shard_total" -v shard="$shard_index" '(NR - 1) % total == shard - 1' \
     "$selected_tests" >"$sliced"
   mv "$sliced" "$selected_tests"
   shard_note=" (shard ${shard_index}/${shard_total}: $(wc -l < "$selected_tests" | tr -d ' ') of ${full_count} files)"

--- a/backend/scripts/run-unit-ci.sh
+++ b/backend/scripts/run-unit-ci.sh
@@ -7,22 +7,60 @@ BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$BACKEND_DIR"
 
 usage() {
-  echo "usage: $0 --all | --changed-files <repo-relative-path-list>" >&2
+  echo "usage: $0 [--all | --changed-files <repo-relative-path-list>] [--shard <total>/<index>]" >&2
   exit 2
 }
 
-mode="${1:-}"
-case "$mode" in
-  --all)
-    [ "$#" -eq 1 ] || usage
-    ;;
-  --changed-files)
-    [ "$#" -eq 2 ] && [ -f "$2" ] || usage
-    ;;
-  *)
-    usage
-    ;;
-esac
+mode=""
+changed_files_arg=""
+shard_spec=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --all)
+      [ -z "$mode" ] || usage
+      mode="--all"
+      ;;
+    --changed-files)
+      [ -z "$mode" ] && [ "$#" -ge 2 ] && [ -f "$2" ] || usage
+      mode="--changed-files"
+      changed_files_arg="$2"
+      shift
+      ;;
+    --shard)
+      [ "$#" -ge 2 ] || usage
+      shard_spec="$2"
+      shift
+      ;;
+    *)
+      usage
+      ;;
+  esac
+  shift
+done
+[ -n "$mode" ] || usage
+
+# Sharding: the suite's cost is per-file pytest process startup (measured
+# 2026-09-10, run 34430370667: 1126 files, one session each, 19m18s of a
+# 21m53s run, while only two files exceeded 4.5s of test time), and sharing
+# one pytest process across files is blocked by dense sys.modules
+# contamination (see the BACKEND_PYTEST_PARALLEL_SESSION measurement in
+# test.sh). CI therefore fans the SAME selection out to N parallel jobs;
+# each shard executes an interleaved slice of the deterministic, sorted
+# file list, so slow files spread across shards and the union of the
+# shards is exactly the full selection (line i runs in shard
+# ((i-1) % total)+1, and every file keeps its own process).
+shard_total=0
+shard_index=0
+if [ -n "$shard_spec" ]; then
+  case "$shard_spec" in
+    */*) ;;
+    *) usage ;;
+  esac
+  shard_total="${shard_spec%%/*}"
+  shard_index="${shard_spec##*/}"
+  [[ "$shard_total" =~ ^[0-9]+$ ]] && [ "$shard_total" -ge 1 ] || usage
+  [[ "$shard_index" =~ ^[0-9]+$ ]] && [ "$shard_index" -ge 1 ] && [ "$shard_index" -le "$shard_total" ] || usage
+fi
 
 PYTHON_BIN="${PYTHON:-}"
 if [ -z "$PYTHON_BIN" ]; then
@@ -41,26 +79,41 @@ selector_args=(--output "$selected_tests" --reason-output "$selection_reason")
 if [ "$mode" = "--all" ]; then
   selector_args+=(--all)
 else
-  selector_args+=(--changed-files "$2")
+  selector_args+=(--changed-files "$changed_files_arg")
 fi
 "$PYTHON_BIN" scripts/select_backend_unit_tests.py "${selector_args[@]}"
+
+shard_note=""
+if [ "$shard_total" -ge 2 ]; then
+  full_count="$(wc -l < "$selected_tests" | tr -d ' ')"
+  sliced="$(mktemp "${TMPDIR:-/tmp}/omi-backend-unit-tests-shard.XXXXXX")"
+  # NB: `index` is an awk builtin, so the shard variable must be named
+  # anything else; passing -v index=… is a syntax error on every awk.
+  awk -v total="$shard_total" -v shard="$shard_index" 'NR % total == (shard - 1) % total' \
+    "$selected_tests" >"$sliced"
+  mv "$sliced" "$selected_tests"
+  shard_note=" (shard ${shard_index}/${shard_total}: $(wc -l < "$selected_tests" | tr -d ' ') of ${full_count} files)"
+fi
 
 selected_count="$(wc -l < "$selected_tests" | tr -d ' ')"
 reason="$(cat "$selection_reason")"
 
+# Preflight and the typecheck boundary decision run in every shard: they are
+# seconds of work, and keeping the runner's phases identical across shards
+# means a shard cannot silently lose a guard its siblings ran.
 PYTHON="$PYTHON_BIN" bash test-preflight.sh
-if [ "$mode" = "--all" ] || "$SCRIPT_DIR/needs-typecheck.sh" "$2"; then
+if [ "$mode" = "--all" ] || "$SCRIPT_DIR/needs-typecheck.sh" "$changed_files_arg"; then
   PYTHON="$PYTHON_BIN" bash scripts/typecheck.sh
 else
   echo "Skipping backend type check: changed paths do not affect the typed boundary."
 fi
 
 if [ "$selected_count" -eq 0 ]; then
-  echo "No backend unit tests selected: $reason"
+  echo "No backend unit tests selected${shard_note}: $reason"
   exit 0
 fi
 
-echo "Selected $selected_count backend unit test file(s): $reason"
+echo "Selected $selected_count backend unit test file(s)${shard_note}: $reason"
 BACKEND_UNIT_TEST_FILE_LIST="$selected_tests" \
 BACKEND_FAST_UNIT_WARN_SECONDS="0.1" \
 BACKEND_FAST_UNIT_FAIL_SECONDS="1.0" \

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -279,6 +279,41 @@ def test_expensive_pr_contracts_cancel_only_superseded_pull_request_runs():
         assert "cancel-in-progress: true" in workflow
 
 
+def test_backend_unit_suite_is_sharded_with_a_literal_gate_and_budget():
+    """The suite is per-file pytest process bound; CI fans it out, guarded.
+
+    Measured 2026-09-10 (run 34430370667): 1126 files each in its own pytest
+    session cost 19m18s of a 21m53s run while only two files exceeded 4.5s of
+    test time, and sharing processes across files is blocked by dense
+    sys.modules contamination (see the BACKEND_PYTEST_PARALLEL_SESSION
+    measurement in backend/test.sh). The workflow therefore runs the SAME
+    selection as four parallel shard jobs whose interleaved slices partition
+    the sorted file list exactly (union = full selection), plus a concurrent
+    guardrails job, and publishes the verdict through a literal-named gate so
+    the required check surface never changes. Each shard carries a wall-clock
+    regression budget; duration drift fails the run instead of publishing
+    green.
+    """
+    repo = BACKEND_DIR.parent
+    workflow = (repo / ".github/workflows/backend-unit-tests.yml").read_text(encoding="utf-8")
+    runner = (BACKEND_DIR / "scripts/run-unit-ci.sh").read_text(encoding="utf-8")
+
+    assert "shard: [1, 2, 3, 4]" in workflow
+    assert "--shard 4/${{ matrix.shard }}" in workflow
+    assert 'BACKEND_UNIT_STEP_BUDGET_SECONDS: "600"' in workflow
+    assert "backend unit shard wall: ${elapsed}s" in workflow
+    # The gate keeps the exact check name and fails closed on any shard or
+    # guardrail result that is not a plain success.
+    assert "name: Backend unit suite" in workflow
+    assert "needs: [backend-unit-shard, backend-unit-guardrails]" in workflow
+    assert 'if [ "$SHARD_RESULT" != "success" ]' in workflow
+    assert 'if [ "$GUARDRAILS_RESULT" != "success" ]' in workflow
+    # The runner slices the deterministic selection round-robin; `index` is
+    # an awk builtin, so the shard variable must be named anything else.
+    assert "NR % total == (shard - 1) % total" in runner
+    assert "awk -v index=" not in runner
+
+
 def test_backend_test_runner_defaults_python_to_utf8():
     runner = (BACKEND_DIR / "test.sh").read_text(encoding="utf-8")
     utf8_export = 'export PYTHONUTF8="${PYTHONUTF8:-1}"'

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -256,7 +256,9 @@ def test_backend_unit_ci_runner_stays_in_ci_while_pre_push_keeps_its_budget():
     assert "scripts/run-unit-ci.sh --all" in workflow_text
     assert "backend/scripts/run-unit-ci.sh" not in pre_push
     assert "backend/scripts/needs-typecheck.sh" in pre_push
-    assert '"$SCRIPT_DIR/needs-typecheck.sh" "$2"' in runner
+    # The runner parses its argv into named variables before this call; the
+    # pin is that the changed-files diff still feeds the typecheck boundary.
+    assert '"$SCRIPT_DIR/needs-typecheck.sh" "$changed_files_arg"' in runner
     assert 'PRE_PUSH_MAX_BACKEND_UNIT_TEST_FILES:-40' in pre_push
     assert "pre-push is intentionally a bounded local-feedback gate" in pre_push
     assert 'BACKEND_FAST_UNIT_WARN_SECONDS="0.1"' in runner

--- a/backend/tests/unit/test_workflow_contracts.py
+++ b/backend/tests/unit/test_workflow_contracts.py
@@ -310,9 +310,11 @@ def test_backend_unit_suite_is_sharded_with_a_literal_gate_and_budget():
     assert "needs: [backend-unit-shard, backend-unit-guardrails]" in workflow
     assert 'if [ "$SHARD_RESULT" != "success" ]' in workflow
     assert 'if [ "$GUARDRAILS_RESULT" != "success" ]' in workflow
-    # The runner slices the deterministic selection round-robin; `index` is
-    # an awk builtin, so the shard variable must be named anything else.
-    assert "NR % total == (shard - 1) % total" in runner
+    # The runner slices the deterministic selection round-robin with the
+    # one-based mapping (line i runs in shard ((i - 1) % total) + 1, so
+    # shard labels match the files they carry); `index` is an awk builtin,
+    # so the shard variable must be named anything else.
+    assert "(NR - 1) % total == shard - 1" in runner
     assert "awk -v index=" not in runner
 
 


### PR DESCRIPTION
## Summary

The backend unit suite measured **21m53s on main** (run 34430370667): 19m18s of that was 1126 per-file pytest sessions — the suite is per-file process startup bound (only two files exceed 4.5s of test time), and sharing processes across files is blocked by dense `sys.modules` contamination (measured in `backend/test.sh`'s `BACKEND_PYTEST_PARALLEL_SESSION` note).

The same selection now fans out to **four parallel shard jobs** whose interleaved slices partition the deterministic sorted file list exactly — union of shards = full selection (verified live: 281+282+282+282 = 1127), every file keeps its own process, isolation semantics unchanged. Standard runners on this public repository are free, so this costs nothing. The slow-marked guardrails move to their own concurrent job, and the verdict publishes through the literal-named **"Backend unit suite"** gate (unchanged required-check surface) that fails closed on any shard or guardrail result. Each shard carries a **600s wall-clock regression budget**, so duration drift fails the run instead of publishing green.

**Measured on this PR's own full-suite run: 6m45s total (was 21m53s), shard walls 219–355s of the 600s budget.**

Review fix (cubic P3): the shard predicate is one-based `(NR - 1) % total == shard - 1` so shard labels match the files they carry.

## Test plan

- [x] Sharding union verified locally and live on CI (exact partition).
- [x] Contract tests pass, including the new pinned shard-topology test.
- [x] This PR's full-suite run green at 6m45s; merge-push run reconfirms on main.

## Failure class (fixes)

Failure-Class: none

The `fix(backend)` commit corrects a one-based labeling defect in the shard
predicate that review caught inside this same PR; the code never merged and
no production or CI failure occurred, so no semantic failure class applies.
