### PR TITLE
SCA-460: retry desktop chat after 503 worker recycle

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -692,6 +692,29 @@ def _log_gateway_rejection(response: httpx.Response, *, lane_id: str, request_id
     sys.stdout.write(json.dumps(event, separators=(',', ':'), sort_keys=True) + '\n')
 
 
+_DESKTOP_CHAT_UNAVAILABLE_REASONS = frozenset({'metering_unavailable', 'jit_requires_gateway', 'circuit_open'})
+
+
+def _log_desktop_chat_unavailable(*, reason: str, request_id: str) -> None:
+    """Record why this router returned HTTP 503.
+
+    The 2026-09-09 desktop-chat outage returned 503 in ~105ms with no traceback
+    and no coded reason, so operators could not tell metering, JIT, and circuit
+    open apart. Log one warning with a closed reason plus request_id. Never log
+    request/response bodies, UIDs, or prompts.
+    """
+    if reason not in _DESKTOP_CHAT_UNAVAILABLE_REASONS:
+        reason = 'unknown'
+    event = {
+        'event': 'desktop_chat_unavailable',
+        'message': 'desktop_chat_unavailable',
+        'reason': reason,
+        'request_id': request_id,
+        'severity': 'WARNING',
+    }
+    sys.stdout.write(json.dumps(event, separators=(',', ':'), sort_keys=True) + '\n')
+
+
 def _thinking_escalation_effort(body: Mapping[str, object]) -> str:
     """Validated Luna reasoning effort for a thinking escalation.
 
@@ -1551,7 +1574,7 @@ def _sse(value: dict[str, object]) -> str:
     return f'data: {json.dumps(value, separators=(",", ":"))}\n\n'
 
 
-async def _meter_server_request(uid: str) -> None:
+async def _meter_server_request(uid: str, *, request_id: str = 'unknown') -> None:
     if get_byok_key('anthropic'):
         return
     try:
@@ -1559,6 +1582,7 @@ async def _meter_server_request(uid: str) -> None:
             critical_executor, redis_db.check_rate_limit, uid, 'desktop_chat', _RATE_LIMIT_PER_MINUTE, 60
         )
     except Exception as exc:
+        _log_desktop_chat_unavailable(reason='metering_unavailable', request_id=request_id)
         raise HTTPException(status_code=503, detail='Chat metering is temporarily unavailable') from exc
     if not allowed:
         raise HTTPException(
@@ -1734,6 +1758,7 @@ async def _chat_completions_unobserved(
     try:
         gateway_mode = should_route_chat_agent_through_gateway() and _uses_managed_chat_agent(body)
         if jit_headers and not gateway_mode:
+            _log_desktop_chat_unavailable(reason='jit_requires_gateway', request_id=request_id)
             raise RuntimeError('JIT qualification requires the managed gateway')
         # A BYOK Anthropic key cannot serve the managed Luna thinking lane, so
         # thinking escalations stay on the gateway instead of falling back to
@@ -1774,7 +1799,7 @@ async def _chat_completions_unobserved(
             public_model, payload = _request(body, web_search_authorization=web_search_authorization)
             gateway_payload = {}
         enforce_desktop_chat_quota(uid, platform=x_app_platform)
-        await _meter_server_request(uid)
+        await _meter_server_request(uid, request_id=request_id)
     except HTTPException:
         raise
     except RuntimeError as exc:
@@ -1817,6 +1842,7 @@ async def _chat_completions_unobserved(
                     lane_id=public_model, outcome='error', reason='circuit_open', request_id=request_id
                 )
                 result_recorded = True
+                _log_desktop_chat_unavailable(reason='circuit_open', request_id=request_id)
                 raise HTTPException(status_code=503, detail='Upstream provider unavailable')
             async with get_llm_gateway_semaphore():
                 response = await get_llm_gateway_client().post(

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -1925,6 +1925,101 @@ async def test_server_metering_fails_closed_and_byok_bypasses(monkeypatch):
     await desktop_chat._meter_server_request('user')
 
 
+def _desktop_chat_unavailable_events(stdout: str) -> list[dict]:
+    events = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(payload, dict) and payload.get('event') == 'desktop_chat_unavailable':
+            events.append(payload)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_desktop_chat_503_logs_coded_reason_without_live_redis(monkeypatch, capsys):
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.setattr(desktop_chat, 'run_blocking', run_blocking)
+    monkeypatch.setattr(desktop_chat, 'get_byok_key', lambda _: None)
+    monkeypatch.setattr(
+        desktop_chat.redis_db,
+        'check_rate_limit',
+        lambda *_: (_ for _ in ()).throw(RuntimeError('redis down')),
+    )
+
+    with pytest.raises(desktop_chat.HTTPException) as error:
+        await desktop_chat._meter_server_request('user', request_id='req-metering')
+    assert error.value.status_code == 503
+    events = _desktop_chat_unavailable_events(capsys.readouterr().out)
+    assert events == [
+        {
+            'event': 'desktop_chat_unavailable',
+            'message': 'desktop_chat_unavailable',
+            'reason': 'metering_unavailable',
+            'request_id': 'req-metering',
+            'severity': 'WARNING',
+        }
+    ]
+    serialized = json.dumps(events)
+    assert 'redis' not in serialized.lower()
+    assert 'user' not in serialized
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_jit_503_logs_coded_reason(monkeypatch, capsys):
+    monkeypatch.setattr(desktop_chat, 'llm_stub_enabled', lambda: False)
+    monkeypatch.setattr(desktop_chat, 'should_route_chat_agent_through_gateway', lambda: False)
+    monkeypatch.setenv('OMI_JIT_PROACTIVITY_BUDGET_CONTRACT', 'jit-cloud-qa-v1')
+
+    with pytest.raises(desktop_chat.HTTPException) as error:
+        await desktop_chat.chat_completions(
+            {'messages': [{'role': 'user', 'content': 'hello'}]},
+            uid='user-1',
+            x_app_platform=None,
+            x_omi_chat_contract_version=None,
+            x_omi_request_id='req-jit',
+            x_omi_jit_contract_version='jit-cloud-qa-v1',
+            x_omi_jit_run_id='jit-direct-run',
+            x_omi_jit_max_attempts='3',
+            x_omi_jit_max_output_tokens='2048',
+            x_omi_jit_max_input_tokens='32768',
+            x_omi_jit_max_spend_micro_usd='50000',
+        )
+
+    assert error.value.status_code == 503
+    events = _desktop_chat_unavailable_events(capsys.readouterr().out)
+    assert [(event['reason'], event['request_id']) for event in events] == [('jit_requires_gateway', 'req-jit')]
+
+
+@pytest.mark.asyncio
+async def test_nonstream_circuit_open_logs_coded_503(monkeypatch, capsys):
+    monkeypatch.setattr(desktop_chat, 'llm_stub_enabled', lambda: False)
+    monkeypatch.setattr(desktop_chat, 'enforce_desktop_chat_quota', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(desktop_chat, '_meter_server_request', lambda *_args, **_kwargs: _done())
+    monkeypatch.setattr(desktop_chat, 'should_route_chat_agent_through_gateway', lambda: True)
+    monkeypatch.setattr(desktop_chat, 'get_byok_key', lambda _: None)
+    monkeypatch.setattr(desktop_chat.gateway_circuit, 'allow_request', lambda: False)
+
+    with pytest.raises(desktop_chat.HTTPException) as error:
+        await desktop_chat.chat_completions(
+            {'messages': [{'role': 'user', 'content': 'hello'}]},
+            uid='user-1',
+            x_app_platform=None,
+            x_omi_chat_contract_version=None,
+            x_omi_request_id='req-circuit',
+        )
+
+    assert error.value.status_code == 503
+    events = _desktop_chat_unavailable_events(capsys.readouterr().out)
+    assert [(event['reason'], event['request_id']) for event in events] == [('circuit_open', 'req-circuit')]
+
+
 @pytest.mark.asyncio
 async def test_server_metering_rejects_exhausted_user(monkeypatch):
     async def run_blocking(_, function, *args):

--- a/desktop/macos/Desktop/Sources/Chat/AgentErrorClassifier.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentErrorClassifier.swift
@@ -124,7 +124,17 @@ enum AgentErrorClassifier {
     // (circuit open, transport failure, upstream timeout) as well as hard
     // rejections, and it does not distinguish them on the wire. Resending is
     // worth one attempt.
-    if lower.contains("upstream provider error") {
+    //
+    // Desktop-backend also answers a coded 503 with an empty body
+    // (`HTTP 503 status code (no body)`). That string never contains
+    // "Upstream provider error", so without a status-shaped rule it fell
+    // through to `unknown` and the generic "Omi couldn't answer this one".
+    if lower.contains("upstream provider error")
+      || lower.range(of: #"\bhttp[\s/]*503\b"#, options: .regularExpression) != nil
+      || lower.range(
+        of: #"\b(?:503\s+status|status(?:\s+code)?\s*[:=]?\s*503)\b"#,
+        options: .regularExpression) != nil
+    {
       return ClassifiedAgentError(
         code: .upstreamProviderFailed,
         userMessage:

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -355,7 +355,7 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
       switch classified.code {
       case .providerBillingExhausted, .planLimitReached:
         classifierOwnsCode = true
-      case .providerAuthExpired, .credentialLeakSuspected:
+      case .providerAuthExpired, .credentialLeakSuspected, .upstreamProviderFailed:
         classifierOwnsCode = failure.failureCode == .unknown
       default:
         classifierOwnsCode = false
@@ -370,7 +370,8 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
         recoveryAction: failure.recoveryAction == "worker_recycled" ? "worker_recycled" : nil,
         recoveryOutcome: ["recovered", "stop_failed", "binding_stale_failed"].contains(failure.recoveryOutcome ?? "")
           ? failure.recoveryOutcome : nil,
-        retryDisposition: failure.retryDisposition == "next_send" ? "next_send" : nil)
+        retryDisposition: ["next_send", "same_turn"].contains(failure.retryDisposition ?? "")
+          ? failure.retryDisposition : nil)
     default:
       return nil
     }

--- a/desktop/macos/Desktop/Tests/AgentErrorClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentErrorClassifierTests.swift
@@ -255,6 +255,7 @@ final class AgentErrorClassifierTests: XCTestCase {
       // it renders as the generic "Omi couldn't answer this one", which is what
       // the 2026-08-20 gateway-parameter outage showed users for ~19 hours.
       ("Upstream provider error", true, true),
+      ("HTTP 503 status code (no body)", true, true),
     ]
     for (raw, mustNotBeUnknown, expectedRetryable) in corpus {
       let c = AgentErrorClassifier.classify(raw)
@@ -276,5 +277,30 @@ final class AgentErrorClassifierTests: XCTestCase {
     XCTAssertNotNil(notice)
     XCTAssertNotEqual(notice?.text, ChatTurnFailureNotice.unclassifiedText)
     XCTAssertEqual(notice?.text, classified.userMessage)
+  }
+
+  /// Reproduced 2026-09-09: desktop-backend returned HTTP 503 with an empty
+  /// body. The classifier had 402 and 502 rules; 503 fell through to unknown
+  /// and the transcript showed "Omi couldn't answer this one".
+  func testBareHTTP503IsClassifiedRetryableLikeUpstreamProviderError() {
+    for raw in [
+      "HTTP 503 status code (no body)",
+      "HTTP 503",
+      "Request failed: http/503",
+      "status 503",
+      "status code: 503",
+    ] {
+      let classified = AgentErrorClassifier.classify(raw)
+      XCTAssertEqual(classified.code, .upstreamProviderFailed, "unclassified: \(raw)")
+      XCTAssertTrue(classified.retryable, "503 is retryable: \(raw)")
+      XCTAssertFalse(
+        classified.userMessage.contains("503"),
+        "raw transport status must not reach the user: \(raw)")
+      XCTAssertNotEqual(classified.userMessage, raw, "must not show the raw transport string: \(raw)")
+    }
+    XCTAssertNotEqual(
+      AgentErrorClassifier.classify("elapsed 1503ms").code,
+      .upstreamProviderFailed,
+      "an unrelated number must not be read as HTTP 503")
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -110,8 +110,44 @@ final class ChatQueryTelemetryTests: XCTestCase {
     XCTAssertEqual(properties["recovery_action"] as? String, "worker_recycled")
     XCTAssertEqual(properties["recovery_outcome"] as? String, "recovered")
     XCTAssertEqual(properties["retry_disposition"] as? String, "next_send")
+    XCTAssertEqual(properties["failure_code"] as? String, "adapter_execution_failed")
     XCTAssertFalse(String(describing: properties).contains("/Users/person"))
     XCTAssertFalse(String(describing: properties).contains("private prompt"))
+  }
+
+  func testWorkerRecoverySameTurnAndHTTP503StayOnClosedVocab() {
+    let failure = AgentRuntimeFailure(
+      code: "adapter_execution_failed",
+      userMessage: "The local agent reset its session after an error. Send your message again.",
+      technicalMessage: "HTTP 503 status code (no body)",
+      source: "adapter_execution",
+      adapterId: "pi-mono",
+      retryable: true,
+      recoveryAction: "worker_recycled",
+      recoveryOutcome: "recovered",
+      retryDisposition: "same_turn"
+    )
+    let detail = ChatQueryErrorDetail.from(BridgeError.agentRuntimeFailure(failure))
+    XCTAssertEqual(detail?.errorCode, "upstream_provider_failed")
+    XCTAssertEqual(detail?.retryable, true)
+    XCTAssertEqual(detail?.failureCode, "adapter_execution_failed")
+    XCTAssertEqual(detail?.recoveryAction, "worker_recycled")
+    XCTAssertEqual(detail?.retryDisposition, "same_turn")
+
+    let event = ChatQueryTelemetryEvent.failed(
+      ChatQueryTelemetryContext(attemptId: "attempt-503", surface: "main_chat", harness: "piMono"),
+      durationMs: 105,
+      errorClass: .agentRuntime,
+      partialResponse: false,
+      detail: detail
+    )
+    let properties = event.analyticsPayload.properties
+    XCTAssertEqual(properties["error_code"] as? String, "upstream_provider_failed")
+    XCTAssertEqual(properties["failure_code"] as? String, "adapter_execution_failed")
+    XCTAssertEqual(properties["retry_disposition"] as? String, "same_turn")
+    XCTAssertEqual(properties["recovery_action"] as? String, "worker_recycled")
+    XCTAssertFalse(String(describing: properties).contains("HTTP 503"))
+    XCTAssertFalse(String(describing: properties).contains("Send your message"))
   }
 
   func testUnknownDaemonAuthFailureReportsClassifierCodeAndIsNotRetryable() {

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -896,7 +896,7 @@ export interface RuntimeFailurePayload {
   retryable?: boolean;
   recoveryAction?: "worker_recycled";
   recoveryOutcome?: "recovered" | "stop_failed" | "binding_stale_failed";
-  retryDisposition?: "next_send";
+  retryDisposition?: "next_send" | "same_turn";
 }
 
 /// One concrete model identity observed serving this turn's completions.

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -40,7 +40,7 @@ export interface RuntimeFailure {
   retryable?: boolean;
   recoveryAction?: "worker_recycled";
   recoveryOutcome?: "recovered" | "stop_failed" | "binding_stale_failed";
-  retryDisposition?: "next_send";
+  retryDisposition?: "next_send" | "same_turn";
   /** Qualification-only gateway attribution; null is explicit unknown. */
   jitCostStatus?: "estimated" | "unknown";
   jitEstimatedCostUsd?: number | null;
@@ -98,6 +98,41 @@ export function applyProviderBillingClassification(failure: RuntimeFailure): Run
     failureCode: "quota_exceeded",
     retryable: false,
   };
+}
+
+/** Recycle succeeded only when the worker stopped and the binding was invalidated. */
+export function workerRecycleRecovered(outcome: {
+  stopSucceeded: boolean;
+  bindingInvalidationSucceeded: boolean;
+}): boolean {
+  return outcome.stopSucceeded && outcome.bindingInvalidationSucceeded;
+}
+
+/** 402 / quota / authentication are not healed by a fresh worker in the same turn. */
+export function blocksSameTurnRetryAfterWorkerRecycle(error: unknown): boolean {
+  const failure = failureFromError(error, {
+    code: "adapter_execution_failed",
+    retryable: true,
+  });
+  if (failure.retryable === false) return true;
+  if (failure.code === "provider_auth_required") return true;
+  return failure.failureCode === "quota_exceeded" || failure.failureCode === "authentication";
+}
+
+export function workerRecycleDisposition(input: {
+  stopSucceeded: boolean;
+  bindingInvalidationSucceeded: boolean;
+  canRetry: boolean;
+  originalError: unknown;
+}): NonNullable<RuntimeFailure["retryDisposition"]> {
+  if (
+    input.canRetry
+    && workerRecycleRecovered(input)
+    && !blocksSameTurnRetryAfterWorkerRecycle(input.originalError)
+  ) {
+    return "same_turn";
+  }
+  return "next_send";
 }
 
 /** Recycle metadata stays on every pi-mono execution throw so the next send

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -8,7 +8,13 @@ import type {
 import type { ContextSnapshotProjection, OutboundMessage, OutboundMessageDraft } from "../protocol.js";
 import { AdapterRegistry } from "./adapter-registry.js";
 import { generateAgentId } from "./sqlite-store.js";
-import { AdapterRuntimeError, attachWorkerRecycle, failureFromError, type RuntimeFailure } from "./failures.js";
+import {
+  AdapterRuntimeError,
+  attachWorkerRecycle,
+  failureFromError,
+  workerRecycleDisposition,
+  type RuntimeFailure,
+} from "./failures.js";
 import {
   clearOwnerSurfaceState,
   importLegacyMainChatSessions,
@@ -1396,7 +1402,7 @@ export class KernelCore {
           onWorkerBindingInvalidated: () => {
             this.markBindingStale(binding, attempt, "pinned_worker_recycled_after_execution_error");
           },
-          onWorkerRecycled: (_bindingId, outcome) => {
+          onWorkerRecycled: (_bindingId, outcome, originalError) => {
             this.appendEvent({
               sessionId: accepted.session.sessionId,
               runId: accepted.run.runId,
@@ -1411,7 +1417,11 @@ export class KernelCore {
                     ? "recovered"
                     : "binding_stale_failed",
                 bindingStalePersisted: outcome.bindingInvalidationSucceeded,
-                retryDisposition: "next_send",
+                retryDisposition: workerRecycleDisposition({
+                  ...outcome,
+                  canRetry: attemptNo < maxAttempts,
+                  originalError,
+                }),
               },
             });
           },
@@ -1475,6 +1485,37 @@ export class KernelCore {
           retryReason = "stale_binding";
           resumeFromAttemptId = attempt.attemptId;
           continue;
+        }
+        if (workerRecovery) {
+          const retryDisposition = workerRecycleDisposition({
+            stopSucceeded: workerRecovery.stopSucceeded,
+            bindingInvalidationSucceeded: workerRecovery.bindingInvalidationSucceeded,
+            canRetry: attemptNo < maxAttempts,
+            originalError: executionError,
+          });
+          if (retryDisposition === "same_turn") {
+            const failure: RuntimeFailure = {
+              ...failureFromError(executionError, {
+                code: "adapter_execution_failed",
+                source: "adapter_execution",
+                adapterId: attempt.adapterId,
+                retryable: true,
+              }),
+              recoveryAction: "worker_recycled",
+              recoveryOutcome: "recovered",
+              retryDisposition: "same_turn",
+            };
+            this.failAttemptBeforeExecution(
+              attempt,
+              "adapter_execution_failed",
+              failure.userMessage,
+              true,
+              failure,
+            );
+            retryReason = "worker_recycled";
+            resumeFromAttemptId = attempt.attemptId;
+            continue;
+          }
         }
         if (
           !workerRecovery

--- a/desktop/macos/agent/src/runtime/worker-pool.ts
+++ b/desktop/macos/agent/src/runtime/worker-pool.ts
@@ -143,7 +143,8 @@ interface WorkerLeaseOptions {
   onWorkerBindingInvalidated?: (bindingId: string | null) => void;
   onWorkerRecycled?: (
     bindingId: string | null,
-    outcome: { stopSucceeded: boolean; bindingInvalidationSucceeded: boolean }
+    outcome: { stopSucceeded: boolean; bindingInvalidationSucceeded: boolean },
+    originalError: unknown,
   ) => void;
 }
 
@@ -306,7 +307,7 @@ export class AdapterWorkerPool {
         options.onWorkerRecycled?.(bindingId, {
           stopSucceeded,
           bindingInvalidationSucceeded,
-        });
+        }, error);
       } catch {
         // Telemetry must not prevent deterministic worker cleanup. The thrown
         // recovery error still carries both bounded lifecycle outcomes.

--- a/desktop/macos/agent/tests/adapter-binding.test.ts
+++ b/desktop/macos/agent/tests/adapter-binding.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { AdapterRuntimeError } from "../src/runtime/failures.js";
 import { baseRunInput, createKernelHarness, FakeRuntimeAdapter } from "./kernel-fakes.js";
 
 const createdDirs: string[] = [];
@@ -112,7 +113,7 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
     store.close();
   });
 
-  it("recycles a poisoned pi-mono worker so the next send succeeds in the same daemon", async () => {
+  it("retries a recycled pi-mono worker on the same turn after a successful recycle", async () => {
     const adapters: FakeRuntimeAdapter[] = [];
     let genericRecoveryCalls = 0;
     const makeAdapter = () => {
@@ -140,39 +141,27 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
       }),
       makeAdapter,
     );
-    adapter.failNextExecutionError = new Error("poisoned local adapter state");
-
-    const failed = await kernel.executeRun({
-      ...baseRunInput,
-      adapterId: "pi-mono",
-      defaultAdapterId: "pi-mono",
-      requestId: "request-poisoned",
-    });
-    expect(failed.terminalStatus).toBe("failed");
-    expect(adapters).toHaveLength(1);
-    expect(adapter.executed).toHaveLength(1);
-    expect(genericRecoveryCalls).toBe(0);
-    expect(adapter.stopped).toBe(1);
-    expect(store.getRow("SELECT status FROM adapter_bindings").status).toBe("stale");
-    expect(JSON.parse(failed.run.resultJson!)).toMatchObject({
-      failure: {
-        code: "adapter_execution_failed",
-        recoveryAction: "worker_recycled",
-        recoveryOutcome: "recovered",
-        retryDisposition: "next_send",
-        retryable: true,
-      },
-    });
+    adapter.failNextExecutionError = new Error("HTTP 503 status code (no body)");
 
     const recovered = await kernel.executeRun({
       ...baseRunInput,
       adapterId: "pi-mono",
       defaultAdapterId: "pi-mono",
-      requestId: "request-after-recycle",
+      requestId: "request-poisoned",
     });
     expect(recovered.terminalStatus).toBe("succeeded");
     expect(adapters).toHaveLength(2);
+    expect(adapter.executed).toHaveLength(1);
     expect(adapters[1]?.executed).toHaveLength(1);
+    expect(genericRecoveryCalls).toBe(0);
+    expect(adapter.stopped).toBe(1);
+    expect(store.allRows(
+      "SELECT attempt_no, status, retry_reason FROM run_attempts WHERE run_id = ? ORDER BY attempt_no",
+      [recovered.run.runId],
+    )).toEqual([
+      expect.objectContaining({ attempt_no: 1, status: "failed" }),
+      expect.objectContaining({ attempt_no: 2, status: "succeeded", retry_reason: "worker_recycled" }),
+    ]);
     expect(store.allRows("SELECT status FROM adapter_bindings ORDER BY binding_generation"))
       .toEqual([
         expect.objectContaining({ status: "closed" }),
@@ -184,6 +173,7 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
     ).payload_json)).toMatchObject({
       recoveryOutcome: "recovered",
       bindingStalePersisted: true,
+      retryDisposition: "same_turn",
     });
     store.close();
   });
@@ -227,6 +217,142 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
       },
     });
     expect(JSON.parse(failed.run.resultJson!).failure.userMessage).not.toContain("Send your message again");
+    store.close();
+  });
+
+  it("keeps next-send when worker recycle stop fails", async () => {
+    const adapters: FakeRuntimeAdapter[] = [];
+    const makeAdapter = () => {
+      const adapter = new FakeRuntimeAdapter("pi-mono");
+      Object.assign(adapter.capabilities, {
+        resumeFidelity: "none",
+        supportsNativeResume: false,
+        requiresPinnedWorker: true,
+        restartBehavior: "process_local_bindings_stale",
+      });
+      adapters.push(adapter);
+      return adapter;
+    };
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(),
+      "pi-mono",
+      1,
+      undefined,
+      undefined,
+      makeAdapter,
+    );
+    adapter.failNextExecutionError = new Error("HTTP 503 status code (no body)");
+    adapter.failNextStop = true;
+
+    const failed = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-stop-failed",
+      maxAttempts: 2,
+    });
+    expect(failed.terminalStatus).toBe("failed");
+    expect(adapters).toHaveLength(1);
+    expect(JSON.parse(failed.run.resultJson!)).toMatchObject({
+      failure: {
+        code: "adapter_execution_failed",
+        recoveryAction: "worker_recycled",
+        recoveryOutcome: "stop_failed",
+        retryDisposition: "next_send",
+        retryable: true,
+      },
+    });
+    expect(JSON.parse(failed.run.resultJson!).failure.userMessage).toContain("Send your message again");
+    store.close();
+  });
+
+  it("does not same-turn retry authentication after a successful recycle", async () => {
+    const makeAdapter = () => {
+      const adapter = new FakeRuntimeAdapter("pi-mono");
+      Object.assign(adapter.capabilities, {
+        resumeFidelity: "none",
+        supportsNativeResume: false,
+        requiresPinnedWorker: true,
+        restartBehavior: "process_local_bindings_stale",
+      });
+      return adapter;
+    };
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(),
+      "pi-mono",
+      1,
+      undefined,
+      undefined,
+      makeAdapter,
+    );
+    adapter.failNextExecutionError = new AdapterRuntimeError({
+      code: "provider_auth_required",
+      failureCode: "authentication",
+      userMessage: "Claude sign-in is required to continue this chat.",
+      retryable: false,
+    });
+
+    const failed = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-auth",
+      maxAttempts: 2,
+    });
+    expect(failed.terminalStatus).toBe("failed");
+    expect(adapter.executed).toHaveLength(1);
+    expect(JSON.parse(failed.run.resultJson!)).toMatchObject({
+      failure: {
+        code: "provider_auth_required",
+        failureCode: "authentication",
+        retryable: false,
+        recoveryAction: "worker_recycled",
+        recoveryOutcome: "recovered",
+      },
+    });
+    expect(JSON.parse(failed.run.resultJson!).failure.retryDisposition).not.toBe("same_turn");
+    store.close();
+  });
+
+  it("keeps next-send when recycle succeeded but attempts are exhausted", async () => {
+    const makeAdapter = () => {
+      const adapter = new FakeRuntimeAdapter("pi-mono");
+      Object.assign(adapter.capabilities, {
+        resumeFidelity: "none",
+        supportsNativeResume: false,
+        requiresPinnedWorker: true,
+        restartBehavior: "process_local_bindings_stale",
+      });
+      return adapter;
+    };
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(),
+      "pi-mono",
+      1,
+      undefined,
+      undefined,
+      makeAdapter,
+    );
+    adapter.failNextExecutionError = new Error("HTTP 503 status code (no body)");
+
+    const failed = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-exhausted",
+      maxAttempts: 1,
+    });
+    expect(failed.terminalStatus).toBe("failed");
+    expect(adapter.executed).toHaveLength(1);
+    expect(JSON.parse(failed.run.resultJson!)).toMatchObject({
+      failure: {
+        code: "adapter_execution_failed",
+        recoveryAction: "worker_recycled",
+        recoveryOutcome: "recovered",
+        retryDisposition: "next_send",
+        retryable: true,
+      },
+    });
     store.close();
   });
 

--- a/desktop/macos/agent/tests/failures.test.ts
+++ b/desktop/macos/agent/tests/failures.test.ts
@@ -6,6 +6,7 @@ import {
   failureFromError,
   isProviderBillingFailure,
   unexpectedQueryErrorDiagnostic,
+  workerRecycleDisposition,
   WORKER_RECYCLED_NEXT_SEND_MESSAGE,
 } from "../src/runtime/failures.js";
 
@@ -71,6 +72,41 @@ describe("provider billing vs worker recycle", () => {
       stopSucceeded: true,
       bindingInvalidationSucceeded: true,
     }).userMessage).not.toBe(WORKER_RECYCLED_NEXT_SEND_MESSAGE);
+  });
+
+  it("same-turn retries a recovered worker unless billing, auth, or recycle failed", () => {
+    const recovered = { stopSucceeded: true, bindingInvalidationSucceeded: true };
+    expect(workerRecycleDisposition({
+      ...recovered,
+      canRetry: true,
+      originalError: new Error("HTTP 503 status code (no body)"),
+    })).toBe("same_turn");
+    expect(workerRecycleDisposition({
+      ...recovered,
+      canRetry: true,
+      originalError: new Error("HTTP 402 status code (no body)"),
+    })).toBe("next_send");
+    expect(workerRecycleDisposition({
+      ...recovered,
+      canRetry: true,
+      originalError: new AdapterRuntimeError({
+        code: "provider_auth_required",
+        failureCode: "authentication",
+        userMessage: "Claude sign-in is required to continue this chat.",
+        retryable: false,
+      }),
+    })).toBe("next_send");
+    expect(workerRecycleDisposition({
+      stopSucceeded: false,
+      bindingInvalidationSucceeded: true,
+      canRetry: true,
+      originalError: new Error("HTTP 503 status code (no body)"),
+    })).toBe("next_send");
+    expect(workerRecycleDisposition({
+      ...recovered,
+      canRetry: false,
+      originalError: new Error("HTTP 503 status code (no body)"),
+    })).toBe("next_send");
   });
 
   it("still invites a next send when the recycled worker was actually poisoned", () => {

--- a/desktop/macos/agent/tests/kernel-fakes.ts
+++ b/desktop/macos/agent/tests/kernel-fakes.ts
@@ -49,6 +49,7 @@ export class FakeRuntimeAdapter implements RuntimeAdapter {
   sinks = new Map<string, AdapterEventSink>();
   failNextOpenError: unknown;
   failNextExecutionError: unknown;
+  failNextStop = false;
   eventBeforeExecutionError: OutboundMessage | undefined;
   failNextResume = false;
   failNextExecutionAsStale = false;
@@ -78,6 +79,10 @@ export class FakeRuntimeAdapter implements RuntimeAdapter {
 
   async stop(): Promise<void> {
     this.stopped += 1;
+    if (this.failNextStop) {
+      this.failNextStop = false;
+      throw new Error("stop failed");
+    }
   }
 
   async openBinding(input: OpenBindingInput): Promise<OpenedBinding> {

--- a/desktop/macos/changelog/unreleased/2026-09-desktop-chat-503-retry.json
+++ b/desktop/macos/changelog/unreleased/2026-09-desktop-chat-503-retry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat now retries a failed turn on a fresh local agent when the server briefly returns HTTP 503, instead of asking you to send the same message again."
+}


### PR DESCRIPTION
## What changed and why

Desktop chat treated a successful pi-mono worker recycle as `next_send`, so HTTP 503 empty-body turns failed with "Interrupted" even after the worker was replaced. Same-turn retry now continues on a recovered worker (like `stale_binding`), HTTP 503 is classified like the existing 502 rule, and desktop-chat logs a coded 503 reason without bodies.

Closes SCA-460

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

This change stays inside the existing kernel attempt loop and the Swift classifier/telemetry allowlist. It does not add a second transcript store, change session identity, or grant extra execution authority.

Line-Count-Exception: backend/routers/desktop_chat.py | 1952 -> 1978 | Coded 503 warning helper plus request_id on existing raise sites; splitting the router is out of this incident-fix scope.

## How it was verified

- `npx vitest run tests/adapter-binding.test.ts tests/failures.test.ts tests/worker-pool-pinned.test.ts` in `desktop/macos/agent` — 31 passed
- `pytest tests/unit/test_desktop_chat.py::test_desktop_chat_503_logs_coded_reason_without_live_redis tests/unit/test_desktop_chat.py::test_chat_completions_jit_503_logs_coded_reason tests/unit/test_desktop_chat.py::test_nonstream_circuit_open_logs_coded_503 tests/unit/test_desktop_chat.py::test_server_metering_fails_closed_and_byok_bypasses` — 4 passed
- `xcrun swift test --package-path Desktop --filter AgentErrorClassifierTests --filter ChatQueryTelemetryTests` — 66 passed, including `testBareHTTP503IsClassifiedRetryableLikeUpstreamProviderError` and `testWorkerRecoverySameTurnAndHTTP503StayOnClosedVocab`

## Tests

- Agent: recycle → same-turn continue on recovered 503; next-send on recycle stop failure, exhausted attempts, 402, and `provider_auth_required`
- `AgentErrorClassifierTests` for `HTTP 503 status code (no body)`
- Chat telemetry closed-vocab for `recovery_action=worker_recycled`, `retry_disposition=same_turn|next_send`, `failure_code=adapter_execution_failed`
- Desktop-chat 503 logging without a live Redis

## Failure class (fixes)

Failure-Class: FC-typed-failure-collapsed-to-generic


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

