### PR TITLE
fix(web): give three known marketplace categories their own metadata

### DIFF
--- a/web/frontend/src/__tests__/category-metadata.test.mjs
+++ b/web/frontend/src/__tests__/category-metadata.test.mjs
@@ -18,26 +18,24 @@ import { readFileSync } from 'node:fs';
 const SOURCE = new URL('../app/apps/utils/category.ts', import.meta.url);
 const source = readFileSync(SOURCE, 'utf8');
 
-// Category ids the backend assigns to apps (backend/utils/apps.py category maps)
-// that must not collapse into the General fallback on the marketplace.
-const REQUIRED_CATEGORY_IDS = [
-  'productivity-and-organization',
-  'conversation-analysis',
-  'education-and-learning',
-  'personality-emulation',
-  'utilities-and-tools',
-  'health-and-wellness',
-  'safety-and-security',
-  'news-and-information',
-  'social-and-relationships',
-  'financial',
-  'entertainment-and-fun',
-  'shopping-and-commerce',
-  'integration',
-  'communication-improvement',
-  'emotional-and-mental-support',
-  'travel-and-exploration',
-];
+// Source of truth for category ids: the backend's base category → master
+// category map. Every key there can be assigned to a published app, so every
+// key must resolve to its own marketplace metadata (not the General fallback).
+const BACKEND_APPS = new URL('../../../../backend/utils/apps.py', import.meta.url);
+const backendSource = readFileSync(BACKEND_APPS, 'utf8');
+
+function backendCategoryIds() {
+  const block = backendSource.match(
+    /^_BASE_CATEGORY_MAPPING: Dict\[str, str\] = \{\n([\s\S]*?)^\}/m,
+  );
+  assert.ok(block, 'could not find _BASE_CATEGORY_MAPPING in backend/utils/apps.py');
+  const ids = [...block[1].matchAll(/^\s+'([a-z0-9-]+)': '/gm)].map((m) => m[1]);
+  assert.ok(ids.length >= 10, `unexpectedly few backend category ids: ${ids.length}`);
+  return ids;
+}
+
+// `other` is the General fallback itself and is checked separately below.
+const REQUIRED_CATEGORY_IDS = backendCategoryIds().filter((id) => id !== 'other');
 
 // Added by this fix; existing entries keep their historical hues (ratchet is no-increase).
 const NEW_CATEGORY_IDS = [
@@ -71,6 +69,10 @@ describe('marketplace categoryMetadata (static checker)', () => {
   }
 
   it('keeps the General entry as the fallback for `other` and unknown ids', () => {
+    assert.ok(
+      backendCategoryIds().includes('other'),
+      'backend map should still define other',
+    );
     const other = entryFor('other');
     assert.ok(other);
     assert.equal(field(other, 'displayName'), 'General');

--- a/web/frontend/src/__tests__/category-metadata.test.mjs
+++ b/web/frontend/src/__tests__/category-metadata.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * STATIC CHECKER (not behavioral coverage) for the public marketplace category map.
+ * Run: npm test  (from web/frontend)
+ *
+ * category.ts imports lucide-react components, so node:test cannot import it
+ * directly. This asserts the source-level contract behind the regression: every
+ * category id the backend can assign to a published app must have its own
+ * metadata entry, so getCategoryMetadata() only falls back to the General
+ * entry for the real `other` category and genuinely unknown ids. Before the
+ * fix, three known ids (communication-improvement, emotional-and-mental-support,
+ * travel-and-exploration) were missing and rendered as duplicate "General"
+ * sections on /apps.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const SOURCE = new URL('../app/apps/utils/category.ts', import.meta.url);
+const source = readFileSync(SOURCE, 'utf8');
+
+// Category ids the backend assigns to apps (backend/utils/apps.py category maps)
+// that must not collapse into the General fallback on the marketplace.
+const REQUIRED_CATEGORY_IDS = [
+  'productivity-and-organization',
+  'conversation-analysis',
+  'education-and-learning',
+  'personality-emulation',
+  'utilities-and-tools',
+  'health-and-wellness',
+  'safety-and-security',
+  'news-and-information',
+  'social-and-relationships',
+  'financial',
+  'entertainment-and-fun',
+  'shopping-and-commerce',
+  'integration',
+  'communication-improvement',
+  'emotional-and-mental-support',
+  'travel-and-exploration',
+];
+
+// Added by this fix; existing entries keep their historical hues (ratchet is no-increase).
+const NEW_CATEGORY_IDS = [
+  'communication-improvement',
+  'emotional-and-mental-support',
+  'travel-and-exploration',
+];
+
+function entryFor(id) {
+  // Matches either a quoted or bare object key at the top level of categoryMetadata.
+  const pattern = new RegExp(`^  '?${id}'?: \\{\\n([\\s\\S]*?)^  \\},$`, 'm');
+  const match = source.match(pattern);
+  return match ? match[1] : null;
+}
+
+function field(entry, name) {
+  const match = entry.match(new RegExp(`^\\s+${name}: '([^']*)',$`, 'm'));
+  return match ? match[1] : null;
+}
+
+describe('marketplace categoryMetadata (static checker)', () => {
+  for (const id of REQUIRED_CATEGORY_IDS) {
+    it(`has a dedicated entry for ${id}`, () => {
+      const entry = entryFor(id);
+      assert.ok(entry, `categoryMetadata is missing an entry for '${id}'`);
+      assert.equal(field(entry, 'id'), id);
+      assert.notEqual(field(entry, 'displayName'), 'General');
+      assert.notEqual(field(entry, 'description'), 'Other useful applications');
+      assert.match(entry, /^\s+icon: [A-Z][A-Za-z0-9]*,$/m);
+    });
+  }
+
+  it('keeps the General entry as the fallback for `other` and unknown ids', () => {
+    const other = entryFor('other');
+    assert.ok(other);
+    assert.equal(field(other, 'displayName'), 'General');
+    assert.match(
+      source,
+      /return categoryMetadata\[category\] \|\| categoryMetadata\.other;/,
+    );
+  });
+
+  it('does not add purple accents to the new entries (INV-UI-1 ratchet)', () => {
+    for (const id of NEW_CATEGORY_IDS) {
+      assert.doesNotMatch(
+        entryFor(id),
+        /purple|violet|fuchsia/,
+        `${id} uses a purple hue`,
+      );
+    }
+  });
+});

--- a/web/frontend/src/app/apps/utils/category.ts
+++ b/web/frontend/src/app/apps/utils/category.ts
@@ -12,6 +12,9 @@ import {
   Gamepad2,
   ShoppingBag,
   Globe,
+  MessagesSquare,
+  HeartHandshake,
+  Compass,
   Sparkles,
   type LucideIcon,
 } from 'lucide-react';
@@ -186,6 +189,42 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
       secondary: 'text-cyan-400',
       accent: 'bg-cyan-500/15',
       background: 'bg-cyan-500/5',
+    },
+  },
+  'communication-improvement': {
+    id: 'communication-improvement',
+    displayName: 'Communication',
+    description: 'Improve your communication skills',
+    icon: MessagesSquare,
+    theme: {
+      primary: 'text-yellow-500',
+      secondary: 'text-yellow-400',
+      accent: 'bg-yellow-500/15',
+      background: 'bg-yellow-500/5',
+    },
+  },
+  'emotional-and-mental-support': {
+    id: 'emotional-and-mental-support',
+    displayName: 'Mental Wellness',
+    description: 'Support for emotional and mental health',
+    icon: HeartHandshake,
+    theme: {
+      primary: 'text-rose-500',
+      secondary: 'text-rose-400',
+      accent: 'bg-rose-500/15',
+      background: 'bg-rose-500/5',
+    },
+  },
+  'travel-and-exploration': {
+    id: 'travel-and-exploration',
+    displayName: 'Travel & Exploration',
+    description: 'Explore new places and plan your trips',
+    icon: Compass,
+    theme: {
+      primary: 'text-lime-500',
+      secondary: 'text-lime-400',
+      accent: 'bg-lime-500/15',
+      background: 'bg-lime-500/5',
     },
   },
   other: {

--- a/web/frontend/src/app/apps/utils/category.ts
+++ b/web/frontend/src/app/apps/utils/category.ts
@@ -197,10 +197,10 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     description: 'Improve your communication skills',
     icon: MessagesSquare,
     theme: {
-      primary: 'text-yellow-500',
-      secondary: 'text-yellow-400',
-      accent: 'bg-yellow-500/15',
-      background: 'bg-yellow-500/5',
+      primary: 'text-lime-500',
+      secondary: 'text-lime-400',
+      accent: 'bg-lime-500/15',
+      background: 'bg-lime-500/5',
     },
   },
   'emotional-and-mental-support': {
@@ -209,10 +209,10 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     description: 'Support for emotional and mental health',
     icon: HeartHandshake,
     theme: {
-      primary: 'text-rose-500',
-      secondary: 'text-rose-400',
-      accent: 'bg-rose-500/15',
-      background: 'bg-rose-500/5',
+      primary: 'text-yellow-500',
+      secondary: 'text-yellow-400',
+      accent: 'bg-yellow-500/15',
+      background: 'bg-yellow-500/5',
     },
   },
   'travel-and-exploration': {
@@ -221,10 +221,10 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     description: 'Explore new places and plan your trips',
     icon: Compass,
     theme: {
-      primary: 'text-lime-500',
-      secondary: 'text-lime-400',
-      accent: 'bg-lime-500/15',
-      background: 'bg-lime-500/5',
+      primary: 'text-red-500',
+      secondary: 'text-red-400',
+      accent: 'bg-red-500/15',
+      background: 'bg-red-500/5',
     },
   },
   other: {


### PR DESCRIPTION
On https://h.omi.me/apps the sections for `communication-improvement`, `emotional-and-mental-support`, and `travel-and-exploration` all render the heading **General** / "Other useful applications", next to the real General section. `web/frontend/src/app/apps/utils/category.ts` had no entries for those three ids, so `getCategoryMetadata()` returned the `other` fallback for them.

Closes #13398

Failure-Class: none

Not a producer/consumer format drift or a guard that silently passed; the category map was simply never extended when the backend added these category ids (`backend/utils/apps.py` master-category maps list all three). `scripts/pr-preflight --suggest` proposed `none`.

## Product invariants affected

none

`scripts/pr-preflight --suggest` reported none. INV-UI-1 ratchet (`.github/scripts/check_brand_ui.py --base <main>`) passes: no purple added.

## What changed

- `web/frontend/src/app/apps/utils/category.ts`: add metadata for the three ids. Display names and descriptions match `web/app/src/components/marketplace/category.ts` where it already has them (Communication, Mental Wellness) and the Flutter app's `categoryTravel` label (Travel & Exploration). Entries are appended before `other`, so existing category order (nav, prev/next) is unchanged. Icons: `MessagesSquare`, `HeartHandshake`, `Compass` (all in the pinned lucide-react 0.438.0). Hues lime / yellow / red are not used by any existing category.
- `web/frontend/src/__tests__/category-metadata.test.mjs`: static checker (same pattern as `app-detail-not-found.test.mjs`, since the module imports lucide components and cannot be loaded by `node:test`). It reads the category ids from `backend/utils/apps.py` (`_BASE_CATEGORY_MAPPING`, the same file the tests lane already treats as a cross-component fixture source) and asserts each one has its own entry whose name is not the General text, that `other` remains the fallback, and that the new entries add no purple hues. A backend category added without frontend metadata now fails this checker.

## Verification

- `bash scripts/run-web-frontend-tests.sh`: 94 tests, 94 pass.
- Regression proof: with `category.ts` reverted to `main` and the new test kept, the three "has a dedicated entry for …" cases fail.
- `npm run lint`: clean. `npx prettier --check` on both files: clean. `npx tsc --noEmit`: 0 errors in touched files (33 pre-existing in `src/components/trends/**`).
- Exercised the real page: `API_URL=https://api.omi.me npx next dev` and fetched `/apps`. Production HTML has 4 × "Other useful applications"; the patched local render has 1 (the real General section), and the three new headings/descriptions appear once each. Counts are in the table below.

| section id | heading on production | heading on patched local render |
| --- | --- | --- |
| `communication-improvement` | General | Communication |
| `emotional-and-mental-support` | General | Mental Wellness |
| `travel-and-exploration` | General | Travel & Exploration |
| `other` | General | General |

"Other useful applications" occurrences: production 4, patched local 1. The local run needed `images.unoptimized: true` and placeholder `NEXT_PUBLIC_FIREBASE_*` values, because live data includes an image host not in `next.config.mjs` and Firebase init throws without a key; neither tweak is part of this PR.

Not covered here: `web/app/src/components/marketplace/category.ts` also lacks `travel-and-exploration`. That map is a different surface and out of this issue's scope.

Prepared with Claude Code on the issue author's proposed scope; I'm not affiliated with the issue author. Bounty eligibility is at the maintainers' discretion per the contribution guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
