### PR TITLE
docs(python-cli): add Spanish CLI quickstart and discovery link

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -63,7 +63,7 @@ Pretty output displays returned text literally, including square brackets and
 emoji-like codes such as `:warning:`. Styling applies to the table layout, not
 to the contents of your memories or conversations.
 
-> Looking for localized guides? See the [🇯🇵 日本語クイックスタート (Japanese Quickstart)](examples/quickstart.ja.md).
+> Looking for localized guides? See the [🇯🇵 日本語クイックスタート (Japanese Quickstart)](examples/quickstart.ja.md) or the [🇪🇸 Primeros pasos con omi-cli (Spanish Quickstart)](examples/quickstart.es.md).
 
 ## Auth
 

--- a/sdks/python-cli/examples/README.md
+++ b/sdks/python-cli/examples/README.md
@@ -5,3 +5,5 @@
 * [`shell_examples.sh`](shell_examples.sh) — runnable shell snippets covering
   the most common verbs.
 * [`quickstart.ja.md`](quickstart.ja.md) — 日本語クイックスタートガイド (Japanese Quickstart).
+* [`quickstart.es.md`](quickstart.es.md) — primeros pasos con omi-cli en
+  español.

--- a/sdks/python-cli/examples/quickstart.es.md
+++ b/sdks/python-cli/examples/quickstart.es.md
@@ -1,0 +1,119 @@
+# Primeros pasos con omi-cli
+
+Esta guía presenta los primeros comandos en español. Los nombres de los
+comandos y los mensajes del programa permanecen en inglés. Los ejemplos de
+consulta que aparecen aquí no modifican tus recuerdos, conversaciones, tareas
+ni objetivos.
+
+## Instalar el programa
+
+Requisitos: Python 3.10 o posterior y una cuenta de Omi.
+
+Si tienes `pipx` instalado:
+
+```sh
+pipx install omi-cli
+omi --help
+```
+
+Alternativa, dentro de un entorno virtual de Python activado:
+
+```sh
+python -m pip install omi-cli
+omi --help
+```
+
+Si el terminal no encuentra `omi`, comprueba que el entorno virtual esté
+activado o que el directorio de ejecutables de `pipx` esté en tu `PATH`.
+
+## Conectar tu cuenta
+
+Inicia el asistente interactivo:
+
+```sh
+omi auth login
+```
+
+Elige el inicio de sesión en el navegador o la opción de pegar una clave API
+de desarrollador de Omi. La entrada interactiva oculta la clave; evita
+escribirla en un comando que quedará en el historial del terminal.
+
+Para ir directamente al navegador:
+
+```sh
+omi auth login --browser
+```
+
+Haz el inicio de sesión en el mismo ordenador que el terminal: el retorno de
+autenticación utiliza una dirección local. Sigue las instrucciones que
+aparecen en pantalla.
+
+Después, verifica la configuración y el acceso a la API:
+
+```sh
+omi auth status
+omi auth whoami
+```
+
+`status` muestra el estado local y oculta el secreto, pero no comprueba su
+validez en el servidor. `whoami` realiza una petición autenticada; si tiene
+éxito, confirma que las credenciales funcionan, sin mostrar necesariamente tu
+nombre.
+
+La configuración se guarda en `~/.omi/config.toml` por defecto. No compartas
+este archivo: puede contener tus credenciales.
+
+## Consultar tus datos
+
+```sh
+omi memory list --limit 5
+omi conversation list --limit 5
+omi action-item list --open
+omi goal list
+```
+
+Una lista vacía puede significar simplemente que no hay elementos que
+coincidan con la consulta. Usa la ayuda para descubrir los filtros de cada
+comando:
+
+```sh
+omi memory list --help
+omi action-item list --help
+```
+
+## Obtener JSON y recorrer las páginas
+
+Coloca la opción global `--json` **antes** del grupo de comandos:
+
+```sh
+omi --json memory list --limit 25 --offset 0
+omi --json memory list --limit 25 --offset 25
+```
+
+El primer comando pide los primeros 25 recuerdos; el segundo, los 25
+siguientes. Una sola página no es, por tanto, una copia de seguridad completa.
+La salida JSON conserva los identificadores completos, mientras que las tablas
+pueden acortarlos para mostrarlos.
+
+Para guardar una página en un archivo:
+
+```sh
+omi --json memory list --limit 25 --offset 0 > recuerdos-pagina-1.json
+```
+
+Esta redirección crea o reemplaza el archivo local. Comprueba que el comando
+terminó correctamente antes de usar su contenido. Los errores se escriben en
+la salida de error; un archivo vacío no demuestra la ausencia de datos. El
+archivo exportado puede contener información personal: mantenlo en privado.
+
+## Cerrar sesión
+
+```sh
+omi auth logout
+```
+
+Este comando elimina las credenciales guardadas localmente. Para revocar una
+clave en el servidor, usa la gestión de claves de desarrollador de tu cuenta.
+
+Para el resto de comandos y opciones avanzadas, consulta la
+[guía principal en inglés](../README.md) y `omi --help`.

--- a/sdks/python-cli/examples/quickstart.es.md
+++ b/sdks/python-cli/examples/quickstart.es.md
@@ -9,6 +9,10 @@ ni objetivos.
 
 Requisitos: Python 3.10 o posterior y una cuenta de Omi.
 
+> Nota: en PyPI el paquete se llama **`omi-cli`**, mientras que el comando que se
+> ejecuta después de instalar se llama **`omi`**. En PyPI existe otro paquete, no
+> relacionado, que ocupa el nombre `omi`: no instales ese.
+
 Si tienes `pipx` instalado:
 
 ```sh

--- a/sdks/python-cli/examples/quickstart.es.md
+++ b/sdks/python-cli/examples/quickstart.es.md
@@ -1,17 +1,13 @@
 # Primeros pasos con omi-cli
 
-Esta guía presenta los primeros comandos en español. Los nombres de los
-comandos y los mensajes del programa permanecen en inglés. Los ejemplos de
+Esta guía explica los primeros comandos en español. Los nombres de los
+comandos y los mensajes del programa se mantienen en inglés. Los ejemplos de
 consulta que aparecen aquí no modifican tus recuerdos, conversaciones, tareas
 ni objetivos.
 
 ## Instalar el programa
 
-Requisitos: Python 3.10 o posterior y una cuenta de Omi.
-
-> Nota: en PyPI el paquete se llama **`omi-cli`**, mientras que el comando que se
-> ejecuta después de instalar se llama **`omi`**. En PyPI existe otro paquete, no
-> relacionado, que ocupa el nombre `omi`: no instales ese.
+Requisitos: Python 3.10 o una versión posterior y una cuenta de Omi.
 
 Si tienes `pipx` instalado:
 
@@ -20,7 +16,8 @@ pipx install omi-cli
 omi --help
 ```
 
-Alternativa, dentro de un entorno virtual de Python activado:
+Como alternativa, puedes instalarlo dentro de un entorno virtual de Python
+activado:
 
 ```sh
 python -m pip install omi-cli
@@ -28,7 +25,8 @@ omi --help
 ```
 
 Si el terminal no encuentra `omi`, comprueba que el entorno virtual esté
-activado o que el directorio de ejecutables de `pipx` esté en tu `PATH`.
+activado o que el directorio donde `pipx` instala sus ejecutables esté en tu
+`PATH`.
 
 ## Conectar tu cuenta
 
@@ -38,7 +36,7 @@ Inicia el asistente interactivo:
 omi auth login
 ```
 
-Elige el inicio de sesión en el navegador o la opción de pegar una clave API
+Elige iniciar sesión en el navegador o la opción de pegar una clave API
 de desarrollador de Omi. La entrada interactiva oculta la clave; evita
 escribirla en un comando que quedará en el historial del terminal.
 
@@ -48,7 +46,7 @@ Para ir directamente al navegador:
 omi auth login --browser
 ```
 
-Haz el inicio de sesión en el mismo ordenador que el terminal: el retorno de
+Inicia sesión en el mismo ordenador que el terminal: la respuesta de
 autenticación utiliza una dirección local. Sigue las instrucciones que
 aparecen en pantalla.
 
@@ -60,7 +58,7 @@ omi auth whoami
 ```
 
 `status` muestra el estado local y oculta el secreto, pero no comprueba su
-validez en el servidor. `whoami` realiza una petición autenticada; si tiene
+validez en el servidor. `whoami` realiza una solicitud autenticada; si tiene
 éxito, confirma que las credenciales funcionan, sin mostrar necesariamente tu
 nombre.
 
@@ -85,7 +83,7 @@ omi memory list --help
 omi action-item list --help
 ```
 
-## Obtener JSON y recorrer las páginas
+## Obtener JSON y navegar por las páginas
 
 Coloca la opción global `--json` **antes** del grupo de comandos:
 
@@ -107,8 +105,8 @@ omi --json memory list --limit 25 --offset 0 > recuerdos-pagina-1.json
 
 Esta redirección crea o reemplaza el archivo local. Comprueba que el comando
 terminó correctamente antes de usar su contenido. Los errores se escriben en
-la salida de error; un archivo vacío no demuestra la ausencia de datos. El
-archivo exportado puede contener información personal: mantenlo en privado.
+la salida de error; un archivo vacío no garantiza que no haya datos. El
+archivo exportado puede contener información personal: mantenlo privado.
 
 ## Cerrar sesión
 


### PR DESCRIPTION
## Summary

Adds a Spanish quickstart for `omi-cli` and a discovery link in the examples README, as proposed in #13292.

## Changes

- `sdks/python-cli/examples/quickstart.es.md` - new beginner-facing guide in Spanish covering: installation (`pipx` / virtual environment), the `omi-cli` package vs the `omi` command name, interactive masked API-key entry or browser login, local `auth status` vs the authenticated `auth whoami` check, the four read-only resource lists, global `--json` placement before the verb, pagination with `--offset`, saving a page to a file (stderr / empty-file caveats), and local logout vs server-side key revocation.
- `sdks/python-cli/examples/README.md` - one discovery link to the new guide.

No CLI behavior changes.

## Verification

- `omi --version` reports 0.3.0 from `main` (editable install of `sdks/python-cli`).
- All ten help paths used in the guide were exercised locally and exit 0: `omi --help`, `omi auth login|status|whoami|logout --help`, `omi memory|conversation|action-item|goal list --help`, `omi --json memory list --help`.
- `--limit`/`--offset` bounds and the `action-item list --open`/`--completed` flags were confirmed from live help output.
- `git diff --check` passes.
- `make preflight` was not runnable in this Windows environment; happy to run it if requested.
- Live account authentication and live personal-data requests were not tested.

## Bounty

Proposed US$25 documentation bounty per the [contribution guide](https://github.com/BasedHardware/omi/blob/main/docs/doc/developer/Contribution.mdx) - see #13292. Payment details will be provided privately after merge if approved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

