### PR TITLE
fix(web): add metadata for three marketplace categories missing from frontend map (#13398)

### DIFF
--- a/web/frontend/src/__tests__/category-known-ids.test.mjs
+++ b/web/frontend/src/__tests__/category-known-ids.test.mjs
@@ -1,0 +1,37 @@
+/**
+ * STATIC CHECKER (not behavioral coverage) for the marketplace category map.
+ * Run: npm test  (from web/frontend)
+ *
+ * category.ts imports lucide-react icon components, so it can't be loaded
+ * directly by node:test without a TSX-aware loader. This asserts the
+ * source-level contract instead: three known category IDs
+ * (emotional-and-mental-support, communication-improvement,
+ * travel-and-exploration) used elsewhere in the product (backend
+ * _get_categories, the Flutter app, web/app marketplace) must have their
+ * own metadata entry here, not silently fall through to the "other"/General
+ * fallback via `categoryMetadata[category] || categoryMetadata.other`.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const CATEGORY_FILE = new URL('../app/apps/utils/category.ts', import.meta.url);
+const source = readFileSync(CATEGORY_FILE, 'utf8');
+
+const KNOWN_CATEGORY_IDS = [
+  'emotional-and-mental-support',
+  'communication-improvement',
+  'travel-and-exploration',
+];
+
+describe('apps category metadata (static checker)', () => {
+  for (const id of KNOWN_CATEGORY_IDS) {
+    it(`has its own metadata entry for '${id}'`, () => {
+      assert.match(source, new RegExp(`'${id}':\\s*{`));
+    });
+  }
+
+  it('still falls back to the "other" entry for unrecognized ids', () => {
+    assert.match(source, /categoryMetadata\[category\] \|\| categoryMetadata\.other/);
+  });
+});

--- a/web/frontend/src/app/apps/utils/category.ts
+++ b/web/frontend/src/app/apps/utils/category.ts
@@ -13,6 +13,8 @@ import {
   ShoppingBag,
   Globe,
   Sparkles,
+  HeartHandshake,
+  Plane,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -186,6 +188,42 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
       secondary: 'text-cyan-400',
       accent: 'bg-cyan-500/15',
       background: 'bg-cyan-500/5',
+    },
+  },
+  'communication-improvement': {
+    id: 'communication-improvement',
+    displayName: 'Communication',
+    description: 'Improve your communication skills',
+    icon: MessageSquare,
+    theme: {
+      primary: 'text-lime-500',
+      secondary: 'text-lime-400',
+      accent: 'bg-lime-500/15',
+      background: 'bg-lime-500/5',
+    },
+  },
+  'emotional-and-mental-support': {
+    id: 'emotional-and-mental-support',
+    displayName: 'Emotional Support',
+    description: 'Support for emotional and mental health',
+    icon: HeartHandshake,
+    theme: {
+      primary: 'text-red-500',
+      secondary: 'text-red-400',
+      accent: 'bg-red-500/15',
+      background: 'bg-red-500/5',
+    },
+  },
+  'travel-and-exploration': {
+    id: 'travel-and-exploration',
+    displayName: 'Travel',
+    description: 'Plan and enhance your travel experiences',
+    icon: Plane,
+    theme: {
+      primary: 'text-yellow-500',
+      secondary: 'text-yellow-400',
+      accent: 'bg-yellow-500/15',
+      background: 'bg-yellow-500/5',
     },
   },
   other: {


### PR DESCRIPTION
## Summary

Fixes #13398. `web/frontend/src/app/apps/utils/category.ts`'s `categoryMetadata` map had no entries for three category IDs (`emotional-and-mental-support`, `communication-improvement`, `travel-and-exploration`) that are real, in-use categories elsewhere in the product (`backend/routers/apps.py::_get_categories`, the Flutter app's `app_localizations_helper.dart`, and `web/app`'s own marketplace category map). `getCategoryMetadata()` falls back to `categoryMetadata.other` for any unknown key, so on https://h.omi.me/apps the sections for these three categories all rendered the same "General" / "Other useful applications" heading as the real `other` section, making distinct app groups look like duplicate generic categories.

Adds the three missing entries with distinct display names, descriptions, icons and theme colors, matching the canonical titles used in `backend/routers/apps.py` and `web/app`'s marketplace map (Communication, Emotional Support, Travel).

## Test plan

- [x] `npm test` in `web/frontend` (`scripts/run-web-frontend-tests.sh`, this repo's CI lane for `web/frontend/**`) — 81/81 passing, including 4 new static-checker assertions in `src/__tests__/category-known-ids.test.mjs` that the three IDs resolve to their own metadata instead of the `other` fallback.
- [x] `npx tsc --noEmit` — same 33 pre-existing errors as on `main` (none in the touched file, verified by diffing against a clean `origin/main` checkout).
- [x] `npx prettier --check` on both changed files — clean.
- [x] Verified `HeartHandshake` and `Plane` are real exports of the pinned `lucide-react@0.438.0` (checked the resolved package on unpkg).

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- Isolated content-completeness gap in a single static lookup table (3 missing keys in one category map), not a recurring systemic pattern — no evidence of the same defect shape elsewhere in this diff's blast radius. -->

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

