### PR TITLE
fix(sdks/python-cli): raise nonzero exit code on Desktop SQL execution failure (#13392)

### DIFF
--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -35,6 +35,11 @@ omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 These codes are **part of the contract** — they won't shift between minor
 versions. Branch on them in your harness without parsing English errors.
 
+Local SQL execution failures return exit code `1` from both `omi local sql`
+and `omi local call execute_sql`, including when Desktop wraps the error in
+an HTTP 200 response. With `--json`, the error goes to stderr and stdout stays
+empty. A successful query with no rows still returns exit code `0`.
+
 ## Authentication: API key vs browser OAuth
 
 The CLI supports both — but for **agents** specifically, the API-key path is

--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -75,7 +75,13 @@ class LocalOmiClient:
         self._maybe_log(name, response)
         if not (200 <= response.status_code < 300):
             raise self._error_from_response(response)
-        return _unwrap_tool_response(_safe_parse_json(response))
+        result = _unwrap_tool_response(_safe_parse_json(response))
+        # Desktop reports this SQL failure as text inside an ok:true envelope.
+        # Match its full message: successful table headings can start with
+        # "SQL Error:" too. Both `local sql` and `local call` share this boundary.
+        if name == "execute_sql" and result == "SQL Error: The local database could not complete that query.":
+            raise CliError(message=result, exit_code=1)
+        return result
 
     def list_tools(self) -> Any:
         """Return Desktop-local tool descriptors."""

--- a/sdks/python-cli/tests/test_local_sql_errors.py
+++ b/sdks/python-cli/tests/test_local_sql_errors.py
@@ -1,0 +1,103 @@
+"""The Desktop SQL failure response must remain a failure at the CLI boundary."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from omi_cli import config as cfg
+from omi_cli.main import main
+
+LOCAL_URL = "http://127.0.0.1:47778"
+# ChatToolExecutor.executeSQL returns this string on a database error.
+SQL_ERROR = "SQL Error: The local database could not complete that query."
+SQL_COMMANDS = [
+    ["local", "sql", "SELECT * FROM missing_table"],
+    ["local", "call", "execute_sql", "--args-json", '{"query":"SELECT * FROM missing_table"}'],
+]
+
+
+@pytest.fixture
+def local_profile(config_path):
+    config = cfg.load()
+    profile = config.get_profile("default")
+    profile.local_api_url = LOCAL_URL
+    profile.local_token = "synthetic_local_token"
+    cfg.save(config)
+
+
+@pytest.mark.parametrize("command", SQL_COMMANDS)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_local_sql_error_exits_nonzero(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    # LocalAgentAPIServer currently wraps SQL errors in an HTTP 200 / ok:true
+    # envelope because its HTTP error check recognizes only the "Error:" prefix.
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": SQL_ERROR}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        route = router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 1
+    assert route.call_count == 1
+    assert json.loads(route.calls[0].request.content)["name"] == "execute_sql"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    if json_mode:
+        assert json.loads(captured.err)["error"] == SQL_ERROR
+    else:
+        assert SQL_ERROR in captured.err
+
+
+@pytest.mark.parametrize("command", SQL_COMMANDS)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_local_sql_empty_result_still_succeeds(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": "No results"}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if json_mode:
+        result = json.loads(captured.out)
+        assert result == ({"rows": [], "columns": [], "row_count": 0} if command[1] == "sql" else "No results")
+    else:
+        assert "No results" in captured.out
+
+
+def test_other_tool_can_return_sql_error_text_as_data(local_profile, monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["omi", "--json", "local", "call", "get_daily_recap"])
+    envelope = {"ok": True, "name": "get_daily_recap", "content_type": "text/plain", "result": SQL_ERROR}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == SQL_ERROR
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "command,json_mode",
+    [
+        (["local", "sql", "SELECT 1 AS 'SQL Error: count'"], False),
+        (["local", "call", "execute_sql", "--args-json", '{"query":"SELECT 1 AS \'SQL Error: count\'"}'], True),
+    ],
+)
+def test_sql_error_column_heading_is_successful_data(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    # SQLQueryResultProjection.format starts successful output with column names.
+    table = "SQL Error: count\n--------------------\n1\n\n1 row(s)"
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": table}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out) if json_mode else captured.out.rstrip()) == table
+    assert captured.err == ""


### PR DESCRIPTION
### Summary

When Desktop wraps an `execute_sql` database error in an HTTP 200 response with `"result": "SQL Error: The local database could not complete that query."`, `LocalOmiClient` now recognizes this error payload and raises `CliError(message=result, exit_code=1)`.

This ensures both `omi local sql` and `omi local call execute_sql` exit with code `1` on query failure rather than masking it as a successful operation.

Closes #13392

### Changes

1. **`sdks/python-cli/omi_cli/local_client.py`**:
   - In `call_tool`, detect when `name == "execute_sql"` and `result == "SQL Error: The local database could not complete that query."`, then raise `CliError(message=result, exit_code=1)`.
   - Preserve successful query results, empty result sets, and table headings starting with `SQL Error:`.
2. **`sdks/python-cli/tests/test_local_sql_errors.py`**:
   - Added 11 unit test cases verifying:
     - `omi local sql` and `omi local call execute_sql` both exit with code 1 on query failure in plain and `--json` modes.
     - Empty result sets still exit with code 0.
     - Other tools returning matching strings as data succeed.
     - Successful queries with column headings starting with `SQL Error:` succeed.
3. **`docs/doc/developer/cli/agents.mdx`**:
   - Documented exit code `1` contract for local SQL failures and stdout/stderr behavior in `--json` mode.

### Bounty Proposal

Following the issue discussion, proposing **US$10** for this fix, comprehensive tests, and contract documentation.

Co-authored-by: denisanzora <denisanzora@users.noreply.github.com>
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

