### PR TITLE
feat(sdks/python-cli): allow clearing a goal's minimum and maximum bounds (#13393)

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -241,7 +241,7 @@ omi
     ├── list [--limit N] [--include-inactive]
     ├── get <id>
     ├── create <title> --target N [--type ...] [--current N] [--unit ...]
-    ├── update <id> [--unit ... | --clear-unit] [...]
+    ├── update <id> [--min N | --clear-min] [--max N | --clear-max] [--unit ... | --clear-unit] [...]
     ├── progress <id> <value>
     ├── history <id> [--days N]
     └── delete <id> [-y]

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -129,13 +129,19 @@ def update_goal(
     target_value: Optional[float] = typer.Option(None, "--target"),
     current_value: Optional[float] = typer.Option(None, "--current"),
     min_value: Optional[float] = typer.Option(None, "--min"),
+    clear_min: bool = typer.Option(False, "--clear-min", help="Remove the existing minimum bound."),
     max_value: Optional[float] = typer.Option(None, "--max"),
+    clear_max: bool = typer.Option(False, "--clear-max", help="Remove the existing maximum bound."),
     unit: Optional[str] = typer.Option(None, "--unit"),
     clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
 ) -> None:
     ctx = _ctx(typer_ctx)
     if clear_unit and unit is not None:
         raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
+    if clear_min and min_value is not None:
+        raise UsageError(message="Conflicting options", detail="--min and --clear-min are mutually exclusive.")
+    if clear_max and max_value is not None:
+        raise UsageError(message="Conflicting options", detail="--max and --clear-max are mutually exclusive.")
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -143,9 +149,13 @@ def update_goal(
         body["target_value"] = target_value
     if current_value is not None:
         body["current_value"] = current_value
-    if min_value is not None:
+    if clear_min:
+        body["min_value"] = None
+    elif min_value is not None:
         body["min_value"] = min_value
-    if max_value is not None:
+    if clear_max:
+        body["max_value"] = None
+    elif max_value is not None:
         body["max_value"] = max_value
     if clear_unit:
         body["unit"] = None
@@ -154,7 +164,7 @@ def update_goal(
     if not body:
         raise UsageError(
             message="No fields to update",
-            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit.",
+            detail="Provide one of --title/--target/--current/--min/--clear-min/--max/--clear-max/--unit/--clear-unit.",
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -215,7 +215,9 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
 
 
 @pytest.mark.parametrize("bound_opt,clear_opt", [("--min", "--clear-min"), ("--max", "--clear-max")])
-def test_goal_update_rejects_set_and_clear_bounds(authed_profile, respx_mock, monkeypatch, capsys, bound_opt, clear_opt) -> None:
+def test_goal_update_rejects_set_and_clear_bounds(
+    authed_profile, respx_mock, monkeypatch, capsys, bound_opt, clear_opt
+) -> None:
     monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", bound_opt, "5", clear_opt])
     with pytest.raises(SystemExit) as exc:
         main()

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -185,6 +185,11 @@ def test_goal_delete(authed_profile, respx_mock, cli_runner) -> None:
         (["--clear-unit"], {"unit": None}),
         (["--title", "drink water"], {"title": "drink water"}),
         (["--clear-unit", "--current", "2"], {"unit": None, "current_value": 2.0}),
+        (["--min", "1.0"], {"min_value": 1.0}),
+        (["--clear-min"], {"min_value": None}),
+        (["--max", "10.0"], {"max_value": 10.0}),
+        (["--clear-max"], {"max_value": None}),
+        (["--clear-min", "--clear-max"], {"min_value": None, "max_value": None}),
     ],
 )
 def test_goal_update_unit_patch(authed_profile, respx_mock, cli_runner, options, expected) -> None:
@@ -206,4 +211,18 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     error = json.loads(output.err)
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
+    assert not respx_mock.calls
+
+
+@pytest.mark.parametrize("bound_opt,clear_opt", [("--min", "--clear-min"), ("--max", "--clear-max")])
+def test_goal_update_rejects_set_and_clear_bounds(authed_profile, respx_mock, monkeypatch, capsys, bound_opt, clear_opt) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", bound_opt, "5", clear_opt])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert bound_opt in error["detail"]
+    assert clear_opt in error["detail"]
     assert not respx_mock.calls


### PR DESCRIPTION
### Summary

The Developer API's `UpdateGoalRequest` accepts null `min_value` and `max_value` to clear existing bounds on a goal, but the CLI previously provided no options to express null.

This PR adds `--clear-min` and `--clear-max` flags to `omi goal update`, mapping them to explicit `null` in the PATCH payload, enforcing mutual exclusivity with `--min` and `--max`, and adding comprehensive test coverage.

Closes #13393

### Changes

1. **`sdks/python-cli/omi_cli/commands/goal.py`**:
   - Added `--clear-min` and `--clear-max` flags to `update_goal`.
   - Mapped flags to explicit `null` in the JSON body.
   - Enforced mutual exclusivity: `--min` with `--clear-min`, and `--max` with `--clear-max`.
   - Updated missing-fields error detail message.
2. **`sdks/python-cli/README.md`**:
   - Updated command syntax overview in goal section.
3. **`sdks/python-cli/tests/test_goal.py`**:
   - Added test cases in `test_goal_update_unit_patch` verifying that `--clear-min`, `--clear-max`, and both together send `null` in the request body.
   - Added `test_goal_update_rejects_set_and_clear_bounds` verifying mutual exclusivity with exit code 1.