### PR TITLE
fix(desktop): keep task undo on canonical identity

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -343,6 +343,7 @@ class TasksViewModel: ObservableObject {
   typealias SelectionSnapshotLoader = (_ completed: Bool) async throws -> [String]
   typealias SearchLoader = (_ query: String, _ includeDeleted: Bool) async throws -> [TaskActionItem]
   typealias BulkDeleteOperation = (_ ids: [String]) async -> TasksStore.BulkDeleteOutcome
+  typealias RestoreTaskOperation = (_ task: TaskActionItem) async -> TaskActionItem?
 
   struct SortOrderSyncOperations: Sendable {
     let updateStorage:
@@ -386,6 +387,7 @@ class TasksViewModel: ObservableObject {
   let selectionSnapshotLoader: SelectionSnapshotLoader
   let searchLoader: SearchLoader
   let bulkDeleteOperation: BulkDeleteOperation
+  let restoreTaskOperation: RestoreTaskOperation
   let bulkDeleteConfirmation: (Int) -> Bool
   private let orderingDefaults: UserDefaults
   private var activeOwnerID: String?
@@ -718,6 +720,7 @@ class TasksViewModel: ObservableObject {
     selectionSnapshotLoader: SelectionSnapshotLoader? = nil,
     searchLoader: SearchLoader? = nil,
     bulkDeleteOperation: BulkDeleteOperation? = nil,
+    restoreTaskOperation: RestoreTaskOperation? = nil,
     bulkDeleteConfirmation: ((Int) -> Bool)? = nil,
     orderingDefaults: UserDefaults = .standard
   ) {
@@ -739,6 +742,10 @@ class TasksViewModel: ObservableObject {
     self.bulkDeleteOperation =
       bulkDeleteOperation ?? { ids in
         await TasksStore.shared.deleteMultipleTasks(ids: ids)
+      }
+    self.restoreTaskOperation =
+      restoreTaskOperation ?? { task in
+        await TasksStore.shared.restoreTask(task)
       }
     self.bulkDeleteConfirmation = bulkDeleteConfirmation ?? Self.confirmBulkDelete
     self.orderingDefaults = orderingDefaults
@@ -2743,13 +2750,15 @@ class TasksViewModel: ObservableObject {
   func undoLastDelete() async {
     guard let lastAction = undoStack.popLast() else { return }
 
-    await store.restoreTask(lastAction.task)
+    guard let restoredTask = await restoreTaskOperation(lastAction.task) else { return }
 
-    // Re-insert into display
-    displayTasks.insert(lastAction.task, at: 0)
+    // The backend hard-delete/recreate flow mints a replacement ID. Rendering
+    // lastAction.task here would keep the deleted ID alive until a refresh and
+    // route the next edit/toggle/delete to a row that no longer exists.
+    displayTasks.insert(restoredTask, at: 0)
     let cat = TaskCategory.today  // Default; will be recategorized on next recompute
     if categorizedTasks[cat] != nil {
-      categorizedTasks[cat]?.insert(lastAction.task, at: 0)
+      categorizedTasks[cat]?.insert(restoredTask, at: 0)
     }
 
     // Hide toast if stack is now empty

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -3287,15 +3287,15 @@ class TasksStore: ObservableObject {
   func restoreTask(
     _ task: TaskActionItem,
     expectedOwnerID: String? = nil
-  ) async {
-    guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return }
+  ) async -> TaskActionItem? {
+    guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return nil }
     // Undo of a tombstoned delete: the row still exists locally (deleted, whether or not
     // the backend acked). Purge it before the re-insert below or undo would duplicate it.
     try? await ActionItemStorage.shared.deleteActionItemByBackendId(
       task.id,
       authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
     )
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
 
     // A local-only task never had a backend row (deleteTask skipped the backend
     // delete). It must not go through the backend-recreate path below: staging
@@ -3304,8 +3304,7 @@ class TasksStore: ObservableObject {
     // re-insert it as an UNSYNCED local row so the pending create-sync pushes it
     // exactly once (carrying completion via retryUnsyncedItems).
     if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
-      await restoreLocalOnlyTask(task, lease: lease)
-      return
+      return await restoreLocalOnlyTask(task, lease: lease)
     }
 
     // 1. Stage as an UNSYNCED local row with no stale backend identity (reusing
@@ -3324,12 +3323,12 @@ class TasksStore: ObservableObject {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-insert task locally for undo", error: error)
       }
-      return
+      return nil
     }
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
     guard let localId = inserted.id else {
       logError("TasksStore: Staged undo row has no local id", error: ActionItemStorageError.recordNotFound)
-      return
+      return nil
     }
     let stagedTask = inserted.toTaskActionItem()
 
@@ -3373,24 +3372,26 @@ class TasksStore: ObservableObject {
         expectedOwnerId: lease.ownerID,
         authorizationSnapshot: lease.authorizationSnapshot
       )
-      guard isCurrent(lease) else { return }
+      guard isCurrent(lease) else { return nil }
       // Bind this same staged row to its new backend ID -- never a second insert.
       try await ActionItemStorage.shared.markSynced(
         id: localId,
         backendId: created.id,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
-      guard isCurrent(lease) else { return }
+      guard isCurrent(lease) else { return nil }
       if stagedTask.completed, let idx = completedTasks.firstIndex(where: { $0.id == stagedTask.id }) {
         completedTasks[idx] = created
       } else if !stagedTask.completed, let idx = incompleteTasks.firstIndex(where: { $0.id == stagedTask.id }) {
         incompleteTasks[idx] = created
       }
       log("TasksStore: Restored task via undo (new backend ID: \(created.id))")
+      return created
     } catch {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-create task on backend (local restore preserved)", error: error)
       }
+      return stagedTask
     }
   }
 
@@ -3416,10 +3417,14 @@ class TasksStore: ObservableObject {
   /// its original rowid so the surfaced "local_<rowid>" id is stable. No backend
   /// recreate: the task never had a backend row, and the pending create-sync
   /// (retryUnsyncedItems) is the single writer that pushes it to the backend.
-  private func restoreLocalOnlyTask(_ task: TaskActionItem, lease: OwnerOperationLease) async {
+  private func restoreLocalOnlyTask(
+    _ task: TaskActionItem,
+    lease: OwnerOperationLease
+  ) async -> TaskActionItem? {
     let record = Self.localOnlyRestoreRecord(from: task)
+    let inserted: ActionItemRecord
     do {
-      try await ActionItemStorage.shared.insertLocalActionItem(
+      inserted = try await ActionItemStorage.shared.insertLocalActionItem(
         record,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
@@ -3427,16 +3432,18 @@ class TasksStore: ObservableObject {
       if isCurrent(lease) {
         logError("TasksStore: Failed to re-insert local-only task for undo", error: error)
       }
-      return
+      return nil
     }
-    guard isCurrent(lease) else { return }
+    guard isCurrent(lease) else { return nil }
+    let restoredTask = inserted.toTaskActionItem()
 
-    if task.completed {
-      completedTasks.insert(task, at: 0)
+    if restoredTask.completed {
+      completedTasks.insert(restoredTask, at: 0)
     } else {
-      incompleteTasks.insert(task, at: 0)
+      incompleteTasks.insert(restoredTask, at: 0)
     }
-    log("TasksStore: Restored local-only task via undo (unsynced, id: \(task.id))")
+    log("TasksStore: Restored local-only task via undo (unsynced, id: \(restoredTask.id))")
+    return restoredTask
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Tests/TasksViewModelUndoTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksViewModelUndoTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class TasksViewModelUndoTests: XCTestCase {
+  override func setUp() async throws {
+    TasksStore.shared.resetSessionState()
+  }
+
+  override func tearDown() async throws {
+    TasksStore.shared.resetSessionState()
+  }
+
+  /// Regression for #13329: the backend restore mints a replacement ID, so
+  /// Undo must render the task returned by the store instead of resurrecting
+  /// the deleted task snapshot (and its dead backend ID) from the undo stack.
+  func testUndoUsesCanonicalRestoredTaskInEveryDisplayProjection() async {
+    let deletedTask = task(id: "deleted-backend-id")
+    let canonicalTask = task(id: "replacement-backend-id")
+    let viewModel = TasksViewModel(restoreTaskOperation: { task in
+      XCTAssertEqual(task.id, deletedTask.id)
+      return canonicalTask
+    })
+    viewModel.recomputeDisplayCaches()
+    viewModel.undoStack = [
+      TasksViewModel.UndoableAction(task: deletedTask, timestamp: Date())
+    ]
+
+    await viewModel.undoLastDelete()
+
+    XCTAssertEqual(viewModel.displayTasks.map(\.id), [canonicalTask.id])
+    XCTAssertEqual(viewModel.categorizedTasks[.today]?.map(\.id), [canonicalTask.id])
+    XCTAssertFalse(viewModel.displayTasks.contains { $0.id == deletedTask.id })
+  }
+
+  /// If the local restore cannot commit (for example after an owner change),
+  /// the UI must not show a row whose backing task does not exist.
+  func testUndoDoesNotRenderDeletedSnapshotWhenRestoreFails() async {
+    let deletedTask = task(id: "deleted-backend-id")
+    let viewModel = TasksViewModel(restoreTaskOperation: { _ in nil })
+    viewModel.recomputeDisplayCaches()
+    viewModel.undoStack = [
+      TasksViewModel.UndoableAction(task: deletedTask, timestamp: Date())
+    ]
+
+    await viewModel.undoLastDelete()
+
+    XCTAssertTrue(viewModel.displayTasks.isEmpty)
+    XCTAssertTrue(viewModel.categorizedTasks.values.allSatisfy(\.isEmpty))
+  }
+
+  private func task(id: String) -> TaskActionItem {
+    TaskActionItem(
+      id: id,
+      description: "restored task",
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 0)
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260910-undo-canonical-task-id.json
+++ b/desktop/macos/changelog/unreleased/20260910-undo-canonical-task-id.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed task Undo showing a restored task under a deleted identity until refresh"
+}


### PR DESCRIPTION
## What changed and why

Fixes task Undo on macOS so the UI renders the task identity that was actually restored, rather than resurrecting the deleted snapshot and its dead backend ID. `TasksStore.restoreTask` now returns the canonical restored `TaskActionItem`, and `TasksViewModel.undoLastDelete()` uses that result for every display projection. Closes #13329.

The failure was split mutation authority: the store/SQLite row moved to the backend's replacement ID after delete-and-recreate, while the view model independently reinserted the old undo-stack snapshot. The row looked restored, but an immediate edit, completion toggle, or delete could target the already-deleted ID until refresh rebuilt the UI.

The restore contract now makes each outcome explicit:

- successful backend recreation returns the replacement backend task;
- a backend recreation failure returns the preserved staged local task so retry can continue from the identity that exists locally;
- a local insertion failure or stale owner lease returns `nil`, so no unbacked row is rendered;
- local-only undo returns the actual row reinserted into local storage.

## Product invariants affected

- INV-NAV-1
- INV-TASK-1

## How it was verified

- Built and launched the isolated named bundle `/Applications/omi-13329-undo-canonical.app` (`com.omi.omi-13329-undo-canonical`) against a synthetic task backend on `127.0.0.1:48961`; production Omi/Omi Beta were not launched, stopped, or modified.
- Created `issue-13329-canonical-proof` as `issue-13329-remote-1`, deleted it through the real undoable view-model path, then invoked Undo. The backend recreated it as `issue-13329-remote-2`.
- Immediately after Undo, the live bridge reported one visible task and one store task, both `issue-13329-remote-2`; `deleted_id_still_visible=false` and `projection_matches_store=true`.
- The isolated bundle's SQLite database contained exactly one active row with ID `issue-13329-remote-2` and `completed=false`.
- Backend trace showed one create for `remote-1`, one delete for `remote-1`, and one recreate for `remote-2`. App logs confirmed the local row was rebound and reported `Restored task via undo (new backend ID: issue-13329-remote-2)`.

## Tests

- `xcrun swift test -c debug --package-path Desktop --filter 'TasksViewModelUndoTests|ActionItemLocalIdentityMutationTests|APIClientCreateActionItemCompletedTests'` — 11 tests passed, 0 failures.
- `TasksViewModelUndoTests.testUndoUsesCanonicalRestoredTaskInEveryDisplayProjection` proves both visible projections use the replacement identity and reject the deleted identity.
- `TasksViewModelUndoTests.testUndoDoesNotRenderDeletedSnapshotWhenRestoreFails` proves a failed local restore cannot surface an unbacked task.
- `./scripts/swift-test-suites.sh` — all 852 Swift suites passed in isolated processes.
- `./scripts/swiftlint-wrapper.sh lint` — 0 violations across 1,686 Swift files.
- `python3 scripts/check_desktop_test_quality.py` — passed at the existing ratchet (53 source-reading files / 143 sites, 16 waits).
- Pinned `swift-format` passed for every changed Swift file. The optional repository-wide format scan still reports five pre-existing violations in untouched `APIClient.swift` and Bluetooth sources; this PR adds none.
- Cross-surface agent logic harness — passed.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## Review disclosures

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift | 6680 -> 6689 | The narrow Undo projection fix and its injectable production seam add nine lines to the existing Tasks page owner.
Line-Count-Exception: desktop/macos/Desktop/Sources/Stores/TasksStore.swift | 3706 -> 3713 | Returning the canonical restored task requires seven net lines in the existing task mutation owner.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

