### PR TITLE
ci(python-cli): verify clean install of the built wheel

### DIFF
--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check dist/*
 
+      - name: Verify clean install of the built wheel
+        run: bash verify-clean-install.sh dist
+
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -52,3 +52,28 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -q
+
+  install-smoke:
+    name: Clean install smoke (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Python 3.10 installs an extra runtime dependency (tomli, selected by
+        # an environment marker), so both supported versions must install and
+        # start the CLI.
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build the wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Verify clean install of the built wheel
+        run: bash verify-clean-install.sh dist

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Install each built artifact into a clean environment and run the console
+# script.
+#
+# The editable dev install (`pip install -e ".[dev]"`) cannot catch a runtime
+# dependency declaration that is missing or too loose, because the dev extras
+# pull in packages the runtime does not declare. omi-cli 0.2.3 shipped that way:
+# its metadata omitted `click` while `omi_cli/main.py` imports it, pip resolved
+# typer 0.27.2 (which no longer depends on click), and every new user's first
+# `omi --version` raised ModuleNotFoundError.
+#
+# Every artifact in the dist directory is verified, so a malformed sdist cannot
+# pass `twine check` and reach PyPI without an installation test. The version
+# the entry point prints is also cross-checked against the version declared in
+# that same artifact's own metadata, so a stale or drifted declared version
+# cannot ship silently.
+#
+# Usage: ./verify-clean-install.sh [dist-dir]   (default: dist)
+set -euo pipefail
+
+dist_dir="${1:-dist}"
+
+shopt -s nullglob
+artifacts=("$dist_dir"/*.whl "$dist_dir"/*.tar.gz)
+shopt -u nullglob
+
+if [ ${#artifacts[@]} -eq 0 ]; then
+  echo "no wheel or sdist found in $dist_dir" >&2
+  exit 1
+fi
+
+# Print the version an artifact declares in its own metadata: the wheel's
+# *.dist-info/METADATA or the sdist's PKG-INFO.
+artifact_version() {
+  python - "$1" <<'PY'
+import sys
+import tarfile
+import zipfile
+
+path = sys.argv[1]
+if path.endswith(".whl"):
+    with zipfile.ZipFile(path) as archive:
+        member = next(
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        )
+        text = archive.read(member).decode("utf-8", "replace")
+else:
+    with tarfile.open(path) as archive:
+        member = next(
+            entry for entry in archive.getmembers() if entry.name.endswith("PKG-INFO")
+        )
+        text = archive.extractfile(member).read().decode("utf-8", "replace")
+
+for line in text.splitlines():
+    if line.startswith("Version:"):
+        print(line.split(":", 1)[1].strip())
+        break
+PY
+}
+
+for artifact in "${artifacts[@]}"; do
+  echo "=== $artifact ==="
+
+  declared_version="$(artifact_version "$artifact")"
+  if [ -z "$declared_version" ]; then
+    echo "no declared version found in $artifact" >&2
+    exit 1
+  fi
+
+  venv_dir="$(mktemp -d)"
+  python -m venv "$venv_dir"
+
+  # Detect the layout only after the venv exists: `mktemp -d` returns an empty
+  # directory, so probing for bin/ before creating the venv always fell back to
+  # Scripts/ and broke every Linux run.
+  venv_bin="$venv_dir/bin"
+  if [ ! -d "$venv_bin" ]; then
+    venv_bin="$venv_dir/Scripts"
+  fi
+
+  venv_python="$venv_bin/python"
+  if [ ! -x "$venv_python" ] && [ -x "$venv_bin/python.exe" ]; then
+    venv_python="$venv_bin/python.exe"
+  fi
+  if [ ! -x "$venv_python" ]; then
+    echo "no interpreter found in $venv_bin (venv creation failed?)" >&2
+    rm -rf "$venv_dir"
+    exit 1
+  fi
+
+  "$venv_python" -m pip install --upgrade pip > /dev/null
+  "$venv_python" -m pip install "$artifact"
+
+  echo "--- installed runtime dependencies ---"
+  "$venv_python" -m pip list --format=freeze
+
+  echo "--- console script ---"
+  printed_version="$("$venv_bin/omi" --version)"
+  echo "$printed_version"
+  "$venv_bin/omi" --help > /dev/null
+
+  expected_version="omi-cli $declared_version"
+  if [ "$printed_version" != "$expected_version" ]; then
+    echo "version drift: $artifact declares '$declared_version' but the CLI prints '$printed_version' (expected '$expected_version')" >&2
+    rm -rf "$venv_dir"
+    exit 1
+  fi
+
+  rm -rf "$venv_dir"
+  echo "clean install smoke: ok ($artifact, version $declared_version)"
+done


### PR DESCRIPTION
ci(python-cli): gate releases on a clean-install smoke test

Adds a clean-install smoke test that the publish workflow runs before uploading,
so an artifact with a missing or too-loose runtime dependency cannot reach PyPI.
This is the guard proposed in #13410.

Why: the publish workflow validated metadata with `twine check` but never
installed what it was about to publish, and the PR lane installs `-e ".[dev]"`,
where dev extras hide a missing runtime dependency. omi-cli 0.2.3 shipped that
way - its metadata omitted `click` while `omi_cli/main.py` imports it, pip
resolved typer 0.27.2 (no longer depending on click), and every fresh install
failed with `ModuleNotFoundError: No module named 'click'`.

What it does:
- `sdks/python-cli/verify-clean-install.sh` installs every artifact in the dist
  directory into a clean venv, runs the console script, and cross-checks the
  version it prints against the version that artifact declares in its own
  metadata (wheel `*.dist-info/METADATA`, sdist `PKG-INFO`).
- `.github/workflows/publish_omi_cli.yml` runs it between `twine check` and
  the artifact upload; the publish job's permissions are untouched.
- `.github/workflows/python-cli-ci.yml` adds an `install-smoke` job on 3.10
  and 3.12, because 3.10 selects an extra runtime dependency (`tomli`) through
  an environment marker.
## Verification

- Local: ash verify-clean-install.sh dist against both artifacts built from
  main - wheel and sdist install into clean venvs, resolve typer 0.25.1 with
  click 8.5.0 present, print omi-cli 0.3.0, and pass the new version cross-check.
- CI on the previous head already ran the new gate: **Clean install smoke
  (Python 3.10)** and **(Python 3.12)** both passed, alongside Linux 3.10/3.12 and
  Windows ACL.
- python .github/scripts/pr_preflight.py --lane local passes for this diff
  except workflow-apt-network-bounds, which cannot build webrtcvad locally on
  Windows (no MSVC); it passed in CI on the previous head.

## Bounty

Proposed US bounty per the contribution guide - see #13410.