### PR TITLE
fix(sdks/python-cli): treat empty HTTP error responses as failures

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -184,9 +184,9 @@ class OmiClient:
         raise RuntimeError("unreachable")
 
     def _handle_response(self, response: httpx.Response) -> Any:
-        if response.status_code == 204 or not response.content:
-            return None
         if 200 <= response.status_code < 300:
+            if response.status_code == 204 or not response.content:
+                return None
             return _safe_parse_json(response)
         raise self._error_from_response(response)
 

--- a/sdks/python-cli/tests/test_client_empty_response.py
+++ b/sdks/python-cli/tests/test_client_empty_response.py
@@ -1,0 +1,62 @@
+"""Tests for empty HTTP response handling in OmiClient."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omi_cli.client import OmiClient
+from omi_cli.config import Profile
+from omi_cli.errors import AuthError, CliError, NotFoundError, RateLimitError, ServerError
+
+
+@pytest.fixture
+def dummy_client() -> OmiClient:
+    profile = Profile(
+        name="test",
+        auth_method="api_key",
+        api_key="omi_dev_test_1234567890abcdef12345678",
+        api_base="https://api.test.omi.local",
+    )
+    return OmiClient(profile)
+
+
+def test_handle_response_empty_200_returns_none(dummy_client: OmiClient) -> None:
+    resp = httpx.Response(200, content=b"")
+    assert dummy_client._handle_response(resp) is None
+
+
+def test_handle_response_204_returns_none(dummy_client: OmiClient) -> None:
+    resp = httpx.Response(204, content=b"")
+    assert dummy_client._handle_response(resp) is None
+
+
+def test_handle_response_200_json_returns_parsed_data(dummy_client: OmiClient) -> None:
+    resp = httpx.Response(200, json={"key": "val"})
+    assert dummy_client._handle_response(resp) == {"key": "val"}
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_error,expected_exit_code",
+    [
+        (400, CliError, 1),
+        (401, AuthError, 2),
+        (403, AuthError, 2),
+        (404, NotFoundError, 5),
+        (422, CliError, 1),
+        (429, RateLimitError, 4),
+        (500, ServerError, 3),
+        (502, ServerError, 3),
+        (503, ServerError, 3),
+    ],
+)
+def test_handle_response_empty_error_raises_exception(
+    dummy_client: OmiClient,
+    status_code: int,
+    expected_error: type[Exception],
+    expected_exit_code: int,
+) -> None:
+    resp = httpx.Response(status_code, content=b"")
+    with pytest.raises(expected_error) as exc_info:
+        dummy_client._handle_response(resp)
+    assert exc_info.value.exit_code == expected_exit_code

--- a/sdks/python-cli/tests/test_delete_output.py
+++ b/sdks/python-cli/tests/test_delete_output.py
@@ -53,3 +53,30 @@ def test_delete_declined_confirmation_makes_no_request(resource, authed_profile,
 
     assert result.exit_code != 0
     assert not route.called
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500])
+def test_delete_empty_http_error_fails_json_mode(
+    resource, status_code, authed_profile, respx_mock, cli_runner
+) -> None:
+    command, path = resource
+    route = respx_mock.delete(path).respond(status_code, content=b"")
+    result = cli_runner.invoke(app, ["--json", command, "delete", "test-id", "--yes"])
+
+    assert result.exit_code != 0, f"Expected non-zero exit code on empty {status_code}"
+    expected_calls = 4 if status_code >= 500 else 1
+    assert route.call_count == expected_calls
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500])
+def test_delete_empty_http_error_fails_pretty_mode(
+    resource, status_code, authed_profile, respx_mock, cli_runner
+) -> None:
+    command, path = resource
+    route = respx_mock.delete(path).respond(status_code, content=b"")
+    result = cli_runner.invoke(app, ["--no-color", command, "delete", "test-id", "--yes"])
+
+    assert result.exit_code != 0, f"Expected non-zero exit code on empty {status_code}"
+    expected_calls = 4 if status_code >= 500 else 1
+    assert route.call_count == expected_calls
+    assert "Deleted" not in result.stderr

--- a/sdks/python-cli/tests/test_delete_output.py
+++ b/sdks/python-cli/tests/test_delete_output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 
 import pytest
 
@@ -57,8 +58,9 @@ def test_delete_declined_confirmation_makes_no_request(resource, authed_profile,
 
 @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500])
 def test_delete_empty_http_error_fails_json_mode(
-    resource, status_code, authed_profile, respx_mock, cli_runner
+    resource, status_code, authed_profile, respx_mock, cli_runner, monkeypatch
 ) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
     command, path = resource
     route = respx_mock.delete(path).respond(status_code, content=b"")
     result = cli_runner.invoke(app, ["--json", command, "delete", "test-id", "--yes"])
@@ -70,8 +72,9 @@ def test_delete_empty_http_error_fails_json_mode(
 
 @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 500])
 def test_delete_empty_http_error_fails_pretty_mode(
-    resource, status_code, authed_profile, respx_mock, cli_runner
+    resource, status_code, authed_profile, respx_mock, cli_runner, monkeypatch
 ) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _: None)
     command, path = resource
     route = respx_mock.delete(path).respond(status_code, content=b"")
     result = cli_runner.invoke(app, ["--no-color", command, "delete", "test-id", "--yes"])


### PR DESCRIPTION
## Summary
Fixes an issue where `OmiClient._handle_response` treated empty HTTP error responses (e.g. 401, 403, 404, 500 without a body) as success, because the `not response.content` check was performed before validating status code boundaries.

## Changes
- In `sdks/python-cli/omi_cli/client.py`: move empty content check inside the `200 <= response.status_code < 300` branch.
- Preserves existing 204 No Content and empty 2xx success handling (returns `None` / JSON `null`).
- Routes non-2xx empty responses into `_error_from_response`, properly raising corresponding `CliError` exceptions (`AuthError`, `NotFoundError`, `RateLimitError`, `ServerError`, `UsageError`).
- Added unit tests in `sdks/python-cli/tests/test_client_empty_response.py` verifying status-to-exception mapping for empty responses.
- Extended `sdks/python-cli/tests/test_delete_output.py` across all four resource types (`memory`, `conversation`, `action-item`, `goal`) in both JSON and pretty modes to verify non-zero exit codes on empty HTTP errors.

## Verification
- `pytest sdks/python-cli/tests/test_client_empty_response.py sdks/python-cli/tests/test_delete_output.py`: all 68 tests passing.
- `git diff --check HEAD~1..HEAD` passes cleanly.

Closes #13390
Failure-Class: none
Co-authored-by: baibenyu <baibenyu@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

