### PR TITLE
fix(mcp): support MCP 2.0 while maintaining backwards compatibility

### DIFF
--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -277,146 +277,175 @@ def search_conversations(
     return response.json()
 
 
+def _get_tools() -> list[Tool]:
+    return [
+        Tool(
+            name=OmiTools.GET_MEMORIES,
+            description="Retrieve a list of memories. A memory is a known fact about the user across multiple domains.",
+            inputSchema=GetMemories.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.SEARCH_MEMORIES,
+            description="Semantic search across memories. Returns memories ranked by relevance to a natural language query.",
+            inputSchema=SearchMemories.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.CREATE_MEMORY,
+            description="Create a new memory. A memory is a known fact about the user across multiple domains.",
+            inputSchema=CreateMemory.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.DELETE_MEMORY,
+            description="Delete a memory by ID. A memory is a known fact about the user across multiple domains.",
+            inputSchema=DeleteMemory.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.EDIT_MEMORY,
+            description="Edit a memory's content. A memory is a known fact about the user across multiple domains.",
+            inputSchema=EditMemory.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.GET_CONVERSATIONS,
+            description="Retrieve a list of conversation metadata. To get full transcripts, use get_conversation_by_id.",
+            inputSchema=GetConversations.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.GET_CONVERSATION_BY_ID,
+            description="Retrieve a conversation by ID including each segment of the transcript.",
+            inputSchema=GetConversationById.model_json_schema(),
+        ),
+        Tool(
+            name=OmiTools.SEARCH_CONVERSATIONS,
+            description="Semantic search across conversations. Returns conversations ranked by relevance to a natural language query.",
+            inputSchema=SearchConversations.model_json_schema(),
+        ),
+    ]
+
+
+async def _execute_tool(name: str, arguments: dict, logger: logging.Logger) -> list[TextContent]:
+    logger.info(f"Calling tool: {name} with arguments: {arguments}")
+
+    api_key = arguments.get("api_key") or os.getenv("OMI_API_KEY")
+    if not api_key:
+        raise ValueError("API key not provided and OMI_API_KEY environment variable not set.")
+
+    if name == OmiTools.GET_MEMORIES:
+        categories_enum = _parse_categories(arguments.get("categories", []), MemoryCategory, logger)
+
+        result = get_memories(
+            logger,
+            api_key,
+            offset=arguments.get("offset", 0),
+            limit=arguments.get("limit", 100),
+            categories=categories_enum,
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.SEARCH_MEMORIES:
+        query = arguments.get("query")
+        if not query:
+            raise ValueError("query is required for search_memories")
+        result = search_memories(
+            logger,
+            api_key,
+            query=query,
+            limit=arguments.get("limit", 10),
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.CREATE_MEMORY:
+        result = create_memory(
+            api_key,
+            content=arguments["content"],
+            category=arguments["category"],
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.DELETE_MEMORY:
+        result = delete_memory(api_key, memory_id=arguments["memory_id"])
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.EDIT_MEMORY:
+        result = edit_memory(
+            api_key,
+            memory_id=arguments["memory_id"],
+            content=arguments["content"],
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.GET_CONVERSATIONS:
+        categories_enum = _parse_categories(arguments.get("categories", []), ConversationCategory, logger)
+
+        result = get_conversations(
+            logger,
+            api_key,
+            start_date=arguments.get("start_date"),
+            end_date=arguments.get("end_date"),
+            categories=categories_enum,
+            limit=arguments.get("limit", 20),
+            offset=arguments.get("offset", 0),
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.GET_CONVERSATION_BY_ID:
+        result = get_conversation_by_id(api_key, conversation_id=arguments["conversation_id"])
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    elif name == OmiTools.SEARCH_CONVERSATIONS:
+        query = arguments.get("query")
+        if not query:
+            raise ValueError("query is required for search_conversations")
+        result = search_conversations(
+            logger,
+            api_key,
+            query=query,
+            limit=arguments.get("limit", 10),
+            start_date=arguments.get("start_date"),
+            end_date=arguments.get("end_date"),
+        )
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    raise ValueError(f"Unknown tool: {name}")
+
+
+def create_server(logger: Optional[logging.Logger] = None) -> Server:
+    log = logger or logging.getLogger(__name__)
+
+    if hasattr(Server, "list_tools"):
+        server = Server("mcp-omi")
+
+        @server.list_tools()
+        async def list_tools() -> list[Tool]:
+            return _get_tools()
+
+        @server.call_tool()
+        async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+            return await _execute_tool(name, arguments, log)
+
+        return server
+    else:
+        async def on_list_tools(ctx, params):
+            from mcp.types import ListToolsResult
+            return ListToolsResult(tools=_get_tools())
+
+        async def on_call_tool(ctx, params):
+            from mcp.types import CallToolResult
+            name = params.name
+            arguments = params.arguments or {}
+            content = await _execute_tool(name, arguments, log)
+            return CallToolResult(content=content)
+
+        return Server(
+            "mcp-omi",
+            on_list_tools=on_list_tools,
+            on_call_tool=on_call_tool,
+        )
+
+
 async def serve(uid: str | None) -> None:
     logger = logging.getLogger(__name__)
-    # if uid is not None:
-    #     logger.info(f"Using uid: {uid}")
-
-    server = Server("mcp-omi")
+    server = create_server(logger)
     logger.info("mcp-omi server started")
-
-    @server.list_tools()
-    async def list_tools() -> list[Tool]:
-        return [
-            Tool(
-                name=OmiTools.GET_MEMORIES,
-                description="Retrieve a list of memories. A memory is a known fact about the user across multiple domains.",
-                inputSchema=GetMemories.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.SEARCH_MEMORIES,
-                description="Semantic search across memories. Returns memories ranked by relevance to a natural language query.",
-                inputSchema=SearchMemories.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.CREATE_MEMORY,
-                description="Create a new memory. A memory is a known fact about the user across multiple domains.",
-                inputSchema=CreateMemory.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.DELETE_MEMORY,
-                description="Delete a memory by ID. A memory is a known fact about the user across multiple domains.",
-                inputSchema=DeleteMemory.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.EDIT_MEMORY,
-                description="Edit a memory's content. A memory is a known fact about the user across multiple domains.",
-                inputSchema=EditMemory.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.GET_CONVERSATIONS,
-                description="Retrieve a list of conversation metadata. To get full transcripts, use get_conversation_by_id.",
-                inputSchema=GetConversations.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.GET_CONVERSATION_BY_ID,
-                description="Retrieve a conversation by ID including each segment of the transcript.",
-                inputSchema=GetConversationById.model_json_schema(),
-            ),
-            Tool(
-                name=OmiTools.SEARCH_CONVERSATIONS,
-                description="Semantic search across conversations. Returns conversations ranked by relevance to a natural language query.",
-                inputSchema=SearchConversations.model_json_schema(),
-            ),
-        ]
-
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
-        logger.info(f"Calling tool: {name} with arguments: {arguments}")
-
-        api_key = arguments.get("api_key") or os.getenv("OMI_API_KEY")
-        if not api_key:
-            raise ValueError("API key not provided and OMI_API_KEY environment variable not set.")
-
-        if name == OmiTools.GET_MEMORIES:
-            # return [TextContent(type="text", text=json.dumps(arguments, indent=2))]
-            categories_enum = _parse_categories(arguments.get("categories", []), MemoryCategory, logger)
-
-            result = get_memories(
-                logger,
-                api_key,
-                offset=arguments.get("offset", 0),
-                limit=arguments.get("limit", 100),
-                categories=categories_enum,
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.SEARCH_MEMORIES:
-            query = arguments.get("query")
-            if not query:
-                raise ValueError("query is required for search_memories")
-            result = search_memories(
-                logger,
-                api_key,
-                query=query,
-                limit=arguments.get("limit", 10),
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.CREATE_MEMORY:
-            # return [TextContent(type="text", text=json.dumps(arguments, indent=2))]
-            result = create_memory(
-                api_key,
-                content=arguments["content"],
-                category=arguments["category"],
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.DELETE_MEMORY:
-            result = delete_memory(api_key, memory_id=arguments["memory_id"])
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.EDIT_MEMORY:
-            result = edit_memory(
-                api_key,
-                memory_id=arguments["memory_id"],
-                content=arguments["content"],
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.GET_CONVERSATIONS:
-            categories_enum = _parse_categories(arguments.get("categories", []), ConversationCategory, logger)
-
-            result = get_conversations(
-                logger,
-                api_key,
-                start_date=arguments.get("start_date"),
-                end_date=arguments.get("end_date"),
-                categories=categories_enum,
-                limit=arguments.get("limit", 20),
-                offset=arguments.get("offset", 0),
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.GET_CONVERSATION_BY_ID:
-            result = get_conversation_by_id(api_key, conversation_id=arguments["conversation_id"])
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        elif name == OmiTools.SEARCH_CONVERSATIONS:
-            query = arguments.get("query")
-            if not query:
-                raise ValueError("query is required for search_conversations")
-            result = search_conversations(
-                logger,
-                api_key,
-                query=query,
-                limit=arguments.get("limit", 10),
-                start_date=arguments.get("start_date"),
-                end_date=arguments.get("end_date"),
-            )
-            return [TextContent(type="text", text=json.dumps(result, indent=2))]
-
-        raise ValueError(f"Unknown tool: {name}")
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):

--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -323,7 +323,8 @@ def _get_tools() -> list[Tool]:
 
 
 async def _execute_tool(name: str, arguments: dict, logger: logging.Logger) -> list[TextContent]:
-    logger.info(f"Calling tool: {name} with arguments: {arguments}")
+    log_args = {k: (v if k != "api_key" else "***") for k, v in arguments.items()}
+    logger.info(f"Calling tool: {name} with arguments: {log_args}")
 
     api_key = arguments.get("api_key") or os.getenv("OMI_API_KEY")
     if not api_key:

--- a/mcp/tests/test_server_lifecycle.py
+++ b/mcp/tests/test_server_lifecycle.py
@@ -80,3 +80,53 @@ async def test_execute_tool_redacts_api_key_in_logs(monkeypatch: pytest.MonkeyPa
     logged_msg = mock_logger.info.call_args[0][0]
     assert "secret_key_123" not in logged_msg
     assert "***" in logged_msg
+
+
+@pytest.mark.anyio
+async def test_create_server_legacy_mcp_1_compatibility(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test legacy MCP 1.x initialization path using list_tools and call_tool decorators."""
+    class MockLegacyServer:
+        def __init__(self, name: str):
+            self.name = name
+            self.list_tools_handler = None
+            self.call_tool_handler = None
+
+        def list_tools(self):
+            def decorator(fn):
+                self.list_tools_handler = fn
+                return fn
+            return decorator
+
+        def call_tool(self):
+            def decorator(fn):
+                self.call_tool_handler = fn
+                return fn
+            return decorator
+
+    monkeypatch.setattr("mcp_server_omi.server.Server", MockLegacyServer)
+    server = create_server()
+    assert isinstance(server, MockLegacyServer)
+    assert server.name == "mcp-omi"
+    assert server.list_tools_handler is not None
+    assert server.call_tool_handler is not None
+
+    tools = await server.list_tools_handler()
+    assert len(tools) == 8
+    assert {t.name for t in tools} == {
+        OmiTools.GET_MEMORIES,
+        OmiTools.SEARCH_MEMORIES,
+        OmiTools.CREATE_MEMORY,
+        OmiTools.DELETE_MEMORY,
+        OmiTools.EDIT_MEMORY,
+        OmiTools.GET_CONVERSATIONS,
+        OmiTools.GET_CONVERSATION_BY_ID,
+        OmiTools.SEARCH_CONVERSATIONS,
+    }
+
+    monkeypatch.setattr("mcp_server_omi.server.get_memories", lambda *args, **kwargs: [{"id": "mem_1"}])
+    result = await server.call_tool_handler(
+        OmiTools.GET_MEMORIES,
+        {"api_key": "test_api_key_123", "offset": 0, "limit": 10},
+    )
+    assert len(result) == 1
+    assert "mem_1" in result[0].text

--- a/mcp/tests/test_server_lifecycle.py
+++ b/mcp/tests/test_server_lifecycle.py
@@ -1,0 +1,64 @@
+"""Tests for standalone MCP server startup, tool listing, and execution."""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+from mcp.client.session import ClientSession
+
+from mcp_server_omi.server import OmiTools, create_server, _get_tools
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_get_tools_contains_all_eight_tools() -> None:
+    tools = _get_tools()
+    assert len(tools) == 8
+    names = {t.name for t in tools}
+    expected = {
+        OmiTools.GET_MEMORIES,
+        OmiTools.SEARCH_MEMORIES,
+        OmiTools.CREATE_MEMORY,
+        OmiTools.DELETE_MEMORY,
+        OmiTools.EDIT_MEMORY,
+        OmiTools.GET_CONVERSATIONS,
+        OmiTools.GET_CONVERSATION_BY_ID,
+        OmiTools.SEARCH_CONVERSATIONS,
+    }
+    assert names == expected
+
+
+def test_create_server_constructs_without_error() -> None:
+    server = create_server()
+    assert server is not None
+    init_opts = server.create_initialization_options()
+    assert init_opts.capabilities.tools is not None
+
+
+@pytest.mark.anyio
+async def test_server_session_list_tools() -> None:
+    server = create_server()
+    init_opts = server.create_initialization_options()
+
+    client_send, server_receive = anyio.create_memory_object_stream(10)
+    server_send, client_receive = anyio.create_memory_object_stream(10)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(server.run, server_receive, server_send, init_opts)
+        async with ClientSession(client_receive, client_send) as session:
+            await session.initialize()
+            tool_res = await session.list_tools()
+            tool_names = [t.name for t in tool_res.tools]
+            assert len(tool_names) == 8
+            assert OmiTools.GET_MEMORIES in tool_names
+            assert OmiTools.SEARCH_MEMORIES in tool_names
+            assert OmiTools.CREATE_MEMORY in tool_names
+            assert OmiTools.DELETE_MEMORY in tool_names
+            assert OmiTools.EDIT_MEMORY in tool_names
+            assert OmiTools.GET_CONVERSATIONS in tool_names
+            assert OmiTools.GET_CONVERSATION_BY_ID in tool_names
+            assert OmiTools.SEARCH_CONVERSATIONS in tool_names
+            tg.cancel_scope.cancel()

--- a/mcp/tests/test_server_lifecycle.py
+++ b/mcp/tests/test_server_lifecycle.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+from unittest.mock import MagicMock
+
 import anyio
 import pytest
 from mcp.client.session import ClientSession
 
-from mcp_server_omi.server import OmiTools, create_server, _get_tools
+from mcp_server_omi.server import OmiTools, _execute_tool, _get_tools, create_server
 
 
 @pytest.fixture
@@ -62,3 +65,18 @@ async def test_server_session_list_tools() -> None:
             assert OmiTools.GET_CONVERSATION_BY_ID in tool_names
             assert OmiTools.SEARCH_CONVERSATIONS in tool_names
             tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
+async def test_execute_tool_redacts_api_key_in_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_logger = MagicMock(spec=logging.Logger)
+    monkeypatch.setattr("mcp_server_omi.server.get_memories", lambda *args, **kwargs: [])
+    await _execute_tool(
+        OmiTools.GET_MEMORIES,
+        {"api_key": "secret_key_123", "offset": 0, "limit": 10},
+        mock_logger,
+    )
+    mock_logger.info.assert_called_once()
+    logged_msg = mock_logger.info.call_args[0][0]
+    assert "secret_key_123" not in logged_msg
+    assert "***" in logged_msg


### PR DESCRIPTION
## Summary
Fixes an issue where `mcp-server-omi` could not start when running under `mcp>=2.0.0` (pinned in `mcp/pyproject.toml` under `constraint-dependencies` as `mcp==2.0.0`). Calling `serve(None)` failed at `@server.list_tools()` with:
```
AttributeError: 'Server' object has no attribute 'list_tools'
```

## Changes
- In `mcp/src/mcp_server_omi/server.py`:
  - Refactored tool extraction into `_get_tools()` and tool execution into `_execute_tool()`.
  - Added `create_server()` that adapts dynamically to the installed MCP version:
    - MCP 2.x: wires `on_list_tools` and `on_call_tool` handlers directly in the `Server` constructor.
    - MCP 1.x: falls back to `@server.list_tools()` and `@server.call_tool()` decorators.
  - `serve()` delegates to `create_server()` and starts stdio communication.
- Added test suite `mcp/tests/test_server_lifecycle.py`:
  - Verifies tool definition count and names across all 8 tools (`get_memories`, `search_memories`, `create_memory`, `delete_memory`, `edit_memory`, `get_conversations`, `get_conversation_by_id`, `search_conversations`).
  - Verifies initialization options and tool capability discovery.
  - Tests end-to-end client session tool listing over an in-memory transport.

## Verification
- `pytest mcp/tests/test_server_lifecycle.py`: all 3 tests passing under MCP 2.x.
- `git diff --check HEAD~1..HEAD` passes cleanly.

Closes #13020
Failure-Class: none
Co-authored-by: sowmyarang26-boop <sowmyarang26-boop@users.noreply.github.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

