### PR TITLE
fix(sdks/python-cli): clean up temp file when atomic config replacement fails

### DIFF
--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -258,18 +258,17 @@ def save(config: Config) -> None:
         try:
             with os.fdopen(fd, "wb") as fh:
                 tomli_w.dump(payload, fh)
+            # Atomic rename. The destination inherits the temp's 0o600 mode.
+            os.replace(tmp_path, config.path)
         except Exception:
-            # Best-effort cleanup if the dump itself failed mid-write.
+            # Best-effort cleanup if the dump or atomic replace failed.
             try:
                 os.unlink(tmp_path)
-            except FileNotFoundError:
+            except OSError:
                 pass
             raise
     finally:
         os.umask(old_umask)
-
-    # Atomic rename. The destination inherits the temp's 0o600 mode.
-    os.replace(tmp_path, config.path)
 
 
 def resolve_profile_name(cli_flag: Optional[str], config: Config) -> str:

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -380,3 +380,52 @@ def test_is_authenticated_states() -> None:
     p.id_token = None
     p.refresh_token = "refr..."
     assert p.is_authenticated()
+
+
+def test_save_cleans_up_temp_file_when_replace_fails(config_path: Path, monkeypatch) -> None:
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_sensitive_key"
+    config.set_profile(profile)
+
+    # Initial valid save
+    cfg.save(config)
+    original_bytes = config_path.read_bytes()
+
+    profile.api_key = "omi_dev_new_sensitive_key"
+    config.set_profile(profile)
+
+    def failing_replace(src, dst):
+        raise PermissionError("Access is denied")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+    with pytest.raises(PermissionError, match="Access is denied"):
+        cfg.save(config)
+
+    # No leftover .tmp files should exist in the directory
+    leftover_tmps = list(config_path.parent.glob(config_path.name + ".*.tmp"))
+    assert leftover_tmps == []
+
+    # Original config is preserved
+    assert config_path.read_bytes() == original_bytes
+
+
+def test_save_cleanup_failure_does_not_mask_original_replace_error(config_path: Path, monkeypatch) -> None:
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.api_key = "omi_dev_test"
+    config.set_profile(profile)
+
+    def failing_replace(src, dst):
+        raise PermissionError("Original replace failure")
+
+    def failing_unlink(path):
+        raise OSError("Unlink failure")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+    monkeypatch.setattr(os, "unlink", failing_unlink)
+
+    with pytest.raises(PermissionError, match="Original replace failure"):
+        cfg.save(config)


### PR DESCRIPTION
## Summary
Fixes an issue where `omi_cli.config.save` left a serialized, credential-bearing temporary file behind if the final atomic `os.replace` failed (e.g. when the destination configuration file was locked or permission was denied on Windows).

## Changes
- In `sdks/python-cli/omi_cli/config.py`:
  - Moved `os.replace(tmp_path, config.path)` inside the `try...except` cleanup boundary.
  - On failure, `os.unlink(tmp_path)` cleans up the temporary credential file.
  - Handled `OSError` during `unlink` so that secondary cleanup failures do not mask the original save/replace error.
- In `sdks/python-cli/tests/test_config.py`:
  - Added `test_save_cleans_up_temp_file_when_replace_fails` verifying that temp files are cleaned up and original config is preserved when `os.replace` fails.
  - Added `test_save_cleanup_failure_does_not_mask_original_replace_error` verifying that the original exception is preserved even if unlinking fails.

## Verification
- `pytest sdks/python-cli/tests/test_config.py`: all 26 tests pass.
- `git diff --check HEAD~1..HEAD` passes cleanly.

Closes #13421
Failure-Class: none
Co-authored-by: JTC-code-repo <JTC-code-repo@users.noreply.github.com>
