### PR TITLE
fix(desktop): activate the app's switches through a Button, not a bare tap

### DIFF
--- a/.github/failure-classes/FC-bare-tap-gesture-activation.json
+++ b/.github/failure-classes/FC-bare-tap-gesture-activation.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-bare-tap-gesture-activation",
+  "violated_contract": "A custom control's activation must accept the whole physical click, not only the clean-tap subset. A bare tap gesture fails whenever the pointer moves a few points between mouse-down and mouse-up inside the control, so a human click that is not a perfectly still tap reads as dead and the user must click again until one lands (observed live in QA on 2026-09-09: Settings switches reported flaky, 'click repeatedly until one lands'). The same bare gesture produces no accessibility element, so a switch built this way is invisible to assistive tech. On macOS a custom ToggleStyle also owns activation entirely — the framework adds no click handling around makeBody — so the style is the only place this contract can be met.",
+  "canonical_prevention": "Wrap the custom control's visual in a Button (plain button style) that drives the control's state: a button fires on up-inside-bounds however far the pointer wandered within the control and is an accessibility element by construction. Hold it with a synthetic-event harness that mounts the real control and asserts exactly one state write for both a still click and a click that drags inside the bounds, plus a static tripwire that no control style under Sources/Theme activates through a bare tap gesture.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/OmiToggleStyleActivationTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/Theme/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
@@ -46,21 +46,34 @@ package struct OmiToggleStyle: ToggleStyle {
     // so the style must not expand beyond the switch itself.
     HStack(spacing: OmiSpacing.sm) {
       configuration.label
-      ZStack(alignment: configuration.isOn ? .trailing : .leading) {
-        Capsule()
-          .fill(Self.trackFill(isOn: configuration.isOn))
-          .frame(width: width, height: height)
-
-        Circle()
-          .fill(Self.knobFill)
-          .frame(width: thumbSize, height: thumbSize)
-          .padding(thumbPadding)
-          .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
-      }
-      .omiAnimation(.easeInOut(duration: 0.15), value: configuration.isOn)
-      .onTapGesture {
+      // A custom `ToggleStyle` owns activation on macOS — the framework adds no click handling
+      // around `makeBody` — and the previous bare tap gesture had two measured defects: it drops
+      // any click whose up-event drifts a few points from its down-event (the user must click
+      // again until a clean tap lands), and it produces no accessibility element at all, so the
+      // app's switches were invisible to assistive tech. A `Button` fires on up-inside-bounds
+      // however far the pointer wandered within the control and is an accessibility element by
+      // construction. `OmiToggleStyleActivationTests` holds both claims.
+      //
+      // The label is a fallback only: every call site passes an empty title, and a style cannot
+      // read a string out of `configuration.label`, so per-feature names belong at the call sites.
+      Button {
         configuration.isOn.toggle()
+      } label: {
+        ZStack(alignment: configuration.isOn ? .trailing : .leading) {
+          Capsule()
+            .fill(Self.trackFill(isOn: configuration.isOn))
+            .frame(width: width, height: height)
+
+          Circle()
+            .fill(Self.knobFill)
+            .frame(width: thumbSize, height: thumbSize)
+            .padding(thumbPadding)
+            .shadow(color: .black.opacity(0.15), radius: 1, x: 0, y: 1)
+        }
       }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Switch")
+      .omiAnimation(.easeInOut(duration: 0.15), value: configuration.isOn)
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
+++ b/desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
@@ -73,6 +73,11 @@ package struct OmiToggleStyle: ToggleStyle {
       }
       .buttonStyle(.plain)
       .accessibilityLabel("Switch")
+      // The element exists (a Button is one by construction) but a switch must also *say* its
+      // state: without a value, assistive tech finds the control yet cannot tell on from off.
+      // The label stays the generic fallback — a style cannot read a string out of
+      // `configuration.label`, and per-feature names belong at the call sites.
+      .accessibilityValue(configuration.isOn ? "on" : "off")
       .omiAnimation(.easeInOut(duration: 0.15), value: configuration.isOn)
     }
   }

--- a/desktop/macos/Desktop/Tests/OmiToggleStyleActivationTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiToggleStyleActivationTests.swift
@@ -65,11 +65,18 @@ final class OmiToggleStyleActivationTests: XCTestCase {
   func testAClickThatDragsInsideTheSwitchStillWritesTheBindingExactlyOnce() throws {
     let latch = SetCountingLatch(isOn: false)
 
-    // Five points of drag, staying well inside the 36×20 track. A human click that isn't a clean
-    // tap moves about this much; the switch's own width is 36, so the whole sequence stays on it.
+    // Five points of drag, staying well inside the 36×20 track, delivered as a real drag: a
+    // `leftMouseDragged` at each intermediate point between the down and the up, which is the
+    // event stream a physical drag produces — not a relocated click. A human click that isn't a
+    // clean tap moves about this much; the switch's own width is 36, so the whole sequence stays
+    // on it.
     click(
       on: styledToggle(latch),
       down: Self.center,
+      dragThrough: [
+        CGPoint(x: Self.center.x + 2, y: Self.center.y),
+        CGPoint(x: Self.center.x + 4, y: Self.center.y),
+      ],
       up: CGPoint(x: Self.center.x + 5, y: Self.center.y))
 
     XCTAssertEqual(
@@ -139,13 +146,16 @@ final class OmiToggleStyleActivationTests: XCTestCase {
 
   // MARK: - Driving a real click
 
-  /// Dispatches a real `leftMouseDown`/`leftMouseUp` pair into a window hosting `view` — the
-  /// `ShellModalScrimDismissTests` harness. Synthetic clicks rather than calls into the style,
-  /// because the thing under test is whether one physical click activates the control exactly
-  /// once, which is a fact about event/gesture routing, not about any one handler. The host is
-  /// square and the view is pinned to its center, so the SwiftUI center and the AppKit center
-  /// (origin bottom-left) are the same point.
-  private func click(on view: some View, down: CGPoint, up: CGPoint) {
+  /// Dispatches a real `leftMouseDown` / `leftMouseDragged`… / `leftMouseUp` sequence into a
+  /// window hosting `view` — the `ShellModalScrimDismissTests` harness, extended with drag
+  /// events. Synthetic clicks rather than calls into the style, because the thing under test is
+  /// whether one physical click activates the control exactly once, which is a fact about
+  /// event/gesture routing, not about any one handler. `dragThrough` is empty for a clean click
+  /// (down and up at the same point, nothing between); for a dragged click it carries the
+  /// intermediate points a physical drag delivers between down and up. The host is square and
+  /// the view is pinned to its center, so the SwiftUI center and the AppKit center (origin
+  /// bottom-left) are the same point.
+  private func click(on view: some View, down: CGPoint, dragThrough: [CGPoint] = [], up: CGPoint) {
     let size = Self.hostSize
     let host = NSHostingView(rootView: view)
     host.frame = NSRect(origin: .zero, size: size)
@@ -166,11 +176,20 @@ final class OmiToggleStyleActivationTests: XCTestCase {
     let downEvent = NSEvent.mouseEvent(
       with: .leftMouseDown, location: toAppKit(down), modifierFlags: [], timestamp: 0,
       windowNumber: window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1)
+    if let downEvent { window.sendEvent(downEvent) }
+    for (index, point) in dragThrough.enumerated() {
+      if let dragEvent = NSEvent.mouseEvent(
+        with: .leftMouseDragged, location: toAppKit(point), modifierFlags: [], timestamp: 0.005,
+        windowNumber: window.windowNumber, context: nil, eventNumber: 2 + index, clickCount: 1,
+        pressure: 1)
+      {
+        window.sendEvent(dragEvent)
+      }
+    }
     let upEvent = NSEvent.mouseEvent(
       with: .leftMouseUp, location: toAppKit(up), modifierFlags: [], timestamp: 0.01,
-      windowNumber: window.windowNumber, context: nil, eventNumber: 2, clickCount: 1, pressure: 0)
-
-    if let downEvent { window.sendEvent(downEvent) }
+      windowNumber: window.windowNumber, context: nil,
+      eventNumber: 2 + dragThrough.count, clickCount: 1, pressure: 0)
     if let upEvent { window.sendEvent(upEvent) }
   }
 

--- a/desktop/macos/Desktop/Tests/OmiToggleStyleActivationTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiToggleStyleActivationTests.swift
@@ -1,0 +1,196 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// **One click on a switch flips it exactly once — including a click that drags.**
+///
+/// `OmiToggleStyle` used to activate on a bare `.onTapGesture`. That had two verified defects:
+///
+/// 1. **Drag intolerance.** A tap gesture fails when the pointer moves between down and up, and a
+///    human click often moves a few points inside the control — the click reads as dead and the
+///    user must click again until a clean tap lands. This is the shape of the QA observation on
+///    2026-09-09 (Settings toggles "flaky, click repeatedly until one lands"): a `Button`'s
+///    activation tracks down-then-up anywhere inside the control, so the same event sequence that
+///    a tap gesture drops still fires it.
+/// 2. **No accessibility.** A bare gesture on drawn shapes produces no accessibility element, so
+///    the app's switches had nothing for assistive tech to find; `Button` is an element by
+///    construction (Apple's documented pattern for custom `ToggleStyle`s). This claim is held by
+///    construction rather than by a live query: the Settings page wraps its content in an
+///    `AXOpaqueProviderGroup` whose subtree System Events cannot see (and often serves stale), a
+///    pre-existing page-level opacity that hides every control on the page equally — before and
+///    after this change alike. Fixing that exposure is a separate, page-level follow-up.
+///
+/// A custom `ToggleStyle` gets no native activation from the framework on macOS — the style owns
+/// activation (Apple's canonical pattern wraps the visual in a `Button` that toggles
+/// `configuration.isOn`) — so these tests pin that the one activation path exists, fires exactly
+/// once, and tolerates a small drag. Driven with the `ShellModalScrimDismissTests` harness: a real
+/// `Toggle` wearing the production style in an `NSHostingView`, synthetic `NSEvent` pairs through
+/// `sendEvent`, recognised synchronously — nothing to wait for.
+@MainActor
+final class OmiToggleStyleActivationTests: XCTestCase {
+
+  private static let hostSize = CGSize(width: 300, height: 300)
+
+  // MARK: - One click, exactly one activation
+
+  /// A click whose up lands where its down did must write the binding exactly once.
+  ///
+  /// Two writes is a double-activation (a dead click: on, then immediately off); zero means
+  /// activation went missing entirely. Both directions are asserted: the count of writes, and the
+  /// state actually flipping.
+  func testOneClickOnTheStyledToggleWritesTheBindingExactlyOnce() throws {
+    let latch = SetCountingLatch(isOn: false)
+
+    click(
+      on: styledToggle(latch),
+      down: Self.center,
+      up: Self.center)
+
+    XCTAssertEqual(
+      latch.setCount, 1,
+      "one click on the switch must write the binding exactly once — two writes is a "
+        + "double-activation (a dead click), zero means activation went missing")
+    XCTAssertTrue(latch.isOn, "one click on an off switch must leave it on")
+  }
+
+  /// The claim this file exists for: a click that drags a few points *inside* the switch between
+  /// down and up must still activate it exactly once.
+  ///
+  /// A bare tap gesture drops this event sequence — the drag fails the tap recognition, the click
+  /// reads as dead, and the user must click again. A `Button` fires on up-inside-bounds however
+  /// far the pointer wandered within the control.
+  func testAClickThatDragsInsideTheSwitchStillWritesTheBindingExactlyOnce() throws {
+    let latch = SetCountingLatch(isOn: false)
+
+    // Five points of drag, staying well inside the 36×20 track. A human click that isn't a clean
+    // tap moves about this much; the switch's own width is 36, so the whole sequence stays on it.
+    click(
+      on: styledToggle(latch),
+      down: Self.center,
+      up: CGPoint(x: Self.center.x + 5, y: Self.center.y))
+
+    XCTAssertEqual(
+      latch.setCount, 1,
+      "a click that drags inside the switch must still activate it exactly once — a control "
+        + "that only answers clean taps reads as flaky")
+    XCTAssertTrue(latch.isOn, "a dragged click on an off switch must leave it on")
+  }
+
+  // MARK: - The style's one activation path
+
+  /// No file under `Sources/Theme/` may activate a control with a bare tap gesture, and the
+  /// toggle style must own exactly one activation path through a `Button`.
+  ///
+  /// A bare `.onTapGesture` is drag-intolerant and invisible to accessibility; gesture arbitration
+  /// is framework-internal so the class cannot be expressed behaviorally for every style body at
+  /// once. The click tests above hold the behavior for the toggle; this holds the boundary for the
+  /// whole style module.
+  func testThemeControlStylesActivateThroughButtonsNotBareTapGestures() throws {
+    let themeRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Theme")
+    let swiftFiles = try FileManager.default
+      .subpathsOfDirectory(atPath: themeRoot.path)
+      .filter { $0.hasSuffix(".swift") }
+      .sorted()
+    XCTAssertFalse(
+      swiftFiles.isEmpty, "precondition: the Theme module still exists where this test looks")
+
+    var toggleStyleSource: String?
+    for relativePath in swiftFiles {
+      // omi-test-quality: source-inspection -- static contract: Theme holds the custom control styles; activation is a Button (drag-tolerant, an accessibility element), and a bare tap gesture is neither.
+      let source = try String(contentsOf: themeRoot.appendingPathComponent(relativePath), encoding: .utf8)
+      XCTAssertFalse(
+        source.contains(".onTapGesture"),
+        """
+        \(relativePath) activates with a bare tap gesture. A tap gesture drops any click that \
+        drags inside the control and produces no accessibility element — wrap the control's \
+        visual in a Button that drives its state instead.
+        """)
+      if relativePath.hasSuffix("OmiToggleStyle.swift") {
+        toggleStyleSource = source
+      }
+    }
+
+    let style = try XCTUnwrap(toggleStyleSource, "the toggle style file is where this test looks")
+    XCTAssertTrue(
+      style.contains("Button {") && style.contains("configuration.isOn.toggle()"),
+      "the toggle style's visual must be wrapped in a Button that toggles configuration.isOn — "
+        + "a custom ToggleStyle has no native activation on macOS, so removing the Button would "
+        + "leave every switch in the app dead")
+  }
+
+  // MARK: - The production control under test
+
+  private func styledToggle(_ latch: SetCountingLatch) -> some View {
+    Toggle("", isOn: latch.binding)
+      .toggleStyle(OmiToggleStyle())
+      .frame(width: 36, height: 20)
+      .position(x: Self.hostSize.width / 2, y: Self.hostSize.height / 2)
+  }
+
+  private static var center: CGPoint {
+    CGPoint(x: hostSize.width / 2, y: hostSize.height / 2)
+  }
+
+  // MARK: - Driving a real click
+
+  /// Dispatches a real `leftMouseDown`/`leftMouseUp` pair into a window hosting `view` — the
+  /// `ShellModalScrimDismissTests` harness. Synthetic clicks rather than calls into the style,
+  /// because the thing under test is whether one physical click activates the control exactly
+  /// once, which is a fact about event/gesture routing, not about any one handler. The host is
+  /// square and the view is pinned to its center, so the SwiftUI center and the AppKit center
+  /// (origin bottom-left) are the same point.
+  private func click(on view: some View, down: CGPoint, up: CGPoint) {
+    let size = Self.hostSize
+    let host = NSHostingView(rootView: view)
+    host.frame = NSRect(origin: .zero, size: size)
+    let window = NSWindow(
+      contentRect: NSRect(origin: .zero, size: size),
+      styleMask: [.borderless], backing: .buffered, defer: false)
+    window.contentView = host
+    NonintrusiveTestWindow.orderIn(window)
+    defer {
+      window.orderOut(nil)
+      window.contentView = nil
+    }
+    host.layoutSubtreeIfNeeded()
+
+    let toAppKit: (CGPoint) -> NSPoint = { point in
+      NSPoint(x: point.x, y: size.height - point.y)
+    }
+    let downEvent = NSEvent.mouseEvent(
+      with: .leftMouseDown, location: toAppKit(down), modifierFlags: [], timestamp: 0,
+      windowNumber: window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1)
+    let upEvent = NSEvent.mouseEvent(
+      with: .leftMouseUp, location: toAppKit(up), modifierFlags: [], timestamp: 0.01,
+      windowNumber: window.windowNumber, context: nil, eventNumber: 2, clickCount: 1, pressure: 0)
+
+    if let downEvent { window.sendEvent(downEvent) }
+    if let upEvent { window.sendEvent(upEvent) }
+  }
+
+  /// A `Binding<Bool>` a test can read back after the view under test has written to it, plus
+  /// the count of those writes — one click must produce exactly one.
+  private final class SetCountingLatch: @unchecked Sendable {
+    private(set) var isOn: Bool
+    private(set) var setCount = 0
+
+    init(isOn: Bool) {
+      self.isOn = isOn
+    }
+
+    var binding: Binding<Bool> {
+      Binding(
+        get: { self.isOn },
+        set: {
+          self.setCount += 1
+          self.isOn = $0
+        })
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260909-settings-toggles-first-click.json
+++ b/desktop/macos/changelog/unreleased/20260909-settings-toggles-first-click.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Settings switches ignoring the first click when it moved slightly — they now flip on the first click and are readable by accessibility tools"
+}

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -5,8 +5,11 @@ description: Settings Notifications section snapshot and API update
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
-  # S1's section screen renders its master toggle through this style; the notifications
-  # master switch is an OmiToggleStyle activation on that page.
+  # Required by the desktop-e2e-flow-coverage strict gate: every changed desktop Swift file
+  # must appear in some flow's covers. Same involvement semantics as the entries below —
+  # S1's section screen renders its master toggle through this style; a step that actually
+  # activates the switch is not expressible today (live AX cannot enumerate the Settings
+  # subtree; the bridge's set_notification_settings bypasses the view layer via APIClient).
   - desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -5,6 +5,9 @@ description: Settings Notifications section snapshot and API update
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+  # S1's section screen renders its master toggle through this style; the notifications
+  # master switch is an OmiToggleStyle activation on that page.
+  - desktop/macos/Desktop/Sources/Theme/OmiToggleStyle.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift


### PR DESCRIPTION
## Summary

`OmiToggleStyle` — the switch every Settings toggle wears (Notifications, Screen Capture, Interface Sounds, Wake Word, and every other switch in the app) — drove its activation with a bare `.onTapGesture` on the drawn shapes. That had one measured defect and one by-construction defect:

**Drag intolerance (measured, deterministic).** A tap gesture fails when the pointer moves between mouse-down and mouse-up, and a human click often moves a few points *inside* the control. Measured in a harness that mounts the real `Toggle` wearing the production style and dispatches real `NSEvent` pairs through `sendEvent`:

| Event sequence | Old (tap gesture) | New (Button) |
|---|---|---|
| Clean click (up where down was) | 1 binding write | 1 binding write |
| Click that drags 5 pt inside the 36 pt track | **0 binding writes — dead click** | 1 binding write |

A dropped click reads as a dead switch and the user must click again until a clean tap lands — exactly the QA observation on 2026-09-09 (Settings switches reported flaky, "click repeatedly until one lands").

**No accessibility element (by construction).** A bare gesture on drawn shapes produces no accessibility element; a `Button` is one by construction (and is Apple's documented pattern for custom `ToggleStyle`s). The switch now carries a generic `Switch` label; every call site passes an empty title today, and a style cannot read a string out of `configuration.label`, so per-feature labels belong at the call sites.

Disclosure: **live AX verification was not possible**, through no fault of the change. The Settings page wraps its content in an `AXOpaqueProviderGroup` whose subtree System Events cannot enumerate (and the AX runtime there often serves a stale subtree from the previous route): the probe returns 0 elements for *every* control on the page, in the old and new code alike — it cannot falsify or verify the improvement. The same blindness equally qualifies the investigation's earlier "no AX element observed live" reading of the old code. See follow-ups.

Also worth saying: a custom `ToggleStyle` owns activation entirely on macOS — the framework adds no click handling around `makeBody` — so the `Button` is the switch's one activation path, and the new tests pin that it exists, fires exactly once per click, and tolerates a drag.

## Investigation summary (hypotheses tested and excluded)

- **Double-activation** ("the `Toggle` natively handles the same pixels, so the gesture double-writes the binding"): excluded — in the same deterministic harness, a click on the old code writes the binding exactly once, never twice, and with the gesture removed a custom-styled `Toggle` writes zero times (no native activation exists on macOS; the gesture was the only activation).
- **Shell click-through over Settings** ("unregistered glass pixels make the window pass clicks through"): excluded — `debug_hit_probe` surface dumps show the Settings route fully covered by registered hit-region surfaces (top bar + lane panel, full width), stable across route swaps; all 8 destinations probe `shellAccepts=true` over their content. Real clicks on the unfixed build flipped the toggle 15/16 times; the single miss was the macOS inactive-window first click.

## What changed

- `Desktop/Sources/Theme/OmiToggleStyle.swift` — the bare `.onTapGesture` is replaced by `Button { configuration.isOn.toggle() }` wrapping the unchanged track/knob drawing (`.buttonStyle(.plain)`, `accessibilityLabel("Switch")`); drawing, animation, and dimensions are unchanged.
- `Desktop/Tests/OmiToggleStyleActivationTests.swift` — new: clean-click single-fire, the drag-tolerance regression test (the load-bearing one), and a Theme-module tripwire that no control style activates through a bare tap gesture and that the toggle style's activation path is a `Button`.
- `changelog/unreleased/20260909-settings-toggles-first-click.json` — changelog fragment.
- `e2e/flows/notifications-settings.yaml` — `covers:` entry for the style file (the flow's S1 renders the Notifications master switch through `OmiToggleStyle`), satisfying the `desktop-e2e-flow-coverage` ratchet for the changed source.
- `.github/failure-classes/FC-bare-tap-gesture-activation.json` — new failure-class definition (guard artifact: the test file above).

Sweep: `OmiToggleStyle` is the app's only custom `ToggleStyle`; every `ButtonStyle` in the tree (`OmiButtonStyle`, `InkButtonStyle`, `GlassIconButtonStyle`, `RewindSearchCardStyle`, `ChatComposerActionStyle`, `DismissButtonPressStyle`) styles real `Button`s and re-implements nothing.

## Verification

- `xcrun swift test --package-path Desktop --filter OmiToggleStyleActivationTests` — **red-first on unfixed main** (dragged click: 0 writes; tripwire: bare tap present), **green after** (clean click: 1 write; dragged click: 1 write; tripwire passes). Layer: unit tests, deterministic synthetic events, no waits.
- `xcrun swift test --package-path Desktop --filter 'OmiToggleStyleActivationTests|GlassLegibilityTests|ShellModalScrimDismissTests'` → 18/18 passed (includes the toggle's existing visual-contrast contract). Layer: unit tests.
- `xcrun swift build -c debug --package-path Desktop` → clean. Layer: compile.
- `scripts/swift-format-wrapper.sh lint -r …` (pinned 602.0.0) clean; `scripts/swiftlint-wrapper.sh lint` → 0 violations; `python3 scripts/check_desktop_test_quality.py` → at baseline (the one source read carries the required annotation). Layer: static checks.
- Named bundle `omi-toggle-button` built from this commit, real `cliclick` clicks on the Settings Notifications master toggle: **5/5 stationary and 5/5 dragged (3 pt) clicks flipped first-try**; second toggle (Daily Summary) flipped first-try stationary and dragged (12/12 total); settings sidebar section navigation unaffected. Layer: live app.

## Product invariants affected

none — no colour, layout, or behavioural contract touched; the switch's drawing and dimensions are byte-identical.

## Failure class (fixes)

Failure-Class: new

`FC-bare-tap-gesture-activation` — a custom control's activation must accept the whole physical click, not only the clean-tap subset, and must be an accessibility element. Definition added in this PR; guard artifact is `OmiToggleStyleActivationTests.swift`.

## Recommended follow-ups (maintainer green light needed)

1. **Settings-page `AXOpaqueProviderGroup` opacity** — arguably the bigger accessibility defect: every control on the Settings page (not just switches) is invisible to assistive tech because the page's scroll container exposes an opaque provider group whose children System Events cannot see, and the runtime often serves a stale subtree from the previous route. Fixing that exposure would also make live AX verification of controls on this page possible for the first time.
2. **Same-class hand-rolled controls under the new FC** (audited, left alone here): `Rewind/UI/RewindPage.swift:1730` (a drawn transcription switch activated by a bare tap — the closest lookalike), `MainWindow/Pages/AppsPage.swift:27` (`SafeDismissButton`), star ratings (`ChatLabView.swift:1119`, `AppsPage.swift:3614`).
3. **Per-call-site accessibility labels** for switches: call sites pass empty titles today; once labelled, they should override the style's generic `Switch` fallback.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

