### PR TITLE
fix(python-cli): clean up credential temp after failed config replacement

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -111,6 +111,9 @@ State lives at `~/.omi/config.toml` (overridable via `$OMI_CONFIG`). The file
 holds one or more named profiles, each with its own auth method and API base.
 Saving configuration preserves unknown settings at both the root and profile
 levels, so editing a known setting does not discard extensions from newer clients.
+If saving fails during serialization or atomic replacement, the CLI attempts to
+remove its own temporary file and reports the original error. It leaves other
+writers' temporary files alone; cleanup is best-effort if the filesystem refuses it.
 Switch between them with `--profile`:
 
 ```bash

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -221,8 +221,7 @@ def save(config: Config) -> None:
     """
     if config.load_error is not None:
         raise PermissionError(
-            f"refusing to overwrite {config.path}: {config.load_error}. "
-            "Fix or remove the config file and try again."
+            f"refusing to overwrite {config.path}: {config.load_error}. " "Fix or remove the config file and try again."
         )
     config.path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir perms too — credentials live underneath. Best-effort:
@@ -258,18 +257,18 @@ def save(config: Config) -> None:
         try:
             with os.fdopen(fd, "wb") as fh:
                 tomli_w.dump(payload, fh)
+            # Atomic rename. The destination inherits the temp's owner-only access.
+            os.replace(tmp_path, config.path)
         except Exception:
-            # Best-effort cleanup if the dump itself failed mid-write.
+            # Clean up our own temp on serialization or replacement failure.
+            # A failed cleanup must not hide the original save error.
             try:
                 os.unlink(tmp_path)
-            except FileNotFoundError:
+            except OSError:
                 pass
             raise
     finally:
         os.umask(old_umask)
-
-    # Atomic rename. The destination inherits the temp's 0o600 mode.
-    os.replace(tmp_path, config.path)
 
 
 def resolve_profile_name(cli_flag: Optional[str], config: Config) -> str:

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -259,8 +259,8 @@ def save(config: Config) -> None:
                 tomli_w.dump(payload, fh)
             # Atomic rename. The destination inherits the temp's owner-only access.
             os.replace(tmp_path, config.path)
-        except Exception:
-            # Clean up our own temp on serialization or replacement failure.
+        except BaseException:
+            # Clean up our own temp even when serialization/replacement is interrupted.
             # A failed cleanup must not hide the original save error.
             try:
                 os.unlink(tmp_path)

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -282,7 +282,8 @@ def test_save_retries_when_unique_temp_name_collides(config_path: Path, monkeypa
     assert reloaded.api_key == "omi_dev_retry"
 
 
-def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize("failure_type", [PermissionError, KeyboardInterrupt, SystemExit])
+def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch, failure_type) -> None:
     config = cfg.load()
     profile = config.get_profile()
     profile.auth_method = "api_key"
@@ -292,7 +293,7 @@ def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch)
     other_temp = config_path.with_suffix(".toml.other-writer.tmp")
     other_temp.write_bytes(b"another writer")
     profile.api_key = "omi_dev_replacement"
-    failure = PermissionError("destination is locked")
+    failure = failure_type("replacement interrupted or failed")
     attempted = []
 
     def fail_replace(source, destination):
@@ -302,7 +303,7 @@ def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch)
         raise failure
 
     monkeypatch.setattr(cfg.os, "replace", fail_replace)
-    with pytest.raises(PermissionError) as exc:
+    with pytest.raises(failure_type) as exc:
         cfg.save(config)
 
     assert exc.value is failure
@@ -311,10 +312,11 @@ def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch)
     assert other_temp.read_bytes() == b"another writer"
 
 
-def test_save_cleanup_failure_preserves_replace_error(config_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize("failure_type", [PermissionError, KeyboardInterrupt, SystemExit])
+def test_save_cleanup_failure_preserves_replace_error(config_path: Path, monkeypatch, failure_type) -> None:
     config = cfg.load()
     config.get_profile().api_key = "omi_dev_synthetic"
-    failure = PermissionError("destination is locked")
+    failure = failure_type("replacement interrupted or failed")
     cleanup_attempts = []
 
     def fail_replace(source, destination):
@@ -327,7 +329,7 @@ def test_save_cleanup_failure_preserves_replace_error(config_path: Path, monkeyp
     with monkeypatch.context() as patcher:
         patcher.setattr(cfg.os, "replace", fail_replace)
         patcher.setattr(cfg.os, "unlink", fail_unlink)
-        with pytest.raises(PermissionError) as exc:
+        with pytest.raises(failure_type) as exc:
             cfg.save(config)
 
     assert exc.value is failure

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -282,6 +282,59 @@ def test_save_retries_when_unique_temp_name_collides(config_path: Path, monkeypa
     assert reloaded.api_key == "omi_dev_retry"
 
 
+def test_save_cleans_own_temp_when_replace_fails(config_path: Path, monkeypatch) -> None:
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_original"
+    cfg.save(config)
+    original = config_path.read_bytes()
+    other_temp = config_path.with_suffix(".toml.other-writer.tmp")
+    other_temp.write_bytes(b"another writer")
+    profile.api_key = "omi_dev_replacement"
+    failure = PermissionError("destination is locked")
+    attempted = []
+
+    def fail_replace(source, destination):
+        attempted.append(Path(source))
+        assert Path(destination) == config_path
+        assert b"omi_dev_replacement" in Path(source).read_bytes()
+        raise failure
+
+    monkeypatch.setattr(cfg.os, "replace", fail_replace)
+    with pytest.raises(PermissionError) as exc:
+        cfg.save(config)
+
+    assert exc.value is failure
+    assert config_path.read_bytes() == original
+    assert attempted and not attempted[0].exists()
+    assert other_temp.read_bytes() == b"another writer"
+
+
+def test_save_cleanup_failure_preserves_replace_error(config_path: Path, monkeypatch) -> None:
+    config = cfg.load()
+    config.get_profile().api_key = "omi_dev_synthetic"
+    failure = PermissionError("destination is locked")
+    cleanup_attempts = []
+
+    def fail_replace(source, destination):
+        raise failure
+
+    def fail_unlink(path):
+        cleanup_attempts.append(Path(path))
+        raise OSError("cleanup also failed")
+
+    with monkeypatch.context() as patcher:
+        patcher.setattr(cfg.os, "replace", fail_replace)
+        patcher.setattr(cfg.os, "unlink", fail_unlink)
+        with pytest.raises(PermissionError) as exc:
+            cfg.save(config)
+
+    assert exc.value is failure
+    assert len(cleanup_attempts) == 1
+    cleanup_attempts[0].unlink()
+
+
 def test_save_concurrent_writers_retry_on_unique_name_collision(config_path: Path) -> None:
     """Real interleaving: a nested save() inside the first writer's dump
     claims a temp path; the outer writer's own path cannot collide with it


### PR DESCRIPTION
## What changed and why

A failed atomic config replacement left the current writer's temporary file, including its serialized API key, behind. Include replacement in the existing cleanup scope, remove only that writer's temp, and preserve the original error if unlink also fails. The cleanup scope catches `BaseException` and re-raises, so `KeyboardInterrupt` and `SystemExit` also trigger best-effort cleanup. Closes #13421.

## Product invariants affected

none

## How it was verified

- Native Windows reproduction with synthetic credentials: hold the destination open, then run `python -m omi_cli config set api_base https://example.invalid`. Baseline leaves one credential-containing temp; the patch leaves none. Both report failure and preserve the destination bytes.
- Configuration suite: 30 passed, including a fresh local run on 2026-09-10. Both cleanup regressions are parameterized over `PermissionError`, `KeyboardInterrupt`, and `SystemExit`; the four added interruption cases failed before the `BaseException` fix and passed afterward. These are injected Python exceptions, not an OS-level SIGINT test.
- Initial complete CLI run: 336 passed, 5 failed. Four failures came from a missing OpenAPI spec in the sparse checkout; after materializing it, all four pass. The remaining transport-login test also fails on unmodified baseline `bce82c1616b5a52ea870a32a80472409f0e9d8c2`. This is not a claim of a fully passing suite.
- Black on changed Python files and `git diff --check` passed.
- `python .github/scripts/pr_preflight.py --lane local --base origin/main --pr-body-file ../omi-pr-draft.md`: all 12 selected checks passed on the local baseline after materializing referenced files. GNU Make is unavailable on this Windows host, so its Python entry point was used; full backend setup was not performed.
- The three uploaded files were fetched back and compared with the tested local files: no differences. The fork's newer base does not change these files.

## Tests

`test_save_cleans_own_temp_when_replace_fails` checks that replacement failure preserves the old config, removes the current writer's temp, and leaves another writer's file alone. `test_save_cleanup_failure_preserves_replace_error` checks original exception identity when cleanup also fails. Each test exercises ordinary replacement failure and both interruption exception types. The interruption fix is in `defbb91`; its regression coverage is in head `557e069`.

## Failure class (fixes)

Failure-Class: none

The nearby host-file-sharing class prescribes bounded retries for status writes; this change instead cleans up an already-failed configuration save and preserves the failure behavior.

## Contribution disclosure

Prepared and tested by an AI coding agent. Related issue #13421 proposes a discretionary USD 10 bounty, which has not been approved or received.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

