### PR TITLE
fix(python-cli): return nonzero for Desktop SQL failures

### DIFF
--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -26,7 +26,7 @@ omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 | Code | Meaning                                                                 |
 | ---- | ----------------------------------------------------------------------- |
 | `0`  | Success.                                                                |
-| `1`  | Usage error — bad flag, missing arg, validation rejection.              |
+| `1`  | Usage/validation error, or the specific Desktop SQL failure described below. |
 | `2`  | Auth error — no creds, expired token, insufficient scope.               |
 | `3`  | Server error — 5xx after retries exhausted, or connection failure.      |
 | `4`  | Rate limited — 429 after retries exhausted. `detail` includes the wait. |

--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -35,6 +35,11 @@ omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 These codes are **part of the contract** — they won't shift between minor
 versions. Branch on them in your harness without parsing English errors.
 
+Local SQL execution failures return exit code `1` from both `omi local sql`
+and `omi local call execute_sql`, including when Desktop wraps the error in
+an HTTP 200 response. With `--json`, the error goes to stderr and stdout stays
+empty. A successful query with no rows still returns exit code `0`.
+
 ## Authentication: API key vs browser OAuth
 
 The CLI supports both — but for **agents** specifically, the API-key path is

--- a/docs/doc/developer/cli/agents.mdx
+++ b/docs/doc/developer/cli/agents.mdx
@@ -35,10 +35,13 @@ omi --json memory list --limit 25 | jq '.[] | {id, content, category}'
 These codes are **part of the contract** — they won't shift between minor
 versions. Branch on them in your harness without parsing English errors.
 
-Local SQL execution failures return exit code `1` from both `omi local sql`
-and `omi local call execute_sql`, including when Desktop wraps the error in
-an HTTP 200 response. With `--json`, the error goes to stderr and stdout stays
-empty. A successful query with no rows still returns exit code `0`.
+When Desktop returns the exact `execute_sql` result
+`SQL Error: The local database could not complete that query.`, both
+`omi local sql` and `omi local call execute_sql` exit with code `1`, including
+when Desktop wraps that result in an HTTP 200 response. With `--json`, this
+error goes to stderr and stdout stays empty. This message match does not
+classify other SQL result strings as failures. A successful query with no
+rows still returns exit code `0`.
 
 ## Authentication: API key vs browser OAuth
 

--- a/sdks/python-cli/omi_cli/local_client.py
+++ b/sdks/python-cli/omi_cli/local_client.py
@@ -75,7 +75,13 @@ class LocalOmiClient:
         self._maybe_log(name, response)
         if not (200 <= response.status_code < 300):
             raise self._error_from_response(response)
-        return _unwrap_tool_response(_safe_parse_json(response))
+        result = _unwrap_tool_response(_safe_parse_json(response))
+        # Desktop reports this SQL failure as text inside an ok:true envelope.
+        # Match its full message: successful table headings can start with
+        # "SQL Error:" too. Both `local sql` and `local call` share this boundary.
+        if name == "execute_sql" and result == "SQL Error: The local database could not complete that query.":
+            raise CliError(message=result, exit_code=1)
+        return result
 
     def list_tools(self) -> Any:
         """Return Desktop-local tool descriptors."""

--- a/sdks/python-cli/tests/test_local_sql_errors.py
+++ b/sdks/python-cli/tests/test_local_sql_errors.py
@@ -1,0 +1,103 @@
+"""The Desktop SQL failure response must remain a failure at the CLI boundary."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from omi_cli import config as cfg
+from omi_cli.main import main
+
+LOCAL_URL = "http://127.0.0.1:47778"
+# ChatToolExecutor.executeSQL returns this string on a database error.
+SQL_ERROR = "SQL Error: The local database could not complete that query."
+SQL_COMMANDS = [
+    ["local", "sql", "SELECT * FROM missing_table"],
+    ["local", "call", "execute_sql", "--args-json", '{"query":"SELECT * FROM missing_table"}'],
+]
+
+
+@pytest.fixture
+def local_profile(config_path):
+    config = cfg.load()
+    profile = config.get_profile("default")
+    profile.local_api_url = LOCAL_URL
+    profile.local_token = "synthetic_local_token"
+    cfg.save(config)
+
+
+@pytest.mark.parametrize("command", SQL_COMMANDS)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_local_sql_error_exits_nonzero(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    # LocalAgentAPIServer currently wraps SQL errors in an HTTP 200 / ok:true
+    # envelope because its HTTP error check recognizes only the "Error:" prefix.
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": SQL_ERROR}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        route = router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        with pytest.raises(SystemExit) as exc:
+            main()
+
+    assert exc.value.code == 1
+    assert route.call_count == 1
+    assert json.loads(route.calls[0].request.content)["name"] == "execute_sql"
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    if json_mode:
+        assert json.loads(captured.err)["error"] == SQL_ERROR
+    else:
+        assert SQL_ERROR in captured.err
+
+
+@pytest.mark.parametrize("command", SQL_COMMANDS)
+@pytest.mark.parametrize("json_mode", [False, True])
+def test_local_sql_empty_result_still_succeeds(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": "No results"}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if json_mode:
+        result = json.loads(captured.out)
+        assert result == ({"rows": [], "columns": [], "row_count": 0} if command[1] == "sql" else "No results")
+    else:
+        assert "No results" in captured.out
+
+
+def test_other_tool_can_return_sql_error_text_as_data(local_profile, monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["omi", "--json", "local", "call", "get_daily_recap"])
+    envelope = {"ok": True, "name": "get_daily_recap", "content_type": "text/plain", "result": SQL_ERROR}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == SQL_ERROR
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "command,json_mode",
+    [
+        (["local", "sql", "SELECT 1 AS 'SQL Error: count'"], False),
+        (["local", "call", "execute_sql", "--args-json", '{"query":"SELECT 1 AS \'SQL Error: count\'"}'], True),
+    ],
+)
+def test_sql_error_column_heading_is_successful_data(local_profile, monkeypatch, capsys, command, json_mode):
+    monkeypatch.setattr("sys.argv", ["omi", *(["--json"] if json_mode else []), *command])
+    # SQLQueryResultProjection.format starts successful output with column names.
+    table = "SQL Error: count\n--------------------\n1\n\n1 row(s)"
+    envelope = {"ok": True, "name": "execute_sql", "content_type": "text/plain", "result": table}
+    with respx.mock(base_url=LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=envelope))
+        main()
+
+    captured = capsys.readouterr()
+    assert (json.loads(captured.out) if json_mode else captured.out.rstrip()) == table
+    assert captured.err == ""


### PR DESCRIPTION
## What changed and why

Closes #13392.

Desktop can report a failed `execute_sql` query as `SQL Error: The local database could not complete that query.` inside an HTTP 200, `ok: true` response. The Python local client previously returned that text as successful data, so both `omi local sql` and `omi local call execute_sql` exited with code 0.

The local-client boundary now maps that exact Desktop failure result to `CliError` with exit code 1. The match is limited to `execute_sql` and the complete current error message, preserving successful empty results, other tools returning the same text as data, and successful tables whose headings start with `SQL Error:`. The CLI contract documentation now records the exit behavior.

## Product invariants affected

none

## Verification

- Rebased onto upstream main `c1ed17c2d7b8af70be7b7b5888aaa027a0ff11be`; the original production change and regression test file are preserved.
- `python -m pytest sdks/python-cli/tests/test_local.py sdks/python-cli/tests/test_local_sql_errors.py -q --tb=short` — 59 passed.
- `python -m pytest sdks/python-cli/tests -q --tb=short` — 380 passed, 1 skipped, 0 failed.
- `python -m black --check sdks/python-cli/omi_cli/local_client.py sdks/python-cli/tests/test_local_sql_errors.py` — passed.
- `python -m isort --check-only sdks/python-cli/omi_cli/local_client.py sdks/python-cli/tests/test_local_sql_errors.py` — passed.
- `PATH="$PWD/backend/.venv/bin:$PATH" make preflight` — 12 selected local checks passed; the failure-class history ratchet defers enforcement in this shallow checkout and requires full history in CI.
- `scripts/pr-preflight --suggest` — passed; no locked product invariant applies.
- `scripts/pr-preflight --pr-body-file <draft>` — passed.
- Original submission's subprocess smoke against a synthetic local Desktop-compatible endpoint — both CLI entry points exited 1, emitted the JSON error on stderr, and kept stdout empty. The review follow-up changes documentation only.

The regression tests execute the production CLI entry point with temporary configuration, a synthetic token, and intercepted local HTTP responses. A live Desktop application and real account were not used.

Backend Hermetic Merge Gate: out of scope — this change touches the Python CLI, its tests, and public CLI documentation.

## Failure class (fixes)

Failure-Class: none

The suggested `FC-private-credential-file-permissions` class concerns atomic owner-only credential persistence. This change does not alter credential storage or permissions; it maps an existing Desktop response into a CLI process outcome.

## Bounty

Bounty proposal: US$10 as requested in #13392, subject to maintainer approval and the documented bounty process.

Prepared with OpenAI Codex.
