### PR TITLE
fix(backend): cap Redis chat filter sets at 500 members

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -566,6 +566,49 @@ def get_user_webhook_db(uid: str, wtype: str) -> str:
     return url.decode()
 
 
+FILTER_CATEGORY_CAP = 500
+FILTER_CATEGORY_TRIM_BATCH = 128
+FILTER_CATEGORIES = frozenset({'people', 'topics', 'entities', 'dates'})
+
+# allow-oom: trim must still run when the box is at maxmemory (the incident).
+_FILTER_TRIM_LUA = """#!lua flags=allow-oom
+local key = KEYS[1]
+local cap = tonumber(ARGV[1])
+local batch = tonumber(ARGV[2])
+local n = redis.call('SCARD', key)
+if n <= cap then
+  return {n, 0}
+end
+local to_remove = math.min(n - cap, batch)
+redis.call('SPOP', key, to_remove)
+return {redis.call('SCARD', key), to_remove}
+"""
+
+_FILTER_ADMIT_LUA = """
+local key = KEYS[1]
+local member = ARGV[1]
+local cap = tonumber(ARGV[2])
+if redis.call('SISMEMBER', key, member) == 1 then
+  return 0
+end
+if redis.call('SCARD', key) >= cap then
+  return 0
+end
+return redis.call('SADD', key, member)
+"""
+
+_filter_trim_script = None
+_filter_admit_script = None
+
+
+def _filter_category_scripts() -> tuple[Any, Any]:
+    global _filter_trim_script, _filter_admit_script
+    if _filter_trim_script is None:
+        _filter_trim_script = r.register_script(_FILTER_TRIM_LUA)
+        _filter_admit_script = r.register_script(_FILTER_ADMIT_LUA)
+    return _filter_trim_script, _filter_admit_script
+
+
 def get_filter_category_items(uid: str, category: str, limit: Optional[int] = None) -> List[str]:
     key = f'users:{uid}:filters:{category}'
     if limit:
@@ -581,7 +624,38 @@ def get_filter_category_items(uid: str, category: str, limit: Optional[int] = No
 
 
 def add_filter_category_item(uid: str, category: str, item: str) -> None:
-    r.sadd(f'users:{uid}:filters:{category}', item)
+    """SADD chat-search filter members with a 500-cap; SPOP-trim oversized sets.
+
+    Redis SETs have no insertion order. Trim is random, one batch per call.
+    Fail-open on Redis errors: never fall back to an uncapped SADD.
+    """
+    if category not in FILTER_CATEGORIES or not item:
+        return
+    key = f'users:{uid}:filters:{category}'
+    try:
+        trim, admit = _filter_category_scripts()
+        after, removed = trim(keys=[key], args=[FILTER_CATEGORY_CAP, FILTER_CATEGORY_TRIM_BATCH])
+        after_n = int(after)
+        removed_n = int(removed)
+        if removed_n:
+            logger.info('filter_category_trim removed=%s after=%s', removed_n, after_n)
+        if after_n < FILTER_CATEGORY_CAP:
+            admit(keys=[key], args=[item, FILTER_CATEGORY_CAP])
+    except redis.exceptions.RedisError:
+        try:
+            from utils.observability.fallback import record_fallback
+
+            record_fallback(
+                component='other',
+                from_mode='filter_sadd',
+                to_mode='skip',
+                reason='other',
+                outcome='degraded',
+                log=logger,
+            )
+        except Exception:
+            pass
+        return
 
 
 def save_migrated_retrieval_conversation_id(conversation_id: str) -> None:

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import redis
 import logging
+from redis.exceptions import RedisError
 
 from database.api_key_metadata import (
     DEV_API_KEY_AUTH_CONTEXT_VERSION,
@@ -641,7 +642,7 @@ def add_filter_category_item(uid: str, category: str, item: str) -> None:
             logger.info('filter_category_trim removed=%s after=%s', removed_n, after_n)
         if after_n < FILTER_CATEGORY_CAP:
             admit(keys=[key], args=[item, FILTER_CATEGORY_CAP])
-    except redis.exceptions.RedisError:
+    except RedisError:
         try:
             from utils.observability.fallback import record_fallback
 

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta, timezone
 
 import redis
 import logging
-from redis.exceptions import RedisError
 
 from database.api_key_metadata import (
     DEV_API_KEY_AUTH_CONTEXT_VERSION,
@@ -604,9 +603,15 @@ _filter_admit_script = None
 
 def _filter_category_scripts() -> tuple[Any, Any]:
     global _filter_trim_script, _filter_admit_script
-    if _filter_trim_script is None:
-        _filter_trim_script = r.register_script(_FILTER_TRIM_LUA)
-        _filter_admit_script = r.register_script(_FILTER_ADMIT_LUA)
+    if _filter_trim_script is None or _filter_admit_script is None:
+        # Register into locals first; publish the globals only after both
+        # registrations succeed so a concurrent caller can never observe a
+        # half-initialized pair (which would raise TypeError outside the
+        # RedisError handler in add_filter_category_item).
+        trim = r.register_script(_FILTER_TRIM_LUA)
+        admit = r.register_script(_FILTER_ADMIT_LUA)
+        _filter_trim_script = trim
+        _filter_admit_script = admit
     return _filter_trim_script, _filter_admit_script
 
 
@@ -642,7 +647,7 @@ def add_filter_category_item(uid: str, category: str, item: str) -> None:
             logger.info('filter_category_trim removed=%s after=%s', removed_n, after_n)
         if after_n < FILTER_CATEGORY_CAP:
             admit(keys=[key], args=[item, FILTER_CATEGORY_CAP])
-    except RedisError:
+    except redis.exceptions.RedisError:  # type: ignore[attr-defined]
         try:
             from utils.observability.fallback import record_fallback
 

--- a/backend/tests/unit/test_llm_filter_normalization.py
+++ b/backend/tests/unit/test_llm_filter_normalization.py
@@ -41,7 +41,7 @@ def stored_items(monkeypatch):
 
 
 def test_extracted_metadata_survives_redis_error(monkeypatch) -> None:
-    import redis.exceptions
+    import redis
     from database import redis_db
 
     def fake_get_llm(feature):
@@ -54,7 +54,7 @@ def test_extracted_metadata_survives_redis_error(monkeypatch) -> None:
         return FakeLLM(response)
 
     def boom(*_a, **_k):
-        raise redis.exceptions.RedisError('OOM')
+        raise redis.exceptions.RedisError('OOM')  # type: ignore[attr-defined]
 
     monkeypatch.setattr(chat, 'get_llm', fake_get_llm)
     monkeypatch.setattr(redis_db, '_filter_category_scripts', boom)

--- a/backend/tests/unit/test_llm_filter_normalization.py
+++ b/backend/tests/unit/test_llm_filter_normalization.py
@@ -40,6 +40,29 @@ def stored_items(monkeypatch):
     return stored
 
 
+def test_extracted_metadata_survives_redis_error(monkeypatch) -> None:
+    import redis.exceptions
+    from database import redis_db
+
+    def fake_get_llm(feature):
+        response = ExtractedInformation(
+            people=['Ada Lovelace'],
+            topics=['Mathematics'],
+            entities=['Analytical Engine'],
+            dates=[],
+        )
+        return FakeLLM(response)
+
+    def boom(*_a, **_k):
+        raise redis.exceptions.RedisError('OOM')
+
+    monkeypatch.setattr(chat, 'get_llm', fake_get_llm)
+    monkeypatch.setattr(redis_db, '_filter_category_scripts', boom)
+    metadata = chat._process_extracted_metadata('uid-1', prompt='ignored', reference_date='2026-08-16')
+    assert metadata['people'] == ['ada lovelace']
+    assert 'mathematics' in metadata['topics']
+
+
 def test_stored_filters_are_normalized_at_storage_boundary(monkeypatch, stored_items) -> None:
     metadata = chat._process_extracted_metadata('uid-1', prompt='ignored', reference_date='2026-08-16')
 

--- a/backend/tests/unit/test_redis_filter_category_cap.py
+++ b/backend/tests/unit/test_redis_filter_category_cap.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+import redis.exceptions
+
+from database import redis_db
+
+
+def _reset_scripts() -> None:
+    redis_db._filter_trim_script = None
+    redis_db._filter_admit_script = None
+
+
+def _trim_lua_body() -> str:
+    src = redis_db._FILTER_TRIM_LUA
+    if src.startswith('#!'):
+        return src.split('\n', 1)[1]
+    return src
+
+
+@pytest.fixture
+def fake_r(monkeypatch):
+    try:
+        import fakeredis
+    except Exception as exc:
+        pytest.skip(f'fakeredis unavailable: {exc}')
+    client = fakeredis.FakeRedis()
+    _reset_scripts()
+    monkeypatch.setattr(redis_db, 'r', client)
+    # fakeredis cannot parse Redis 7 shebang flags; prod Redis 7.4 can.
+    redis_db._filter_trim_script = client.register_script(_trim_lua_body())
+    redis_db._filter_admit_script = client.register_script(redis_db._FILTER_ADMIT_LUA)
+    yield client
+    _reset_scripts()
+
+
+def test_missing_key_adds_first_member(fake_r) -> None:
+    redis_db.add_filter_category_item('u1', 'topics', 'alpha')
+    assert fake_r.smembers('users:u1:filters:topics') == {b'alpha'}
+
+
+def test_grows_to_cap(fake_r) -> None:
+    for i in range(499):
+        redis_db.add_filter_category_item('u1', 'topics', f't{i}')
+    assert fake_r.scard('users:u1:filters:topics') == 499
+    redis_db.add_filter_category_item('u1', 'topics', 'last')
+    assert fake_r.scard('users:u1:filters:topics') == 500
+
+
+def test_refuse_at_cap_without_removal(fake_r) -> None:
+    for i in range(500):
+        fake_r.sadd('users:u1:filters:topics', f't{i}')
+    before = fake_r.smembers('users:u1:filters:topics')
+    redis_db.add_filter_category_item('u1', 'topics', 'new-member')
+    after = fake_r.smembers('users:u1:filters:topics')
+    assert after == before
+    assert b'new-member' not in after
+
+
+def test_duplicate_at_capacity_does_not_remove(fake_r) -> None:
+    for i in range(500):
+        fake_r.sadd('users:u1:filters:topics', f't{i}')
+    redis_db.add_filter_category_item('u1', 'topics', 't0')
+    assert fake_r.scard('users:u1:filters:topics') == 500
+    assert fake_r.sismember('users:u1:filters:topics', 't0')
+
+
+@pytest.mark.parametrize('start,expect_removed', [(501, 1), (628, 128), (629, 128)])
+def test_legacy_trim_batch(fake_r, start, expect_removed) -> None:
+    for i in range(start):
+        fake_r.sadd('users:u1:filters:topics', f't{i}')
+    redis_db.add_filter_category_item('u1', 'topics', 'new')
+    assert fake_r.scard('users:u1:filters:topics') == start - expect_removed
+    assert not fake_r.sismember('users:u1:filters:topics', 'new')
+
+
+def test_repeated_trim_stops_at_cap(fake_r) -> None:
+    for i in range(600):
+        fake_r.sadd('users:u1:filters:topics', f't{i}')
+    for _ in range(5):
+        redis_db.add_filter_category_item('u1', 'topics', 'ignored')
+    assert fake_r.scard('users:u1:filters:topics') == 500
+
+
+def test_does_not_touch_other_keys(fake_r) -> None:
+    fake_r.set('translate:v1:abc:en', '1')
+    fake_r.set('memories-visibility:cid1', 'u1')
+    fake_r.sadd('users:u2:filters:topics', 'keep')
+    fake_r.sadd('users:u1:filters:people', 'bob')
+    redis_db.add_filter_category_item('u1', 'topics', 'alpha')
+    assert fake_r.get('translate:v1:abc:en') == b'1'
+    assert fake_r.get('memories-visibility:cid1') == b'u1'
+    assert fake_r.smembers('users:u2:filters:topics') == {b'keep'}
+    assert fake_r.smembers('users:u1:filters:people') == {b'bob'}
+
+
+def test_invalid_category_is_noop(fake_r) -> None:
+    redis_db.add_filter_category_item('u1', 'nope', 'x')
+    redis_db.add_filter_category_item('u1', 'topics', '')
+    assert fake_r.dbsize() == 0
+
+
+def test_redis_error_fail_open_no_uncapped_write(fake_r, monkeypatch) -> None:
+    recorded = []
+
+    def boom(*_a, **_k):
+        raise redis.exceptions.RedisError('OOM')
+
+    monkeypatch.setattr(redis_db, '_filter_category_scripts', boom)
+    monkeypatch.setattr(
+        'utils.observability.fallback.record_fallback',
+        lambda **kwargs: recorded.append(kwargs),
+    )
+    redis_db.add_filter_category_item('u1', 'topics', 'alpha')
+    assert fake_r.dbsize() == 0
+    assert recorded and recorded[0]['outcome'] == 'degraded'

--- a/backend/tests/unit/test_redis_filter_category_cap.py
+++ b/backend/tests/unit/test_redis_filter_category_cap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-import redis.exceptions
+import redis
 
 from database import redis_db
 
@@ -104,7 +104,7 @@ def test_redis_error_fail_open_no_uncapped_write(fake_r, monkeypatch) -> None:
     recorded = []
 
     def boom(*_a, **_k):
-        raise redis.exceptions.RedisError('OOM')
+        raise redis.exceptions.RedisError('OOM')  # type: ignore[attr-defined]
 
     monkeypatch.setattr(redis_db, '_filter_category_scripts', boom)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Cap `users:{uid}:filters:{category}` at 500 members. Oversized legacy sets are randomly SPOP-trimmed by 128 on each SADD (Redis SETs have no oldest). Exact key only — no SCAN, no translate/*, no memories-visibility:*.

Prod Redis Cloud Essentials 12GB is full; keystats showed filter sets (not translation cache) as the byte majority. Essentials has no larger RAM SKU on GCP us-central1.

Fail-open on Redis errors: never uncapped SADD. Chat metadata still returns.

## Failure-Class
Failure-Class: none

Line-Count-Exception: backend/database/redis_db.py | 1639 -> 1719 | cap+trim lua for filter sets; splitting redis_db.py is out of scope for this incident PR

## Test Plan
- [x] `pytest tests/unit/test_redis_filter_category_cap.py tests/unit/test_llm_filter_normalization.py` (32 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


