### PR TITLE
fix(cli): preserve ambiguous local SQL results

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -310,15 +310,22 @@ def _normalize_sql_result(result: Any) -> Any:
         return {"text": result}
 
     columns = [part.strip() for part in header.split("|")] if "|" in header else [header.strip()]
+    data_lines = non_empty[2:-1]
+    row_count = int(row_count_match.group(1))
+    if len(data_lines) != row_count or any(line.startswith("Result truncated after ") for line in data_lines):
+        return {"text": result}
+
     rows = []
-    for line in non_empty[2:-1]:
+    for line in data_lines:
         values = [part.strip() for part in line.split("|")] if "|" in line else [line.strip()]
+        if len(values) != len(columns):
+            return {"text": result}
         rows.append({column: values[index] if index < len(values) else "" for index, column in enumerate(columns)})
 
     return {
         "columns": columns,
         "rows": rows,
-        "row_count": int(row_count_match.group(1)),
+        "row_count": row_count,
     }
 
 

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -315,6 +315,28 @@ def test_sql_json_structures_single_column_table_text(config_path: Path, cli_run
     }
 
 
+@pytest.mark.parametrize(
+    "sql_text",
+    [
+        "value\n--------------------\na|b\n\n1 row(s)",
+        "value\n--------------------\nfirst line\nsecond line\n\n1 row(s)",
+        (
+            "value\n--------------------\na\n"
+            "Result truncated after 1 row(s) to protect chat context. "
+            "Refine the projection or aggregate the result.\n\n2 row(s)"
+        ),
+    ],
+)
+def test_sql_json_preserves_ambiguous_table_text(config_path: Path, cli_runner, sql_text: str) -> None:
+    _configure_local_profile(config_path)
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(sql_text)))
+        result = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT value FROM probe"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"text": sql_text}
+
+
 def test_task_commands_route_to_local_tools(config_path: Path, cli_runner) -> None:
     _configure_local_profile(config_path)
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:


### PR DESCRIPTION
## What changed and why

`omi --json local sql` now returns the original Desktop text when delimiter and row counts show that the table cannot be parsed losslessly. Before this change, a one-column `a|b` cell became `a`, a multiline cell became multiple rows, and the Desktop truncation notice could become row data. Closes #13432.

## Product invariants affected

none

## How it was verified

- Exercised the real `python -m omi_cli.main --json local sql "SELECT value FROM probe"` entry point against a loopback-only synthetic Desktop response; the returned JSON preserved the complete `a|b` cell in `{"text": ...}` with exit 0 and empty stderr.
- `python -m pytest sdks/python-cli/tests/test_local.py -q`: 49 passed.
- Repository preflight CI lane: all 12 selected checks passed after rebasing head `e351fc34` onto current `main` at `f400a3e7`.
- The hosted full Python CLI suite reproduced only `test_transport_failure_during_login_leaves_saved_config_unchanged` in Linux / Python 3.10, Linux / Python 3.12, and Windows ACL / Python 3.12 ([run 34470864659](https://github.com/BasedHardware/omi/actions/runs/34470864659)). The identical assertion fails when run against an untouched archive of current `main` at `f400a3e7`; this change does not touch authentication.
- Repository metadata, hygiene, and all selected non-Python gates passed.
- Black and isort checks passed on both changed files; `git diff --check` passed.

The transport and credentials used for verification were synthetic. No live account or production service was used. OpenAI Codex assisted with the implementation and verification.

## Tests

`test_sql_json_preserves_ambiguous_table_text` drives the real Typer command through intercepted HTTP for pipe-delimited cells, multiline cells, and truncated results. Existing table-structure tests continue to cover unambiguous one- and two-column output.

## Failure class (fixes)

Failure-Class: none
