### PR TITLE
fix(backend): keep single-line triple-backtick inline code in notification text (#13430)

### DIFF
--- a/backend/tests/unit/test_notification_text.py
+++ b/backend/tests/unit/test_notification_text.py
@@ -28,3 +28,11 @@ def test_keeps_plain_text_and_intra_word_punctuation() -> None:
 
 def test_empty_body_is_unchanged() -> None:
     assert to_plain_text('') == ''
+
+
+def test_keeps_single_line_triple_backtick_inline_code() -> None:
+    assert to_plain_text('```omi start``` before continuing.') == 'omi start before continuing.'
+
+
+def test_still_strips_multiline_fenced_code_block() -> None:
+    assert to_plain_text('```sh\nomi start\n```') == 'omi start'

--- a/backend/utils/notification_text.py
+++ b/backend/utils/notification_text.py
@@ -8,7 +8,7 @@ chat) — only the displayed body is flattened.
 
 import re
 
-_FENCE_RE = re.compile(r'^\s*```.*$', re.MULTILINE)
+_FENCE_RE = re.compile(r'^\s*`{3,}[^`\n]*$', re.MULTILINE)
 _IMAGE_RE = re.compile(r'!\[([^\]]*)\]\([^)]*\)')
 _LINK_RE = re.compile(r'\[([^\]]*)\]\([^)]*\)')
 _HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s+', re.MULTILINE)


### PR DESCRIPTION
## Summary
- `backend/utils/notification_text.py::to_plain_text` silently dropped the rest of a push-notification body when the source markdown used a single-line triple-backtick inline code span (e.g. ```` ```omi start``` before continuing. ````), because the fence-stripping regex matched any line starting with three backticks and deleted the whole line before the inline-code handler could run.
- Narrowed `_FENCE_RE` to require that a real fence-marker line's info string contain no backticks (per CommonMark §4.5, a fence's info string cannot contain backticks), so it still matches multi-line fenced blocks but stops matching a line that opens and closes inline code on itself.

## Root cause
`_FENCE_RE = re.compile(r'^\s*```.*$', re.MULTILINE)` combined with `.*` greedily consumed a same-line closing fence, so `to_plain_text('```omi start``` before continuing.')` returned `''` instead of `'omi start before continuing.'`.

## Fix
`_FENCE_RE = re.compile(r'^\s*`{3,}[^`\n]*$', re.MULTILINE)` — a genuine fence line cannot contain a backtick after its opening run, so this still strips real fenced-block markers but falls through to `_INLINE_CODE_RE` for same-line inline code.

## Testing
- Added `test_keeps_single_line_triple_backtick_inline_code` and `test_still_strips_multiline_fenced_code_block` to `backend/tests/unit/test_notification_text.py`.
- Ran `PYTHON=.venv/bin/python bash test.sh` (full selector-driven suite) — `tests/unit/test_notification_text.py` 6/6 passed. Pre-existing failures in unrelated files (`test_modulate_stt.py`, `test_streaming_deepgram_backoff.py`, `test_stt_session_failover.py`, `test_backend_runtime_env_validator.py`, `test_monitoring_dashboard_absence_contract.py`) are unrelated to this change (STT/deepgram provider routing, env validation, monitoring dashboard — none touch `notification_text.py` or its tests).

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

