### PR TITLE
fix(sdks/python-cli): preserve saved credentials on transport failure during login (#13191)

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -34,7 +34,7 @@ from tenacity import (
 
 from omi_cli import __version__
 from omi_cli.config import Profile
-from omi_cli.errors import CliError, RateLimitError, ServerError, from_status
+from omi_cli.errors import CliError, RateLimitError, ServerError, TransportError, from_status
 
 USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
@@ -171,11 +171,11 @@ class OmiClient:
             ):
                 raise _unknown_write_outcome(method) from exc
             if method in {"POST", "PATCH"}:
-                raise ServerError(
+                raise TransportError(
                     message="Connection failed",
                     detail=f"{type(exc).__name__} after {MAX_RETRY_ATTEMPTS} attempts. Check your connection and retry.",
                 ) from exc
-            raise ServerError(
+            raise TransportError(
                 message="Connection failed",
                 detail="Unable to reach the Omi API. Check your network connection or try again shortly.",
             ) from exc

--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -13,7 +13,7 @@ from omi_cli.auth import api_key as api_key_auth
 from omi_cli.auth import oauth as oauth_auth
 from omi_cli.auth.store import clear_credentials
 from omi_cli.client import OmiClient
-from omi_cli.errors import AuthError, CliError, UsageError
+from omi_cli.errors import AuthError, CliError, TransportError, UsageError
 
 if TYPE_CHECKING:
     from omi_cli.main import AppContext
@@ -145,11 +145,12 @@ def _do_api_key_login(ctx: "AppContext", api_key: str) -> None:
     verification_warning = None
 
     # Sanity check on a tolerant endpoint — see the original launch PR's
-    # rationale. AuthError leaves disk unchanged; other CliError warns and keeps.
+    # rationale. Auth and transport failures leave disk unchanged; other
+    # HTTP errors preserve the existing warn-and-store policy.
     try:
         with OmiClient(profile, verbose=ctx.verbose) as client:
             client.get("/v1/dev/user/memories", params={"limit": 1})
-    except AuthError:
+    except (AuthError, TransportError):
         raise
     except CliError as exc:
         verification_warning = (

--- a/sdks/python-cli/omi_cli/errors.py
+++ b/sdks/python-cli/omi_cli/errors.py
@@ -91,6 +91,10 @@ class ServerError(CliError):
     exit_code = EXIT_SERVER
 
 
+class TransportError(ServerError):
+    """The request failed at the transport layer, without a usable HTTP response."""
+
+
 class NotFoundError(CliError):
     exit_code = EXIT_NOT_FOUND
 

--- a/sdks/python-cli/tests/test_auth_api_key.py
+++ b/sdks/python-cli/tests/test_auth_api_key.py
@@ -154,3 +154,17 @@ def test_transport_failure_during_login_leaves_saved_config_unchanged(
     assert result.exit_code != 0
     assert route.call_count == 1
     assert config_path.read_bytes() == before
+
+
+def test_transport_timeout_during_login_leaves_saved_config_unchanged(
+    config_path, authed_profile, respx_mock, cli_runner, monkeypatch
+) -> None:
+    import httpx
+
+    monkeypatch.setattr("omi_cli.client.MAX_RETRY_ATTEMPTS", 1)
+    before = config_path.read_bytes()
+    route = respx_mock.get("/v1/dev/user/memories").mock(side_effect=httpx.ConnectTimeout("Connection timed out"))
+    result = cli_runner.invoke(app, ["auth", "login", "--api-key", "omi_dev_" + "n" * 32])
+    assert result.exit_code == 3
+    assert route.call_count == 1
+    assert config_path.read_bytes() == before


### PR DESCRIPTION
### Summary

Fixes #13191.

During developer API-key login (`omi auth login --api-key ...`), candidate verification sends a probe request to verify the credentials. Previously, `_do_api_key_login` caught all `CliError` instances and treated them as non-fatal warnings, saving unverified credentials to disk and exiting with code `0`, even when transport / connection failures occurred.

This contradicted the documented contract in `README.md` ("A transport failure leaves saved credentials unchanged") and caused the pre-existing regression test `test_transport_failure_during_login_leaves_saved_config_unchanged` to fail across Python CLI CI runs on `main`.

### Changes

1. **`sdks/python-cli/omi_cli/errors.py`**: Added `TransportError` (subclass of `ServerError`, preserving `EXIT_SERVER = 3`).
2. **`sdks/python-cli/omi_cli/client.py`**: Raised `TransportError` on `httpx.TransportError` (connection refusal, timeouts, network unreachability).
3. **`sdks/python-cli/omi_cli/commands/auth.py`**: Updated `_do_api_key_login` to reraise `(AuthError, TransportError)` so candidate credentials are not persisted when connection fails. Recoverable HTTP 503 errors retain the existing warn-and-store behavior.
4. **`sdks/python-cli/tests/test_auth_api_key.py`**: Added companion test for transport timeout during login verification, confirming exit code 3 and unchanged configuration.

### Verification

- Full Python CLI test suite: 339 passed, 0 failed.
- Regression tests in `tests/test_auth_api_key.py`: 17 passed, 0 failed.
- Whitespace and formatting clean (`git diff --check HEAD` clean, all lines <= 120 chars).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
