### PR TITLE
fix(sdks/python-cli): don't treat empty-body HTTP errors as success

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -184,9 +184,9 @@ class OmiClient:
         raise RuntimeError("unreachable")
 
     def _handle_response(self, response: httpx.Response) -> Any:
-        if response.status_code == 204 or not response.content:
-            return None
         if 200 <= response.status_code < 300:
+            if response.status_code == 204 or not response.content:
+                return None
             return _safe_parse_json(response)
         raise self._error_from_response(response)
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -129,6 +129,29 @@ def test_cli_auth_error_with_markup_preserves_exit_code(
         assert detail in captured.err
 
 
+def test_empty_body_401_maps_to_auth_error(authed_profile, respx_mock) -> None:
+    """An empty-body 401 must still raise, not be treated like an empty 204 success."""
+    respx_mock.delete("/v1/dev/user/memories/abc").respond(401, content=b"")
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(AuthError):
+            client.delete("/v1/dev/user/memories/abc")
+
+
+def test_empty_body_404_maps_to_not_found(authed_profile, respx_mock) -> None:
+    respx_mock.delete("/v1/dev/user/memories/abc").respond(404, content=b"")
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(NotFoundError):
+            client.delete("/v1/dev/user/memories/abc")
+
+
+def test_204_delete_still_returns_none(authed_profile, respx_mock) -> None:
+    """Guard the success path the fix must not regress: empty 2xx bodies stay silent."""
+    respx_mock.delete("/v1/dev/user/memories/abc").respond(204, content=b"")
+    with OmiClient(authed_profile) as client:
+        result = client.delete("/v1/dev/user/memories/abc")
+    assert result is None
+
+
 def test_403_maps_to_auth_error(authed_profile, respx_mock) -> None:
     respx_mock.post("/v1/dev/user/memories").respond(
         403, json={"detail": "Insufficient permissions. Required scope: memories:write"}
@@ -224,7 +247,6 @@ def test_503_retry_after_http_date(authed_profile, respx_mock, monkeypatch) -> N
     assert result == []
     assert len(sleeps) == 1
     assert 8.0 <= sleeps[0] <= 11.0
-
 
 
 def test_429_surfaces_rate_limit_with_policy(authed_profile, respx_mock) -> None:


### PR DESCRIPTION
## What
`OmiClient._handle_response` checked `not response.content` before checking the
status code, so any HTTP error response with an empty body (a bare 401/403/404
with no JSON detail) was treated as a silent success and returned `None`
instead of raising.

## Why
`omi delete memory <id>` (and any other DELETE/PATCH call) would print
"Deleted" and exit 0 even when the server rejected the request, because some
error responses come back with an empty body.

## Fix
Move the empty-body short-circuit inside the `200 <= status < 300` branch so
it only applies to real 2xx success responses (incl. 204). Any non-2xx status
now always falls through to `_error_from_response`, empty body or not.

## Testing
`sdks/python-cli`: `python -m pytest tests/` — 373 passed, 1 skipped (full
suite, on Python 3.12). Added three regression tests: empty-body 401 and 404
now raise `AuthError`/`NotFoundError`, and a 204 empty body still returns
`None` (guards the success path against a regression).

Failure-Class: none

fixes #13390

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

