### PR TITLE
fix(backend): fail export closed on NaN/Infinity instead of writing invalid JSON (#4678)

### DIFF
--- a/backend/services/users/data_export.py
+++ b/backend/services/users/data_export.py
@@ -105,6 +105,31 @@ def _json_default(obj: object) -> str:
     raise TypeError(f"Type {type(obj)} not serializable")
 
 
+def _dumps(obj: object, **kwargs: Any) -> str:
+    """json.dumps that fails closed on NaN/Infinity instead of writing an invalid JSON token.
+
+    Firestore permits these non-finite float values, but the default json encoder
+    (allow_nan=True) writes them as bare NaN/Infinity/-Infinity tokens, which strict
+    JSON parsers reject -- silently corrupting the completed export.
+    """
+    try:
+        return json.dumps(obj, default=_json_default, allow_nan=False, **kwargs)
+    except ValueError as exc:
+        raise PortabilityExportIncomplete(
+            "retained record contains a non-finite numeric value (NaN/Infinity) that cannot be exported as JSON"
+        ) from exc
+
+
+def _dump(obj: object, fp: IO[str], **kwargs: Any) -> None:
+    """json.dump counterpart of `_dumps` for direct-to-spool writes."""
+    try:
+        json.dump(obj, fp, default=_json_default, allow_nan=False, **kwargs)
+    except ValueError as exc:
+        raise PortabilityExportIncomplete(
+            "retained record contains a non-finite numeric value (NaN/Infinity) that cannot be exported as JSON"
+        ) from exc
+
+
 def _iter_paginated(
     fetch_page: Callable[[int, int], Sequence[Mapping[str, Any]]], *, batch_size: int = 1000
 ) -> Iterator[Mapping[str, Any]]:
@@ -126,7 +151,7 @@ def _yield_json_array(items: Iterable[Mapping[str, Any]]) -> Iterator[str]:
         if not first:
             yield ',\n'
         first = False
-        yield '    ' + json.dumps(item, default=_json_default, indent=4)
+        yield '    ' + _dumps(item, indent=4)
     yield '\n  ]'
 
 
@@ -146,7 +171,7 @@ def _spool_export_memories_json(uid: str) -> IO[str]:
             if not first:
                 spool.write(",\n")
             first = False
-            spool.write("    " + json.dumps(memory.model_dump(mode="json"), default=_json_default, indent=4))
+            spool.write("    " + _dumps(memory.model_dump(mode="json"), indent=4))
         spool.write("\n  ]")
         spool.seek(0)
         return spool
@@ -249,7 +274,7 @@ def _iter_user_data_export_from_spool(uid: str, memories_spool: IO[str]) -> Iter
     yield "{\n"
 
     profile = cast(JsonRecord | None, get_user_profile(uid))
-    yield ('  "profile": ' + json.dumps(profile if profile else {}, default=_json_default, indent=2) + ",\n")
+    yield ('  "profile": ' + _dumps(profile if profile else {}, indent=2) + ",\n")
 
     # Photo manifests can contain base64 image bytes. Spool them independently
     # while conversations stream so account size cannot turn export into an
@@ -265,7 +290,7 @@ def _iter_user_data_export_from_spool(uid: str, memories_spool: IO[str]) -> Iter
             if not first:
                 yield ",\n"
             first = False
-            yield "    " + json.dumps(conv, default=_json_default, indent=4)
+            yield "    " + _dumps(conv, indent=4)
         yield "\n  ],\n"
 
         for conversation_id, photo in conversations_db.iter_all_conversation_photos(uid):
@@ -274,10 +299,9 @@ def _iter_user_data_export_from_spool(uid: str, memories_spool: IO[str]) -> Iter
             if photo_count:
                 photo_spool.write(",\n")
             photo_spool.write("    ")
-            json.dump(
+            _dump(
                 _export_photo_manifest(uid, str(conversation_id), photo, require_bytes=False),
                 photo_spool,
-                default=_json_default,
                 indent=4,
             )
             photo_count += 1
@@ -370,7 +394,7 @@ def _iter_user_data_export_from_spool(uid: str, memories_spool: IO[str]) -> Iter
     yield '  },\n'
 
     people = cast(Sequence[Mapping[str, Any]], get_people(uid))
-    yield '  "people": ' + json.dumps(people, default=_json_default, indent=2) + ",\n"
+    yield '  "people": ' + _dumps(people, indent=2) + ",\n"
 
     yield '  "action_items": '
     yield from _yield_json_array(
@@ -410,7 +434,7 @@ def _iter_user_data_export_from_spool(uid: str, memories_spool: IO[str]) -> Iter
         if not first:
             yield ",\n"
         first = False
-        yield "    " + json.dumps(msg, default=_json_default, indent=4)
+        yield "    " + _dumps(msg, indent=4)
     yield "\n  ]\n"
 
     yield "}\n"

--- a/backend/tests/services/users/test_data_export.py
+++ b/backend/tests/services/users/test_data_export.py
@@ -498,6 +498,37 @@ def test_json_default_raises_type_error_for_unsupported_types():
         data_export._json_default(set())
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_dumps_aborts_instead_of_emitting_invalid_json_token(value):
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="non-finite numeric value"):
+        data_export._dumps({"score": value})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_dump_aborts_instead_of_emitting_invalid_json_token(value):
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="non-finite numeric value"):
+        data_export._dump({"score": value}, StringIO())
+
+
+def test_iter_user_data_export_aborts_before_streaming_on_non_finite_conversation_field(monkeypatch):
+    """A NaN/Infinity value anywhere in exported data must fail the export before
+    any bytes are returned, not silently produce a corrupt JSON download."""
+    monkeypatch.setattr(data_export, "get_user_profile", MagicMock(return_value={}))
+    monkeypatch.setattr(
+        data_export,
+        "MemoryService",
+        MagicMock(return_value=MagicMock(iter_portability_export_memories=MagicMock(return_value=iter([])))),
+    )
+    monkeypatch.setattr(
+        data_export.conversations_db,
+        "iter_all_conversations",
+        MagicMock(return_value=iter([{"id": "conv1", "score": float("nan")}])),
+    )
+
+    with pytest.raises(data_export.PortabilityExportIncomplete, match="non-finite numeric value"):
+        data_export.iter_user_data_export("uid1")
+
+
 def test_iter_user_data_export_does_not_call_list_export(monkeypatch):
     """Large-account export must use the portability stream, not list materialization."""
     monkeypatch.setattr(data_export, "get_user_profile", MagicMock(return_value={}))


### PR DESCRIPTION
## Summary
- Data export (`GET /v1/users/export`) writes every record through `json.dumps(..., default=_json_default)`, which defaults to `allow_nan=True`. A stored `NaN`/`Infinity`/`-Infinity` float (Firestore permits these; strict JSON does not) is written as a bare invalid token, so the response still returns 200 with a file that fails `JSON.parse` for the user — matching the "loads then gives an empty/broken file" symptom reported in #4678.
- `iter_user_data_export` fully materializes the export into a spool before the HTTP response is returned, so failing closed here is safe: it becomes a clean 500 instead of corrupting an in-flight stream, the same contract `PortabilityExportIncomplete` already enforces for malformed retained image bytes.
- Routes every `default=_json_default` call through new `_dumps`/`_dump` helpers that set `allow_nan=False` and raise `PortabilityExportIncomplete` on the resulting `ValueError`.

## Product invariants affected

- INV-MEM-3 — path-glob match only (`backend/services/users/data_export.py` touches memory export serialization). This change does not alter memory read/authority logic; it only makes the existing JSON serialization of already-authorized export data fail closed instead of emitting a corrupt token, for every export section (profile, conversations, memories, people, chat, tasks), not just memory rows.

## Failure class (fixes)

Failure-Class: none

No existing `.github/failure-classes/` definition matches (checked scope hints and serialization-related classes, e.g. `FC-serialiser-dialect-mismatch-retypes-values` is about a reader/writer dialect mismatch on round-trip edits, not a producer accepting an unrepresentable value). This is a narrow, single-encoder-call-site fix, not an established recurring pattern, so `none` rather than `new`.

## Test plan
- `tests/services/users/test_data_export.py` (53 passed) — added `test_dumps_aborts_instead_of_emitting_invalid_json_token`, `test_dump_aborts_instead_of_emitting_invalid_json_token`, `test_iter_user_data_export_aborts_before_streaming_on_non_finite_conversation_field`.
- `tests/unit/test_data_export_cursor_pagination.py` (2 passed) — unaffected.
- `tests/routers/test_users.py -k export` (2 passed) — existing `test_export_all_user_data_returns_500_before_streaming_headers_when_memory_preflight_fails` already asserts this exception class returns 500 before headers are sent.
- Ran via the shared `backend/.venv` from the primary `omi` checkout (`test-preflight.sh` env unavailable in this worktree).

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

