### PR TITLE
test: add assertions to Zapier on_memory_created test

### DIFF
--- a/plugins/zapier/omi-zap/test/triggers/on_memory_created.test.js
+++ b/plugins/zapier/omi-zap/test/triggers/on_memory_created.test.js
@@ -8,13 +8,20 @@ zapier.tools.env.inject();
 
 describe('triggers.on_memory_created', () => {
   it('should run', async () => {
-    const bundle = { inputData: {} };
+    const bundle = {
+      inputData: {},
+      cleanedRequest: {
+        id: 123,
+        title: 'Test Memory',
+      },
+    };
 
     const results = await appTester(
       App.triggers['on_memory_created'].operation.perform,
       bundle
     );
     expect(results).toBeDefined();
-    // TODO: add more assertions
+    expect(results.length).toBe(1);
+    expect(results[0]).toEqual(bundle.cleanedRequest);
   });
 });


### PR DESCRIPTION
Failure-Class: none
Adds mock `cleanedRequest` data to the test bundle and asserts that it is returned correctly by the webhook hook, replacing the `TODO: add more assertions` comment in `plugins/zapier/omi-zap/test/triggers/on_memory_created.test.js`.

---
*PR created automatically by Jules for task [2867951329403104948](https://jules.google.com/task/2867951329403104948) started by @undivisible*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the Zapier plugin with no production or runtime impact.
> 
> **Overview**
> Strengthens the Zapier **`on_memory_created`** trigger test by supplying a mock **`cleanedRequest`** on the test bundle (sample `id` and `title`) and asserting the hook **`perform`** returns a single item that matches that payload.
> 
> This replaces the previous **`TODO: add more assertions`** with concrete expectations on result length and equality, aligning the test with the trigger’s behavior of echoing **`bundle.cleanedRequest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590191a333ff56696ede985c731f0e3480be644f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->