### PR TITLE
fix(ci): sign the pusher dev probe with the Firebase auth project's signer

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -98,9 +98,9 @@ checks:
     reason: "#11641: a self-signed developer build carrying the production bundle id wrote certificate-pinned TCC records that no re-grant could clear, breaking Screen Recording and Microphone on a user's Mac for days; a build not signed for release must never claim the production identifiers"
   - id: desktop-release-process-guards
     command: ["bash", "scripts/run-release-process-guards.sh"]
-    triggers: ["codemagic.yaml", ".github/workflows/desktop_promote_beta.yml", ".github/scripts/check-release-process-guards.py", ".github/scripts/git_bash.py", "scripts/dev-harness/_resolve_python.sh", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
+    triggers: ["codemagic.yaml", ".github/workflows/**", ".github/scripts/check-release-process-guards.py", ".github/scripts/git_bash.py", "scripts/dev-harness/_resolve_python.sh", "scripts/run-release-process-guards.sh", "backend/tests/unit/test_desktop_release_scripts.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "normal Beta promotion must stay on Codemagic signed-smoke evidence and must not reintroduce a qualification-completion trigger"
+    reason: "normal Beta promotion must stay on Codemagic signed-smoke evidence and must not reintroduce a qualification-completion trigger; the trigger set is all of .github/workflows/** because check_firebase_probe_signer_identity scans every workflow, and the two-file list let 7883c816db ship a release probe whose signer could never satisfy its own --firebase-project"
   - id: desktop-release-process-guard-tests
     command: ["bash", "scripts/run-release-process-guard-tests.sh"]
     triggers: [".github/scripts/check-release-process-guards.py", ".github/scripts/test_check_release_process_guards.py", ".github/scripts/git_bash.py", "codemagic.yaml", ".github/scripts/fixtures/codemagic_workflow_contract/**", "scripts/run-release-process-guard-tests.sh", ".github/checks-manifest.yaml"]

--- a/.github/failure-classes/FC-release-gate-unsatisfiable-by-its-own-principal.json
+++ b/.github/failure-classes/FC-release-gate-unsatisfiable-by-its-own-principal.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-release-gate-unsatisfiable-by-its-own-principal",
+  "violated_contract": "A fail-closed gate must be satisfiable by the principal it runs as. When a gate compares a credential's own scope against a target that credential can never belong to -- a signer whose project_id is checked against a foreign --firebase-project, a token checked against an authority it was never issued for -- it cannot pass in any environment. It stops qualifying releases and starts blocking them, and because a permanently red gate is indistinguishable from an ordinary flaky or legitimately failing check, the block is invisible: the release lane simply stays red while merged fixes pile up behind it, live on the tiers that deploy through other lanes and absent on the one it guards.",
+  "canonical_prevention": "Pair a gate's credential with the authority it is checked against at authoring time, and prove the pairing before the gate is allowed to block anything: a new fail-closed gate ships with a test showing an existing principal passes it (AGENTS.md's legacy-principal rule), and the wiring itself is pinned by a check that reads which secret feeds the gate rather than trusting the name. When triaging a red release lane, compare the lane's last green run against the gate's introduction: if the last success predates the gate, the gate has never passed and the defect is the gate, not the code behind it.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check-release-process-guards.py",
+    ".github/scripts/test_check_release_process_guards.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    ".github/workflows/**",
+    ".github/scripts/check-release-process-guards.py",
+    "backend/scripts/firebase_release_probe_token.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -521,6 +521,7 @@ def main() -> int:
     errors.extend(check_python_cli_release_version_source())
     errors.extend(check_react_native_release_tags())
     errors.extend(check_firmware_release_metadata())
+    errors.extend(check_firebase_probe_signer_identity())
 
     if errors:
         for error in errors:
@@ -529,6 +530,51 @@ def main() -> int:
 
     print("release process guard checks passed")
     return 0
+
+
+def check_firebase_probe_signer_identity() -> list[str]:
+    """A release probe must sign with a credential that belongs to the Firebase auth project.
+
+    `firebase_release_probe_token.py` fails closed when the signer credential's `project_id`
+    differs from `--firebase-project`, and every environment's `GCP_CREDENTIALS` is that
+    environment's own deploy identity (`based-hardware-dev` in development). Wiring the two
+    together produces a gate that can never pass in any environment.
+
+    That shipped: `7883c816db` added the development Pusher semantic probe with
+    `FIREBASE_SIGNER_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}` and
+    `--firebase-project based-hardware`. It failed `signer_credentials/project_mismatch` on
+    every run from the day it landed, blocking the Pusher dev qualification -- and therefore
+    every production Pusher release -- for ten days, which stranded the #12663 custom-STT
+    revert on a stale tier while ~3.5k conversations a day silently lost their summaries.
+    `secrets.GCP_SERVICE_ACCOUNT` is the based-hardware signer the desktop development lane
+    already mints probe tokens with; that is the credential a probe signer must come from.
+    """
+
+    errors: list[str] = []
+    workflows = sorted((ROOT / ".github/workflows").glob("*.yml"))
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        relative = workflow.relative_to(ROOT)
+        for name, secret in re.findall(
+            r"^\s*([A-Za-z0-9_]*SIGNER[A-Za-z0-9_]*)\s*:\s*\$\{\{\s*secrets\.([A-Za-z0-9_]+)\s*\}\}",
+            text,
+            re.MULTILINE,
+        ):
+            if secret == "GCP_SERVICE_ACCOUNT":
+                continue
+            errors.append(
+                f"{relative}: {name} is fed from secrets.{secret}; a Firebase probe signer must come "
+                "from secrets.GCP_SERVICE_ACCOUNT, which belongs to the based-hardware auth project. "
+                "A per-environment deploy identity fails signer_credentials/project_mismatch on every run."
+            )
+        if "firebase_release_probe_token.py" not in text or "--signer-credentials-file" not in text:
+            continue
+        if "secrets.GCP_SERVICE_ACCOUNT" not in text:
+            errors.append(
+                f"{relative}: mints a Firebase probe token from a signer credentials file but never reads "
+                "secrets.GCP_SERVICE_ACCOUNT; the signer must belong to the --firebase-project it signs for."
+            )
+    return errors
 
 
 def check_desktop_codemagic_release() -> list[str]:

--- a/.github/scripts/check-release-process-guards.py
+++ b/.github/scripts/check-release-process-guards.py
@@ -533,26 +533,34 @@ def main() -> int:
 
 
 def check_firebase_probe_signer_identity() -> list[str]:
-    """A release probe must sign with a credential that belongs to the Firebase auth project.
+    """A release probe must sign with a principal that can sign for its Firebase project.
 
-    `firebase_release_probe_token.py` fails closed when the signer credential's `project_id`
-    differs from `--firebase-project`, and every environment's `GCP_CREDENTIALS` is that
-    environment's own deploy identity (`based-hardware-dev` in development). Wiring the two
-    together produces a gate that can never pass in any environment.
+    `firebase_release_probe_token.py` fails closed when the signer's project differs from
+    `--firebase-project`, and every environment's `GCP_CREDENTIALS` is that environment's own
+    deploy identity. A development lane minting a token for `based-hardware` while signing as
+    `based-hardware-dev` therefore cannot pass in any environment.
 
-    That shipped: `7883c816db` added the development Pusher semantic probe with
+    That shipped: `7883c816db` (2026-08-30) added the development Pusher semantic probe with
     `FIREBASE_SIGNER_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}` and
-    `--firebase-project based-hardware`. It failed `signer_credentials/project_mismatch` on
-    every run from the day it landed, blocking the Pusher dev qualification -- and therefore
-    every production Pusher release -- for ten days, which stranded the #12663 custom-STT
-    revert on a stale tier while ~3.5k conversations a day silently lost their summaries.
-    `secrets.GCP_SERVICE_ACCOUNT` is the based-hardware signer the desktop development lane
-    already mints probe tokens with; that is the credential a probe signer must come from.
+    `--firebase-project based-hardware`. It returned `signer_credentials/project_mismatch` on
+    every run from the day it landed, and because production Pusher promotion requires a
+    successful development qualification with no break-glass, it froze pusher for ten days --
+    stranding the #12663 custom-STT revert on a tier that still ran the old gate while ~3.5k
+    conversations a day silently lost their summaries.
+
+    Two resolutions are legitimate, so this rejects exactly one thing -- signing as the lane's
+    own deploy identity: supply the Firebase project's signer credential (what `gcp_backend.yml`
+    does), or name that signer and impersonate it via `--signer-service-account` (what a workflow
+    forbidden to materialize a key must do -- see
+    `test_backend_deploy_workflows_do_not_materialize_an_ignored_service_account_key`).
+
+    Whether an *unnamed* signer is correct cannot be decided from the workflow text: it depends on
+    which project the lane's environment resolves to, and `gcp_backend_pusher.yml` legitimately
+    signs as its production deploy identity. That case is deliberately not checked here.
     """
 
     errors: list[str] = []
-    workflows = sorted((ROOT / ".github/workflows").glob("*.yml"))
-    for workflow in workflows:
+    for workflow in sorted((ROOT / ".github/workflows").glob("*.yml")):
         text = workflow.read_text(encoding="utf-8")
         relative = workflow.relative_to(ROOT)
         for name, secret in re.findall(
@@ -560,20 +568,14 @@ def check_firebase_probe_signer_identity() -> list[str]:
             text,
             re.MULTILINE,
         ):
-            if secret == "GCP_SERVICE_ACCOUNT":
-                continue
-            errors.append(
-                f"{relative}: {name} is fed from secrets.{secret}; a Firebase probe signer must come "
-                "from secrets.GCP_SERVICE_ACCOUNT, which belongs to the based-hardware auth project. "
-                "A per-environment deploy identity fails signer_credentials/project_mismatch on every run."
-            )
-        if "firebase_release_probe_token.py" not in text or "--signer-credentials-file" not in text:
-            continue
-        if "secrets.GCP_SERVICE_ACCOUNT" not in text:
-            errors.append(
-                f"{relative}: mints a Firebase probe token from a signer credentials file but never reads "
-                "secrets.GCP_SERVICE_ACCOUNT; the signer must belong to the --firebase-project it signs for."
-            )
+            if secret == "GCP_CREDENTIALS":
+                errors.append(
+                    f"{relative}: {name} is fed from secrets.GCP_CREDENTIALS, this lane's own deploy "
+                    "identity. A probe signer must belong to the --firebase-project it signs for, so "
+                    "this fails signer_credentials/project_mismatch on every run. Supply the Firebase "
+                    "project's signer credential, or name it with --signer-service-account and "
+                    "impersonate it."
+                )
     return errors
 
 

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -1001,39 +1001,47 @@ _PROBE_STEP = """jobs:
     steps:
       - name: Probe
         env:
-          FIREBASE_SIGNER_CREDENTIALS_B64: ${{{{ secrets.{secret} }}}}
+          FIREBASE_SIGNER_CREDENTIALS: ${{{{ secrets.{secret} }}}}
         run: |
-          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS_B64" | base64 --decode > "$signer_file"
           python3 backend/scripts/firebase_release_probe_token.py \\
             --firebase-project based-hardware \\
             --signer-credentials-file "$signer_file" \\
             --token-output "$token_file"
 """
 
+_IMPERSONATION_STEP = """jobs:
+  deploy:
+    environment: development
+    steps:
+      - name: Probe
+        env:
+          FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}
+        run: |
+          python3 backend/scripts/firebase_release_probe_token.py \\
+            --firebase-project based-hardware \\
+            --signer-service-account "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" \\
+            --token-output "$token_file"
+"""
 
-def test_probe_signer_from_the_environment_deploy_identity_is_rejected(tmp_path, monkeypatch):
-    """The exact wiring 7883c816db shipped: a based-hardware-dev identity signing for
-    based-hardware. It failed signer_credentials/project_mismatch on every run for ten days
-    and blocked every production Pusher release behind it."""
+
+def test_probe_signing_as_the_lane_deploy_identity_is_rejected(tmp_path, monkeypatch):
+    """The exact wiring 7883c816db shipped: a based-hardware-dev deploy identity signing for
+    based-hardware. It returned signer_credentials/project_mismatch on every run for ten days
+    and froze every production Pusher release behind it."""
     errors = _workflow_tree(tmp_path, monkeypatch, _PROBE_STEP.format(secret="GCP_CREDENTIALS"))
 
-    assert any("GCP_CREDENTIALS" in error and "GCP_SERVICE_ACCOUNT" in error for error in errors), errors
+    assert any("GCP_CREDENTIALS" in error and "project_mismatch" in error for error in errors), errors
 
 
-def test_probe_signer_from_the_firebase_project_signer_is_accepted(tmp_path, monkeypatch):
-    """The wiring the desktop development lane already mints probe tokens with."""
+def test_probe_signing_with_the_firebase_projects_own_credential_is_accepted(tmp_path, monkeypatch):
+    """gcp_backend.yml's resolution: supply the Firebase project's signer key."""
     assert _workflow_tree(tmp_path, monkeypatch, _PROBE_STEP.format(secret="GCP_SERVICE_ACCOUNT")) == []
 
 
-def test_probe_with_a_signer_file_must_name_the_firebase_signer_secret(tmp_path, monkeypatch):
-    """A signer file assembled without the based-hardware secret cannot satisfy the probe."""
-    body = _PROBE_STEP.format(secret="GCP_SERVICE_ACCOUNT").replace(
-        "FIREBASE_SIGNER_CREDENTIALS_B64: ${{ secrets.GCP_SERVICE_ACCOUNT }}",
-        "OTHER_INPUT: ${{ secrets.DOCKER_PAT }}",
-    )
-    errors = _workflow_tree(tmp_path, monkeypatch, body)
-
-    assert any("never reads secrets.GCP_SERVICE_ACCOUNT" in error for error in errors), errors
+def test_probe_impersonating_a_named_signer_is_accepted(tmp_path, monkeypatch):
+    """The resolution a workflow forbidden to materialize a key must use: name the signer and
+    impersonate it, so no service-account key enters a backend image build."""
+    assert _workflow_tree(tmp_path, monkeypatch, _IMPERSONATION_STEP) == []
 
 
 def test_live_workflows_satisfy_the_probe_signer_contract():

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -984,3 +984,57 @@ def test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger(tmp_
     promotion.write_text(original + "\nqualification_run_id: 1\n", encoding="utf-8")
     errors = GUARDS.check_desktop_promotion_independent_of_qualification()
     assert any("still depends on qualification" in error for error in errors), errors
+
+
+def _workflow_tree(tmp_path: Path, monkeypatch, body: str) -> list[str]:
+    """Run the signer guard against a single synthetic workflow."""
+    workflows = tmp_path / ".github/workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / "probe.yml").write_text(body, encoding="utf-8")
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+    return GUARDS.check_firebase_probe_signer_identity()
+
+
+_PROBE_STEP = """jobs:
+  deploy:
+    environment: development
+    steps:
+      - name: Probe
+        env:
+          FIREBASE_SIGNER_CREDENTIALS_B64: ${{{{ secrets.{secret} }}}}
+        run: |
+          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS_B64" | base64 --decode > "$signer_file"
+          python3 backend/scripts/firebase_release_probe_token.py \\
+            --firebase-project based-hardware \\
+            --signer-credentials-file "$signer_file" \\
+            --token-output "$token_file"
+"""
+
+
+def test_probe_signer_from_the_environment_deploy_identity_is_rejected(tmp_path, monkeypatch):
+    """The exact wiring 7883c816db shipped: a based-hardware-dev identity signing for
+    based-hardware. It failed signer_credentials/project_mismatch on every run for ten days
+    and blocked every production Pusher release behind it."""
+    errors = _workflow_tree(tmp_path, monkeypatch, _PROBE_STEP.format(secret="GCP_CREDENTIALS"))
+
+    assert any("GCP_CREDENTIALS" in error and "GCP_SERVICE_ACCOUNT" in error for error in errors), errors
+
+
+def test_probe_signer_from_the_firebase_project_signer_is_accepted(tmp_path, monkeypatch):
+    """The wiring the desktop development lane already mints probe tokens with."""
+    assert _workflow_tree(tmp_path, monkeypatch, _PROBE_STEP.format(secret="GCP_SERVICE_ACCOUNT")) == []
+
+
+def test_probe_with_a_signer_file_must_name_the_firebase_signer_secret(tmp_path, monkeypatch):
+    """A signer file assembled without the based-hardware secret cannot satisfy the probe."""
+    body = _PROBE_STEP.format(secret="GCP_SERVICE_ACCOUNT").replace(
+        "FIREBASE_SIGNER_CREDENTIALS_B64: ${{ secrets.GCP_SERVICE_ACCOUNT }}",
+        "OTHER_INPUT: ${{ secrets.DOCKER_PAT }}",
+    )
+    errors = _workflow_tree(tmp_path, monkeypatch, body)
+
+    assert any("never reads secrets.GCP_SERVICE_ACCOUNT" in error for error in errors), errors
+
+
+def test_live_workflows_satisfy_the_probe_signer_contract():
+    assert GUARDS.check_firebase_probe_signer_identity() == []

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -186,36 +186,37 @@ jobs:
       - name: Probe deployed development Pusher finalization semantics
         env:
           # The development backend authenticates against PRODUCTION Firebase
-          # (FIREBASE_PROJECT_ID=based-hardware on the dev backend), so the signer must
-          # belong to based-hardware: firebase_release_probe_token.py fails closed when
-          # the credential's project_id differs from --firebase-project. GCP_CREDENTIALS
-          # is the based-hardware-dev deploy identity and can never satisfy that, which is
-          # why this gate had never passed since it shipped. GCP_SERVICE_ACCOUNT is the
-          # based-hardware signer the desktop development lane already mints probe tokens
-          # with (desktop_backend_auto_dev.yml, same environment, same --firebase-project).
-          FIREBASE_SIGNER_CREDENTIALS_B64: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # (FIREBASE_PROJECT_ID=based-hardware on the dev Cloud Run service), so the
+          # custom token must be signed by a based-hardware principal.
+          # firebase_release_probe_token.py fails closed when the signer's project differs
+          # from --firebase-project, and this lane's deploy identity is based-hardware-dev,
+          # so signing as the deploy identity can never pass -- that is the
+          # signer_credentials/project_mismatch this gate returned on every run since it
+          # shipped in 7883c816db.
+          #
+          # Name the Firebase project's own signer and impersonate it (IAM signJwt) rather
+          # than materializing a service-account key: this workflow builds a backend image,
+          # and test_backend_deploy_workflows_do_not_materialize_an_ignored_service_account_key
+          # forbids a key secret here. Impersonation needs
+          # roles/iam.serviceAccountTokenCreator for the deploy identity on that signer.
+          FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}
         run: |
           set -euo pipefail
           umask 077
           python3 -m pip install -q websockets==12.0
           token_file="$(mktemp "$RUNNER_TEMP/omi-pusher-probe-token.XXXXXX")"
-          signer_file="$(mktemp "$RUNNER_TEMP/omi-pusher-probe-signer.XXXXXX")"
-          cleanup() {
-            rm -f "$token_file" "$signer_file"
-            unset FIREBASE_SIGNER_CREDENTIALS_B64
-          }
+          cleanup() { rm -f "$token_file"; }
           trap cleanup EXIT
-          if [[ -z "$FIREBASE_SIGNER_CREDENTIALS_B64" ]]; then
-            echo "Development Pusher semantic probe requires the GCP_SERVICE_ACCOUNT Firebase signer." >&2
+          if [[ -z "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" ]]; then
+            echo "Development Pusher semantic probe requires FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT:" >&2
+            echo "a based-hardware signer this lane's deploy identity may impersonate." >&2
             exit 1
           fi
-          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS_B64" | base64 --decode > "$signer_file"
           python3 backend/scripts/firebase_release_probe_token.py \
             --secret-project "${{ vars.GCP_PROJECT_ID }}" \
             --firebase-project based-hardware \
-            --signer-credentials-file "$signer_file" \
+            --signer-service-account "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" \
             --token-output "$token_file"
-          rm -f "$signer_file"
           python3 backend/scripts/pusher_semantic_probe.py \
             --api-url https://api.omiapi.com \
             --bearer-token-file "$token_file" \

--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -185,7 +185,15 @@ jobs:
 
       - name: Probe deployed development Pusher finalization semantics
         env:
-          FIREBASE_SIGNER_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          # The development backend authenticates against PRODUCTION Firebase
+          # (FIREBASE_PROJECT_ID=based-hardware on the dev backend), so the signer must
+          # belong to based-hardware: firebase_release_probe_token.py fails closed when
+          # the credential's project_id differs from --firebase-project. GCP_CREDENTIALS
+          # is the based-hardware-dev deploy identity and can never satisfy that, which is
+          # why this gate had never passed since it shipped. GCP_SERVICE_ACCOUNT is the
+          # based-hardware signer the desktop development lane already mints probe tokens
+          # with (desktop_backend_auto_dev.yml, same environment, same --firebase-project).
+          FIREBASE_SIGNER_CREDENTIALS_B64: ${{ secrets.GCP_SERVICE_ACCOUNT }}
         run: |
           set -euo pipefail
           umask 077
@@ -194,14 +202,14 @@ jobs:
           signer_file="$(mktemp "$RUNNER_TEMP/omi-pusher-probe-signer.XXXXXX")"
           cleanup() {
             rm -f "$token_file" "$signer_file"
-            unset FIREBASE_SIGNER_CREDENTIALS
+            unset FIREBASE_SIGNER_CREDENTIALS_B64
           }
           trap cleanup EXIT
-          if [[ -z "$FIREBASE_SIGNER_CREDENTIALS" ]]; then
-            echo "Development Pusher semantic probe requires the existing GCP_CREDENTIALS Firebase signer." >&2
+          if [[ -z "$FIREBASE_SIGNER_CREDENTIALS_B64" ]]; then
+            echo "Development Pusher semantic probe requires the GCP_SERVICE_ACCOUNT Firebase signer." >&2
             exit 1
           fi
-          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS" > "$signer_file"
+          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS_B64" | base64 --decode > "$signer_file"
           python3 backend/scripts/firebase_release_probe_token.py \
             --secret-project "${{ vars.GCP_PROJECT_ID }}" \
             --firebase-project based-hardware \


### PR DESCRIPTION
## Problem

Custom-STT users still have no summaries, a week after the fix for it merged.

`#12663` (merged 2026-09-03) removed the `#7690` Omi-paid LLM gate. It is live on Cloud Run `backend` and on `backend-listen`. It is **not** live on `pusher`, which is where listen finalization runs — `prod-omi-pusher` is still on its 2026-08-31 image, three days older than the revert. Measured 2026-09-10 on prod pusher:

```
INFO:utils.conversations.process_conversation:custom STT: skipping Omi-paid post-processing for uid=… conv=…
```

**3,571 conversations in 24h** (~106/h, ~38 distinct users/h). Cloud Run: 0. backend-listen: 0.

Pusher is frozen because production promotion requires a successful development qualification artifact — and there is no break-glass for that requirement — while the dev lane `gcp_backend_pusher_auto_deploy.yml` has failed **every run since 2026-08-31T06:42Z** (0 successes in the last 200 runs).

## Root cause

`7883c816db` (2026-08-30) added `Probe deployed development Pusher finalization semantics` wired to a credential that can never satisfy it:

```yaml
FIREBASE_SIGNER_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}   # project_id=based-hardware-dev
...
  --firebase-project based-hardware
```

The dev backend authenticates against production Firebase (`FIREBASE_PROJECT_ID=based-hardware` on the dev Cloud Run service), and [firebase_release_probe_token.py:215](backend/scripts/firebase_release_probe_token.py#L215) fails closed when the credential's `project_id` differs from `--firebase-project`. So the step returns `signer_credentials/project_mismatch` in every environment, always.

It has never passed: the secret is unchanged since 2024-10-09, and the last green run (2026-08-31T06:22Z, `f1bc776b50`) predates the step. An earlier Grafana-token failure masked it until `294e377273` (2026-09-07) moved the failure one step later.

## Fix

Sign as a based-hardware principal without materializing its key: name the Firebase project's own signer and impersonate it via IAM `signJwt` (`--signer-service-account`), which is the second resolution `firebase_release_probe_token.py` already supports and `deploy-backend-stack` already exposes as `firebase_probe_signer_service_account`.

The obvious fix — supplying `secrets.GCP_SERVICE_ACCOUNT`, which is what `gcp_backend.yml` does for development — is **not available here**. `test_backend_deploy_workflows_do_not_materialize_an_ignored_service_account_key` forbids that secret in the five workflows that build backend images, and `gcp_backend_pusher_auto_deploy.yml` is on that list. CI caught the first version of this PR doing exactly that; the contract stands and the fix moved rather than the test.

### This needs one-time infrastructure before the lane can go green

The step fails with an explicit message until both exist:

1. `FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT` (repo or `development` environment variable) set to a based-hardware signer — e.g. `firebase-adminsdk-4z2mm@based-hardware.iam.gserviceaccount.com`. It is currently unset.
2. `roles/iam.serviceAccountTokenCreator` for this lane's deploy identity on that service account. That SA currently has no IAM bindings.

Neither is a code change, and I have not made them: granting impersonation on the production Firebase admin service account is a production IAM change.

## Guard

Nothing caught a release gate shipping unsatisfiable. `check_firebase_probe_signer_identity` (in the existing release-process guard) rejects a `*SIGNER*` env fed from `secrets.GCP_CREDENTIALS` — the lane's own deploy identity, which is the actual defect — and accepts both legitimate resolutions: the Firebase project's signer credential, or a named signer impersonated via `--signer-service-account`.

It deliberately does **not** flag an *unnamed* signer. `gcp_backend_pusher.yml`'s production lane legitimately signs as a deploy identity that does belong to based-hardware, and the workflow text cannot say which project an environment resolves to. An earlier draft of the guard had that rule and false-positived on exactly that lane.

It is not a shared primitive because the contract is specific to this script's fail-closed comparison of the signer's project against `--firebase-project`. It would have caught `7883c816db` on the day it landed.

The guard also **ran in no lane for this change class**: `desktop-release-process-guards` triggered only on `codemagic.yaml` and one desktop workflow, so edits to any other workflow never invoked it. Triggers widen to `.github/workflows/**`, matching what the guard scans.

## Verification

```
bash scripts/run-release-process-guards.sh                    -> release process guard checks passed
bash scripts/run-release-process-guard-tests.sh               -> 100 passed
pytest tests/unit/test_preflight_cloud_run_deploy.py          -> 18 passed
pytest ... validate-backend-runtime-env.py --env dev / prod   -> passed for both
```

Restoring the pre-fix env line reproduces the guard error, so the guard is pinned to the real defect.

The probe itself cannot be exercised locally — it needs the deployed development Pusher, the environment, and the IAM grant above. **The dev lane run is the real test**, and the promotion to prod pusher afterwards is what actually restores custom-STT summaries.

## Product invariants affected

- INV-DATA-1

Unchanged by this PR. `--firebase-project based-hardware` is kept exactly as it was: the
development backend already authenticates against production Firebase
(`FIREBASE_PROJECT_ID=based-hardware` on the dev Cloud Run service), and this PR does not move
it. The only change is *which credential signs* the probe's custom token — from the development
deploy identity, which cannot sign for that project, to the based-hardware signer the desktop
development lane already uses for the same purpose. No protected authority, Firebase project,
Firestore project, or serving endpoint is retargeted, so the invariant's "change a protected
authority or Firebase/Firestore project as incidental release-pipeline work" prohibition is
respected rather than exercised.

Failure-Class: new

A fail-closed release gate must be satisfiable by the principal it runs as. This gate compared a credential's project against a project that credential can never belong to, so it could not pass in any environment — it blocked releases instead of qualifying them, and did so silently, looking like an ordinary red check for ten days.
