### PR TITLE
fix(cli): validate active_profile is a string in config.load (#13442)

### DIFF
--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -200,6 +200,14 @@ def load(path: Optional[Path] = None) -> Config:
             )
 
     active = data.get("active_profile", DEFAULT_PROFILE_NAME)
+    if not isinstance(active, str):
+        return Config(
+            path=p,
+            active_profile=DEFAULT_PROFILE_NAME,
+            profiles={},
+            load_error=f"'active_profile' must be a string, got {type(active).__name__}",
+        )
+
     profiles_data = data.get("profiles", {})
     
     # Validate that profiles is a table (dict), not a string or other scalar.

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -415,3 +415,52 @@ def test_no_profiles_section(config_path: Path) -> None:
     config = cfg.load()
     assert not config.was_load_error
     assert config.active_profile == "other"
+
+
+# -- Regression tests for non-string active_profile selector (Issue #13442) --
+
+
+@pytest.mark.parametrize(
+    "invalid_toml,expected_type",
+    [
+        ('active_profile = ["work"]\n', "list"),
+        ("active_profile = 42\n", "int"),
+        ("active_profile = true\n", "bool"),
+        ("[active_profile]\nname = 'work'\n", "dict"),
+    ],
+)
+def test_active_profile_non_string_records_load_error(
+    config_path: Path, invalid_toml: str, expected_type: str
+) -> None:
+    """active_profile must be a string; non-string values should set load_error instead of crashing."""
+    config_path.write_text(invalid_toml, encoding="utf-8")
+    config = cfg.load()
+    assert config.was_load_error
+    assert config.active_profile == cfg.DEFAULT_PROFILE_NAME
+    assert config.profiles == {}
+    assert config.load_error is not None
+    assert f"'active_profile' must be a string, got {expected_type}" in config.load_error
+
+
+def test_active_profile_non_string_refuses_save_overwrite(config_path: Path) -> None:
+    """A config with invalid active_profile type must not be overwritten by save()."""
+    config_path.write_text('active_profile = ["work"]\n[profiles.work]\napi_base = "https://api.omi.me"\n', encoding="utf-8")
+    config = cfg.load()
+    assert config.was_load_error
+
+    with pytest.raises(PermissionError, match="refusing to overwrite"):
+        cfg.save(config)
+
+    # The file on disk is preserved intact
+    assert 'active_profile = ["work"]' in config_path.read_text(encoding="utf-8")
+
+
+def test_active_profile_non_string_diagnostics_succeed(config_path: Path, cli_runner) -> None:
+    """Read-only diagnostics commands must still succeed when active_profile is invalid."""
+    config_path.write_text('active_profile = ["work"]\n', encoding="utf-8")
+    result = cli_runner.invoke(app, ["version"])
+    assert result.exit_code == 0, result.output
+
+    result_path = cli_runner.invoke(app, ["config", "path"])
+    assert result_path.exit_code == 0, result_path.output
+

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -463,4 +463,3 @@ def test_active_profile_non_string_diagnostics_succeed(config_path: Path, cli_ru
 
     result_path = cli_runner.invoke(app, ["config", "path"])
     assert result_path.exit_code == 0, result_path.output
-


### PR DESCRIPTION
Fixes #13442

Validates that `active_profile` in the config file is a string during `config.load()`. If a non-string value is present (such as a list, integer, boolean, or inline table from an otherwise valid TOML file), `load_error` is populated and `active_profile` falls back to the default profile rather than crashing with unhandled runtime exceptions.

### Problem & Root Cause

At `main`, `config.load()` reads `active = data.get("active_profile", DEFAULT_PROFILE_NAME)` without validating its type. 

When a TOML configuration contains a valid TOML non-string scalar or collection (for instance, `active_profile = ["work"]` or `active_profile = 42`):
1. `Config.active_profile` receives the non-string object and `Config.load_error` remains `None`.
2. When subsequent commands invoke `config.get_profile()`, the lookup `target in self.profiles` crashes with `TypeError: unhashable type: 'list'`.
3. Commands like `auth status` or `config set` abort with an unhandled traceback instead of reporting a clean diagnostic error.
4. Because `load_error` was not set, `save()` does not refuse to overwrite, which could clobber or corrupt the user's repairable config file.

### Changes

1. **`sdks/python-cli/omi_cli/config.py`**:
   - Added validation immediately after reading `active_profile`:
     ```python
     active = data.get("active_profile", DEFAULT_PROFILE_NAME)
     if not isinstance(active, str):
         return Config(
             path=p,
             active_profile=DEFAULT_PROFILE_NAME,
             profiles={},
             load_error=f"'active_profile' must be a string, got {type(active).__name__}",
         )
     ```
   - Matches the error-handling idiom previously introduced for `'profiles' must be a table` in #13349.
   - Ensures `Config.was_load_error` is `True`, so `save()` refuses to overwrite and protects user configs.

2. **`sdks/python-cli/tests/test_config.py`**:
   - Added parametrized regression tests covering multiple non-string types (`list`, `int`, `bool`, `dict`).
   - Added test verifying that `save()` raises `PermissionError` and refuses to overwrite when `active_profile` has an invalid type.
   - Added test verifying that read-only diagnostics commands (`omi version`, `omi config path`) continue to execute successfully when `active_profile` is invalid.

### Verification & Test Results

Ran test suite with `pytest tests/test_config.py`:
- 34 of 34 tests pass (including all 6 new regression cases).
- Verified `save()` refusal against corrupt configuration.
- Verified CLI diagnostics (`version`, `config path`) remain functional.

## Product invariants affected
none

## Failure class (fixes)
Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

