### PR TITLE
fix: respect long Retry-After cooldowns

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -263,6 +263,8 @@ class _RetryableHttp(Exception):
 def _may_retry(method: str, exc: BaseException) -> bool:
     """Only replay writes when the failure establishes they were not applied."""
     if isinstance(exc, _RetryableHttp):
+        if exc.retry_after is not None and exc.retry_after > MAX_RETRY_AFTER_SECONDS:
+            return False
         return method not in {"POST", "PATCH"} or exc.response.status_code == 429
     if isinstance(exc, httpx.TransportError):
         return method not in {"POST", "PATCH"} or isinstance(

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -185,7 +185,7 @@ def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
 
 @pytest.mark.parametrize(
     ("retry_after", "expected_wait"),
-    [("3", 3.0), ("99999", 60.0), ("invalid", 0.25), (None, 0.25)],
+    [("3", 3.0), ("invalid", 0.25), (None, 0.25)],
 )
 def test_cli_503_uses_retry_after_or_backoff(
     authed_profile, respx_mock, monkeypatch, cli_runner, retry_after, expected_wait
@@ -213,6 +213,32 @@ def test_cli_503_uses_retry_after_or_backoff(
     assert json.loads(result.stdout) == []
     assert route.call_count == 2
     assert sleeps == [expected_wait]
+
+
+def test_cli_503_retry_after_over_cap_does_not_retry(
+    authed_profile, respx_mock, monkeypatch, cli_runner
+) -> None:
+    """A Retry-After longer than the automatic retry cap must not trigger a retry."""
+    from omi_cli.main import app
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[
+            httpx.Response(
+                503,
+                headers={"Retry-After": "300"},
+                json={"detail": "Temporarily unavailable"},
+            ),
+        ]
+    )
+
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+
+    assert result.exit_code != 0
+    assert route.call_count == 1
+    assert sleeps == []
 
 
 def test_503_retry_after_exhaustion_preserves_server_error(authed_profile, respx_mock, monkeypatch) -> None:
@@ -313,25 +339,29 @@ def test_429_with_retry_after_waits_at_least_that_long(authed_profile, respx_moc
     assert sleeps[0] == 3.0
 
 
-def test_429_retry_after_is_capped(authed_profile, respx_mock, monkeypatch) -> None:
-    """A pathologically large Retry-After value must be capped so the CLI
-    doesn't pin for hours on a misbehaving upstream."""
-    import time
-
+def test_429_retry_after_over_cap_does_not_retry(
+    authed_profile, respx_mock, monkeypatch
+) -> None:
+    """A Retry-After longer than the automatic retry cap must not trigger a retry."""
     sleeps: list[float] = []
-    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(time, "sleep", sleeps.append)
 
-    from omi_cli import client as client_module
-
-    respx_mock.get("/v1/dev/user/memories").mock(
+    route = respx_mock.get("/v1/dev/user/memories").mock(
         side_effect=[
-            httpx.Response(429, headers={"Retry-After": "99999"}, json={"detail": "wait"}),
-            httpx.Response(200, json=[]),
+            httpx.Response(
+                429,
+                headers={"Retry-After": "300"},
+                json={"detail": "slow down"},
+            ),
         ]
     )
-    with OmiClient(authed_profile) as cli:
-        cli.get("/v1/dev/user/memories")
-    assert sleeps[0] == client_module.MAX_RETRY_AFTER_SECONDS
+
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(RateLimitError):
+            client.get("/v1/dev/user/memories")
+
+    assert route.call_count == 1
+    assert sleeps == []
 
 
 def test_validation_error_detail_string_is_formatted(authed_profile, respx_mock) -> None:


### PR DESCRIPTION
What does this fix?

The Python CLI could retry a request before a long server-provided `Retry-After` cooldown had expired.

For example, a `429` or `503` response with `Retry-After: 300` was previously capped to 60 seconds and then retried, causing another request before the server's requested cooldown had elapsed.

This change makes the CLI stop automatic retries when the numeric `Retry-After` value exceeds the existing 60-second retry cap.

Shorter `Retry-After` values continue to use the existing retry behavior.

Changes

* Prevent automatic retries when `Retry-After` exceeds `MAX_RETRY_AFTER_SECONDS`.
* Updated the existing 503 retry test.
* Added regression coverage for long `Retry-After` values on 503 and 429 responses.

Testing

* `python3 -m pytest tests/test_client_retry.py -q`
* 33 tests passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

