### PR TITLE
fix: declare the descending action_items created-range composite and select action_items indexes for jit-qa

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -1027,7 +1027,13 @@ ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY = FirestoreQuerySpec(
         FirestoreQueryFilter('created_at', '<', 'end'),
         FirestoreQueryFilter('completed', '==', 'completed'),
     ),
-    index_fields=(_asc('completed'), _asc('created_at'), _asc('__name__')),
+    # ``get_action_items`` orders a created-date range newest-first
+    # (``_apply_action_item_date_filters``), so the composite must be declared
+    # descending. The ascending declaration only worked where an undeclared
+    # descending index already existed; a database provisioned from this
+    # manifest alone failed GET /v1/action-items?start_date=... with
+    # FailedPrecondition (measured on the isolated jit-qa database, 2026-09-10).
+    index_fields=(_asc('completed'), _desc('created_at'), _desc('__name__')),
 )
 
 CHAT_FIRST_DEFERRALS_DUE_QUERY = FirestoreQuerySpec(

--- a/backend/scripts/jit_qa_firestore_index_operator.py
+++ b/backend/scripts/jit_qa_firestore_index_operator.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from database.firestore_index_registry import (
+    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
+    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
     CURRENT_CHAT_SESSION_ORDERED_QUERY,
     DAILY_SWEEP_ACTIVE_FACT_ENTITY_CONTENT_QUERY,
     DAILY_SWEEP_ACTIVE_FACT_ENTITY_QUERY,
@@ -97,6 +99,13 @@ TARGET_REQUIREMENTS = (
     CURRENT_CHAT_SESSION_ORDERED_QUERY.index_requirement,
     MESSAGES_BY_APP_ORDERED_QUERY.index_requirement,
     MESSAGES_BY_SESSION_ORDERED_QUERY.index_requirement,
+    # The named QA app's signed-in startup reads its task dashboard and scores
+    # through GET /v1/action-items (due-date and created-date ranges with the
+    # ``completed`` equality) and GET /v1/scores. Without these two composites
+    # every such read returned 500 on the isolated database while the JIT
+    # plan still reported "none missing" (measured 2026-09-10).
+    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY.index_requirement,
+    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.index_requirement,
 )
 
 # Firestore returns COLLECTION_GROUP_ASC for this query as a single-field

--- a/backend/tests/unit/test_action_items_due_range_index_contract.py
+++ b/backend/tests/unit/test_action_items_due_range_index_contract.py
@@ -132,3 +132,38 @@ def test_due_range_composites_are_declared_in_the_firestore_index_manifest(monke
             # No equality filter: Firestore's automatic single-field index serves it.
             continue
         assert signature in declared, f'undeclared Firestore composite for {filters}: {signature}'
+
+
+def _record_created_range_queries(monkeypatch, **filters):
+    recorder = _RecordingQuery()
+    monkeypatch.setattr(action_items, 'db', recorder)
+    action_items.get_action_items(
+        'uid-under-test',
+        start_date=BASE,
+        end_date=BASE + timedelta(days=7),
+        limit=50,
+        **filters,
+    )
+    return recorder.queries
+
+
+def test_created_range_read_filters_completed_and_orders_created_at_descending(monkeypatch):
+    (recorded,) = _record_created_range_queries(monkeypatch, completed=False)
+    assert ('where', 'completed', '==') in recorded
+    assert ('order_by', 'created_at', action_items.firestore.Query.DESCENDING) in recorded
+
+
+def test_completed_created_range_composite_is_declared_descending(monkeypatch):
+    """GET /v1/action-items?start_date=...&completed=false orders newest-first.
+
+    The registry used to declare (completed ASC, created_at ASC, __name__ ASC) for this
+    read, which serves only the reverse ordering. Databases that happened to carry an
+    undeclared descending composite masked it; a database provisioned from the manifest
+    alone (the isolated jit-qa database, 2026-09-10) failed every such read with
+    ``FailedPrecondition: 400 The query requires an index``.
+    """
+    declared = _declared_action_item_signatures()
+    for query in _record_created_range_queries(monkeypatch, completed=False):
+        signature = _index_signature(query)
+        assert signature[1] == ('created_at', 'DESCENDING')
+        assert signature in declared, f'undeclared action_items composite: {signature}'

--- a/backend/tests/unit/test_jit_qa_firestore_index_operator.py
+++ b/backend/tests/unit/test_jit_qa_firestore_index_operator.py
@@ -56,7 +56,7 @@ def _field_api_request(*, ready: bool = False, api_scope: object = _UNSET):
 def test_selected_manifest_is_canonical_and_contains_only_bounded_required_queries():
     manifest, signatures = operator.selected_manifest()
 
-    assert len(manifest["indexes"]) == 14
+    assert len(manifest["indexes"]) == 16
     assert signatures == {requirement.signature for requirement in operator.TARGET_REQUIREMENTS}
     assert {
         (
@@ -87,9 +87,9 @@ def test_plan_reads_only_fixed_named_database_and_reports_all_required_indexes(m
         {"project": "based-hardware-dev", "database": "jit-qa", "runner": operator.reconciler.subprocess.run}
     ]
     assert result["manifest_validated"] is True
-    assert result["selected_index_count"] == 14
+    assert result["selected_index_count"] == 16
     assert result["selected_field_index_count"] == 1
-    assert result["missing_count"] == 15
+    assert result["missing_count"] == 17
     assert {entry["state"] for entry in result["indexes"]} == {"MISSING"}
     assert {entry["identifier"] for entry in result["indexes"]} == {
         "memory_items_universal_list_scan",
@@ -106,6 +106,8 @@ def test_plan_reads_only_fixed_named_database_and_reports_all_required_indexes(m
         "chat_sessions_current_by_app_created_at",
         "messages_by_app_created_at",
         "messages_by_session_created_at",
+        "action_items_completed_due_range",
+        "action_items_completed_created_range",
     }
     assert result["field_indexes"] == [
         {
@@ -161,13 +163,13 @@ def test_apply_requires_confirmation_and_delegates_only_selected_signatures(monk
         field_api_request=field_api,
     )
     assert result["schema_version"] == "omi.jit.qa.firestore-index-apply.v1"
-    assert result["created_index_count"] == 14
+    assert result["created_index_count"] == 16
     assert result["created_field_index_count"] == 1
     assert calls[0][0] == "provision"
     assert calls[1][0] == "wait"
     assert calls[0][1]["project"] == operator.PROJECT
     assert calls[0][1]["database"] == operator.DATABASE
-    assert len(calls[0][1]["expected"]) == 14
+    assert len(calls[0][1]["expected"]) == 16
     assert calls[1][1]["expected"] == calls[0][1]["expected"]
 
 
@@ -202,7 +204,7 @@ def test_apply_cli_keeps_reconciler_progress_out_of_json_receipt(monkeypatch, ca
     captured = capsys.readouterr()
     receipt = json.loads(captured.out)
     assert receipt["missing_count"] == 0
-    assert receipt["created_index_count"] == 14
+    assert receipt["created_index_count"] == 16
     assert receipt["created_field_index_count"] == 1
     assert "READY" in captured.err
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -747,6 +747,24 @@
       ]
     },
     {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "completed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "candidates",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Summary

`GET /v1/action-items?start_date=…&completed=false` orders `created_at` **descending** (`_apply_action_item_date_filters`), but the index registry declared the composite as `(completed ASC, created_at ASC, __name__ ASC)`, which serves only the reverse ordering. The development `(default)` database happened to carry an undeclared descending composite, so the gap never surfaced there. The isolated `jit-qa` database, provisioned from the manifest alone, returned **500 FailedPrecondition "The query requires an index"** on that read at signed-in app startup, and also on the due-range reads (`/v1/action-items?due_start_date=…` and `/v1/scores`) because the bounded JIT QA operator never selected the `action_items` composites at all while its plan reported "none missing" (measured 2026-09-10, Cloud Run request logs for `backend-jit-qa`).

Changes:

- `backend/database/firestore_index_registry.py`: `ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY` now declares `(completed ASC, created_at DESC, __name__ DESC)`, matching the production query builder. The ascending composite stays in the manifest because another spec declares it; reconciliation is create-only.
- `firestore.indexes.json`: regenerated (one new `action_items` entry).
- `backend/scripts/jit_qa_firestore_index_operator.py`: the bounded jit-qa set adds `ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY` and `ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY` (14 → 16 composites) so the named QA app's task dashboard and scores reads are served.
- Tests: the due-range contract test gains the created-range behavioral case (records the real read path's filters/orderings and asserts the manifest declares the descending composite); operator tests updated for the two new requirements.

Not covered: `conversation_id` + created-range reads have no declared composite either; nothing in the app issues that shape today, so it is left as is rather than adding a speculative index.

## Operational note

Merging changes `firestore.indexes.json`, which queues `gcp_firestore_indexes.yml` for prod (create-only; the prod GitHub Environment reviewer approves it). The jit-qa database is reconciled separately by dispatching `jit_qa_manual_operator.yml` with `operation=indexes-apply` and `confirmation=APPLY_JIT_QA_INDEXES`.

Failure-Class: FC-undeclared-serving-query-index
Line-Count-Exception: backend/database/firestore_index_registry.py | 1527 -> 1533 | six comment lines explaining why the created-range composite is declared descending; the registry is the single generated-manifest source and cannot be split for one direction fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

