### PR TITLE
fix: keep the action_items created-range count composite ascending and select the newest-first composite for jit-qa

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -283,6 +283,17 @@ INDEX_ONLY_REQUIREMENTS = (
         'COLLECTION',
         (_asc('completed'), _asc('created_at'), _asc('__name__')),
     ),
+    # GET /v1/action-items?start_date=...&completed=... orders created_at
+    # newest-first (``_apply_action_item_date_filters``). The ascending
+    # composite above serves the ``get_scores`` count but not that ordering;
+    # a database provisioned from this manifest alone (isolated jit-qa,
+    # 2026-09-10) failed the read with FailedPrecondition until this existed.
+    FirestoreIndexRequirement(
+        'action_items_completed_created_newest_first',
+        'action_items',
+        'COLLECTION',
+        (_asc('completed'), _desc('created_at'), _desc('__name__')),
+    ),
     FirestoreIndexRequirement(
         'action_items_conversation_due',
         'action_items',
@@ -1027,13 +1038,11 @@ ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY = FirestoreQuerySpec(
         FirestoreQueryFilter('created_at', '<', 'end'),
         FirestoreQueryFilter('completed', '==', 'completed'),
     ),
-    # ``get_action_items`` orders a created-date range newest-first
-    # (``_apply_action_item_date_filters``), so the composite must be declared
-    # descending. The ascending declaration only worked where an undeclared
-    # descending index already existed; a database provisioned from this
-    # manifest alone failed GET /v1/action-items?start_date=... with
-    # FailedPrecondition (measured on the isolated jit-qa database, 2026-09-10).
-    index_fields=(_asc('completed'), _desc('created_at'), _desc('__name__')),
+    # ``build`` is the ``get_scores`` weekly count aggregation (no ordering),
+    # which Firestore serves only from the ascending composite; the
+    # newest-first list read in ``_apply_action_item_date_filters`` is a
+    # different composite, declared as ``action_items_completed_created_newest_first``.
+    index_fields=(_asc('completed'), _asc('created_at'), _asc('__name__')),
 )
 
 CHAT_FIRST_DEFERRALS_DUE_QUERY = FirestoreQuerySpec(

--- a/backend/scripts/jit_qa_firestore_index_operator.py
+++ b/backend/scripts/jit_qa_firestore_index_operator.py
@@ -34,6 +34,7 @@ from database.firestore_index_registry import (
     DAILY_SWEEP_ACTIVE_FACT_SUBJECT_QUERY,
     ENTITY_TIMELINE_CONVERSATIONS_QUERY,
     FINALIZATION_OLDEST_NONTERMINAL_QUERY,
+    INDEX_ONLY_REQUIREMENTS,
     MESSAGES_BY_APP_ORDERED_QUERY,
     MESSAGES_BY_SESSION_ORDERED_QUERY,
     UNIVERSAL_CANONICAL_LIST_SCAN_QUERY,
@@ -76,6 +77,14 @@ class FieldIndexTarget:
         }
 
 
+def _index_only_requirement(identifier: str):
+    """Select a registry composite that no ``FirestoreQuerySpec`` builds (index-only)."""
+    for requirement in INDEX_ONLY_REQUIREMENTS:
+        if requirement.identifier == identifier:
+            return requirement
+    raise KeyError(f"index-only requirement {identifier} is not declared in the registry")
+
+
 TARGET_REQUIREMENTS = (
     UNIVERSAL_CANONICAL_LIST_SCAN_QUERY.index_requirement,
     ENTITY_TIMELINE_CONVERSATIONS_QUERY.index_requirement,
@@ -106,6 +115,7 @@ TARGET_REQUIREMENTS = (
     # plan still reported "none missing" (measured 2026-09-10).
     ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY.index_requirement,
     ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.index_requirement,
+    _index_only_requirement("action_items_completed_created_newest_first"),
 )
 
 # Firestore returns COLLECTION_GROUP_ASC for this query as a single-field

--- a/backend/tests/unit/test_action_items_due_range_index_contract.py
+++ b/backend/tests/unit/test_action_items_due_range_index_contract.py
@@ -167,3 +167,24 @@ def test_completed_created_range_composite_is_declared_descending(monkeypatch):
         signature = _index_signature(query)
         assert signature[1] == ('created_at', 'DESCENDING')
         assert signature in declared, f'undeclared action_items composite: {signature}'
+
+
+def test_scores_weekly_count_composite_is_declared_ascending():
+    """``get_scores`` counts completed tasks created in the last week through
+    ``ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.build`` with no ordering; Firestore serves that
+    aggregation only from the ascending composite, which must stay declared alongside the
+    newest-first list composite (both were missing on the isolated jit-qa database, 2026-09-10).
+    """
+    from database.firestore_index_registry import ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY
+
+    requirement = ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.index_requirement
+    assert requirement.signature[2] == (
+        ('completed', 'ASCENDING'),
+        ('created_at', 'ASCENDING'),
+        ('__name__', 'ASCENDING'),
+    )
+    declared = {
+        (index['collectionGroup'], index['queryScope'], tuple((f['fieldPath'], f['order']) for f in index['fields']))
+        for index in firebase_index_manifest()['indexes']
+    }
+    assert requirement.signature in declared

--- a/backend/tests/unit/test_jit_qa_firestore_index_operator.py
+++ b/backend/tests/unit/test_jit_qa_firestore_index_operator.py
@@ -56,7 +56,7 @@ def _field_api_request(*, ready: bool = False, api_scope: object = _UNSET):
 def test_selected_manifest_is_canonical_and_contains_only_bounded_required_queries():
     manifest, signatures = operator.selected_manifest()
 
-    assert len(manifest["indexes"]) == 16
+    assert len(manifest["indexes"]) == 17
     assert signatures == {requirement.signature for requirement in operator.TARGET_REQUIREMENTS}
     assert {
         (
@@ -87,9 +87,9 @@ def test_plan_reads_only_fixed_named_database_and_reports_all_required_indexes(m
         {"project": "based-hardware-dev", "database": "jit-qa", "runner": operator.reconciler.subprocess.run}
     ]
     assert result["manifest_validated"] is True
-    assert result["selected_index_count"] == 16
+    assert result["selected_index_count"] == 17
     assert result["selected_field_index_count"] == 1
-    assert result["missing_count"] == 17
+    assert result["missing_count"] == 18
     assert {entry["state"] for entry in result["indexes"]} == {"MISSING"}
     assert {entry["identifier"] for entry in result["indexes"]} == {
         "memory_items_universal_list_scan",
@@ -108,6 +108,7 @@ def test_plan_reads_only_fixed_named_database_and_reports_all_required_indexes(m
         "messages_by_session_created_at",
         "action_items_completed_due_range",
         "action_items_completed_created_range",
+        "action_items_completed_created_newest_first",
     }
     assert result["field_indexes"] == [
         {
@@ -163,13 +164,13 @@ def test_apply_requires_confirmation_and_delegates_only_selected_signatures(monk
         field_api_request=field_api,
     )
     assert result["schema_version"] == "omi.jit.qa.firestore-index-apply.v1"
-    assert result["created_index_count"] == 16
+    assert result["created_index_count"] == 17
     assert result["created_field_index_count"] == 1
     assert calls[0][0] == "provision"
     assert calls[1][0] == "wait"
     assert calls[0][1]["project"] == operator.PROJECT
     assert calls[0][1]["database"] == operator.DATABASE
-    assert len(calls[0][1]["expected"]) == 16
+    assert len(calls[0][1]["expected"]) == 17
     assert calls[1][1]["expected"] == calls[0][1]["expected"]
 
 
@@ -204,7 +205,7 @@ def test_apply_cli_keeps_reconciler_progress_out_of_json_receipt(monkeypatch, ca
     captured = capsys.readouterr()
     receipt = json.loads(captured.out)
     assert receipt["missing_count"] == 0
-    assert receipt["created_index_count"] == 16
+    assert receipt["created_index_count"] == 17
     assert receipt["created_field_index_count"] == 1
     assert "READY" in captured.err
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -509,6 +509,24 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "completed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "conversation_id",
           "order": "ASCENDING"
         },
@@ -743,24 +761,6 @@
         {
           "fieldPath": "__name__",
           "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "action_items",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "completed",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "created_at",
-          "order": "DESCENDING"
-        },
-        {
-          "fieldPath": "__name__",
-          "order": "DESCENDING"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Follow-up to #13454. After its indexes were applied to the isolated `jit-qa` database, `GET /v1/action-items` returned 200 but `GET /v1/scores` still returned 500 (`FailedPrecondition`): the weekly count in `get_scores` is `ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.build(...)` with no ordering, and Firestore serves that aggregation only from the **ascending** `(completed, created_at, __name__)` composite. #13454 had flipped that spec to descending, which is what the newest-first *list* read needs but not what the count needs, and the ascending composite is declared by an index-only requirement (`action_items_completed_created`) the bounded jit-qa operator never selected.

Changes (registry stays truthful for both consumers; the generated manifest's index set is unchanged, only entry order moves):

- `backend/database/firestore_index_registry.py`: `ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY` is ascending again, documented as the `get_scores` count aggregation; the newest-first list composite `(completed ASC, created_at DESC, __name__ DESC)` is now the index-only requirement `action_items_completed_created_newest_first`, beside its `action_items_*` siblings.
- `backend/scripts/jit_qa_firestore_index_operator.py`: selects index-only requirements by identifier and adds `action_items_completed_created_newest_first` (16 → 17 composites for jit-qa).
- Tests: contract test adds the scores-count case (ascending composite declared); operator tests updated.

Verified so far on jit-qa: after #13454's apply, six `/v1/action-items` reads returned 200 in Cloud Run logs and only `/v1/scores` remained at 500 with the ascending-index suggestion.

Failure-Class: FC-undeclared-serving-query-index
Line-Count-Exception: backend/database/firestore_index_registry.py | 1533 -> 1542 | one new index-only requirement plus its rationale comment in the single generated-manifest source; not splittable for one composite

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

