### PR TITLE
fix(python-cli): abort retries when Retry-After exceeds 60s

### DIFF
--- a/sdks/python-cli/omi_cli/client.py
+++ b/sdks/python-cli/omi_cli/client.py
@@ -17,10 +17,10 @@ loop here would buy nothing.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 import json
 import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Iterator, Mapping, Optional
 
 import httpx
@@ -39,9 +39,9 @@ from omi_cli.errors import CliError, RateLimitError, ServerError, TransportError
 USER_AGENT = f"omi-cli/{__version__} (+https://github.com/BasedHardware/omi)"
 DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 MAX_RETRY_ATTEMPTS = 4
-# Cap on how long we'll honor a server-supplied Retry-After hint. Without this,
-# a misconfigured upstream could pin the CLI for hours; agents will get a
-# RateLimitError they can act on much sooner.
+# Maximum server-supplied Retry-After the CLI will wait before retrying. When
+# the hint exceeds this, automatic retries stop and the caller gets the mapped
+# CliError immediately instead of sleeping a truncated delay and retrying early.
 MAX_RETRY_AFTER_SECONDS = 60.0
 
 # Backend rate-limit policies surfaced to users on 429 (see
@@ -148,17 +148,19 @@ class OmiClient:
                     response = self._http.request(method, path, params=cleaned_params, json=json_body)
                     self._maybe_log(method, path, response)
                     if response.status_code >= 500:
-                        raise _RetryableHttp(
-                            response,
-                            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-                        )
+                        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                        if _retry_after_exceeds_automatic_wait(retry_after):
+                            if method in {"POST", "PATCH"}:
+                                raise _unknown_write_outcome(method, response=response)
+                            raise self._error_from_response(response)
+                        raise _RetryableHttp(response, retry_after=retry_after)
                     if response.status_code == 429:
+                        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+                        if _retry_after_exceeds_automatic_wait(retry_after):
+                            raise self._error_from_response(response)
                         # Surface the structured RateLimitError so callers can show
                         # a useful message; tenacity treats this as retryable.
-                        raise _RetryableHttp(
-                            response,
-                            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
-                        )
+                        raise _RetryableHttp(response, retry_after=retry_after)
                     return self._handle_response(response)
         except _RetryableHttp as exc:
             if method in {"POST", "PATCH"} and exc.response.status_code >= 500:
@@ -292,19 +294,24 @@ def _unknown_write_outcome(method: str, *, response: Optional[httpx.Response] = 
 _jittered_backoff = wait_exponential_jitter(initial=0.5, max=8.0)
 
 
+def _retry_after_exceeds_automatic_wait(retry_after: Optional[float]) -> bool:
+    """Return True when the server cooldown exceeds what the CLI will wait."""
+    return retry_after is not None and retry_after > MAX_RETRY_AFTER_SECONDS
+
+
 def _retry_wait(retry_state: RetryCallState) -> float:
     """Wait strategy: server-supplied Retry-After when available, jitter otherwise.
 
-    A 429 or 5xx that includes numeric ``Retry-After`` ends up here as a ``_RetryableHttp``
-    with ``retry_after`` populated. We honor it but cap to
-    :data:`MAX_RETRY_AFTER_SECONDS` so a pathological upstream can't pin the
-    CLI for an unbounded time. Without a positive numeric hint, and for
-    transport errors, we fall back to exponential jitter.
+    A 429 or 5xx with ``Retry-After`` at or below
+    :data:`MAX_RETRY_AFTER_SECONDS` ends up here as a ``_RetryableHttp`` with
+    ``retry_after`` populated and is honored verbatim. Longer hints abort
+    automatic retries in ``_request`` before this runs. Without a positive hint,
+    and for transport errors, we fall back to exponential jitter.
     """
     outcome = retry_state.outcome
     exc = outcome.exception() if outcome is not None and outcome.failed else None
     if isinstance(exc, _RetryableHttp) and exc.retry_after is not None and exc.retry_after > 0:
-        return min(exc.retry_after, MAX_RETRY_AFTER_SECONDS)
+        return exc.retry_after
     return float(_jittered_backoff(retry_state))
 
 

--- a/sdks/python-cli/tests/test_client_retry.py
+++ b/sdks/python-cli/tests/test_client_retry.py
@@ -185,7 +185,7 @@ def test_500_then_200_succeeds_after_retry(authed_profile, respx_mock) -> None:
 
 @pytest.mark.parametrize(
     ("retry_after", "expected_wait"),
-    [("3", 3.0), ("99999", 60.0), ("invalid", 0.25), (None, 0.25)],
+    [("3", 3.0), ("invalid", 0.25), (None, 0.25)],
 )
 def test_cli_503_uses_retry_after_or_backoff(
     authed_profile, respx_mock, monkeypatch, cli_runner, retry_after, expected_wait
@@ -313,25 +313,79 @@ def test_429_with_retry_after_waits_at_least_that_long(authed_profile, respx_moc
     assert sleeps[0] == 3.0
 
 
-def test_429_retry_after_is_capped(authed_profile, respx_mock, monkeypatch) -> None:
-    """A pathologically large Retry-After value must be capped so the CLI
-    doesn't pin for hours on a misbehaving upstream."""
-    import time
+@pytest.mark.parametrize(
+    ("method", "path", "status", "json_body", "error_type"),
+    [
+        ("GET", "/v1/dev/user/memories", 429, None, RateLimitError),
+        ("GET", "/v1/dev/user/goals", 503, None, ServerError),
+        ("POST", "/v1/dev/user/conversations", 429, {"text": "x"}, RateLimitError),
+    ],
+)
+def test_long_retry_after_aborts_automatic_retries(
+    authed_profile, respx_mock, monkeypatch, method, path, status, json_body, error_type
+) -> None:
+    """Retry-After values above MAX_RETRY_AFTER_SECONDS must not sleep or retry early."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    responses = [
+        httpx.Response(status, headers={"Retry-After": "300"}, json={"detail": "synthetic cooldown"}),
+        httpx.Response(200, json={"synthetic": True}),
+    ]
+    route = getattr(respx_mock, method.lower())(path).mock(side_effect=responses)
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(error_type) as info:
+            if method == "GET":
+                client.get(path)
+            else:
+                client.post(path, json_body=json_body)
+    assert route.call_count == 1
+    assert sleeps == []
+    if error_type is RateLimitError:
+        assert info.value.retry_after_seconds == 300.0
+
+
+def test_long_retry_after_http_date_aborts_automatic_retries(authed_profile, respx_mock, monkeypatch) -> None:
+    from email.utils import formatdate
 
     sleeps: list[float] = []
-    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
-
-    from omi_cli import client as client_module
-
-    respx_mock.get("/v1/dev/user/memories").mock(
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+    future_date = formatdate(time.time() + 300.0, usegmt=True)
+    route = respx_mock.get("/v1/dev/user/goals").mock(
         side_effect=[
-            httpx.Response(429, headers={"Retry-After": "99999"}, json={"detail": "wait"}),
+            httpx.Response(503, headers={"Retry-After": future_date}, json={"detail": "Maintenance"}),
             httpx.Response(200, json=[]),
         ]
     )
-    with OmiClient(authed_profile) as cli:
-        cli.get("/v1/dev/user/memories")
-    assert sleeps[0] == client_module.MAX_RETRY_AFTER_SECONDS
+    with OmiClient(authed_profile) as client:
+        with pytest.raises(ServerError):
+            client.get("/v1/dev/user/goals")
+    assert route.call_count == 1
+    assert sleeps == []
+
+
+def test_retry_after_at_cap_still_retries(authed_profile, respx_mock, monkeypatch) -> None:
+    """Retry-After exactly at MAX_RETRY_AFTER_SECONDS keeps the wait-then-retry path."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    from omi_cli import client as client_module
+
+    route = respx_mock.get("/v1/dev/user/memories").mock(
+        side_effect=[
+            httpx.Response(
+                429,
+                headers={"Retry-After": str(int(client_module.MAX_RETRY_AFTER_SECONDS))},
+                json={"detail": "slow down"},
+            ),
+            httpx.Response(200, json=[]),
+        ]
+    )
+    with OmiClient(authed_profile) as client:
+        result = client.get("/v1/dev/user/memories")
+    assert result == []
+    assert route.call_count == 2
+    assert sleeps == [client_module.MAX_RETRY_AFTER_SECONDS]
 
 
 def test_validation_error_detail_string_is_formatted(authed_profile, respx_mock) -> None:


### PR DESCRIPTION
## What changed and why

Fixes #13451. The Python CLI capped `_retry_wait` at 60 seconds, so a `429 Retry-After: 300` (or `503` with a long hint) slept only 60s and retried before the server cooldown expired. When `Retry-After` exceeds `MAX_RETRY_AFTER_SECONDS`, automatic retries now stop immediately and the existing mapped `CliError` is returned. Delays at or below 60s keep the current wait-then-retry behavior.

## Product invariants affected

none

## How it was verified

```bash
cd sdks/python-cli
pip install -e ".[dev]"
python3 -m pytest tests/test_client_retry.py -v
python3 -m black omi_cli/client.py tests/test_client_retry.py
python3 -m isort omi_cli/client.py tests/test_client_retry.py
```

All 36 tests in `tests/test_client_retry.py` passed, including new cases for GET/429, GET/503, POST/429 with `Retry-After: 300`, HTTP-date long cooldowns, and boundary behavior at exactly 60s.

## Tests

- `test_long_retry_after_aborts_automatic_retries` — parametrized GET/429, GET/503, POST/429 with 300s cooldown: one HTTP call, zero sleeps, correct error type.
- `test_long_retry_after_http_date_aborts_automatic_retries` — HTTP-date form >60s aborts without retry.
- `test_retry_after_at_cap_still_retries` — exactly 60s still waits and retries.
- Updated `test_cli_503_uses_retry_after_or_backoff` to remove the old capped-retry expectation for `99999`.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

