### PR TITLE
security: P0 uid-as-auth + ADMIN_KEY default-off

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -37,9 +37,19 @@ DEEPGRAM_API_KEY=
 MODULATE_API_KEY=
 
 ADMIN_KEY=
-# Set to 'false' to disable the ADMIN_KEY<uid> local-dev auth bypass entirely
-# (it defaults to 'true' for backward compatibility with existing deployments).
-ADMIN_KEY_AUTH_ENABLED=true
+# ADMIN_KEY<uid> Bearer impersonation. Defaults OFF (fail-closed) when unset.
+# Set ADMIN_KEY_AUTH_ENABLED=true intentionally for local/dev/CI/break-glass
+# that need Authorization: Bearer <ADMIN_KEY><uid>. Do not enable in prod
+# unless you have a dedicated break-glass plan. Admin router auth via the
+# `secret-key` header still uses ADMIN_KEY and is independent of this flag.
+ADMIN_KEY_AUTH_ENABLED=false
+
+# Shared HMAC secret for backend → plugin webhook/tool identity
+# (X-Omi-Signature / X-Omi-Uid / X-Omi-Timestamp). When set, the backend
+# signs outbound plugin calls; plugins using omi_plugin_sdk.auth reject
+# bare uid. Leave unset only during migration; set the same value on
+# plugin services that enforce signed uid.
+OMI_PLUGIN_WEBHOOK_SECRET=
 # Server-side HMAC pepper for stored BYOK key fingerprints. When unset,
 # fingerprints are stored as the plain client SHA-256 (legacy); when set,
 # they are wrapped with this secret before storage/comparison so a leaked

--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -13,6 +13,7 @@ import httpx
 from database.apps import get_app_by_id_db
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.other.endpoints import enforce_account_deletion_http_access
+from utils.plugin_auth import maybe_plugin_auth_headers
 from utils.http_client import safe_request_target, get_auth_client, UnsafeWebhookURLError
 from database.redis_db import enable_app, increase_app_installs_count
 from utils.apps import is_user_app_enabled, get_is_user_paid_app, is_tester
@@ -219,9 +220,11 @@ async def oauth_token(
                     db_executor, safe_request_target, app.external_integration.setup_completed_url
                 )
                 client = get_auth_client()
+                setup_headers = dict(pin_kwargs['headers'])
+                setup_headers.update(maybe_plugin_auth_headers(uid=uid, body=b''))
                 res = await client.get(
                     pinned_url + f'?uid={uid}',
-                    headers=pin_kwargs['headers'],
+                    headers=setup_headers,
                     extensions=pin_kwargs['extensions'],
                     follow_redirects=False,
                 )

--- a/backend/testing/listen_pusher_stack/run.py
+++ b/backend/testing/listen_pusher_stack/run.py
@@ -217,6 +217,7 @@ class Stack:
                 'FIRESTORE_DATABASE_ID': '(default)',
                 'ENCRYPTION_SECRET': 'omi_listen_pusher_stack_test_secret_32_bytes',
                 'ADMIN_KEY': ADMIN_KEY,
+                'ADMIN_KEY_AUTH_ENABLED': 'true',
                 'METRICS_SECRET': METRICS_SECRET,
                 'REDIS_DB_HOST': '127.0.0.1',
                 'REDIS_DB_PORT': str(self.redis_port),

--- a/backend/testing/replay_harness_phase0a/runner.py
+++ b/backend/testing/replay_harness_phase0a/runner.py
@@ -130,6 +130,7 @@ class Harness:
                 "FIRESTORE_DATABASE_ID": "(default)",
                 "ENCRYPTION_SECRET": ENCRYPTION_SECRET,
                 "ADMIN_KEY": ADMIN_KEY,
+                "ADMIN_KEY_AUTH_ENABLED": "true",
                 "REDIS_DB_HOST": "127.0.0.1",
                 "REDIS_DB_PORT": str(self.ports["redis"]),
                 "REDIS_DB_PASSWORD": "",

--- a/backend/testing/sync_cloud_tasks_stack/run.py
+++ b/backend/testing/sync_cloud_tasks_stack/run.py
@@ -203,6 +203,7 @@ class Stack:
                 'FIRESTORE_DATABASE_ID': '(default)',
                 'ENCRYPTION_SECRET': ENCRYPTION_SECRET,
                 'ADMIN_KEY': ADMIN_KEY,
+                'ADMIN_KEY_AUTH_ENABLED': 'true',
                 'REDIS_DB_HOST': '127.0.0.1',
                 'REDIS_DB_PORT': str(self.redis_port),
                 'REDIS_DB_PASSWORD': '',

--- a/backend/tests/unit/test_plugin_auth.py
+++ b/backend/tests/unit/test_plugin_auth.py
@@ -1,0 +1,52 @@
+"""Tests for backend.utils.plugin_auth (mirrors omi_plugin_sdk.auth)."""
+
+import hmac
+import time
+from hashlib import sha256
+
+from utils.plugin_auth import (
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    UID_HEADER,
+    build_plugin_auth_headers,
+    get_plugin_webhook_secret,
+    maybe_plugin_auth_headers,
+    sign_plugin_payload,
+)
+
+
+def test_sign_matches_sdk_algorithm():
+    secret = 's'
+    uid = 'u1'
+    ts = '1700000000'
+    body = b'{"a":1}'
+    expected = hmac.new(secret.encode(), f'{uid}.{ts}.'.encode() + body, sha256).hexdigest()
+    assert sign_plugin_payload(secret=secret, uid=uid, timestamp=ts, body=body) == expected
+
+
+def test_build_headers_roundtrip_shape(monkeypatch):
+    monkeypatch.setenv('OMI_PLUGIN_WEBHOOK_SECRET', 'sekrit')
+    body = b'x'
+    headers = build_plugin_auth_headers(secret='sekrit', uid='uid-1', body=body)
+    assert headers[UID_HEADER] == 'uid-1'
+    assert headers[TIMESTAMP_HEADER].isdigit()
+    assert len(headers[SIGNATURE_HEADER]) == 64
+
+
+def test_maybe_headers_empty_without_secret(monkeypatch):
+    monkeypatch.delenv('OMI_PLUGIN_WEBHOOK_SECRET', raising=False)
+    assert maybe_plugin_auth_headers(uid='u', body=b'') == {}
+
+
+def test_maybe_headers_when_secret_set(monkeypatch):
+    monkeypatch.setenv('OMI_PLUGIN_WEBHOOK_SECRET', 'sekrit')
+    headers = maybe_plugin_auth_headers(uid='u', body=b'abc')
+    assert headers[UID_HEADER] == 'u'
+    assert SIGNATURE_HEADER in headers
+
+
+def test_get_secret_strips(monkeypatch):
+    monkeypatch.setenv('OMI_PLUGIN_WEBHOOK_SECRET', '  abc  ')
+    assert get_plugin_webhook_secret() == 'abc'
+    monkeypatch.setenv('OMI_PLUGIN_WEBHOOK_SECRET', '   ')
+    assert get_plugin_webhook_secret() is None

--- a/backend/tests/unit/test_verify_token_admin_and_local_dev_gating.py
+++ b/backend/tests/unit/test_verify_token_admin_and_local_dev_gating.py
@@ -134,13 +134,15 @@ def test_admin_key_path_enabled_when_flag_is_true(monkeypatch):
     assert verify_token(ADMIN_KEY + 'target-uid') == 'target-uid'
 
 
-def test_admin_key_path_defaults_to_enabled_when_flag_is_unset(monkeypatch):
-    """Backward compatibility: existing deployments/CI that set ADMIN_KEY but
-    have never heard of ADMIN_KEY_AUTH_ENABLED must keep working."""
+def test_admin_key_path_defaults_to_disabled_when_flag_is_unset(monkeypatch):
+    """Fail-closed: ADMIN_KEY set but ADMIN_KEY_AUTH_ENABLED unset must NOT
+    impersonate. Operators enable the path intentionally."""
     _clear_admin_env(monkeypatch)
+    _clear_local_dev_env(monkeypatch)
     monkeypatch.setenv('ADMIN_KEY', ADMIN_KEY)
 
-    assert verify_token(ADMIN_KEY + 'another-uid') == 'another-uid'
+    with pytest.raises(InvalidIdTokenError):
+        verify_token(ADMIN_KEY + 'another-uid')
 
 
 def test_non_matching_token_falls_through_to_firebase_even_when_enabled(monkeypatch):

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import List
@@ -17,6 +18,7 @@ from utils.http_client import (
     latest_wins_check,
 )
 from utils.executors import db_executor, postprocess_executor, run_blocking
+from utils.plugin_auth import maybe_plugin_auth_headers
 from utils.async_tasks import gather_safe
 import utils.dev_cache as dev_cache
 import database.mentor_gate_state as mentor_gate_state
@@ -299,14 +301,17 @@ async def trigger_external_integrations(
 
         try:
             payload = serialize_datetimes(conversation_dict)
+            body_bytes = json.dumps(payload, default=str, separators=(',', ':')).encode('utf-8')
             headers = dict(pin_kwargs['headers'])
+            headers['Content-Type'] = 'application/json'
+            headers.update(maybe_plugin_auth_headers(uid=uid, body=body_bytes))
             if idempotency_key:
                 headers['X-Omi-Idempotency-Key'] = idempotency_key
             async with get_webhook_semaphore():
                 client = get_webhook_client()
                 response = await client.post(
                     pinned_url,
-                    json=payload,
+                    content=body_bytes,
                     headers=headers,
                     extensions=pin_kwargs['extensions'],
                     follow_redirects=False,
@@ -1067,15 +1072,17 @@ async def _async_trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: 
             return
 
         try:
+            body_bytes = bytes(data)
             headers = dict(pin_kwargs['headers'])
             headers['Content-Type'] = 'application/octet-stream'
+            headers.update(maybe_plugin_auth_headers(uid=uid, body=body_bytes))
             async with get_webhook_semaphore():
                 if not latest_wins_check(uid, version):
                     return  # Check again after acquiring semaphore
                 client = get_webhook_client()
                 response = await client.post(
                     pinned_url,
-                    content=bytes(data),
+                    content=body_bytes,
                     headers=headers,
                     extensions=pin_kwargs['extensions'],
                     follow_redirects=False,
@@ -1183,12 +1190,17 @@ async def _async_trigger_realtime_integrations(
             return
 
         try:
+            payload = {"session_id": uid, "segments": segments}
+            body_bytes = json.dumps(payload, default=str, separators=(',', ':')).encode('utf-8')
+            headers = dict(pin_kwargs['headers'])
+            headers['Content-Type'] = 'application/json'
+            headers.update(maybe_plugin_auth_headers(uid=uid, body=body_bytes))
             async with get_webhook_semaphore():
                 client = get_webhook_client()
                 response = await client.post(
                     pinned_url,
-                    json={"session_id": uid, "segments": segments},
-                    headers=pin_kwargs['headers'],
+                    content=body_bytes,
+                    headers=headers,
                     extensions=pin_kwargs['extensions'],
                     follow_redirects=False,
                 )

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -109,17 +109,15 @@ def verify_token(token: str) -> str:
     """
     # ADMIN_KEY impersonation: token format is "<ADMIN_KEY><uid>" (kept as-is —
     # this exact concatenation is depended on by this repo's own integration
-    # tests, the listen/sync test stacks, and the production
-    # memory-continuity-gauntlet smoke test, so changing the format would
-    # break first-party tooling, not just close a hole). What actually
-    # changes: the prefix compare is constant-time instead of `startswith`
-    # (closes a timing side-channel on ADMIN_KEY itself), every successful
-    # use is logged so impersonation is auditable instead of silent, and
-    # ADMIN_KEY_AUTH_ENABLED lets an operator who doesn't need this feature
-    # turn it off entirely — default stays "true" so existing deployments
-    # and CI that already rely on it keep working unchanged.
+    # tests, the listen/sync test stacks, and the memory-continuity-gauntlet
+    # smoke test, so changing the format would break first-party tooling).
+    # Prefix compare is constant-time; successful use is logged for audit.
+    # ADMIN_KEY_AUTH_ENABLED defaults OFF (fail-closed). Set it to 'true'
+    # intentionally for local/dev/CI/break-glass that need Bearer
+    # <ADMIN_KEY><uid> impersonation. Admin router `secret-key: ADMIN_KEY`
+    # auth is a separate path and is not gated by this flag.
     admin_key = os.getenv('ADMIN_KEY')
-    if admin_key and os.getenv('ADMIN_KEY_AUTH_ENABLED', 'true').lower() == 'true':
+    if admin_key and os.getenv('ADMIN_KEY_AUTH_ENABLED', 'false').lower() == 'true':
         if len(admin_key) < 16:
             logger.warning('ADMIN_KEY is under 16 chars — trivially guessable if this deployment is internet-facing')
         candidate = token[: len(admin_key)].encode()

--- a/backend/utils/plugin_auth.py
+++ b/backend/utils/plugin_auth.py
@@ -1,0 +1,71 @@
+"""Backend copy of plugin webhook/tool HMAC signing.
+
+Canonical implementation lives in ``plugins/omi-plugin-sdk``
+(``omi_plugin_sdk.auth``). Backend does not depend on that package, so this
+module mirrors the algorithm:
+
+    signature = hex(HMAC-SHA256(secret, f"{uid}.{timestamp}.".encode() + body))
+
+Headers: X-Omi-Uid / X-Omi-Timestamp / X-Omi-Signature
+Env: OMI_PLUGIN_WEBHOOK_SECRET
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+import time
+from hashlib import sha256
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_HEADER = 'X-Omi-Signature'
+UID_HEADER = 'X-Omi-Uid'
+TIMESTAMP_HEADER = 'X-Omi-Timestamp'
+WEBHOOK_SECRET_ENV = 'OMI_PLUGIN_WEBHOOK_SECRET'
+
+_warned_missing_secret = False
+
+
+def get_plugin_webhook_secret() -> str | None:
+    raw = os.getenv(WEBHOOK_SECRET_ENV)
+    if raw is None:
+        return None
+    secret = raw.strip()
+    return secret or None
+
+
+def sign_plugin_payload(*, secret: str, uid: str, timestamp: str, body: bytes = b'') -> str:
+    message = f'{uid}.{timestamp}.'.encode('utf-8') + body
+    return hmac.new(secret.encode('utf-8'), message, sha256).hexdigest()
+
+
+def build_plugin_auth_headers(*, secret: str, uid: str, body: bytes = b'') -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    signature = sign_plugin_payload(secret=secret, uid=uid, timestamp=timestamp, body=body)
+    return {
+        UID_HEADER: uid,
+        TIMESTAMP_HEADER: timestamp,
+        SIGNATURE_HEADER: signature,
+    }
+
+
+def maybe_plugin_auth_headers(*, uid: str, body: bytes = b'') -> dict[str, str]:
+    """Return signing headers when OMI_PLUGIN_WEBHOOK_SECRET is configured.
+
+    When unset, returns {} and logs a one-time warning. Outbound delivery still
+    proceeds (plugins may not all enforce yet); configure the secret in prod.
+    """
+    global _warned_missing_secret
+    secret = get_plugin_webhook_secret()
+    if not secret:
+        if not _warned_missing_secret:
+            logger.warning(
+                '%s unset — outbound plugin calls are unsigned; '
+                'plugins that enforce omi_plugin_sdk.auth will reject bare uid',
+                WEBHOOK_SECRET_ENV,
+            )
+            _warned_missing_secret = True
+        return {}
+    return build_plugin_auth_headers(secret=secret, uid=uid, body=body)

--- a/backend/utils/retrieval/tools/app_tools.py
+++ b/backend/utils/retrieval/tools/app_tools.py
@@ -6,6 +6,7 @@ in the Omi chat when the app is installed by a user.
 """
 
 import contextvars
+import json
 from typing import Any, Dict, List, Optional, cast
 import httpx
 from pydantic import BaseModel, Field, create_model
@@ -30,6 +31,7 @@ from database.webhook_health import (
 from models.app import App, ChatTool
 from utils.mcp_client import call_mcp_tool
 from utils.http_client import get_webhook_circuit_breaker
+from utils.plugin_auth import maybe_plugin_auth_headers
 from utils.executors import db_executor, run_blocking
 from utils.notifications import send_notification
 import logging
@@ -321,17 +323,20 @@ async def _call_tool_endpoint(
     if geolocation:
         payload['geolocation'] = geolocation
 
-    # Prepare headers
+        # Sign the exact JSON body for mutating methods. GET signs empty body
+    # (query params are not covered by the HMAC — uid still carried in headers).
+    method = app_tool.method.upper()
+    if method in ['POST', 'PUT', 'PATCH']:
+        body_bytes = json.dumps(payload, default=str, separators=(',', ':')).encode('utf-8')
+    else:
+        body_bytes = b''
+
     headers = {
         'Content-Type': 'application/json',
     }
-
-    # Add authentication if required
-    if app_tool.auth_required:
-        # Get user's API key or auth token for this app
-        # For now, we'll pass the uid and let the app handle auth
-        # In the future, you might want to store app-specific tokens
-        pass
+    # Shared HMAC identity (OMI_PLUGIN_WEBHOOK_SECRET). Bare uid in the payload
+    # is not authentication — plugins must verify X-Omi-* headers.
+    headers.update(maybe_plugin_auth_headers(uid=uid, body=body_bytes))
 
     if await run_blocking(db_executor, is_app_webhook_disabled, app_id):
         return f"The {app_tool.name} tool is temporarily disabled due to sustained failures. The app developer has been notified."
@@ -342,13 +347,12 @@ async def _call_tool_endpoint(
 
     try:
         async with httpx.AsyncClient(timeout=120.0) as client:
-            method = app_tool.method.upper()
             request_kwargs: Dict[str, Any] = {
                 'headers': headers,
             }
 
             if method in ['POST', 'PUT', 'PATCH']:
-                request_kwargs['json'] = payload
+                request_kwargs['content'] = body_bytes
             elif method == 'GET':
                 request_kwargs['params'] = payload
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,12 +2,17 @@
 
 This directory contains three distinct things:
 
-## 1. `omi-plugin-sdk/` — shared SDK (models only)
+## 1. `omi-plugin-sdk/` — shared SDK (models + HMAC auth)
 
 `omi-plugin-sdk` is a small Python package that owns the Omi webhook
 payload models (`omi_plugin_sdk.models`: `Conversation`, `TranscriptSegment`,
-`ActionItem`, ...). It is intentionally models-only — auth/webhook/FastAPI
-helpers were removed in July 2026.
+`ActionItem`, ...) and shared HMAC auth helpers (`omi_plugin_sdk.auth`).
+
+**Auth rule:** a query/body `uid` is an identity *hint*, not authentication.
+Plugins must call `resolve_authenticated_uid` / `verify_headers` and reject
+unsigned requests. Backend signs outbound plugin calls when
+`OMI_PLUGIN_WEBHOOK_SECRET` is set (`X-Omi-Uid` / `X-Omi-Timestamp` /
+`X-Omi-Signature`).
 
 SDK installation differs by consumer:
 

--- a/plugins/notifications/hey_omi.py
+++ b/plugins/notifications/hey_omi.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import JSONResponse
 import logging
+import hmac
 import time
 import os
 import requests
@@ -159,13 +160,26 @@ def send_omi_notification(uid: str, message: str):
         return False
 
 
+def _require_hey_omi_inbound_auth(http_request: Request) -> None:
+    """Reject unauthenticated inbound webhooks.
+
+    Prefer Authorization: Bearer <HEY_OMI_APP_SECRET> (same secret used outbound).
+    Bare body uid is not authentication.
+    """
+    auth = (http_request.headers.get('Authorization') or '').strip()
+    expected = f'Bearer {omi_app_secret}'
+    if not auth or not hmac.compare_digest(auth, expected):
+        raise HTTPException(status_code=401, detail='authenticated webhook required')
+
+
 @router.post('/webhook')
-async def webhook(request: WebhookRequest):
+async def webhook(http_request: Request, request: WebhookRequest):
+    _require_hey_omi_inbound_auth(http_request)
     logger.info("Received webhook POST request")
     logger.info(f"Received data: {request.dict()}")
 
     session_id = request.session_id
-    uid = request.uid or session_id  # Use session_id as uid if uid is not provided
+    uid = request.uid or session_id  # session_id/uid only after auth
     logger.info(f"Processing request for session_id: {session_id}, uid: {uid}")
 
     if not session_id:

--- a/plugins/oauth/client.py
+++ b/plugins/oauth/client.py
@@ -1,5 +1,8 @@
 import base64
 import os
+import hmac
+import time
+from hashlib import sha256
 
 import requests
 
@@ -96,10 +99,47 @@ class NotionClient:
         self.oauth_redirect_uri = oauth_redirect_uri
         self.auth_url = auth_url
 
+    def _oauth_state_secret(self) -> str:
+        # Prefer dedicated secret; fall back to shared plugin webhook secret or Notion client secret.
+        return (
+            os.getenv("NOTION_OAUTH_STATE_SECRET")
+            or os.getenv("OMI_PLUGIN_WEBHOOK_SECRET")
+            or self.oauth_client_secret
+            or ""
+        ).strip()
+
     def get_oauth_url(self, uid: str):
-        # Should use encryption on state (with some salt) to prevent attacks
-        state = uid
+        """Build Notion OAuth URL with HMAC-signed state (not bare uid)."""
+        secret = self._oauth_state_secret()
+        if not secret:
+            raise ValueError(
+                "NOTION_OAUTH_STATE_SECRET / OMI_PLUGIN_WEBHOOK_SECRET / oauth_client_secret required to sign OAuth state"
+            )
+        ts = str(int(time.time()))
+        sig = hmac.new(secret.encode("utf-8"), f"{uid}.{ts}".encode("utf-8"), sha256).hexdigest()
+        state = f"{uid}.{ts}.{sig}"
         return f"{self.auth_url}&state={state}"
+
+    def verify_oauth_state(self, state: str, *, max_age_seconds: int = 600) -> str:
+        """Verify HMAC-signed OAuth state and return uid. Raises ValueError on failure."""
+        parts = (state or "").split(".")
+        if len(parts) != 3:
+            raise ValueError("invalid oauth state format")
+        uid, ts, sig = parts
+        secret = self._oauth_state_secret()
+        if not secret or not uid or not ts or not sig:
+            raise ValueError("invalid oauth state")
+        try:
+            if abs(time.time() - int(ts)) > max_age_seconds:
+                raise ValueError("oauth state expired")
+        except ValueError as e:
+            if "expired" in str(e):
+                raise
+            raise ValueError("invalid oauth state timestamp") from e
+        expected = hmac.new(secret.encode("utf-8"), f"{uid}.{ts}".encode("utf-8"), sha256).hexdigest()
+        if not hmac.compare_digest(expected, sig):
+            raise ValueError("invalid oauth state signature")
+        return uid
 
     def get_database(self, database_id: str, access_token: str):
         resp: requests.Response

--- a/plugins/oauth/conversation_created.py
+++ b/plugins/oauth/conversation_created.py
@@ -45,7 +45,13 @@ async def callback_auth_notion_crm(request: Request, state: str, code: str):
     Callback from Notion Oauth.
     """
 
-    uid = state
+    try:
+        uid = get_notion().verify_oauth_state(state)
+    except ValueError as e:
+        print(f"Invalid Notion OAuth state: {e}")
+        return response_setup_notion_crm_page(
+            request, "", f"Invalid or expired OAuth state. Please restart setup. \n (code: 400003)"
+        )
 
     # Get access token
     oauth_ok = get_notion().get_access_token(code)

--- a/plugins/omi-dropbox-app/db.py
+++ b/plugins/omi-dropbox-app/db.py
@@ -197,6 +197,45 @@ def delete_oauth_state(uid: str):
             _save_json(OAUTH_STATE_FILE, states)
 
 
+
+
+def store_oauth_state_by_token(state: str, uid: str):
+    """Store opaque OAuth state → uid mapping (preferred over uid→state)."""
+    r = _get_redis()
+    if r:
+        key = f"{OAUTH_STATE_PREFIX}token:{state}"
+        r.set(key, uid)
+        r.expire(key, 60 * 10)
+    else:
+        states = _load_json(OAUTH_STATE_FILE)
+        states[f"token:{state}"] = {
+            "uid": uid,
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        _save_json(OAUTH_STATE_FILE, states)
+
+
+def pop_oauth_uid_for_state(state: str) -> Optional[str]:
+    """Look up and delete uid for an opaque OAuth state token."""
+    r = _get_redis()
+    if r:
+        key = f"{OAUTH_STATE_PREFIX}token:{state}"
+        uid = r.get(key)
+        if uid is not None:
+            r.delete(key)
+            return uid
+        return None
+    states = _load_json(OAUTH_STATE_FILE)
+    key = f"token:{state}"
+    state_data = states.get(key)
+    if not state_data:
+        return None
+    uid = state_data.get("uid")
+    del states[key]
+    _save_json(OAUTH_STATE_FILE, states)
+    return uid
+
+
 # ============== User Settings Management ==============
 
 def get_user_settings(uid: str) -> Dict[str, Any]:

--- a/plugins/omi-dropbox-app/main.py
+++ b/plugins/omi-dropbox-app/main.py
@@ -16,7 +16,8 @@ from urllib.parse import urlencode
 
 import requests
 from dotenv import load_dotenv
-from fastapi import FastAPI, Query, Request
+from omi_plugin_sdk.auth import PluginAuthError, get_webhook_secret, resolve_authenticated_uid
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 
 from db import (
@@ -27,6 +28,8 @@ from db import (
     store_oauth_state,
     get_oauth_state,
     delete_oauth_state,
+    store_oauth_state_by_token,
+    pop_oauth_uid_for_state,
     get_user_settings,
     store_user_settings,
 )
@@ -319,7 +322,25 @@ def get_home_page_html(
 # ============== Endpoints ==============
 
 
+
+def _require_uid(request: Request, *, query_uid: str | None = None, body_uid: str | None = None, body: bytes = b"") -> str:
+    try:
+        return resolve_authenticated_uid(
+            secret=get_webhook_secret(),
+            header_map=request.headers,
+            query_uid=query_uid,
+            body_uid=body_uid,
+            body=body,
+        )
+    except PluginAuthError as e:
+        raise HTTPException(
+            status_code=getattr(e, "status_code", 401),
+            detail="authenticated uid required (uid query/body alone is not auth)",
+        ) from e
+
+
 @app.get("/", response_class=HTMLResponse)
+# TODO(security): setup URL uid must be signed by Omi backend (product)
 async def home(uid: str = Query(None)):
     """Home page - shows connection status and settings."""
     if not uid:
@@ -362,18 +383,22 @@ async def check_setup(uid: str = Query(...)):
 
 
 @app.get("/auth/dropbox")
+# TODO(security): OAuth start uid from unsigned query — product must sign setup identity
 async def auth_dropbox(uid: str = Query(...)):
-    """Start Dropbox OAuth flow."""
-    # Generate state for CSRF protection
-    state = f"{uid}:{secrets.token_urlsafe(32)}"
+    """Start Dropbox OAuth flow.
+
+    Uses an opaque random state token mapped server-side to uid (not uid-in-state).
+    """
+    state = secrets.token_urlsafe(32)
+    store_oauth_state_by_token(state, uid)
+    # Keep legacy uid→state store for any transitional readers
     store_oauth_state(uid, state)
 
-    # Build authorization URL
     params = {
         "client_id": DROPBOX_APP_KEY,
         "redirect_uri": DROPBOX_REDIRECT_URI,
         "response_type": "code",
-        "token_access_type": "offline",  # Get refresh token
+        "token_access_type": "offline",
         "state": state,
     }
 
@@ -408,19 +433,18 @@ async def auth_callback(
     if not code or not state:
         return HTMLResponse("Missing code or state", status_code=400)
 
-    # Extract uid from state
-    try:
-        uid = state.split(":")[0]
-    except Exception:
-        return HTMLResponse("Invalid state format", status_code=400)
-
-    # Verify state for CSRF protection
-    stored_state = get_oauth_state(uid)
-    if stored_state != state:
-        return HTMLResponse("State mismatch - possible CSRF attack", status_code=400)
-
-    # Clean up state
-    delete_oauth_state(uid)
+    # Resolve uid from opaque state token (preferred). Fall back to legacy uid:nonce.
+    uid = pop_oauth_uid_for_state(state)
+    if not uid:
+        try:
+            legacy_uid = state.split(":")[0]
+        except Exception:
+            return HTMLResponse("Invalid state format", status_code=400)
+        stored_state = get_oauth_state(legacy_uid)
+        if stored_state != state:
+            return HTMLResponse("State mismatch - possible CSRF attack", status_code=400)
+        uid = legacy_uid
+        delete_oauth_state(uid)
 
     # Exchange code for tokens
     try:
@@ -479,8 +503,9 @@ async def auth_callback(
 
 
 @app.get("/disconnect")
-async def disconnect(uid: str = Query(...)):
-    """Disconnect Dropbox account."""
+async def disconnect(request: Request, uid: str = Query(None)):
+    """Disconnect Dropbox account. Requires HMAC auth — bare ?uid= is rejected."""
+    uid = _require_uid(request, query_uid=uid, body=b"")
     delete_dropbox_tokens(uid)
     return RedirectResponse(url=f"/?uid={uid}")
 
@@ -489,9 +514,15 @@ async def disconnect(uid: str = Query(...)):
 
 
 @app.post("/settings")
-async def update_settings(request: Request, uid: str = Query(...)):
-    """Update user settings."""
-    form_data = await request.form()
+async def update_settings(request: Request, uid: str = Query(None)):
+    """Update user settings. Requires HMAC auth — bare ?uid= is rejected."""
+    # Read raw body for signature verification before form parse is unavailable;
+    # form posts from the setup HTML cannot mint HMAC — product must sign setup.
+    raw_body = await request.body()
+    uid = _require_uid(request, query_uid=uid, body=raw_body)
+    # Re-parse form from raw body
+    from urllib.parse import parse_qs
+    form_data = {k: (v[0] if v else "") for k, v in parse_qs(raw_body.decode("utf-8"), keep_blank_values=True).items()}
 
     settings = {
         "folder_name": form_data.get("folder_name", "Omi Conversations"),
@@ -509,13 +540,16 @@ async def update_settings(request: Request, uid: str = Query(...)):
 
 @app.post("/conversation", response_model=EndpointResponse)
 async def on_conversation_created(
-    conversation: Conversation,
-    uid: str = Query(...),
+    request: Request,
+    uid: str = Query(None),
 ):
     """
     Webhook called by Omi when a conversation is created.
-    Saves summary and transcript to Dropbox.
+    Saves summary and transcript to Dropbox. Requires HMAC auth.
     """
+    raw_body = await request.body()
+    uid = _require_uid(request, query_uid=uid, body=raw_body)
+    conversation = Conversation.model_validate_json(raw_body)
     print(f"[WEBHOOK] Received conversation for uid={uid}")
     print(f"[WEBHOOK] Title: {conversation.structured.title}")
     print(f"[WEBHOOK] Overview: {conversation.structured.overview[:100]}...")

--- a/plugins/omi-github-app/main.py
+++ b/plugins/omi-github-app/main.py
@@ -5,6 +5,7 @@ This app provides GitHub integration through OAuth2 authentication
 and chat tools for creating and managing GitHub issues.
 """
 import sys
+import json
 from fastapi import FastAPI, Request, HTTPException, Query
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 import os
@@ -15,6 +16,11 @@ from simple_storage import SimpleUserStorage
 from github_client import GitHubClient
 from issue_detector import ai_select_labels
 from models import ChatToolResponse
+from omi_plugin_sdk.auth import (
+    PluginAuthError,
+    get_webhook_secret,
+    resolve_authenticated_uid,
+)
 from agent_providers import (
     run_agent_provider,
     PROVIDERS,
@@ -43,6 +49,24 @@ app = FastAPI(
 
 # Store OAuth states temporarily (in production, use Redis or similar)
 oauth_states = {}
+
+
+def _require_uid(request: Request, *, query_uid: str | None = None, body_uid: str | None = None, body: bytes = b"") -> str:
+    """Reject bare uid — require HMAC headers (OMI_PLUGIN_WEBHOOK_SECRET)."""
+    try:
+        return resolve_authenticated_uid(
+            secret=get_webhook_secret(),
+            header_map=request.headers,
+            query_uid=query_uid,
+            body_uid=body_uid,
+            body=body,
+        )
+    except PluginAuthError as e:
+        raise HTTPException(
+            status_code=getattr(e, "status_code", 401),
+            detail="authenticated uid required (uid query/body alone is not auth)",
+        ) from e
+
 
 
 # ============================================
@@ -256,11 +280,12 @@ async def tool_create_issue(request: Request):
     Chat tool for Omi - creates an issue in the specified or default repository.
     """
     try:
-        body = await request.json()
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
         log(f"=== CREATE_ISSUE START ===")
         log(f"Request: {body}")
 
-        uid = body.get("uid")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         title = body.get("title")
         issue_body = body.get("body", "")
         labels = body.get("labels", [])
@@ -343,8 +368,9 @@ async def tool_list_repos(request: Request):
     List user's GitHub repositories.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
 
         if not uid:
             return ChatToolResponse(error="User ID is required")
@@ -387,8 +413,9 @@ async def tool_list_issues(request: Request):
     List issues in a GitHub repository.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         repo = body.get("repo")
         state = body.get("state", "open")
         limit = min(body.get("limit", 10), 50)
@@ -434,8 +461,9 @@ async def tool_get_issue(request: Request):
     Get details of a specific GitHub issue.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         issue_number = body.get("issue_number")
         repo = body.get("repo")
 
@@ -500,8 +528,9 @@ async def tool_list_labels(request: Request):
     List available labels in a repository.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         repo = body.get("repo")
 
         if not uid:
@@ -543,8 +572,9 @@ async def tool_add_comment(request: Request):
     Add a comment to a GitHub issue.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         issue_number = body.get("issue_number")
         comment_body = body.get("body")
         repo = body.get("repo")
@@ -593,6 +623,7 @@ async def tool_add_comment(request: Request):
 # ============================================
 
 @app.get("/")
+# TODO(security): setup URL uid must be signed by Omi backend (product)
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage with repo selection (mobile-first UI)."""
     if not uid:
@@ -960,11 +991,17 @@ async def root(uid: str = Query(None)):
                     }}
 
                     try {{
-                        await fetch('/save-agent-key?uid={uid}&provider=' + encodeURIComponent(provider) + '&key=' + encodeURIComponent(apiKey), {{
-                            method: 'POST'
+                        const resp = await fetch('/save-agent-key', {{
+                            method: 'POST',
+                            headers: {{ 'Content-Type': 'application/json' }},
+                            body: JSON.stringify({{ uid: '{uid}', provider, key: apiKey }})
                         }});
-
-                        alert('API key saved successfully!');
+                        const result = await resp.json().catch(() => ({{}}));
+                        if (resp.ok && result.success) {{
+                            alert('API key saved successfully!');
+                        }} else {{
+                            alert('Save failed (' + resp.status + '): ' + (result.detail || result.error || 'auth required — setup UI cannot mint plugin HMAC'));
+                        }}
                     }} catch (error) {{
                         alert('Error: ' + error.message);
                     }}
@@ -1051,6 +1088,7 @@ async def root(uid: str = Query(None)):
 
 
 @app.get("/auth")
+# TODO(security): OAuth start uid from unsigned query — product must sign setup identity
 async def auth_start(uid: str = Query(..., description="User ID from OMI")):
     """Start OAuth flow for GitHub authentication."""
     redirect_uri = os.getenv("OAUTH_REDIRECT_URL", "http://localhost:8000/auth/callback")
@@ -1215,6 +1253,7 @@ async def auth_callback(
 
 
 @app.get("/setup-completed")
+# TODO(security): verify X-Omi-* when secret configured
 async def check_setup(uid: str = Query(..., description="User ID from OMI")):
     """Check if user has completed setup (authenticated with GitHub)."""
     is_authenticated = SimpleUserStorage.is_authenticated(uid)
@@ -1226,33 +1265,48 @@ async def check_setup(uid: str = Query(..., description="User ID from OMI")):
 
 
 @app.post("/update-repo")
-async def update_repo(
-    uid: str = Query(...),
-    repo: str = Query(...)
-):
-    """Update user's selected repository."""
+async def update_repo(request: Request):
+    """Update user's selected repository. Requires HMAC auth."""
     try:
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}") if raw_body else {}
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
+        repo = data.get("repo") or request.query_params.get("repo")
+        if not repo:
+            return {"success": False, "error": "repo required"}
         success = SimpleUserStorage.update_repo_selection(uid, repo)
         if success:
             return {"success": True, "message": f"Repository updated to {repo}"}
-        else:
-            return {"success": False, "error": "User not found"}
+        return {"success": False, "error": "User not found"}
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+
 @app.post("/refresh-repos")
-async def refresh_repos(uid: str = Query(...)):
-    """Refresh user's repository list from GitHub."""
+async def refresh_repos(request: Request):
+    """Refresh user's repository list from GitHub. Requires HMAC auth."""
     try:
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}") if raw_body else {}
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
         user = SimpleUserStorage.get_user(uid)
         if not user or not user.get("access_token"):
             return {"success": False, "error": "User not authenticated"}
 
-        # Fetch fresh repo list
         repos = github_client.list_user_repos(user["access_token"])
-
-        # Update storage
         SimpleUserStorage.save_user(
             uid=uid,
             access_token=user["access_token"],
@@ -1260,19 +1314,27 @@ async def refresh_repos(uid: str = Query(...)):
             selected_repo=user.get("selected_repo"),
             available_repos=repos
         )
-
         return {"success": True, "repos_count": len(repos)}
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+
 @app.post("/check-repo-access")
-async def check_repo_access(
-    uid: str = Query(...),
-    repo: str = Query(None)
-):
-    """Check authenticated user's permissions for a repository."""
+async def check_repo_access(request: Request):
+    """Check authenticated user's permissions for a repository. Requires HMAC auth."""
     try:
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}") if raw_body else {}
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
+        repo = data.get("repo") or request.query_params.get("repo")
         user = SimpleUserStorage.get_user(uid)
         if not user or not user.get("access_token"):
             return {"success": False, "error": "User not authenticated"}
@@ -1305,18 +1367,26 @@ async def check_repo_access(
             "permissions": permissions,
             "message": f"{level} access"
         }
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+
 @app.post("/save-agent-provider")
-async def save_agent_provider(
-    uid: str = Query(...),
-    provider: str = Query(...)
-):
-    """Save user's agent provider selection."""
+async def save_agent_provider(request: Request):
+    """Save user's agent provider selection. Requires HMAC auth."""
     try:
-        provider = provider.lower().strip()
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}") if raw_body else {}
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
+        provider = str(data.get("provider") or request.query_params.get("provider") or "").lower().strip()
         if provider not in PROVIDERS:
             return {"success": False, "error": "Unsupported provider"}
 
@@ -1328,19 +1398,32 @@ async def save_agent_provider(
         if success:
             return {"success": True, "message": "Agent provider saved"}
         return {"success": False, "error": "Failed to save"}
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+
 @app.post("/save-agent-key")
-async def save_agent_key(
-    uid: str = Query(...),
-    provider: str = Query(...),
-    key: str = Query(...)
-):
-    """Save user's API key for an agent provider."""
+async def save_agent_key(request: Request):
+    """Save user's API key for an agent provider.
+
+    Requires HMAC auth. Key/provider must be in JSON body — never query string.
+    """
     try:
-        provider = provider.lower().strip()
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
+        provider = str(data.get("provider") or "").lower().strip()
+        key = str(data.get("key") or "").strip()
+        if not provider or not key:
+            return {"success": False, "error": "provider and key required in JSON body"}
         if provider not in PROVIDERS:
             return {"success": False, "error": "Unsupported provider"}
 
@@ -1352,35 +1435,47 @@ async def save_agent_key(
         if success:
             return {"success": True, "message": "Agent API key saved"}
         return {"success": False, "error": "Failed to save"}
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+
 @app.post("/delete-agent-key")
-async def delete_agent_key(
-    uid: str = Query(...),
-    provider: str = Query(...)
-):
-    """Delete user's API key for an agent provider."""
+async def delete_agent_key(request: Request):
+    """Delete user's API key for an agent provider. Requires HMAC auth."""
     try:
-        provider = provider.lower().strip()
-        if provider not in PROVIDERS:
+        raw_body = await request.body()
+        data = json.loads(raw_body.decode("utf-8") or "{}") if raw_body else {}
+        uid = _require_uid(
+            request,
+            query_uid=request.query_params.get("uid"),
+            body_uid=data.get("uid"),
+            body=raw_body,
+        )
+        provider = str(data.get("provider") or request.query_params.get("provider") or "").lower().strip()
+        if not provider or provider not in PROVIDERS:
             return {"success": False, "error": "Unsupported provider"}
 
         success = SimpleUserStorage.delete_agent_api_key(uid, provider)
         if success:
             return {"success": True, "message": "Agent API key deleted"}
         return {"success": False, "error": "Key not found"}
+    except HTTPException:
+        raise
     except Exception as e:
         return {"success": False, "error": str(e)}
+
 
 
 @app.post("/test-agent")
 async def test_agent(request: Request):
     """Send a direct test command to the selected agent provider."""
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         prompt = body.get("prompt")
         repo = body.get("repo")
         provider_override = body.get("provider")
@@ -1489,8 +1584,9 @@ async def tool_code_feature(request: Request):
     AI-powered coding tool - implement features using Claude.
     """
     try:
-        body = await request.json()
-        uid = body.get("uid")
+        raw_body = await request.body()
+        body = json.loads(raw_body.decode("utf-8") or "{}")
+        uid = _require_uid(request, body_uid=body.get("uid"), body=raw_body)
         feature = body.get("feature")
         repo = body.get("repo")  # Optional: owner/repo format
         merge = body.get("merge", False)  # Optional: merge PR after creation

--- a/plugins/omi-github-app/requirements.txt
+++ b/plugins/omi-github-app/requirements.txt
@@ -1,3 +1,4 @@
+../omi-plugin-sdk
 fastapi==0.104.1
 uvicorn==0.24.0
 python-dotenv==1.2.2

--- a/plugins/omi-plugin-sdk/README.md
+++ b/plugins/omi-plugin-sdk/README.md
@@ -22,5 +22,18 @@ from omi_plugin_sdk.models import (
 )
 ```
 
-The SDK owns Omi webhook payload models. App-specific OAuth state, persisted
-settings, provider clients, and business logic stay inside each app.
+The SDK owns Omi webhook payload models and shared HMAC auth helpers
+(`omi_plugin_sdk.auth`). Bare query/body `uid` is an identity hint, **not**
+authentication — plugins must call `resolve_authenticated_uid` (or
+`verify_headers`) and reject unsigned requests.
+
+App-specific OAuth state, persisted settings, provider clients, and business
+logic stay inside each app.
+
+```python
+from omi_plugin_sdk.auth import (
+    build_auth_headers,
+    get_webhook_secret,
+    resolve_authenticated_uid,
+)
+```

--- a/plugins/omi-plugin-sdk/pyproject.toml
+++ b/plugins/omi-plugin-sdk/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omi-plugin-sdk"
-version = "0.1.0"
-description = "Shared Omi plugin webhook models and small integration primitives."
+version = "0.2.0"
+description = "Shared Omi plugin webhook models and HMAC auth primitives."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["pydantic>=2.0.0"]

--- a/plugins/omi-plugin-sdk/src/omi_plugin_sdk/__init__.py
+++ b/plugins/omi-plugin-sdk/src/omi_plugin_sdk/__init__.py
@@ -1,5 +1,18 @@
 """Shared Omi plugin SDK."""
 
+from omi_plugin_sdk.auth import (
+    PluginAuthError,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    UID_HEADER,
+    WEBHOOK_SECRET_ENV,
+    build_auth_headers,
+    get_webhook_secret,
+    resolve_authenticated_uid,
+    sign_payload,
+    verify_headers,
+    verify_payload,
+)
 from omi_plugin_sdk.models import (
     ActionItem,
     ActionItemsExtraction,
@@ -30,8 +43,19 @@ __all__ = [
     "ExternalIntegrationConversationSource",
     "ExternalIntegrationCreateConversation",
     "Geolocation",
+    "PluginAuthError",
     "PluginResult",
+    "SIGNATURE_HEADER",
     "Section",
     "Structured",
+    "TIMESTAMP_HEADER",
     "TranscriptSegment",
+    "UID_HEADER",
+    "WEBHOOK_SECRET_ENV",
+    "build_auth_headers",
+    "get_webhook_secret",
+    "resolve_authenticated_uid",
+    "sign_payload",
+    "verify_headers",
+    "verify_payload",
 ]

--- a/plugins/omi-plugin-sdk/src/omi_plugin_sdk/auth.py
+++ b/plugins/omi-plugin-sdk/src/omi_plugin_sdk/auth.py
@@ -1,0 +1,168 @@
+"""Shared HMAC auth for Omi backend → plugin identity.
+
+Canonical copy of the webhook/tool signing scheme. Backend keeps a matching
+helper in ``backend/utils/plugin_auth.py`` (backend does not depend on this
+package). Algorithm must stay in sync:
+
+    signature = hex(HMAC-SHA256(secret, f"{uid}.{timestamp}.".encode() + body))
+
+Headers:
+    X-Omi-Uid / X-Omi-Timestamp / X-Omi-Signature
+
+Bare query/body ``uid`` is an identity *hint*, never authentication.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import time
+from collections.abc import Mapping
+from hashlib import sha256
+from typing import Any
+
+SIGNATURE_HEADER = "X-Omi-Signature"
+UID_HEADER = "X-Omi-Uid"
+TIMESTAMP_HEADER = "X-Omi-Timestamp"
+WEBHOOK_SECRET_ENV = "OMI_PLUGIN_WEBHOOK_SECRET"
+
+_DEFAULT_MAX_AGE_SECONDS = 300
+
+
+class PluginAuthError(Exception):
+    """Raised when plugin request identity cannot be verified."""
+
+    def __init__(self, message: str = "plugin auth failed", *, status_code: int = 401) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def get_webhook_secret() -> str | None:
+    raw = os.getenv(WEBHOOK_SECRET_ENV)
+    if raw is None:
+        return None
+    secret = raw.strip()
+    return secret or None
+
+
+def sign_payload(*, secret: str, uid: str, timestamp: str, body: bytes = b"") -> str:
+    if not secret or not uid or not timestamp:
+        raise ValueError("secret, uid, and timestamp are required")
+    message = f"{uid}.{timestamp}.".encode("utf-8") + body
+    return hmac.new(secret.encode("utf-8"), message, sha256).hexdigest()
+
+
+def verify_payload(
+    *,
+    secret: str,
+    uid: str,
+    timestamp: str,
+    body: bytes,
+    signature: str,
+    max_age_seconds: int = _DEFAULT_MAX_AGE_SECONDS,
+    now: float | None = None,
+) -> bool:
+    if not secret or not uid or not timestamp or not signature:
+        return False
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        return False
+    current = time.time() if now is None else now
+    if abs(current - ts) > max_age_seconds:
+        return False
+    expected = sign_payload(secret=secret, uid=uid, timestamp=timestamp, body=body)
+    return hmac.compare_digest(expected, signature)
+
+
+def build_auth_headers(*, secret: str, uid: str, body: bytes = b"", now: float | None = None) -> dict[str, str]:
+    timestamp = str(int(time.time() if now is None else now))
+    signature = sign_payload(secret=secret, uid=uid, timestamp=timestamp, body=body)
+    return {
+        UID_HEADER: uid,
+        TIMESTAMP_HEADER: timestamp,
+        SIGNATURE_HEADER: signature,
+    }
+
+
+def _header_get(headers: Mapping[Any, Any], name: str) -> str:
+    # Support Starlette/FastAPI Headers (case-insensitive) and plain dicts.
+    if hasattr(headers, "get"):
+        value = headers.get(name)
+        if value is None:
+            value = headers.get(name.lower())
+        if value is None and hasattr(headers, "get"):
+            # brute case variants for plain dicts
+            for key in headers:
+                if str(key).lower() == name.lower():
+                    value = headers[key]
+                    break
+        return "" if value is None else str(value).strip()
+    return ""
+
+
+def verify_headers(
+    *,
+    secret: str,
+    headers: Mapping[Any, Any],
+    body: bytes = b"",
+    expected_uid: str | None = None,
+    max_age_seconds: int = _DEFAULT_MAX_AGE_SECONDS,
+    now: float | None = None,
+) -> str:
+    uid = _header_get(headers, UID_HEADER)
+    timestamp = _header_get(headers, TIMESTAMP_HEADER)
+    signature = _header_get(headers, SIGNATURE_HEADER)
+    if not uid or not timestamp or not signature:
+        raise PluginAuthError("missing plugin auth headers")
+    if expected_uid is not None and expected_uid.strip() and not hmac.compare_digest(uid, expected_uid.strip()):
+        raise PluginAuthError("uid mismatch")
+    if not verify_payload(
+        secret=secret,
+        uid=uid,
+        timestamp=timestamp,
+        body=body,
+        signature=signature,
+        max_age_seconds=max_age_seconds,
+        now=now,
+    ):
+        raise PluginAuthError("invalid plugin auth signature")
+    return uid
+
+
+def resolve_authenticated_uid(
+    *,
+    secret: str | None,
+    header_map: Mapping[Any, Any],
+    query_uid: str | None,
+    body_uid: str | None,
+    body: bytes = b"",
+    allow_uid_only: bool = False,
+    max_age_seconds: int = _DEFAULT_MAX_AGE_SECONDS,
+    now: float | None = None,
+) -> str:
+    """Resolve a verified uid for a plugin request.
+
+    When ``secret`` is set, HMAC headers are required. Query/body uid alone is
+    never authentication unless ``allow_uid_only`` is explicitly True (legacy
+    escape hatch — default False, fail-closed).
+    """
+    hinted = (query_uid or body_uid or "").strip() or None
+
+    if secret:
+        uid = verify_headers(
+            secret=secret,
+            headers=header_map,
+            body=body,
+            expected_uid=hinted,
+            max_age_seconds=max_age_seconds,
+            now=now,
+        )
+        return uid
+
+    if allow_uid_only:
+        if not hinted:
+            raise PluginAuthError("uid required")
+        return hinted
+
+    raise PluginAuthError("authenticated uid required (uid query/body alone is not auth)")

--- a/plugins/omi-plugin-sdk/tests/test_auth.py
+++ b/plugins/omi-plugin-sdk/tests/test_auth.py
@@ -1,0 +1,98 @@
+"""Unit tests for omi_plugin_sdk.auth."""
+
+import time
+
+import pytest
+
+from omi_plugin_sdk.auth import (
+    PluginAuthError,
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    UID_HEADER,
+    build_auth_headers,
+    resolve_authenticated_uid,
+    sign_payload,
+    verify_headers,
+    verify_payload,
+)
+
+
+SECRET = "test-plugin-webhook-secret"
+UID = "user-abc"
+
+
+def test_sign_verify_roundtrip():
+    body = b'{"hello":"world"}'
+    ts = str(int(time.time()))
+    sig = sign_payload(secret=SECRET, uid=UID, timestamp=ts, body=body)
+    assert verify_payload(secret=SECRET, uid=UID, timestamp=ts, body=body, signature=sig)
+
+
+def test_tampered_body_rejected():
+    ts = str(int(time.time()))
+    sig = sign_payload(secret=SECRET, uid=UID, timestamp=ts, body=b"a")
+    assert not verify_payload(secret=SECRET, uid=UID, timestamp=ts, body=b"b", signature=sig)
+
+
+def test_skew_rejected():
+    body = b""
+    old_ts = str(int(time.time()) - 10_000)
+    sig = sign_payload(secret=SECRET, uid=UID, timestamp=old_ts, body=body)
+    assert not verify_payload(secret=SECRET, uid=UID, timestamp=old_ts, body=body, signature=sig)
+
+
+def test_build_and_verify_headers():
+    body = b'{"x":1}'
+    headers = build_auth_headers(secret=SECRET, uid=UID, body=body)
+    assert headers[UID_HEADER] == UID
+    assert TIMESTAMP_HEADER in headers and SIGNATURE_HEADER in headers
+    assert verify_headers(secret=SECRET, headers=headers, body=body) == UID
+
+
+def test_resolve_rejects_bare_uid_without_secret():
+    with pytest.raises(PluginAuthError):
+        resolve_authenticated_uid(
+            secret=None,
+            header_map={},
+            query_uid=UID,
+            body_uid=None,
+            body=b"",
+        )
+
+
+def test_resolve_accepts_signed_headers():
+    body = b'{"uid":"user-abc"}'
+    headers = build_auth_headers(secret=SECRET, uid=UID, body=body)
+    got = resolve_authenticated_uid(
+        secret=SECRET,
+        header_map=headers,
+        query_uid=UID,
+        body_uid=None,
+        body=body,
+    )
+    assert got == UID
+
+
+def test_resolve_uid_mismatch_rejected():
+    headers = build_auth_headers(secret=SECRET, uid=UID, body=b"")
+    with pytest.raises(PluginAuthError):
+        resolve_authenticated_uid(
+            secret=SECRET,
+            header_map=headers,
+            query_uid="other-uid",
+            body_uid=None,
+            body=b"",
+        )
+
+
+def test_allow_uid_only_escape_hatch():
+    assert (
+        resolve_authenticated_uid(
+            secret=None,
+            header_map={},
+            query_uid=UID,
+            body_uid=None,
+            allow_uid_only=True,
+        )
+        == UID
+    )


### PR DESCRIPTION
## Summary

Draft fix for the two **omi P0s** from the 2026-09-11 Grok audit (`.grok-audits/grok-audit-omi-20260911.md` on the auditor checkout). Based on current `origin/main` (worktree `/Users/undivisible/projects/omi-sec-p0`).

### P0-2 — `ADMIN_KEY_AUTH_ENABLED` fail-closed
- `verify_token` now defaults `ADMIN_KEY_AUTH_ENABLED` to **off** (`false`).
- Feature retained: set `ADMIN_KEY_AUTH_ENABLED=true` intentionally for local/dev/CI/break-glass that need `Authorization: Bearer <ADMIN_KEY><uid>`.
- Admin router auth via `secret-key: ADMIN_KEY` is **unchanged** (separate path).
- Prod overlays leave the flag unset → stay fail-closed.
- First-party harnesses (`listen_pusher_stack`, `sync_cloud_tasks_stack`, `replay_harness_phase0a`) set the flag explicitly.

### P0-1 — Plugin fleet uid-as-auth (shared pattern)
- Restored `omi_plugin_sdk.auth` HMAC helpers (`X-Omi-Uid` / `X-Omi-Timestamp` / `X-Omi-Signature`).
- Backend signs outbound plugin webhooks/tools/setup_completed checks when `OMI_PLUGIN_WEBHOOK_SECRET` is set (`backend/utils/plugin_auth.py` mirrors the SDK algorithm).
- Wired reject-bare-uid on high-risk surfaces:
  - **GitHub**: mutations (`/save-agent-key` JSON body only, no key-in-query), tools, etc.
  - **Dropbox**: disconnect / settings / conversation webhook; opaque OAuth state→uid map
  - **hey_omi**: inbound webhook requires `Authorization: Bearer <HEY_OMI_APP_SECRET>`
  - **Legacy Notion OAuth**: HMAC-signed state (not bare uid)

## How to enable `ADMIN_KEY` impersonation intentionally
```bash
# backend/.env (local/dev/CI/break-glass only)
ADMIN_KEY=<long-random-secret>
ADMIN_KEY_AUTH_ENABLED=true
```
Do **not** set `ADMIN_KEY_AUTH_ENABLED=true` in prod overlays unless you have a dedicated break-glass plan.

## How to enable plugin HMAC
```bash
# Same value on API + plugin services that enforce auth
OMI_PLUGIN_WEBHOOK_SECRET=<long-random-secret>
```
Until this secret is deployed to both backend and enforcing plugins, signed delivery is optional on the backend (warns once if unset) and enforcing plugin endpoints return **401** on bare uid (fail-closed).

## Residual risk / follow-ups (out of scope for this PR)
- **Product call required:** Omi must pass a **signed** uid / auth headers when opening plugin `app_home_url` / OAuth start (`?uid=` alone is still forgeable for setup/OAuth-start binding). TODOs left in GitHub/Dropbox setup + auth-start handlers.
- Remaining `omi-*-app` fleet (Notion app, Slack, Whoop, Shopify, …) not mass-migrated — SDK is ready; migrate per app.
- P1s deferred: developer webhook SSRF, Firestore plaintext integration tokens, macOS BYOK Keychain, BLE GATT encrypt, platform-integration issues.

## Test plan
- [x] `plugins/omi-plugin-sdk/tests/test_auth.py` (8 passed)
- [x] `backend/tests/unit/test_plugin_auth.py` + `test_verify_token_admin_and_local_dev_gating.py` (14 passed)
- [ ] Deploy `OMI_PLUGIN_WEBHOOK_SECRET` to backend + GitHub/Dropbox plugins before relying on 401 enforcement in prod
- [ ] Confirm web admin / desktop release workflows that use `secret-key: ADMIN_KEY` still work (impersonation flag does not gate them)
- [ ] Do not admin-merge until product signs setup URLs or accepts temporary setup-UI breakage (GitHub/Dropbox browser mutations now need HMAC)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

