### PR TITLE
fix: select every registry composite for the isolated jit-qa Firestore database

### DIFF
--- a/backend/scripts/jit_qa_firestore_index_operator.py
+++ b/backend/scripts/jit_qa_firestore_index_operator.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
-"""Reconcile the bounded Firestore schema required by the isolated JIT QA path.
+"""Reconcile the Firestore composite schema required by the isolated JIT QA path.
 
-The checked-in manifest is the source of truth, but the QA database is a
-separate development database that must not receive the full production
-manifest merely to exercise JIT history and entity-timeline reads.  This
-operator validates the complete generated manifest, selects a bounded set of named query
-requirements from it, and delegates inventory/provisioning/waiting to the
-shared Firestore reconciler.
+The checked-in manifest is the source of truth.  The QA database is a separate
+development database, and the named QA app now runs the full shared desktop
+path against it for real working days, so every composite the registry
+declares must be servable there: each registry entry was added because a
+production query needs it, and a fresh database provisioned from a subset
+returns ``FailedPrecondition`` on the first read that reaches an unselected
+query (measured 2026-09-10 on ``action_items`` and 2026-09-11 on
+``chat_first_deferrals`` while the bounded plan reported "none missing").
+This operator validates the complete generated manifest, selects every
+registry composite from it, keeps the QA-only single-field target explicit,
+and delegates inventory/provisioning/waiting to the shared Firestore
+reconciler.  Project, database, and confirmation stay fixed.
 """
 
 from __future__ import annotations
@@ -22,25 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-from database.firestore_index_registry import (
-    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
-    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
-    CURRENT_CHAT_SESSION_ORDERED_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_CONTENT_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_SLOT_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_SLOT_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_SUBJECT_CONTENT_QUERY,
-    DAILY_SWEEP_ACTIVE_FACT_SUBJECT_QUERY,
-    ENTITY_TIMELINE_CONVERSATIONS_QUERY,
-    FINALIZATION_OLDEST_NONTERMINAL_QUERY,
-    INDEX_ONLY_REQUIREMENTS,
-    MESSAGES_BY_APP_ORDERED_QUERY,
-    MESSAGES_BY_SESSION_ORDERED_QUERY,
-    UNIVERSAL_CANONICAL_LIST_SCAN_QUERY,
-    UNIVERSAL_HISTORICAL_CREATED_LIST_SCAN_QUERY,
-    UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY,
-)
+from database.firestore_index_registry import INDEX_REQUIREMENTS
 from scripts import reconcile_firestore_indexes as reconciler
 
 PROJECT = "based-hardware-dev"
@@ -77,46 +65,12 @@ class FieldIndexTarget:
         }
 
 
-def _index_only_requirement(identifier: str):
-    """Select a registry composite that no ``FirestoreQuerySpec`` builds (index-only)."""
-    for requirement in INDEX_ONLY_REQUIREMENTS:
-        if requirement.identifier == identifier:
-            return requirement
-    raise KeyError(f"index-only requirement {identifier} is not declared in the registry")
-
-
-TARGET_REQUIREMENTS = (
-    UNIVERSAL_CANONICAL_LIST_SCAN_QUERY.index_requirement,
-    ENTITY_TIMELINE_CONVERSATIONS_QUERY.index_requirement,
-    UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY.index_requirement,
-    UNIVERSAL_HISTORICAL_CREATED_LIST_SCAN_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_SUBJECT_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_SLOT_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_SLOT_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_SUBJECT_CONTENT_QUERY.index_requirement,
-    DAILY_SWEEP_ACTIVE_FACT_ENTITY_CONTENT_QUERY.index_requirement,
-    # The backend startup health gauge runs this query even when QA leaves
-    # Cloud Tasks finalization dispatch in its safe inline default.
-    # Keep the existing production registry requirement in the bounded QA set.
-    FINALIZATION_OLDEST_NONTERMINAL_QUERY.index_requirement,
-    # The named QA app exercises the shared desktop/mobile chat path.  Include
-    # the timestamped session shape and both message scopes so a fresh QA
-    # database does not rely on production-only indexes. The legacy session
-    # fallback uses Firestore's automatic same-direction key index and is
-    # intentionally absent from the generated composite manifest.
-    CURRENT_CHAT_SESSION_ORDERED_QUERY.index_requirement,
-    MESSAGES_BY_APP_ORDERED_QUERY.index_requirement,
-    MESSAGES_BY_SESSION_ORDERED_QUERY.index_requirement,
-    # The named QA app's signed-in startup reads its task dashboard and scores
-    # through GET /v1/action-items (due-date and created-date ranges with the
-    # ``completed`` equality) and GET /v1/scores. Without these two composites
-    # every such read returned 500 on the isolated database while the JIT
-    # plan still reported "none missing" (measured 2026-09-10).
-    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY.index_requirement,
-    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.index_requirement,
-    _index_only_requirement("action_items_completed_created_newest_first"),
-)
+# Every registry composite.  The registry is exactly the set production is
+# reconciled against, so selecting all of it makes the isolated QA database
+# serve whatever shared query the QA app reaches next instead of failing one
+# path per working day.  QA-only extras that must never reach production stay
+# in ``TARGET_FIELD_INDEXES`` below.
+TARGET_REQUIREMENTS = INDEX_REQUIREMENTS
 
 # Firestore returns COLLECTION_GROUP_ASC for this query as a single-field
 # collection-group configuration.  It must not be represented as a one-field

--- a/backend/tests/unit/test_jit_qa_firestore_index_operator.py
+++ b/backend/tests/unit/test_jit_qa_firestore_index_operator.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
+from database import firestore_index_registry as registry
 from scripts import jit_qa_firestore_index_operator as operator
+
+# Every registry composite is selected; the count follows the registry so a new
+# production query requirement is provisioned on the isolated QA database too.
+_REGISTRY_COUNT = len(registry.INDEX_REQUIREMENTS)
 
 _UNSET = object()
 
@@ -53,10 +58,12 @@ def _field_api_request(*, ready: bool = False, api_scope: object = _UNSET):
     return request
 
 
-def test_selected_manifest_is_canonical_and_contains_only_bounded_required_queries():
+def test_selected_manifest_is_canonical_and_contains_every_registry_composite():
     manifest, signatures = operator.selected_manifest()
 
-    assert len(manifest["indexes"]) == 17
+    assert _REGISTRY_COUNT >= 78
+    assert len(manifest["indexes"]) == _REGISTRY_COUNT
+    assert operator.TARGET_REQUIREMENTS is registry.INDEX_REQUIREMENTS
     assert signatures == {requirement.signature for requirement in operator.TARGET_REQUIREMENTS}
     assert {
         (
@@ -87,29 +94,18 @@ def test_plan_reads_only_fixed_named_database_and_reports_all_required_indexes(m
         {"project": "based-hardware-dev", "database": "jit-qa", "runner": operator.reconciler.subprocess.run}
     ]
     assert result["manifest_validated"] is True
-    assert result["selected_index_count"] == 17
+    assert result["selected_index_count"] == _REGISTRY_COUNT
     assert result["selected_field_index_count"] == 1
-    assert result["missing_count"] == 18
+    assert result["missing_count"] == _REGISTRY_COUNT + 1
     assert {entry["state"] for entry in result["indexes"]} == {"MISSING"}
     assert {entry["identifier"] for entry in result["indexes"]} == {
-        "memory_items_universal_list_scan",
-        "conversations_entity_timeline_completed",
-        "memories_universal_list_scan_updated_at",
-        "memories_universal_list_scan_created_at",
-        "daily_sweep_active_fact_subject",
-        "daily_sweep_active_fact_slot",
-        "daily_sweep_active_fact_entity",
-        "daily_sweep_active_fact_entity_slot",
-        "daily_sweep_active_fact_subject_content",
-        "daily_sweep_active_fact_entity_content",
-        "conversation_finalization_jobs_oldest_nonterminal",
-        "chat_sessions_current_by_app_created_at",
-        "messages_by_app_created_at",
-        "messages_by_session_created_at",
-        "action_items_completed_due_range",
-        "action_items_completed_created_range",
-        "action_items_completed_created_newest_first",
+        requirement.identifier for requirement in registry.INDEX_REQUIREMENTS
     }
+    assert {
+        "chat_first_deferrals_due",
+        "action_items_completed_created_newest_first",
+        "memory_items_canonical_atlas_read",
+    } <= {entry["identifier"] for entry in result["indexes"]}
     assert result["field_indexes"] == [
         {
             "identifier": "conversations_status_collection_group_ascending",
@@ -164,13 +160,13 @@ def test_apply_requires_confirmation_and_delegates_only_selected_signatures(monk
         field_api_request=field_api,
     )
     assert result["schema_version"] == "omi.jit.qa.firestore-index-apply.v1"
-    assert result["created_index_count"] == 17
+    assert result["created_index_count"] == _REGISTRY_COUNT
     assert result["created_field_index_count"] == 1
     assert calls[0][0] == "provision"
     assert calls[1][0] == "wait"
     assert calls[0][1]["project"] == operator.PROJECT
     assert calls[0][1]["database"] == operator.DATABASE
-    assert len(calls[0][1]["expected"]) == 17
+    assert len(calls[0][1]["expected"]) == _REGISTRY_COUNT
     assert calls[1][1]["expected"] == calls[0][1]["expected"]
 
 
@@ -205,7 +201,7 @@ def test_apply_cli_keeps_reconciler_progress_out_of_json_receipt(monkeypatch, ca
     captured = capsys.readouterr()
     receipt = json.loads(captured.out)
     assert receipt["missing_count"] == 0
-    assert receipt["created_index_count"] == 17
+    assert receipt["created_index_count"] == _REGISTRY_COUNT
     assert receipt["created_field_index_count"] == 1
     assert "READY" in captured.err
 


### PR DESCRIPTION
## Summary

The isolated `jit-qa` Firestore database is provisioned by the bounded QA operator, which selected 17 of the 78 registry composites. Every shared query outside that set returns `FailedPrecondition` on the QA plane while the plan reports "none missing":

- 2026-09-10: `GET /v1/action-items` and `GET /v1/scores` (closed by #13454 / #13457 with three more composites)
- 2026-09-11: `POST /v2/chat/materialize-prompts` → `chat_first_intents.release_due_deferrals` needs `chat_first_deferrals (account_generation, state, due_at)`, which the registry already declares as `chat_first_deferrals_due`

The QA app now runs the full shared desktop path for real working days, so adding composites one measured failure at a time costs a PR plus an apply run per path. The registry is exactly the set production is reconciled against, so the operator now selects all of it. Project, database, confirmation, and the QA-only single-field target are unchanged, and `firestore.indexes.json` is untouched (no prod reconciliation run is queued by this change).

## Verification

- `backend/tests/unit/test_jit_qa_firestore_index_operator.py` and `test_action_items_due_range_index_contract.py`: 28 passed
- After merge: dispatch `jit_qa_manual_operator.yml` `operation=indexes-apply` and confirm the deferral query serves on jit-qa

Failure-Class: FC-undeclared-serving-query-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

