### PR TITLE
test(desktop): guard the DEBUG-only turn-evidence seam so the release-mode test build compiles (#13458)

### DIFF
--- a/desktop/macos/Desktop/Tests/RealtimeTurnEvidenceTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeTurnEvidenceTests.swift
@@ -512,131 +512,136 @@ final class RealtimeTurnEvidenceTests: XCTestCase {
     XCTAssertEqual(ledger.evidence(for: key), evidence)
   }
 
-  func testOCRBeforeJournalRowDoesNotAttachAndLaterAdmissionCarriesEvidence() async throws {
-    try await withNativeEvidenceTestOwner { ownerID in
-      let controller = RealtimeHubController()
-      let turnID = VoiceTurnID()
-      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
-      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
-      let key = try XCTUnwrap(
-        controller.turnEvidenceLedger.begin(
-          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
-      var attachCount = 0
-      controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, _, _ in
-        attachCount += 1
-        return true
-      }
-
-      controller.resolveNativeTurnEvidence(
-        turnID: turnID,
-        ownerID: ownerID,
-        capturedAt: Date(timeIntervalSince1970: 11),
-        text: "form instructions")
-
-      XCTAssertEqual(attachCount, 0)
-      let resolved = try XCTUnwrap(controller.turnEvidenceLedger.evidence(for: key))
-      XCTAssertEqual(resolved.bodyText, "form instructions")
-      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
-      XCTAssertNil(controller.turnEvidenceLedger.entry(for: key)?.journalUserTurnID)
-
-      let projection = RealtimeStreamingJournalProjection(
-        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface,
-        evidence: [resolved])
-      XCTAssertEqual(projection.userMessage(text: "which form?").metadata?.evidence, [resolved])
-
-      XCTAssertTrue(
-        controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: projection.userTurnID))
-      let persisted = await controller.persistNativeEvidenceAfterJournalAdmission(
-        ownerID: ownerID, continuityKey: continuityKey)
-      XCTAssertTrue(persisted)
-      XCTAssertEqual(attachCount, 1)
-      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
-      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
-    }
-  }
-
-  func testOCRAfterBoundUserRowAndFinalizedStreamingAttachesOnce() async throws {
-    try await withNativeEvidenceTestOwner { ownerID in
-      let controller = RealtimeHubController()
-      let turnID = VoiceTurnID()
-      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
-      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
-      let producingRow = KernelTurnProjection.stableTurnID(continuityKey: continuityKey, role: "user")
-      let key = try XCTUnwrap(
-        controller.turnEvidenceLedger.begin(
-          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
-      XCTAssertTrue(controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: producingRow))
-
-      let projection = RealtimeStreamingJournalProjection(
-        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
-      XCTAssertTrue(
-        controller.streamingJournalWriteLedger.begin(projection: projection) { _ in true })
-      let finalized = await controller.streamingJournalWriteLedger.finalize(
-        continuityKey: continuityKey
-      ) { _ in true }
-      XCTAssertEqual(finalized, .completed(true))
-      XCTAssertFalse(controller.streamingJournalWriteLedger.contains(continuityKey: continuityKey))
-
-      var attachedTurnIDs: [String] = []
-      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-        controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, userTurnID, _ in
-          attachedTurnIDs.append(userTurnID)
-          continuation.resume()
-          return true
-        }
-        controller.resolveNativeTurnEvidence(
-          turnID: turnID,
-          ownerID: ownerID,
-          capturedAt: Date(timeIntervalSince1970: 12),
-          text: "visible form")
-      }
-
-      XCTAssertEqual(attachedTurnIDs, [producingRow])
-      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
-    }
-  }
-
-  func testOCRWhileStreamingLedgerContainsKeyWaitsForRecordTask() async throws {
-    try await withNativeEvidenceTestOwner { ownerID in
-      let controller = RealtimeHubController()
-      let turnID = VoiceTurnID()
-      let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
-      let surface = AgentSurfaceReference.mainChat(chatId: "chat")
-      let key = try XCTUnwrap(
-        controller.turnEvidenceLedger.begin(
-          ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
-      let projection = RealtimeStreamingJournalProjection(
-        ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
-      let recordLatch = MainActorLatch()
-      var events: [String] = []
-      XCTAssertTrue(
-        controller.streamingJournalWriteLedger.begin(projection: projection) { _ in
-          await recordLatch.wait()
-          events.append("record")
-          return true
-        })
-      await Task.yield()
-
-      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+  #if DEBUG
+    // These three tests drive `RealtimeTurnEvidenceLedger.testingAttachRealtimeUserEvidence`,
+    // a seam that exists only in DEBUG builds. `swift test -c release` compiles this file
+    // too (the UserNotifications release regression step), so the release build must not see them.
+    func testOCRBeforeJournalRowDoesNotAttachAndLaterAdmissionCarriesEvidence() async throws {
+      try await withNativeEvidenceTestOwner { ownerID in
+        let controller = RealtimeHubController()
+        let turnID = VoiceTurnID()
+        let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+        let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+        let key = try XCTUnwrap(
+          controller.turnEvidenceLedger.begin(
+            ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+        var attachCount = 0
         controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, _, _ in
-          events.append("attach")
-          continuation.resume()
+          attachCount += 1
           return true
         }
+
         controller.resolveNativeTurnEvidence(
           turnID: turnID,
           ownerID: ownerID,
-          capturedAt: Date(timeIntervalSince1970: 13),
-          text: "streaming screen")
-        XCTAssertEqual(events, [])
-        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
-        recordLatch.release()
-      }
+          capturedAt: Date(timeIntervalSince1970: 11),
+          text: "form instructions")
 
-      XCTAssertEqual(events, ["record", "attach"])
-      XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+        XCTAssertEqual(attachCount, 0)
+        let resolved = try XCTUnwrap(controller.turnEvidenceLedger.evidence(for: key))
+        XCTAssertEqual(resolved.bodyText, "form instructions")
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+        XCTAssertNil(controller.turnEvidenceLedger.entry(for: key)?.journalUserTurnID)
+
+        let projection = RealtimeStreamingJournalProjection(
+          ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface,
+          evidence: [resolved])
+        XCTAssertEqual(projection.userMessage(text: "which form?").metadata?.evidence, [resolved])
+
+        XCTAssertTrue(
+          controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: projection.userTurnID))
+        let persisted = await controller.persistNativeEvidenceAfterJournalAdmission(
+          ownerID: ownerID, continuityKey: continuityKey)
+        XCTAssertTrue(persisted)
+        XCTAssertEqual(attachCount, 1)
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+      }
     }
-  }
+
+    func testOCRAfterBoundUserRowAndFinalizedStreamingAttachesOnce() async throws {
+      try await withNativeEvidenceTestOwner { ownerID in
+        let controller = RealtimeHubController()
+        let turnID = VoiceTurnID()
+        let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+        let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+        let producingRow = KernelTurnProjection.stableTurnID(continuityKey: continuityKey, role: "user")
+        let key = try XCTUnwrap(
+          controller.turnEvidenceLedger.begin(
+            ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+        XCTAssertTrue(controller.turnEvidenceLedger.attachJournalUserTurn(key: key, turnID: producingRow))
+
+        let projection = RealtimeStreamingJournalProjection(
+          ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+        XCTAssertTrue(
+          controller.streamingJournalWriteLedger.begin(projection: projection) { _ in true })
+        let finalized = await controller.streamingJournalWriteLedger.finalize(
+          continuityKey: continuityKey
+        ) { _ in true }
+        XCTAssertEqual(finalized, .completed(true))
+        XCTAssertFalse(controller.streamingJournalWriteLedger.contains(continuityKey: continuityKey))
+
+        var attachedTurnIDs: [String] = []
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+          controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, userTurnID, _ in
+            attachedTurnIDs.append(userTurnID)
+            continuation.resume()
+            return true
+          }
+          controller.resolveNativeTurnEvidence(
+            turnID: turnID,
+            ownerID: ownerID,
+            capturedAt: Date(timeIntervalSince1970: 12),
+            text: "visible form")
+        }
+
+        XCTAssertEqual(attachedTurnIDs, [producingRow])
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+      }
+    }
+
+    func testOCRWhileStreamingLedgerContainsKeyWaitsForRecordTask() async throws {
+      try await withNativeEvidenceTestOwner { ownerID in
+        let controller = RealtimeHubController()
+        let turnID = VoiceTurnID()
+        let continuityKey = RealtimeHubController.voiceContinuityKey(for: turnID)
+        let surface = AgentSurfaceReference.mainChat(chatId: "chat")
+        let key = try XCTUnwrap(
+          controller.turnEvidenceLedger.begin(
+            ownerID: ownerID, turnID: turnID, continuityKey: continuityKey, surface: surface))
+        let projection = RealtimeStreamingJournalProjection(
+          ownerID: ownerID, continuityKey: continuityKey, admissionSurface: surface)
+        let recordLatch = MainActorLatch()
+        var events: [String] = []
+        XCTAssertTrue(
+          controller.streamingJournalWriteLedger.begin(projection: projection) { _ in
+            await recordLatch.wait()
+            events.append("record")
+            return true
+          })
+        await Task.yield()
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+          controller.turnEvidenceLedger.testingAttachRealtimeUserEvidence = { _, _, _, _ in
+            events.append("attach")
+            continuation.resume()
+            return true
+          }
+          controller.resolveNativeTurnEvidence(
+            turnID: turnID,
+            ownerID: ownerID,
+            capturedAt: Date(timeIntervalSince1970: 13),
+            text: "streaming screen")
+          XCTAssertEqual(events, [])
+          XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.persistenceFailed, false)
+          recordLatch.release()
+        }
+
+        XCTAssertEqual(events, ["record", "attach"])
+        XCTAssertEqual(controller.turnEvidenceLedger.entry(for: key)?.evidencePersisted, true)
+      }
+    }
+  #endif
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Closes #13458.

- `swift test -c release` compiles the whole desktop test target. `RealtimeTurnEvidenceLedger.testingAttachRealtimeUserEvidence` is declared under `#if DEBUG` (#13235), but the three `RealtimeTurnEvidenceTests` methods that assign it were not guarded, so the "Test UserNotifications callback regression in release mode" step has failed on every PR that touched `desktop/macos/Desktop/Tests/*.swift` since 2026-09-09.
- Main looked green because that step is path-filtered (`should_notification_release_regression`) and every main push since skipped the whole job.
- This PR guards the DEBUG-only test seams so the release-mode test build compiles again. Workflow un-skipping is left to the maintainer (no `.github/workflows` change here).

## Product invariants affected

None. Test-target guards only; no source behaviour changes.

## Failure-Class

Failure-Class: FC-path-filter-masks-default-branch-health

Same class as #12275 / #12931: a path-filtered job hid a compile failure on main behind newer green runs.

## What changed

- `desktop/macos/Desktop/Tests/RealtimeTurnEvidenceTests.swift` — the three tests that assign `testingAttachRealtimeUserEvidence` are wrapped in `#if DEBUG … #endif`, matching the seam's declaration in `RealtimeTurnEvidence.swift`. Same commit as carried on #13456 (`0fcadb3536`), cherry-picked onto main.
- Audit of the whole test target: 75 `#if DEBUG` regions across 32 source files; every other DEBUG-only seam referenced from `Desktop/Tests` is already guarded (file-level `omi-release-compile` wrappers or local `#if DEBUG`). No other unguarded reference found.

## Verification

From `desktop/macos` on Xcode 26.6 / Swift 6.3.3:

- `xcrun swift build --build-tests --package-path Desktop` → Build complete (268.9 s)
- `xcrun swift test --package-path Desktop --filter RealtimeTurnEvidenceTests/` → 26 tests, 0 failures (the three guarded tests still run in debug)
- `xcrun swift test -c release --package-path Desktop --filter UserNotificationCallbackBridgeTests/` (CI's exact release step) → Build complete (491.1 s); 11 tests, 0 failures

Note for the maintainer: `should_notification_release_regression` fires only for paths whose name contains `Notification` (`scripts/pre_push_ci_prediction.py` `_is_desktop_notification_input`), so this PR's CI will skip the step this fix repairs; the local run above is the evidence. Widening that selector to every `Desktop/Tests/*.swift` change, or running the step whenever the Release Compile job already runs, would make the gate match the failure class. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

