### PR TITLE
fix(desktop): invalidate leaked run-loop timers and pump the live-scroll test drain to its deadline (#13460)

### DIFF
--- a/.github/failure-classes/FC-run-loop-timer-outlives-owner.json
+++ b/.github/failure-classes/FC-run-loop-timer-outlives-owner.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-run-loop-timer-outlives-owner",
+  "violated_contract": "A repeating Timer added to RunLoop.main (or scheduled with Timer.scheduledTimer) is retained by the run loop, not by the object that armed it. An owner that dies without invalidating leaves a repeating source firing after the owner is gone. In production the leak is a silent CPU wake; in the test process it makes every later single-shot RunLoop.main.run(mode:before:) drain return early, so unrelated suites fail only when batched after the leaking one (#13460).",
+  "canonical_prevention": "Every type that arms a repeating run-loop timer invalidates it in deinit as well as in its explicit stop path, and its guard test proves that releasing the armed owner leaves the timer invalid. Test harnesses that wait on queued main-thread work pump the run loop until a deadline instead of a single run(mode:before:) call.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift",
+    "desktop/macos/Desktop/Tests/WALServiceUploadTests.swift"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/",
+    "desktop/macos/Desktop/Tests/"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
@@ -170,6 +170,10 @@ final class ChatFollowGlide {
   private var timer: Timer?
   private var isGliding = false
 
+  #if DEBUG
+    var debugRunLoopTimer: Timer? { timer }
+  #endif
+
   /// True while a glide is moving the viewport. Reader input checks this the
   /// same way it checks a pending scroll.
   var isActive: Bool { isGliding }
@@ -218,6 +222,16 @@ final class ChatFollowGlide {
     isGliding = false
   }
 
+  deinit {
+    // The run loop retains the timer independently of this object. Without an
+    // invalidate here, SwiftUI dropping a transcript (or a test releasing the
+    // glide) leaves a 60 Hz `.common` source on `RunLoop.main` that ends later
+    // `run(mode:before:)` drains before queued main-async work can run.
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { cancel() }
+    }
+  }
+
   private func moveTo(_ origin: NSPoint, in clipView: NSClipView) {
     clipView.setBoundsOrigin(origin)
     if let scrollView = clipView.enclosingScrollView {
@@ -254,6 +268,10 @@ final class ChatLiveEdgePinner {
   private(set) var isPinning = false
   private var track: (() -> Void)?
 
+  #if DEBUG
+    var debugRunLoopTimer: Timer? { timer }
+  #endif
+
   var isActive: Bool { isPinning }
 
   /// Begin (or keep) pinning. An already-armed pinner keeps its cadence and
@@ -280,6 +298,14 @@ final class ChatLiveEdgePinner {
     timer = nil
     isPinning = false
     track = nil
+  }
+
+  deinit {
+    // Same run-loop ownership as `ChatFollowGlide`: `RunLoop.main.add(_:forMode: .common)`
+    // keeps the tick alive after this object is gone unless we invalidate it.
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { cancel() }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/WAL/WALService.swift
+++ b/desktop/macos/Desktop/Sources/WAL/WALService.swift
@@ -222,6 +222,11 @@ final class WALService: ObservableObject {
   private var flushTimer: Timer?
   private var chunkTimer: Timer?
 
+  #if DEBUG
+    var debugChunkTimer: Timer? { chunkTimer }
+    var debugFlushTimer: Timer? { flushTimer }
+  #endif
+
   // Active capture and frozen persistence batches have separate immutable
   // identities so a failed device-A write can never absorb device-B frames.
   private var activeFrameBuffer: ActiveFrameBuffer?
@@ -579,6 +584,16 @@ final class WALService: ObservableObject {
     chunkTimer = nil
     flushTimer?.invalidate()
     flushTimer = nil
+  }
+
+  deinit {
+    // `Timer.scheduledTimer` retains itself on the current run loop. Releasing
+    // a service that is still recording (tests, or a forgotten stopRecording)
+    // would otherwise leave repeating default-mode sources that end later
+    // `RunLoop.main.run(mode:before:)` drains before queued main-async work.
+    if Thread.isMainThread {
+      MainActor.assumeIsolated { stopTimers() }
+    }
   }
 
   private func checkAndChunk() {

--- a/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
@@ -419,7 +419,14 @@ final class UserScrollDetectorTests: XCTestCase {
 
   private func drainMainQueue() {
     // omi-test-quality: wall-clock-wait -- drives the AppKit notification callback and its next-turn terminal bounds read.
-    _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+    // A single `run(mode:before:)` returns as soon as any source fires. When an earlier suite in the
+    // same process left a repeating `.common`-mode timer behind, that timer ends the drain before the
+    // detector's `DispatchQueue.main.async` terminal read has run, and the settled count stays 0.
+    // Pump until the deadline so the drain length does not depend on which suites ran before this one.
+    let deadline = Date().addingTimeInterval(0.05)
+    repeat {
+      _ = RunLoop.main.run(mode: .default, before: deadline)
+    } while Date() < deadline
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
@@ -417,6 +417,39 @@ final class UserScrollDetectorTests: XCTestCase {
     return event
   }
 
+  #if DEBUG
+    func testFollowGlideInvalidatesItsCommonModeTimerOnDeinit() {
+      let (scrollView, _) = makeScrollViewAtBottom()
+      weak var leftover: Timer?
+      autoreleasepool {
+        let glide = ChatFollowGlide()
+        XCTAssertTrue(
+          glide.glide(clipView: scrollView.contentView, to: NSPoint(x: 0, y: 200), duration: 0.16),
+          "the harness document is far enough from the target for a glide to arm")
+        leftover = glide.debugRunLoopTimer
+        XCTAssertEqual(leftover?.isValid, true)
+      }
+      XCTAssertNotEqual(
+        leftover?.isValid, true,
+        "deinit must invalidate the run-loop timer; a leftover repeating .common source starves later main-async drains"
+      )
+    }
+
+    func testLiveEdgePinnerInvalidatesItsCommonModeTimerOnDeinit() {
+      weak var leftover: Timer?
+      autoreleasepool {
+        let pinner = ChatLiveEdgePinner()
+        pinner.start(track: {})
+        leftover = pinner.debugRunLoopTimer
+        XCTAssertEqual(leftover?.isValid, true)
+      }
+      XCTAssertNotEqual(
+        leftover?.isValid, true,
+        "deinit must invalidate the run-loop timer; a leftover repeating .common source starves later main-async drains"
+      )
+    }
+  #endif
+
   private func drainMainQueue() {
     // omi-test-quality: wall-clock-wait -- drives the AppKit notification callback and its next-turn terminal bounds read.
     // A single `run(mode:before:)` returns as soon as any source fires. When an earlier suite in the

--- a/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
+++ b/desktop/macos/Desktop/Tests/UnhandledKeystrokeSilenceTests.swift
@@ -58,7 +58,10 @@ final class UnhandledKeystrokeSilenceTests: XCTestCase {
   func testTheFloatingPanelAbsorbsUnhandledKeysButStillActsOnEscape() throws {
     let window = FloatingControlBarWindow(
       contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
-    defer { window.close() }
+    defer {
+      window.contentView = nil
+      window.close()
+    }
     let probe = NextResponderProbe()
     window.nextResponder = probe
 

--- a/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
+++ b/desktop/macos/Desktop/Tests/WALServiceUploadTests.swift
@@ -361,6 +361,25 @@ import XCTest
       XCTAssertEqual(metadata.wals.first?.status, .synced)
     }
 
+    func testRecordingTimersInvalidateOnDeinit() {
+      weak var chunk: Timer?
+      weak var flush: Timer?
+      autoreleasepool {
+        let isolated = makeService()
+        isolated.startRecording(device: "dev1", codec: "opus")
+        chunk = isolated.debugChunkTimer
+        flush = isolated.debugFlushTimer
+        XCTAssertEqual(chunk?.isValid, true)
+        XCTAssertEqual(flush?.isValid, true)
+      }
+      XCTAssertNotEqual(
+        chunk?.isValid, true,
+        "deinit must invalidate the chunk timer so it cannot starve later main-async drains")
+      XCTAssertNotEqual(
+        flush?.isValid, true,
+        "deinit must invalidate the flush timer so it cannot starve later main-async drains")
+    }
+
     func testDegradedDirectoryRetainsCurrentFramesAndRecordsHealth() throws {
       service = makeService(walDirectoryAvailable: false)
       service.startRecording(device: "dev1", codec: "opus")

--- a/desktop/macos/changelog/unreleased/2026-09-10-chat-scroll-timer-invalidation.json
+++ b/desktop/macos/changelog/unreleased/2026-09-10-chat-scroll-timer-invalidation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed: chat follow/pin scroll timers and recording timers no longer keep running after their owner is gone, removing a small idle CPU wake."
+}


### PR DESCRIPTION
## Summary

Closes #13460.

- `UserScrollDetectorTests.testCompletedLiveScrollAtBottomCanResumeFollowing` passes alone and fails when batched with CI's `worker-0-2-h1` suites on an unmodified `origin/main` tree. The detector reads its terminal position via `DispatchQueue.main.async`; the test drained with a single `RunLoop.main.run(mode:before:)`, which returns as soon as any leftover `.common`-mode timer from an earlier suite fires.
- The per-suite isolation re-run this triggers (38 × ~55 s) is what pushed the "Test desktop Swift app" step past its 1800 s budget on #13456.
- This PR pumps the drain to its deadline (the pattern `ChatTranscriptGestureHarnessTests` and `AuthRestoreWatchdogTests` already use) and fixes the leak at its source: the chat follow glide, the live-edge pinner, and the WAL recording timers now invalidate on `deinit`, with guard tests that release an armed owner and assert the timer is invalid.

## Product invariants affected

- **INV-CHAT-1** — `ChatScrollBehavior.swift` only gains `deinit` timer invalidation on the follow glide and live-edge pinner. No transcript, session, or agent state is stored or mirrored; the kernel-owned transcript is untouched.
- **INV-CHAT-2** — `ChatScrollLiveEdgeTests.swift` is this invariant's guard test; only the harness drain changes. Scroll ownership, placement, and virtualization behaviour and the guarded assertions are unchanged.

## Failure-Class

Failure-Class: new

`FC-run-loop-timer-outlives-owner`, defined in this PR: a repeating timer on `RunLoop.main` is retained by the run loop, not its owner, so an owner released without invalidating keeps firing. Guard tests in `ChatScrollLiveEdgeTests` and `WALServiceUploadTests` are the prevention artifact.

## What changed

- `Desktop/Tests/ChatScrollLiveEdgeTests.swift` — `drainMainQueue()` pumps `RunLoop.main` until its 50 ms deadline (same commit as carried on #13456); new DEBUG-guarded tests prove a released `ChatFollowGlide` / `ChatLiveEdgePinner` leaves no live timer.
- `Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift` — `ChatFollowGlide` and `ChatLiveEdgePinner` invalidate their 60 Hz `.common` timer in `deinit` (main-thread `assumeIsolated`, same shape as `ChatOmiMarkFrameView`). Behaviour while alive is unchanged.
- `Desktop/Sources/WAL/WALService.swift` — chunk/flush timers invalidate in `deinit`; `WALServiceUploadTests` gains `testRecordingTimersInvalidateOnDeinit`.
- `Desktop/Tests/UnhandledKeystrokeSilenceTests.swift` — drops the panel's hosting view before closing so the hosted SwiftUI tree leaves no run-loop sources behind.
- `.github/failure-classes/FC-run-loop-timer-outlives-owner.json` — the class definition.

Root cause found in CI's `worker-0-2-h1` batch: earlier suites left `.common`/default-mode repeating timers on `RunLoop.main` (armed glide/pinner released without `cancel()`, `WALService` instances released while recording, a real floating-bar panel closed with its hosting view attached). The detector's `DispatchQueue.main.async` read then lost the race with a single `run(mode:before:)` drain.

## Verification

From `desktop/macos` on Xcode 26.6 / Swift 6.3.3, CI's exact batch (38 suites `SuggestionCommitmentGuardTests`…`WorkContextCheapPathTests`, one SwiftPM process):

- Unmodified `022432d0f8`: 280 tests, 1 failure (`UserScrollDetectorTests.testCompletedLiveScrollAtBottomCanResumeFollowing`, `settledAtBottom` 0 ≠ 1) — reproduces the issue.
- This branch, 3 consecutive runs: 282 tests, 0 failures each.
- Touched suites alone: `UserScrollDetectorTests` (6), `ChatScrollLiveEdgeTests` (14), `UnhandledKeystrokeSilenceTests` (4), `WALServiceUploadTests` (25), `WALServiceOrphanSdCardTests`, `WifiSyncServiceTests` — all green.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — OK.

Known limit: the `deinit` invalidation only runs when the owner is released on the main thread (same tradeoff as `ChatOmiMarkFrameView`). Other repeating-timer owners (`DesktopUsageDailyReporter`, `MeetingDetector`, `RecordingTimer`, `ResourceMonitor`, …) have the same shape and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

