### PR TITLE
fix(desktop): stray white line above the chat jump-to-latest button

### DIFF
--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -330,6 +330,24 @@ package enum InkGlass {
   /// is — a highlight is light, and INV-UI-1 wants that light neutral.
   package static let sheenAlpha: CGFloat = 0.5
 
+  /// How much of a panel's top edge the sheen line spans: the straight run between its two corners.
+  ///
+  /// The highlight is a *line* (`InkGlassView.sheenHeight` is one point, and the comment there says
+  /// why a band is wrong), and a straight line is the top edge only where that edge is straight.
+  /// Outside the run there is no top edge, only curve, and a straight band laid across a curve stops
+  /// touching it: on a disc — `cornerRadius` at half the side, which is what the chat transcript's
+  /// jump-to-latest button asks for — the run is zero and what renders is a bright chord hanging at
+  /// the apex over a one-point sliver of ground. That reads as a stray white line floating above the
+  /// button rather than as a highlight on it, which is the reported defect.
+  ///
+  /// The radius is resolved the way the shape itself resolves it — clamped to half the smaller side —
+  /// so the stadium call sites that ask for `cornerRadius: 999` are measured on the corner they
+  /// actually get and keep the full run their flat top has, instead of a hugely negative one.
+  nonisolated package static func sheenWidth(panelSize: CGSize, cornerRadius: CGFloat) -> CGFloat {
+    let radius = max(0, min(cornerRadius, min(panelSize.width, panelSize.height) / 2))
+    return max(0, panelSize.width - 2 * radius)
+  }
+
   /// The alpha of the `Ink.surface` ground, given the user's Reduce Transparency setting.
   ///
   /// Opaque when the setting is on, and the material goes with it — glass that ignores the setting is
@@ -612,10 +630,15 @@ package final class InkGlassView: NSView {
     panel.frame = frame
     material.frame = panel.bounds
     ground.frame = panel.bounds
-    // The top edge, in a flipped-off (AppKit) coordinate space: maxY is the top.
+    // The top edge, in a flipped-off (AppKit) coordinate space: maxY is the top. Centred on the
+    // panel's straight top run rather than spanning the full width — the same rule the SwiftUI
+    // panel follows, from the same function, so the two cannot drift into different highlights.
+    let sheenWidth = InkGlass.sheenWidth(
+      panelSize: panel.bounds.size, cornerRadius: style.cornerRadius)
     sheen.frame = NSRect(
-      x: 0, y: panel.bounds.maxY - InkGlassView.sheenHeight,
-      width: panel.bounds.width, height: InkGlassView.sheenHeight)
+      x: (panel.bounds.width - sheenWidth) / 2,
+      y: panel.bounds.maxY - InkGlassView.sheenHeight,
+      width: sheenWidth, height: InkGlassView.sheenHeight)
     shadowHost.frame = bounds
     applyShadow()
   }
@@ -835,10 +858,18 @@ package struct InkGlassPanelModifier: ViewModifier {
           // clip — a `clipShape` evaluated inside a 1 pt box degenerates to a straight bar and is what
           // squared the corners in the first place. Order is the whole fix.
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {
-            Color.white.opacity(InkGlass.sheenAlpha)
-              .frame(height: InkGlassView.sheenHeight)
-              .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-              .clipShape(shape)
+            // The width is the panel's straight top run (`InkGlass.sheenWidth`), read from the
+            // panel rather than assumed, so the line stops where the corner starts instead of
+            // being carried into the curve by the clip below and detaching from the edge there.
+            GeometryReader { proxy in
+              Color.white.opacity(InkGlass.sheenAlpha)
+                .frame(
+                  width: InkGlass.sheenWidth(panelSize: proxy.size, cornerRadius: cornerRadius),
+                  height: InkGlassView.sheenHeight
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .clipShape(shape)
+            }
           }
         }
         .environment(\.colorScheme, .light)

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -857,6 +857,10 @@ package struct InkGlassPanelModifier: ViewModifier {
           // `maxHeight` frame first, so the band's *own* frame is the whole panel, and only then the
           // clip — a `clipShape` evaluated inside a 1 pt box degenerates to a straight bar and is what
           // squared the corners in the first place. Order is the whole fix.
+          //
+          // The band no longer spans the full width — `InkGlass.sheenWidth` stops it where the corner
+          // starts — so it cannot reach a corner to square one off. The clip stays as the second
+          // guard the paragraph above earned, not as the only thing keeping the highlight in shape.
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {
             // The width is the panel's straight top run (`InkGlass.sheenWidth`), read from the
             // panel rather than assumed, so the line stops where the corner starts instead of

--- a/desktop/macos/Desktop/Tests/GlassSheenGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassSheenGeometryTests.swift
@@ -1,0 +1,150 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// The glass sheen is a highlight *on* the panel's top edge, and these guard the one thing that can
+/// silently stop being true: where the line is allowed to be.
+///
+/// The reported defect was a bright white line hanging above the chat transcript's jump-to-latest
+/// disc. Nothing logged and nothing crashed — the sheen was a full-width 1 pt band relying on the
+/// panel's `clipShape` to trim it, and on a disc (`cornerRadius` at half the side) a clip does not
+/// trim a straight band into an arc, it leaves the chord across the top of the circle. The chord sat
+/// over a 1 pt sliver of ground, so it read as a detached line rather than as an edge catching light.
+@MainActor
+final class GlassSheenGeometryTests: XCTestCase {
+
+  // MARK: - The rule
+
+  /// A disc has no straight top edge, so it gets no straight highlight. This is the reported case.
+  func testADiscGetsNoSheenBecauseItHasNoFlatTopEdge() {
+    XCTAssertEqual(
+      InkGlass.sheenWidth(panelSize: CGSize(width: 32, height: 32), cornerRadius: 16), 0,
+      "a disc's top edge is entirely curve; any straight line drawn across it is the floating chord")
+  }
+
+  /// A card's highlight spans the run between its corners — not the full width, which is what carried
+  /// the line into the curve in the first place.
+  func testACardsSheenSpansTheRunBetweenItsCorners() {
+    let size = CGSize(width: 400, height: 200)
+    XCTAssertEqual(InkGlass.sheenWidth(panelSize: size, cornerRadius: 22), 400 - 44)
+    XCTAssertEqual(
+      InkGlass.sheenWidth(panelSize: size, cornerRadius: 0), 400,
+      "a square-cornered panel is all flat top edge")
+  }
+
+  /// **The case that makes this a clamp rather than a subtraction.** Several call sites ask for a
+  /// stadium with `cornerRadius: 999`; the shape resolves that to half the height, and so must this,
+  /// or every pill in the app loses the highlight its flat top actually has.
+  func testAStadiumAskingFor999KeepsTheRunItsFlatTopHas() {
+    let bar = CGSize(width: 300, height: 38)
+    XCTAssertEqual(
+      InkGlass.sheenWidth(panelSize: bar, cornerRadius: 999), 300 - 38,
+      "measured on the requested radius instead of the resolved one, a pill's run goes negative and "
+        + "the highlight disappears from surfaces that never had the defect")
+    XCTAssertEqual(
+      InkGlass.sheenWidth(panelSize: bar, cornerRadius: 19), 300 - 38,
+      "the stadium and its explicit-radius twin are the same shape and must get the same line")
+  }
+
+  /// Never negative, whatever a caller passes.
+  func testTheRunIsNeverNegative() {
+    XCTAssertEqual(InkGlass.sheenWidth(panelSize: CGSize(width: 10, height: 80), cornerRadius: 999), 0)
+    XCTAssertEqual(InkGlass.sheenWidth(panelSize: .zero, cornerRadius: 12), 0)
+    XCTAssertEqual(
+      InkGlass.sheenWidth(panelSize: CGSize(width: 40, height: 40), cornerRadius: -5), 40,
+      "a negative radius is a square corner, not a run wider than the panel")
+  }
+
+  // MARK: - …and the rule really reaches the pixels
+
+  /// The defect as the user saw it: a bright run across the top of the disc.
+  ///
+  /// Both tones are **measured by this harness in this run** rather than written down. An offscreen
+  /// `NSVisualEffectView` renders as a lighter substitute for the material it stands in for, so any
+  /// absolute number here would be a property of the substitute; what is stable is the *gap* the
+  /// sheen opens between its own row and the row under it. So a flat-topped panel supplies the two
+  /// references — the tone of a sheen that is supposed to be there, and the ground beneath it — and
+  /// the disc is then required to land on the ground side of the midpoint between them.
+  ///
+  /// The panels ask for `reduceTransparency: false` because the sheen is hidden under that setting by
+  /// design: read from the machine, this case would pass on an accessibility-configured Mac while
+  /// drawing nothing at all.
+  func testTheDiscDoesNotWearTheLineAFlatToppedPanelWears() throws {
+    let cardSize = CGSize(width: 120, height: 60)
+    let card = try render(
+      Color.clear.frame(width: cardSize.width, height: cardSize.height)
+        .inkGlassPanel(cornerRadius: 0, shadow: nil, reduceTransparency: false),
+      size: cardSize, overTone: 0.5)
+
+    let sheenTone = try XCTUnwrap(brightness(card, x: card.pixelsWide / 2, y: 0))
+    let groundTone = try XCTUnwrap(
+      brightness(card, x: card.pixelsWide / 2, y: sheenBandRows(card, pointHeight: cardSize.height)))
+
+    // **The control.** Without it, "the disc has no bright line" is also what a harness that renders
+    // no sheen at all reports, and the case would survive the highlight being deleted outright.
+    XCTAssertGreaterThan(
+      sheenTone, groundTone + 0.02,
+      "the harness cannot see a specular line on a panel that has one, so it cannot miss one either")
+
+    let discSize = CGSize(width: 32, height: 32)
+    let disc = try render(
+      Color.clear.frame(width: discSize.width, height: discSize.height)
+        .inkGlassPanel(cornerRadius: 16, shadow: nil, reduceTransparency: false),
+      size: discSize, overTone: 0.5)
+
+    let band = sheenBandRows(disc, pointHeight: discSize.height)
+    let brightest = (0..<band).flatMap { y in
+      (0..<disc.pixelsWide).compactMap { brightness(disc, x: $0, y: y) }
+    }.max()
+    let peak = try XCTUnwrap(brightest, "the disc did not render")
+
+    XCTAssertLessThan(
+      peak, (groundTone + sheenTone) / 2,
+      """
+      The brightest pixel across the disc's top band rendered \(String(format: "%.3f", peak)), \
+      nearer a drawn specular line (\(String(format: "%.3f", sheenTone))) than the ground under one \
+      (\(String(format: "%.3f", groundTone))). A shape with no straight top edge is wearing a \
+      straight highlight — the stray white line reported above the jump-to-latest button.
+      """)
+  }
+
+  // MARK: - Harness
+
+  /// Renders `view` over a flat tone and reads the bitmap back. Top-left origin, matching the
+  /// coordinates the assertions above are written in.
+  private func render(_ view: some View, size: CGSize, overTone tone: CGFloat) throws
+    -> NSBitmapImageRep
+  {
+    let host = NSHostingView(rootView: view.frame(width: size.width, height: size.height))
+    host.appearance = InkGlass.appearance
+    host.frame = NSRect(origin: .zero, size: size)
+
+    let backdrop = NSView(frame: host.frame)
+    backdrop.appearance = InkGlass.appearance
+    backdrop.wantsLayer = true
+    backdrop.layer?.backgroundColor =
+      NSColor(srgbRed: tone, green: tone, blue: tone, alpha: 1).cgColor
+    backdrop.addSubview(host)
+    backdrop.layoutSubtreeIfNeeded()
+
+    let rep = try XCTUnwrap(backdrop.bitmapImageRepForCachingDisplay(in: backdrop.bounds))
+    backdrop.cacheDisplay(in: backdrop.bounds, to: rep)
+    return rep
+  }
+
+  /// How many device rows the 1 pt sheen occupies in `rep`, from the backing scale the harness
+  /// actually rendered at. Asserting on row 0 alone would read half the line on a Retina render and
+  /// none of it on a 1x one.
+  private func sheenBandRows(_ rep: NSBitmapImageRep, pointHeight: CGFloat) -> Int {
+    let scale = CGFloat(rep.pixelsHigh) / pointHeight
+    return max(1, Int((InkGlassView.sheenHeight * scale).rounded()))
+  }
+
+  private func brightness(_ rep: NSBitmapImageRep, x: Int, y: Int) -> CGFloat? {
+    guard x >= 0, y >= 0, x < rep.pixelsWide, y < rep.pixelsHigh else { return nil }
+    return rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB)?.brightnessComponent
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260911-scroll-jump-sheen-line.json
+++ b/desktop/macos/changelog/unreleased/20260911-scroll-jump-sheen-line.json
@@ -1,0 +1,3 @@
+{
+  "change": "The jump-to-latest button in a chat transcript no longer shows a stray white line above the arrow. The glass highlight is a line along a panel's top edge, and it now stops where the edge stops curving instead of being drawn straight across a round button."
+}


### PR DESCRIPTION
The jump-to-latest disc in a chat transcript rendered a bright white line hanging above the arrow.

## What was wrong

The line is not the button's — it is the glass primitive's specular top edge. `InkGlassPanelModifier` drew the sheen as a full-width 1 pt white band pinned to the top of the panel's box and relied on the panel's `clipShape` to trim it.

A clip cannot turn a straight band into an arc. On a disc — `cornerRadius: diameter / 2`, which is what `ChatMessagesView` asks for — trimming a straight band to a circle leaves the *chord* across the top of that circle, sitting over a 1 pt sliver of ground. So it reads as a detached line floating above the button rather than as an edge catching light.

## The fix

`InkGlass.sheenWidth(panelSize:cornerRadius:)` returns the panel's straight top run — the distance between its two corners — and both render paths use it: the SwiftUI panel and the AppKit `InkGlassView`, so the two cannot drift into different highlights.

The radius is resolved the way the shape itself resolves it, clamped to half the smaller side. That is what keeps this a clamp rather than a subtraction: several call sites ask for a stadium with `cornerRadius: 999`, and measuring on the requested radius instead of the resolved one would send their run negative and delete the highlight from surfaces that never had the defect. A disc's run is zero, so it gets no line.

## Verification

- `swift test --filter GlassSheenGeometryTests` — 5 pass.
- The rendered case fails on the previous code with the real signal: brightest top-band pixel `0.893` against a ground of `0.860`, which is exactly the tone a drawn sheen renders. After the fix it is `0.824`. It carries its own control — a flat-topped panel must still show its line — so it cannot pass by rendering nothing.
- `swift test --filter "Glass|InkGlass|Notch"` — 274 pass.
- Reproduced the artifact first, in an isolated `ImageRenderer` render of the same geometry, before
  touching the primitive; the same render is clean after.
- Built and launched the dev bundle. **Not** eyeballed in the running app — the disc only appears
  once a transcript is scrolled up, and driving that needs synthetic input on a Mac someone is
  using. The rendered test above is the pixel evidence.

## Product invariants affected

none

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsLaZrg6FbKvZymCHpknpe
