### PR TITLE
fix(desktop): can't record a shortcut that another shortcut already uses

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -566,8 +566,27 @@ class PushToTalkManager: ObservableObject {
 
   // MARK: - Shortcut Handling
 
+  /// Whether a keyboard event may drive push-to-talk at all.
+  ///
+  /// `isRecordingAShortcut` is the half added for the rebinding defect: a recorder owns the keyboard
+  /// while it is listening, and without this, rebinding push-to-talk onto the chord it is *already*
+  /// bound to starts a voice turn instead of recording the chord. That is the same failure
+  /// `ShortcutCaptureSession` fixes for Ask Omi, at the one layer that is an in-process monitor and
+  /// so can be gated rather than unregistered.
+  ///
+  /// A function rather than two `guard`s inline because the monitors it protects cannot be driven
+  /// from a hermetic test without real audio, and an ungated admission rule is exactly the kind that
+  /// gets a third condition bolted on at one call site.
+  nonisolated static func acceptsShortcutEvents(isRecordingAShortcut: Bool, pttEnabled: Bool) -> Bool {
+    !isRecordingAShortcut && pttEnabled
+  }
+
   private func handleShortcutEvent(_ event: NSEvent) {
-    guard ShortcutSettings.shared.pttEnabled else { return }
+    guard
+      Self.acceptsShortcutEvents(
+        isRecordingAShortcut: ShortcutCaptureSession.isCapturing,
+        pttEnabled: ShortcutSettings.shared.pttEnabled)
+    else { return }
     let shortcut = ShortcutSettings.shared.pttShortcut
 
     switch event.type {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutCaptureSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutCaptureSession.swift
@@ -1,0 +1,89 @@
+import AppKit
+
+/// While the user is recording a shortcut, every surface in this app that *acts* on one stands down.
+///
+/// The defect this exists for: in Settings, pressing the chord a shortcut is already bound to did not
+/// rebind it — it ran it. Ask Omi is a Carbon hotkey, and a Carbon hotkey is not merely first in line,
+/// it *preempts* (`GlobalShortcutManager.registerSummonHotkey` documents the measurement). The
+/// recorder listens with `NSEvent.addLocalMonitorForEvents`, so for the one chord the user is most
+/// likely to retype — the one they are trying to change — the monitor never saw the event at all and
+/// the window toggled instead. Anything with ⌘ had a second way to lose: the main menu claims ⌘W
+/// before a local monitor does, so recording over that chord closed the window.
+///
+/// Three owners have to stand down, and the reason they cannot be one flag is that they intercept at
+/// three different layers:
+///
+/// * **Carbon hotkeys** are held by the window server, so they must be genuinely *unregistered* —
+///   a Boolean the handler consults is checked after the event has already been taken away.
+/// * **The main menu** is AppKit's, and key equivalents are matched before the responder chain.
+/// * **Push-to-talk** is an `NSEvent` monitor in this process, which a Boolean does reach
+///   (`PushToTalkManager.acceptsShortcutEvents`).
+///
+/// Onboarding had the first two inline and Settings had none of them, which is the whole bug: the
+/// rule lived in one call site instead of in a type both could hold. It is here so a third recorder
+/// cannot be written without it.
+@MainActor
+final class ShortcutCaptureSession {
+  /// Whether a recorder currently owns the keyboard. Read by `PushToTalkManager` — the one stander-down
+  /// that is an in-process monitor and can be gated rather than torn down.
+  private(set) static var isCapturing = false
+
+  private var savedMainMenu: NSMenu?
+  private var isActive = false
+
+  /// The two side effects, injected rather than reached for. `GlobalShortcutManager` registers
+  /// system-wide hotkeys and `NSApp` does not exist in a unit-test process at all (the test bundle is
+  /// required not to create one), so a session that called both directly could only be asserted by
+  /// taking real chords away from the machine running the suite.
+  private let suspendGlobalShortcuts: (Bool) -> Void
+  private let readMainMenu: () -> NSMenu?
+  private let writeMainMenu: (NSMenu?) -> Void
+
+  init(
+    suspendGlobalShortcuts: @escaping (Bool) -> Void = {
+      GlobalShortcutManager.shared.setRegistrationSuspended($0)
+    },
+    // Optional-chained rather than force-unwrapped: `NSApp` is an implicitly unwrapped optional, and
+    // reading it is a crash anywhere it is nil rather than the no-op the name suggests.
+    readMainMenu: @escaping () -> NSMenu? = { NSApp?.mainMenu },
+    writeMainMenu: @escaping (NSMenu?) -> Void = { NSApp?.mainMenu = $0 }
+  ) {
+    self.suspendGlobalShortcuts = suspendGlobalShortcuts
+    self.readMainMenu = readMainMenu
+    self.writeMainMenu = writeMainMenu
+  }
+
+  /// Stands the app's shortcut handlers down. Idempotent: a recorder that re-arms without disarming
+  /// (Settings starts a capture by stopping the previous one) must not lose the real menu by saving
+  /// the `nil` it already installed.
+  func begin() {
+    guard !isActive else { return }
+    isActive = true
+    Self.isCapturing = true
+    suspendGlobalShortcuts(true)
+    savedMainMenu = readMainMenu()
+    writeMainMenu(nil)
+  }
+
+  /// Hands the keyboard back. Also idempotent, and safe to call on a session that never began —
+  /// a recorder's teardown runs on paths where capture never started.
+  func end() {
+    guard isActive else { return }
+    isActive = false
+    Self.isCapturing = false
+    if let savedMainMenu {
+      writeMainMenu(savedMainMenu)
+      self.savedMainMenu = nil
+    }
+    suspendGlobalShortcuts(false)
+  }
+
+  deinit {
+    // A recorder torn down mid-capture — its view dismissed, its window closed — must not leave the
+    // Mac without its menu bar and without Ask Omi. `isActive` is the session's own state and
+    // `isCapturing` is the app's, so this restores both rather than assuming a caller will.
+    MainActor.assumeIsolated {
+      end()
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutCaptureSession.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutCaptureSession.swift
@@ -78,12 +78,16 @@ final class ShortcutCaptureSession {
     suspendGlobalShortcuts(false)
   }
 
-  deinit {
-    // A recorder torn down mid-capture — its view dismissed, its window closed — must not leave the
-    // Mac without its menu bar and without Ask Omi. `isActive` is the session's own state and
-    // `isCapturing` is the app's, so this restores both rather than assuming a caller will.
-    MainActor.assumeIsolated {
-      end()
-    }
+  /// A recorder torn down mid-capture — its view dismissed, its window closed — must not leave the
+  /// Mac without its menu bar and without Ask Omi. `isActive` is the session's own state and
+  /// `isCapturing` is the app's, so this restores both rather than assuming a caller will.
+  ///
+  /// `isolated` rather than a bare `deinit` calling `MainActor.assumeIsolated`: a `deinit` is
+  /// **not** isolated to its class's actor by default, so the assuming version is a trap — literally,
+  /// `assumeIsolated` fatalErrors — on any release that happens off the main thread. Nothing here
+  /// guarantees the last reference is dropped there; a stray retain from a capture, a SwiftUI
+  /// teardown off the main queue, and the safety net becomes the crash.
+  isolated deinit {
+    end()
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -48,8 +48,6 @@ struct ShortcutsSettingsSection: View {
       pttSoundsCard
       muteAudioCard
     }
-    .onAppear {
-    }
     .onDisappear {
       stopShortcutCapture()
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -27,6 +27,9 @@ struct ShortcutsSettingsSection: View {
   @State private var captureError: String?
   @State private var pendingModifierOnlyShortcut: ShortcutSettings.KeyboardShortcut?
   @State private var localShortcutCaptureMonitor: Any?
+  /// Held for the life of the view rather than made per capture: `deinit` is what returns the menu
+  /// bar and Ask Omi if Settings is dismissed while a recorder is still listening.
+  @State private var captureSession = ShortcutCaptureSession()
 
   init(highlightedSettingId: Binding<String?> = .constant(nil)) {
     self._highlightedSettingId = highlightedSettingId
@@ -446,6 +449,10 @@ struct ShortcutsSettingsSection: View {
     recordingTarget = target
     captureError = nil
     pendingModifierOnlyShortcut = nil
+    // Before the monitor, not after: the chord the user is about to press is most likely the one
+    // already bound, and until this runs that chord belongs to a Carbon hotkey or a menu key
+    // equivalent and never reaches the monitor at all.
+    captureSession.begin()
 
     localShortcutCaptureMonitor = NSEvent.addLocalMonitorForEvents(matching: [
       .flagsChanged, .keyDown,
@@ -459,6 +466,7 @@ struct ShortcutsSettingsSection: View {
       NSEvent.removeMonitor(monitor)
       localShortcutCaptureMonitor = nil
     }
+    captureSession.end()
     recordingTarget = nil
     captureError = nil
     pendingModifierOnlyShortcut = nil

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -582,20 +582,14 @@ extension SBOnboardingModel {
       beginShortcutRecording(isTalk: isTalk)
       shortcutRecording = false
     }
-    GlobalShortcutManager.shared.setRegistrationSuspended(true)
-    if savedMainMenu == nil { savedMainMenu = NSApp.mainMenu }
-    NSApp.mainMenu = nil
+    shortcutCaptureSession.begin()
     installShortcutMonitors()
   }
 
   func disarmShortcutSummon() {
     for m in shortcutMonitors { NSEvent.removeMonitor(m) }
     shortcutMonitors.removeAll()
-    if let saved = savedMainMenu {
-      NSApp.mainMenu = saved
-      savedMainMenu = nil
-    }
-    GlobalShortcutManager.shared.setRegistrationSuspended(false)
+    shortcutCaptureSession.end()
   }
 
   private func installShortcutMonitors() {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -148,9 +148,11 @@ final class SBOnboardingModel: ObservableObject {
   var openShortcutSelection: ShortcutSettings.KeyboardShortcut?
   var talkShortcutSelection: ShortcutSettings.KeyboardShortcut?
   var shortcutMonitors: [Any] = []
-  /// Main menu stashed while the shortcut step's key monitor is armed (menu key
-  /// equivalents like ⌘O would otherwise swallow the press before we see it).
-  var savedMainMenu: NSMenu?
+  /// Stands the app's own shortcut handlers down while this step's key monitor is armed — the Carbon
+  /// hotkeys, the main menu's key equivalents (⌘O would otherwise swallow the press before we see
+  /// it), and push-to-talk. Shared with the Settings recorder so the two cannot disagree about what
+  /// "recording a shortcut" suspends.
+  let shortcutCaptureSession = ShortcutCaptureSession()
 
   // Screen + voice demo
   @Published var screenThings: [String] = []

--- a/desktop/macos/Desktop/Tests/ShortcutCaptureSessionTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutCaptureSessionTests.swift
@@ -1,0 +1,139 @@
+import AppKit
+import XCTest
+
+@testable import Omi_Computer
+
+/// The rule that makes a shortcut recorder work at all: while it is listening, nothing else in this
+/// app may act on a keystroke.
+///
+/// The reported defect was that Settings could not rebind a shortcut onto the chord it was already
+/// bound to — pressing it ran the old binding and toggled the window instead of recording. Ask Omi is
+/// a Carbon hotkey and a Carbon hotkey *preempts* the frontmost app, so the recorder's
+/// `NSEvent.addLocalMonitorForEvents` never saw the event; ⌘-chords had a second way to lose, to the
+/// main menu's key equivalents. Onboarding stood both down inline and Settings stood down neither,
+/// which is why the rule now lives in a type instead of at a call site.
+@MainActor
+final class ShortcutCaptureSessionTests: XCTestCase {
+
+  /// A stand-in for the app's menu bar. `NSApp` does not exist in this process and the test bundle is
+  /// required not to create one (see `HomeStageCloseSemanticsTests`), so the session is handed a
+  /// menu slot instead of reaching for the real one.
+  private final class MenuSlot {
+    var menu: NSMenu?
+    init(_ menu: NSMenu?) { self.menu = menu }
+  }
+
+  private func makeSession(
+    menu: MenuSlot, suspensions: @escaping (Bool) -> Void = { _ in }
+  ) -> ShortcutCaptureSession {
+    ShortcutCaptureSession(
+      suspendGlobalShortcuts: suspensions,
+      readMainMenu: { menu.menu },
+      writeMainMenu: { menu.menu = $0 })
+  }
+
+  // MARK: - Standing down
+
+  /// All three layers, in one call. Each is listed because each intercepts somewhere different, and
+  /// a session that suspended two of them would still lose the chord the user is most likely to type.
+  func testBeginningACaptureStandsDownEveryLayerThatCouldEatTheChord() {
+    let menu = MenuSlot(NSMenu(title: "test"))
+    var suspensions: [Bool] = []
+    let session = makeSession(menu: menu) { suspensions.append($0) }
+
+    session.begin()
+
+    XCTAssertEqual(suspensions, [true], "the Carbon hotkeys are still registered and still preempt")
+    XCTAssertNil(menu.menu, "a menu key equivalent claims ⌘W before a local monitor ever runs")
+    XCTAssertTrue(
+      ShortcutCaptureSession.isCapturing,
+      "push-to-talk reads this; without it, rebinding the talk chord starts a voice turn instead")
+
+    session.end()
+  }
+
+  /// And hands all three back — the same menu object, not a rebuilt one.
+  func testEndingACaptureHandsTheKeyboardBack() {
+    let original = NSMenu(title: "test")
+    let menu = MenuSlot(original)
+    var suspensions: [Bool] = []
+    let session = makeSession(menu: menu) { suspensions.append($0) }
+
+    session.begin()
+    session.end()
+
+    XCTAssertEqual(suspensions, [true, false])
+    XCTAssertIdentical(menu.menu, original, "the app got back a different menu than it handed over")
+    XCTAssertFalse(ShortcutCaptureSession.isCapturing)
+  }
+
+  // MARK: - Re-entry
+
+  /// **The case that makes this a session rather than two calls.** Settings begins a capture by
+  /// stopping the previous one, and a recorder that re-arms without disarming would otherwise save
+  /// the `nil` menu it installed itself — and the Mac would never get its menu bar back.
+  func testReArmingWithoutDisarmingDoesNotLoseTheMenu() {
+    let original = NSMenu(title: "test")
+    let menu = MenuSlot(original)
+    let session = makeSession(menu: menu)
+
+    session.begin()
+    session.begin()
+    session.end()
+
+    XCTAssertIdentical(menu.menu, original)
+    XCTAssertFalse(ShortcutCaptureSession.isCapturing)
+  }
+
+  /// Teardown runs on paths where capture never started — a Settings pane dismissed without anyone
+  /// pressing Save. Ending a session that never began must not suspend, resume, or blank the menu.
+  func testEndingASessionThatNeverBeganIsANoOp() {
+    let original = NSMenu(title: "test")
+    let menu = MenuSlot(original)
+    var suspensions: [Bool] = []
+    let session = makeSession(menu: menu) { suspensions.append($0) }
+
+    session.end()
+
+    XCTAssertEqual(suspensions, [], "a resume nobody asked for re-registers hotkeys out of turn")
+    XCTAssertIdentical(menu.menu, original)
+    XCTAssertFalse(ShortcutCaptureSession.isCapturing)
+  }
+
+  /// A recorder torn down mid-capture — its view dismissed, its window closed — must not leave the
+  /// Mac without a menu bar and without Ask Omi.
+  func testASessionDroppedMidCaptureRestoresTheApp() {
+    let original = NSMenu(title: "test")
+    let menu = MenuSlot(original)
+    var suspensions: [Bool] = []
+
+    do {
+      let session = makeSession(menu: menu) { suspensions.append($0) }
+      session.begin()
+      XCTAssertTrue(ShortcutCaptureSession.isCapturing)
+    }
+
+    XCTAssertEqual(suspensions, [true, false], "the hotkeys stayed suspended for the rest of the run")
+    XCTAssertIdentical(menu.menu, original)
+    XCTAssertFalse(ShortcutCaptureSession.isCapturing)
+  }
+
+  // MARK: - The layer a Boolean can reach
+
+  /// Push-to-talk is the one stander-down that is an in-process monitor, so it is gated rather than
+  /// torn down. The gate is the reported defect in its own right: the talk chord is exactly the one a
+  /// user retypes when rebinding talk.
+  func testPushToTalkIgnoresTheKeyboardWhileARecorderOwnsIt() {
+    XCTAssertFalse(
+      PushToTalkManager.acceptsShortcutEvents(isRecordingAShortcut: true, pttEnabled: true),
+      "rebinding push-to-talk onto its own chord starts a voice turn instead of recording it")
+    XCTAssertTrue(
+      PushToTalkManager.acceptsShortcutEvents(isRecordingAShortcut: false, pttEnabled: true),
+      "the gate outlived the recorder and push-to-talk is deaf")
+    XCTAssertFalse(
+      PushToTalkManager.acceptsShortcutEvents(isRecordingAShortcut: false, pttEnabled: false),
+      "the pre-existing `pttEnabled` gate must survive being folded into this one")
+    XCTAssertFalse(
+      PushToTalkManager.acceptsShortcutEvents(isRecordingAShortcut: true, pttEnabled: false))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260911-shortcut-rebind-conflict.json
+++ b/desktop/macos/changelog/unreleased/20260911-shortcut-rebind-conflict.json
@@ -1,0 +1,3 @@
+{
+  "change": "You can now record a shortcut over the keys an existing one already uses. Retyping the chord Ask Omi was bound to used to run it and toggle the window instead of rebinding, retyping a ⌘ chord could close the window, and retyping the push-to-talk chord started a voice turn. While a recorder is listening, Omi's own shortcuts now stand down."
+}

--- a/desktop/macos/e2e/flows/keyboard-shortcuts.yaml
+++ b/desktop/macos/e2e/flows/keyboard-shortcuts.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutCaptureSession.swift
 preconditions:
   - automation_bridge_ready
 


### PR DESCRIPTION
Recording a new shortcut in Settings over the chord an existing one was bound to did not rebind it — it ran it, and the window toggled as though you had clicked close.

## What was wrong

The recorder listens with `NSEvent.addLocalMonitorForEvents`, but the bindings it is trying to replace intercept earlier, at three different layers:

- **Ask Omi is a Carbon hotkey**, and a Carbon hotkey does not queue behind the frontmost app, it *preempts* it — `GlobalShortcutManager.registerSummonHotkey` already documents that measurement. So for the one chord a user is most likely to retype, the chord they are changing, the monitor never received an event at all.
- **The main menu** matches key equivalents before the responder chain, so recording over ⌘W closed the window.
- **Push-to-talk's own `NSEvent` monitor** started a voice turn when the talk chord was retyped.

Onboarding's shortcut step already suspended the first two, inline. Settings suspended none of them.

## The fix

That split is the failure-class boundary: the rule lived at a call site rather than in a type. `ShortcutCaptureSession` now owns "a recorder holds the keyboard" — Carbon hotkeys genuinely unregistered (a Boolean cannot help once the window server has taken the event), the main menu detached, and push-to-talk gated through `PushToTalkManager.acceptsShortcutEvents`. Both recorders go through it, and onboarding's inline copy is gone, so a third recorder cannot be written without it.

The session's side effects are injected because neither can be asserted otherwise: `GlobalShortcutManager` takes real chords away from the machine running the suite, and `NSApp` does not exist in the test process at all — the bundle is required not to create one (`HomeStageCloseSemanticsTests`). Reading it through optional chaining also drops a force-unwrap that was a crash rather than the no-op the name suggests.

The session's safety-net `deinit` — the one that gives the menu bar and Ask Omi back if a recorder is torn down mid-capture — is `isolated`. A `deinit` is not isolated to its class's actor by default, so the `MainActor.assumeIsolated` it would otherwise need is a trap on any release that happens off the main thread, and nothing guarantees the last reference is dropped there. The net that exists to stop a recorder stranding the Mac would have been the crash instead.

## Verification

- `swift test --filter ShortcutCaptureSessionTests` — 6 pass, covering each layer, re-arming without disarming (which would have stranded the menu bar), ending a session that never began, and a recorder dropped mid-capture.
- `swift test --filter "Shortcut|Onboarding|PTT|PushToTalk"` — 529 pass.
- Built and launched the dev bundle. **Not** exercised by hand end to end: reproducing it means
  pressing a global chord on a Mac someone is using, and synthesising that would fight them for
  the keyboard. The mechanism is confirmed from the code path instead — the recorder's monitor is
  `addLocalMonitorForEvents`, and `registerSummonHotkey` already records the measurement that a
  Carbon hotkey preempts the frontmost app's key-down monitor entirely. Worth a manual pass
  before this leaves draft.

## Product invariants affected

- INV-CHAT-1
- INV-VOICE-1

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift | 4232 -> 4251 | the admission gate push-to-talk already had is now a named function next to the monitors it protects, because the private handler it guards cannot be driven from a hermetic test without real audio. Nineteen lines, seventeen of them the comment explaining why. Splitting this file is worth doing and is not this PR.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsLaZrg6FbKvZymCHpknpe
