### PR TITLE
fix(desktop): custom shortcut button says Save instead of Redo

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -20,6 +20,21 @@ enum PushToTalkSettingsGuidance {
   }
 }
 
+/// What the recorder card's button says.
+///
+/// It said "Save", and the button has never saved anything: its action is `startShortcutCapture`,
+/// and a recorded chord is committed the moment the keys go down, by the capture handler. So the
+/// card offered a Save for a shortcut that was already saved, and the only thing pressing it could
+/// do was throw that shortcut away and listen again. Which is the useful action — it just needed to
+/// say so.
+enum ShortcutRecorderAction {
+  /// The card is only mounted while recording or once a custom shortcut exists, so the idle case is
+  /// always "there is already a chord here" and never a first run with nothing to redo.
+  static func label(isRecording: Bool) -> String {
+    isRecording ? "Listening…" : "Redo"
+  }
+}
+
 struct ShortcutsSettingsSection: View {
   @ObservedObject private var settings = ShortcutSettings.shared
   @Binding var highlightedSettingId: String?
@@ -418,10 +433,19 @@ struct ShortcutsSettingsSection: View {
 
         Spacer()
 
+        // A control's own ground rather than the filled primary: this is a quiet "do it again" next
+        // to the chord it would replace, not the card's call to action. `settingsGlassWell` is the
+        // pane's glass for exactly that — and the pane may not wear real `inkGlassPanel` glass,
+        // which would be a second ground inside the window's own.
         Button(action: action) {
-          Text(isRecording ? "Listening..." : "Save")
+          Text(ShortcutRecorderAction.label(isRecording: isRecording))
+            .scaledFont(size: OmiType.body, weight: .medium)
+            .foregroundColor(isRecording ? Ink.secondary : Ink.primary)
+            .padding(.horizontal, OmiSpacing.md)
+            .padding(.vertical, OmiSpacing.xs)
+            .settingsGlassWell()
         }
-        .buttonStyle(OmiButtonStyle(.primary, size: .compact))
+        .buttonStyle(.plain)
       }
 
       Text(helperText)

--- a/desktop/macos/Desktop/Tests/ShortcutRecorderActionTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutRecorderActionTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// What the shortcut recorder card's button offers to do.
+///
+/// The card used to offer "Save" for a shortcut that was already saved. Its button's action is
+/// `startShortcutCapture`, and the capture handler commits a chord the moment the keys go down, so
+/// there has never been an unsaved state for a Save to resolve — pressing it discarded the chord and
+/// listened again. A label naming an action the control does not perform is the kind of thing that
+/// reads fine in a diff and wrong in the app, so it is stated here instead.
+final class ShortcutRecorderActionTests: XCTestCase {
+
+  /// The reported complaint, as the assertion that would have caught it.
+  func testTheIdleButtonOffersToRedoRatherThanToSave() {
+    XCTAssertEqual(ShortcutRecorderAction.label(isRecording: false), "Redo")
+  }
+
+  /// While the monitor is armed the button reports the state instead, so the card has somewhere to
+  /// say "your keystroke is being read right now" — the one moment the user needs that feedback.
+  func testTheButtonReportsListeningWhileTheRecorderIsArmed() {
+    XCTAssertEqual(ShortcutRecorderAction.label(isRecording: true), "Listening…")
+  }
+
+  /// Neither state may name an action this button cannot perform. Pinned as a claim rather than left
+  /// to the two equalities above, because "Save" is the word anyone would reach for again.
+  func testNeitherStatePromisesToSave() {
+    for isRecording in [true, false] {
+      XCTAssertFalse(
+        ShortcutRecorderAction.label(isRecording: isRecording).localizedCaseInsensitiveContains(
+          "save"),
+        "the recorder has no unsaved state: the chord is committed on key-down, not by this button")
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260911-shortcut-redo-button.json
+++ b/desktop/macos/changelog/unreleased/20260911-shortcut-redo-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "The custom shortcut card no longer offers a Save button for a shortcut that is already saved. Once you have recorded a chord the button says Redo, and it is a quiet glass control next to the keys rather than a filled call to action."
+}


### PR DESCRIPTION
The custom shortcut card offered a **Save** button for a shortcut that was already saved.

## What was wrong

The button's action is `startShortcutCapture`. A recorded chord is committed the moment the keys go down, by the capture handler — there has never been an unsaved state for a Save to resolve. So the only thing pressing it could do was discard the chord you just set and listen again.

That is the useful action. It just needed to say so, and to stop being the card's filled call to action while it said it.

## The change

- The label comes from `ShortcutRecorderAction`, which has two states and neither names a Save: **Redo** when idle, **Listening…** while the monitor is armed.
- The control wears `settingsGlassWell` — `Ink.wash` behind an `Ink.hairline` outline — instead of the filled `OmiButtonStyle(.primary)`. It now reads as a sibling of the key tokens beside it while keeping the outline that says it is pressable.

Deliberately *not* real `inkGlassPanel` glass: the window already wears that, and a second piece of glass inside the first is the "two grounds" failure `settingsGlassCard` documents. `settingsGlassWell` is this pane's vocabulary for a control's own ground.

## Verification

- `swift test --filter ShortcutRecorderActionTests` — 3 pass, including the claim that neither state promises to save, pinned separately because "Save" is the word anyone would reach for again.
- Rendered both states offscreen alongside the old filled button to compare their weight; the new control sits with the key chips rather than competing with them.
- Built and launched the dev bundle. The card only mounts once a custom shortcut is set, so reaching it by hand means binding a global chord on a Mac someone is using — left for a manual pass before this leaves draft.

## Product invariants affected

none

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsLaZrg6FbKvZymCHpknpe


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

