### PR TITLE
feat(cli): add 'omi conversation export' for SRT subtitle output

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -214,6 +214,7 @@ omi
 ├── conversation
 │   ├── list [--limit N] [--start-date ...] [--end-date ...] [--include-transcript]
 │   ├── get <id> [--include-transcript]
+│   ├── export <id> --output transcript.srt [--force]
 │   ├── create [--text ...] [--text-source ...] [...]
 │   ├── from-segments <file.json> [--source ...]
 │   ├── update <id> [--title ...] [--discarded/--no-discarded]

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -101,11 +102,24 @@ def _srt_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
 
 
+def _clean_srt_text(text: str) -> str:
+    """Collapse whitespace-only lines so text can never contain an SRT cue separator."""
+    return "\n".join(line.strip() for line in text.splitlines() if line.strip())
+
+
+def _valid_srt_timing(value: object) -> bool:
+    """Accept only finite, non-negative real numbers (bool excluded)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value) and value >= 0
+
+
 def _render_srt(segments: list) -> tuple[str, int]:
     """Render transcript_segments as SRT text; returns (srt, skipped_count).
 
-    Segments with missing/invalid timing or empty text are skipped and counted,
-    never silently included with fabricated timestamps.
+    Segments with missing/invalid timing (including negative or non-finite
+    values) or empty text are skipped and counted, never silently included
+    with fabricated timestamps.
     """
     blocks: list[str] = []
     skipped = 0
@@ -115,15 +129,8 @@ def _render_srt(segments: list) -> tuple[str, int]:
             continue
         start = seg.get("start")
         end = seg.get("end")
-        text = str(seg.get("text") or "").strip()
-        if (
-            isinstance(start, bool)
-            or isinstance(end, bool)
-            or not isinstance(start, (int, float))
-            or not isinstance(end, (int, float))
-            or end < start
-            or not text
-        ):
+        text = _clean_srt_text(str(seg.get("text") or ""))
+        if not _valid_srt_timing(start) or not _valid_srt_timing(end) or end < start or not text:
             skipped += 1
             continue
         blocks.append(f"{len(blocks) + 1}\n{_srt_timestamp(start)} --> {_srt_timestamp(end)}\n{text}")

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -93,6 +93,82 @@ def get_conversation(
     ctx.renderer.emit(result, title="conversation")
 
 
+def _srt_timestamp(seconds: float) -> str:
+    total_ms = max(0, int(round(seconds * 1000)))
+    hours, rem = divmod(total_ms, 3_600_000)
+    minutes, rem = divmod(rem, 60_000)
+    secs, millis = divmod(rem, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def _render_srt(segments: list) -> tuple[str, int]:
+    """Render transcript_segments as SRT text; returns (srt, skipped_count).
+
+    Segments with missing/invalid timing or empty text are skipped and counted,
+    never silently included with fabricated timestamps.
+    """
+    blocks: list[str] = []
+    skipped = 0
+    for seg in segments:
+        if not isinstance(seg, dict):
+            skipped += 1
+            continue
+        start = seg.get("start")
+        end = seg.get("end")
+        text = str(seg.get("text") or "").strip()
+        if (
+            isinstance(start, bool)
+            or isinstance(end, bool)
+            or not isinstance(start, (int, float))
+            or not isinstance(end, (int, float))
+            or end < start
+            or not text
+        ):
+            skipped += 1
+            continue
+        blocks.append(f"{len(blocks) + 1}\n{_srt_timestamp(start)} --> {_srt_timestamp(end)}\n{text}")
+    if not blocks:
+        return "", skipped
+    return "\n\n".join(blocks) + "\n", skipped
+
+
+@app.command("export", help="Export a conversation transcript as an SRT subtitle file.")
+def export_conversation(
+    typer_ctx: typer.Context,
+    conversation_id: str = typer.Argument(..., help="Conversation ID."),
+    output: Path = typer.Option(..., "--output", "-o", help="Output .srt file path."),
+    force: bool = typer.Option(False, "--force", help="Overwrite the output file if it exists."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    if output.exists() and not force:
+        raise UsageError(
+            message=f"Output file already exists: {output}",
+            detail="Use --force to overwrite the existing file.",
+        )
+    with ctx.make_client() as client:
+        result = client.get(
+            f"/v1/dev/user/conversations/{conversation_id}",
+            params={"include_transcript": True},
+        )
+    segments = result.get("transcript_segments") or []
+    srt_text, skipped = _render_srt(segments)
+    if not srt_text:
+        raise UsageError(
+            message=f"Conversation {conversation_id} has no valid transcript segments",
+            detail="Fetch the conversation with --include-transcript and check transcript_segments.",
+        )
+    output.write_text(srt_text, encoding="utf-8")
+    exported = len(srt_text.rstrip("\n").split("\n\n"))
+    suffix = f" ({skipped} invalid segment(s) skipped)" if skipped else ""
+    ctx.renderer.success(
+        f"Exported [bold]{exported}[/bold] segment(s) to [bold]{output}[/bold]{suffix}"
+    )
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(
+            {"conversation_id": conversation_id, "output": str(output), "segments": exported, "skipped": skipped}
+        )
+
+
 @app.command("create", help="Create a conversation from raw text.")
 def create_conversation(
     typer_ctx: typer.Context,

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -201,3 +201,29 @@ def test_conversation_export_missing_timing_handled(authed_profile, respx_mock, 
     result = cli_runner.invoke(app, ["conversation", "export", "c1", "--output", str(out)])
     assert result.exit_code == 1
     assert not out.exists()
+
+
+def test_conversation_export_rejects_bad_timing_and_blank_lines(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    body = json.dumps(
+        {
+            "id": "c1",
+            "transcript_segments": [
+                {"text": "string start", "start": "0.5", "end": 1.0},
+                {"text": "negative", "start": -2.0, "end": 1.0},
+                {"text": "nan start", "start": float("nan"), "end": 1.0},
+                {"text": "inf end", "start": 0.0, "end": float("inf")},
+                {"text": "multi\n\nline\ntext", "start": 0.0, "end": 1.0},
+            ],
+        }
+    )  # allow_nan default keeps NaN/Infinity literals, which standard JSON parsers reject
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(content=body.encode("utf-8"))
+    out = tmp_path / "out.srt"
+    result = cli_runner.invoke(app, ["--json", "conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["segments"] == 1
+    assert payload["skipped"] == 4
+    content = out.read_text(encoding="utf-8")
+    # surviving cue has the blank line collapsed - never an SRT cue separator inside text
+    assert "multi\nline\ntext" in content
+    assert "\n\n" not in content.rstrip("\n")

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -106,3 +106,98 @@ def test_conversation_from_segments_rejects_invalid_unicode(config_path, respx_m
     assert result.exit_code == 1
     assert "Invalid JSON" in result.stderr
     assert not respx_mock.calls
+
+
+def test_conversation_export_writes_srt(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "structured": {"title": "x"},
+            "transcript_segments": [
+                {"text": "hi", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00"},
+                {"text": "hello", "start": 1.5, "end": 2.5, "speaker": "SPEAKER_01"},
+            ],
+        }
+    )
+    out = tmp_path / "out.srt"
+    result = cli_runner.invoke(app, ["--json", "conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["segments"] == 2
+    assert payload["skipped"] == 0
+    content = out.read_text(encoding="utf-8")
+    assert content.splitlines()[0] == "1"
+    assert "00:00:00,000 --> 00:00:01,000" in content
+    assert "00:00:01,500 --> 00:00:02,500" in content
+    assert "hello" in content
+
+
+def test_conversation_export_skips_invalid_segments(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "structured": {"title": "x"},
+            "transcript_segments": [
+                {"text": "good", "start": 0.0, "end": 1.0},
+                {"text": "no end", "start": 2.0},
+                {"text": "reversed", "start": 5.0, "end": 4.0},
+                {"text": "", "start": 6.0, "end": 7.0},
+                "not-a-dict",
+            ],
+        }
+    )
+    out = tmp_path / "out.srt"
+    result = cli_runner.invoke(app, ["--json", "conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["segments"] == 1
+    assert payload["skipped"] == 4
+    content = out.read_text(encoding="utf-8")
+    assert "good" in content and "no end" not in content
+
+
+def test_conversation_export_refuses_overwrite_without_force(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": [{"text": "hi", "start": 0.0, "end": 1.0}]}
+    )
+    out = tmp_path / "out.srt"
+    out.write_text("existing", encoding="utf-8")
+    result = cli_runner.invoke(app, ["conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 1
+    assert "already exists" in result.stderr.lower()
+    assert out.read_text(encoding="utf-8") == "existing"
+
+
+def test_conversation_export_force_overwrites(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": [{"text": "hi", "start": 0.0, "end": 1.0}]}
+    )
+    out = tmp_path / "out.srt"
+    out.write_text("existing", encoding="utf-8")
+    result = cli_runner.invoke(app, ["conversation", "export", "c1", "--output", str(out), "--force"])
+    assert result.exit_code == 0, result.output
+    assert "hi" in out.read_text(encoding="utf-8")
+
+
+def test_conversation_export_no_valid_segments(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "structured": {"title": "x"}, "transcript_segments": []}
+    )
+    out = tmp_path / "out.srt"
+    result = cli_runner.invoke(app, ["conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 1
+    assert "no valid transcript segments" in result.stderr.lower()
+    assert not out.exists()
+
+
+def test_conversation_export_missing_timing_handled(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "transcript_segments": [{"text": "bool start", "start": True, "end": 1.0}],
+        }
+    )
+    out = tmp_path / "out.srt"
+    result = cli_runner.invoke(app, ["conversation", "export", "c1", "--output", str(out)])
+    assert result.exit_code == 1
+    assert not out.exists()


### PR DESCRIPTION
## What this does

Adds `omi conversation export <id> --output transcript.srt [--force]` to the Python CLI, per #13482.

The command:
- fetches the conversation with `include_transcript=true` through the existing client
- renders `transcript_segments` as UTF-8 SRT using each segment's own `start`/`end` timestamps
- prints a success line with the exported segment count (and any skipped invalid segments)

## Behavior details

- **Invalid segments are skipped, counted, and reported** - missing `start`/`end`, non-numeric/boolean timing, `end < start`, empty text, or non-dict entries never get fabricated timestamps.
- **No accidental overwrite** - the command refuses to write over an existing output file unless `--force` is passed.
- **No silent empty output** - if the conversation has no valid transcript segments, it exits with a clear `UsageError` and writes nothing.
- **UTF-8 always** - output written with `encoding="utf-8"` regardless of platform locale.

## Tests

`tests/test_conversation.py`: 6 new tests (11 existing still pass, **17/17 green**):

- export writes correct SRT (index lines, `HH:MM:SS,mmm` timestamps, text) + JSON payload `segments`/`skipped`
- invalid segments (missing end, reversed timing, empty text, non-dict) skipped & counted, never rendered
- refuses overwrite without `--force` (file untouched), overwrite works with `--force`
- no valid segments -> exit 1, no file written
- boolean `start` treated as invalid (not coerced to 1)

Full suite: 375 passed; the 4 `test_openapi_contract.py` failures also fail on pristine `main` (live public-OpenAPI fetch, unrelated to this change).

## Docs

CLI README command tree updated with the new `export` verb.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

