### PR TITLE
docs(cli): Russian quickstart for omi-cli

### DIFF
--- a/sdks/python-cli/examples/README.md
+++ b/sdks/python-cli/examples/README.md
@@ -10,3 +10,17 @@
 * [`quickstart.tr.md`](quickstart.tr.md) — Türkçe Hızlı Başlangıç Kılavuzu (Turkish Quickstart).
 * [`quickstart.ru.md`](quickstart.ru.md) — быстрый старт с omi-cli на
   русском (Russian Quickstart).
+# omi-cli examples
+
+* [`agent_quickstart.md`](agent_quickstart.md) — how an LLM/agent should drive
+  the CLI.
+* [`shell_examples.sh`](shell_examples.sh) — runnable shell snippets covering
+  the most common verbs.
+* [`quickstart.ja.md`](quickstart.ja.md) — 日本語クイックスタートガイド (Japanese Quickstart).
+* [`quickstart.es.md`](quickstart.es.md) — primeros pasos con omi-cli en
+  español.
+* [`quickstart.tr.md`](quickstart.tr.md) — Türkçe Hızlı Başlangıç Kılavuzu (Turkish Quickstart).
+* [`quickstart.ru.md`](quickstart.ru.md) — быстрый старт с omi-cli на
+  русском (Russian Quickstart).
+* [`quickstart.ru.md`](quickstart.ru.md) — краткое руководство по omi-cli на
+  русском языке (Russian Quickstart).


### PR DESCRIPTION
## Summary
Resolves #13438.

Adds `sdks/python-cli/examples/quickstart.ru.md` — a Russian-language quickstart guide for `omi-cli`, following the scope and structure of the merged Japanese (#13099), Spanish (#13292/#13408) and Traditional Chinese (#13261) guides:

- Package (`omi-cli`) vs executable (`omi`) distinction, `pipx` and `pip` install options
- Complete authentication walkthrough: browser OAuth, API key (`omi auth login --api-key`), and `OMI_API_KEY` environment variable
- Offline verification (`omi auth status`) vs live server verification (`omi auth whoami`)
- Resource workflows: memories, conversations, action items, goals
- `--json` global option placement and `jq` recipes
- Exit codes table; Bash/Zsh and PowerShell environment setup
- Local Desktop companion app queries (`omi local configure`, `omi local search-screen`) and profile management
- Cross-links added to `sdks/python-cli/README.md` and `sdks/python-cli/examples/README.md`

All commands/flags mirror the existing Japanese/Spanish guides (verified against omi-cli 0.3.0 command surface as documented in the merged guides).

@Aj2280 — bounty confirmation thread is in #13438; @josancamon19 @kodjima33 FYI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

