### PR TITLE
fix: fan in paired Omi and desktop listen captures (#3244)

### DIFF
--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -707,6 +707,7 @@ class GeneratedConversation {
   final String? processingMemoryId;
   final String? processingState;
   final bool screenshotSharingEnabled;
+  final bool sharedCapture;
   final String? source;
   final bool starred;
   final DateTime? startedAt;
@@ -752,6 +753,7 @@ class GeneratedConversation {
     this.processingMemoryId,
     this.processingState,
     this.screenshotSharingEnabled = true,
+    this.sharedCapture = false,
     this.source = "omi",
     this.starred = false,
     required this.startedAt,
@@ -799,6 +801,7 @@ class GeneratedConversation {
       processingMemoryId: _readFieldValue<String>(_readField(json, const ["processing_memory_id"]), "processing_memory_id", _readString, requiredField: false, nullable: true),
       processingState: _readFieldValue<String>(_readField(json, const ["processing_state"]), "processing_state", _readString, requiredField: false, nullable: true),
       screenshotSharingEnabled: _required(_readFieldValue<bool>(_readField(json, const ["screenshot_sharing_enabled"]), "screenshot_sharing_enabled", _readBool, requiredField: false, nullable: false, defaultValue: true), "screenshot_sharing_enabled"),
+      sharedCapture: _required(_readFieldValue<bool>(_readField(json, const ["shared_capture"]), "shared_capture", _readBool, requiredField: false, nullable: false, defaultValue: false), "shared_capture"),
       source: _readFieldValue<String>(_readField(json, const ["source"]), "source", _readString, requiredField: false, nullable: true, defaultValue: "omi"),
       starred: _required(_readFieldValue<bool>(_readField(json, const ["starred"]), "starred", _readBool, requiredField: false, nullable: false, defaultValue: false), "starred"),
       startedAt: _readFieldValue<DateTime>(_readField(json, const ["started_at"]), "started_at", _readDateTime, requiredField: true, nullable: true),
@@ -847,6 +850,7 @@ class GeneratedConversation {
       'processing_memory_id': processingMemoryId,
       'processing_state': processingState,
       'screenshot_sharing_enabled': screenshotSharingEnabled,
+      'shared_capture': sharedCapture,
       'source': source,
       'starred': starred,
       'started_at': startedAt?.toUtc().toIso8601String(),
@@ -1084,6 +1088,7 @@ class GeneratedConversationSearchItem {
   final String? processingMemoryId;
   final String? processingState;
   final bool screenshotSharingEnabled;
+  final bool sharedCapture;
   final String? source;
   final bool starred;
   final DateTime? startedAt;
@@ -1130,6 +1135,7 @@ class GeneratedConversationSearchItem {
     this.processingMemoryId,
     this.processingState,
     this.screenshotSharingEnabled = true,
+    this.sharedCapture = false,
     this.source = "omi",
     this.starred = false,
     required this.startedAt,
@@ -1178,6 +1184,7 @@ class GeneratedConversationSearchItem {
       processingMemoryId: _readFieldValue<String>(_readField(json, const ["processing_memory_id"]), "processing_memory_id", _readString, requiredField: false, nullable: true),
       processingState: _readFieldValue<String>(_readField(json, const ["processing_state"]), "processing_state", _readString, requiredField: false, nullable: true),
       screenshotSharingEnabled: _required(_readFieldValue<bool>(_readField(json, const ["screenshot_sharing_enabled"]), "screenshot_sharing_enabled", _readBool, requiredField: false, nullable: false, defaultValue: true), "screenshot_sharing_enabled"),
+      sharedCapture: _required(_readFieldValue<bool>(_readField(json, const ["shared_capture"]), "shared_capture", _readBool, requiredField: false, nullable: false, defaultValue: false), "shared_capture"),
       source: _readFieldValue<String>(_readField(json, const ["source"]), "source", _readString, requiredField: false, nullable: true, defaultValue: "omi"),
       starred: _required(_readFieldValue<bool>(_readField(json, const ["starred"]), "starred", _readBool, requiredField: false, nullable: false, defaultValue: false), "starred"),
       startedAt: _readFieldValue<DateTime>(_readField(json, const ["started_at"]), "started_at", _readDateTime, requiredField: true, nullable: true),
@@ -1227,6 +1234,7 @@ class GeneratedConversationSearchItem {
       'processing_memory_id': processingMemoryId,
       'processing_state': processingState,
       'screenshot_sharing_enabled': screenshotSharingEnabled,
+      'shared_capture': sharedCapture,
       'source': source,
       'starred': starred,
       'started_at': startedAt?.toUtc().toIso8601String(),

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -952,6 +952,31 @@ def update_conversation(uid: str, conversation_id: str, update_data: dict) -> bo
     return True
 
 
+def mark_conversation_shared_capture(
+    uid: str,
+    conversation_id: str,
+    *,
+    firestore_client: Any = None,
+) -> bool:
+    """Persist the explicit Omi/desktop pairing marker on the conversation."""
+    client = firestore_client if firestore_client is not None else db
+    conversation_ref = (
+        client.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
+    )
+
+    @firestore.transactional
+    def _mark(transaction) -> bool:
+        snapshot = conversation_ref.get(transaction=transaction)
+        if not getattr(snapshot, 'exists', False):
+            return False
+        if bool((snapshot.to_dict() or {}).get('shared_capture', False)):
+            return True
+        transaction.update(conversation_ref, {'shared_capture': True})
+        return True
+
+    return run_transactional(client, _mark)
+
+
 def try_claim_conversation_memory_analytics(uid: str, conversation_id: str, firestore_client: Any = None) -> bool:
     """Atomically claim the one analytics success slot for a conversation.
 

--- a/backend/database/recording_sessions.py
+++ b/backend/database/recording_sessions.py
@@ -97,6 +97,9 @@ def _create_or_get_recording_session_txn(
         current = snapshot.to_dict() or {}
         if current.get('uid') != uid or current.get('recording_session_id') != recording_session_id:
             raise ValueError('recording session identity does not match its document binding')
+        if shared_capture and not bool(current.get('shared_capture', False)):
+            current = {**current, 'shared_capture': True, 'updated_at': now}
+            transaction.update(session_ref, {'shared_capture': True, 'updated_at': now})
         return _binding(
             current,
             recording_session_id,

--- a/backend/database/recording_sessions.py
+++ b/backend/database/recording_sessions.py
@@ -40,6 +40,7 @@ class RecordingSessionBinding(TypedDict):
     lifecycle_phase: str
     lifecycle_sequence: int
     mapping_conflict: bool
+    shared_capture: bool
 
 
 class RecordingSessionEvent(TypedDict):
@@ -50,6 +51,7 @@ class RecordingSessionEvent(TypedDict):
     lifecycle_sequence: int
     accepted: bool
     discard_reason: str | None
+    shared_capture: bool
 
 
 def _now() -> datetime:
@@ -77,6 +79,7 @@ def _binding(data: dict[str, Any], recording_session_id: str, *, mapping_conflic
         'lifecycle_phase': str(data.get('lifecycle_phase') or 'in_progress'),
         'lifecycle_sequence': int(data.get('lifecycle_sequence') or 0),
         'mapping_conflict': mapping_conflict,
+        'shared_capture': bool(data.get('shared_capture', False)),
     }
 
 
@@ -86,6 +89,7 @@ def _create_or_get_recording_session_txn(
     uid: str,
     recording_session_id: str,
     proposed_conversation_id: str,
+    shared_capture: bool,
     now: datetime,
 ) -> RecordingSessionBinding:
     snapshot = session_ref.get(transaction=transaction)
@@ -107,6 +111,7 @@ def _create_or_get_recording_session_txn(
         'lifecycle_version': LIFECYCLE_ENVELOPE_VERSION,
         'lifecycle_phase': 'in_progress',
         'lifecycle_sequence': 0,
+        'shared_capture': shared_capture,
         'created_at': now,
         'updated_at': now,
     }
@@ -119,6 +124,7 @@ def create_or_get_recording_session(
     recording_session_id: str,
     proposed_conversation_id: str,
     *,
+    shared_capture: bool = False,
     firestore_client: Any = None,
 ) -> RecordingSessionBinding:
     """Atomically bind a session to exactly one canonical conversation ID."""
@@ -133,6 +139,7 @@ def create_or_get_recording_session(
         uid,
         recording_session_id,
         proposed_conversation_id,
+        shared_capture,
         _now(),
     )
 
@@ -244,8 +251,10 @@ def _record_lifecycle_event_txn(
             'lifecycle_sequence': 0,
             'accepted': False,
             'discard_reason': 'missing_session',
+            'shared_capture': False,
         }
     current = snapshot.to_dict() or {}
+    shared_capture = bool(current.get('shared_capture', False))
     bound_conversation_id = str(current.get('conversation_id') or '')
     version = int(current.get('lifecycle_version') or LIFECYCLE_ENVELOPE_VERSION)
     sequence = int(current.get('lifecycle_sequence') or 0)
@@ -259,6 +268,7 @@ def _record_lifecycle_event_txn(
             'lifecycle_sequence': sequence,
             'accepted': False,
             'discard_reason': 'mapping_conflict',
+            'shared_capture': shared_capture,
         }
     if current_phase in _TERMINAL_PHASES and phase != current_phase:
         return {
@@ -269,6 +279,7 @@ def _record_lifecycle_event_txn(
             'lifecycle_sequence': sequence,
             'accepted': False,
             'discard_reason': 'terminal_immutable',
+            'shared_capture': shared_capture,
         }
     if _PHASE_ORDER[phase] < _PHASE_ORDER.get(current_phase, -1):
         return {
@@ -279,6 +290,7 @@ def _record_lifecycle_event_txn(
             'lifecycle_sequence': sequence,
             'accepted': False,
             'discard_reason': 'stale_event',
+            'shared_capture': shared_capture,
         }
     if phase == current_phase:
         return {
@@ -289,6 +301,7 @@ def _record_lifecycle_event_txn(
             'lifecycle_sequence': sequence,
             'accepted': True,
             'discard_reason': None,
+            'shared_capture': shared_capture,
         }
 
     next_sequence = sequence + 1
@@ -304,6 +317,7 @@ def _record_lifecycle_event_txn(
         'lifecycle_sequence': next_sequence,
         'accepted': True,
         'discard_reason': None,
+        'shared_capture': shared_capture,
     }
 
 

--- a/backend/docs/listen_pusher_pipeline.mdx
+++ b/backend/docs/listen_pusher_pipeline.mdx
@@ -103,8 +103,9 @@ cross-source pairing. When the second socket finds the other source's fresh
 `in_progress` conversation, it creates its own durable recording-session binding
 to that canonical conversation and marks both the binding and conversation
 `shared_capture`. Other cross-source combinations remain separate conversations.
-The conversation marker lets an already-running first socket apply the same
-policy as the joining socket. In a shared capture,
+The active listen-session registry propagates the pairing state to an already-
+running first socket; the durable marker remains lifecycle provenance rather
+than a permanent dedupe switch. In a shared capture,
 the live transcript writer applies shrink-only dedupe for substantial text that
 matches after punctuation/case normalization and has nearly the same timeline;
 short backchannels and repeated text at different times remain distinct. The

--- a/backend/docs/listen_pusher_pipeline.mdx
+++ b/backend/docs/listen_pusher_pipeline.mdx
@@ -6,7 +6,7 @@ description: "Sequence diagrams and finalization policy for the /v4/listen WebSo
 
 # Listen + Pusher Pipeline — Sequence Diagrams
 
-> Last updated: 2026-08-30 (provider-scoped speaker identity and bounded clustering; durable meeting receipt; bounded client-kind propagation; end-of-conversation wake-word command adjudication; private conversation start-location provenance; explicit finalization capability admission; semantic release probes; identity-bound Pusher promotion receipts)
+> Last updated: 2026-09-11 (provider-scoped speaker identity and bounded clustering; durable meeting receipt; bounded client-kind propagation; end-of-conversation wake-word command adjudication; private conversation start-location provenance; explicit finalization capability admission; semantic release probes; identity-bound Pusher promotion receipts; paired Omi/desktop capture binding)
 >
 > These diagrams document the real behavior observed during E2E testing with
 > live services (backend, pusher, STT providers, embedding API). Update when the
@@ -98,6 +98,20 @@ The resource atomically binds the recording to exactly one conversation, so
 reconnects return the original canonical mapping rather than falling back to a
 user-global Redis pointer.
 
+An Omi hardware socket and the macOS desktop socket are the one explicit
+cross-source pairing. When the second socket finds the other source's fresh
+`in_progress` conversation, it creates its own durable recording-session binding
+to that canonical conversation and marks both the binding and conversation
+`shared_capture`. Other cross-source combinations remain separate conversations.
+The conversation marker lets an already-running first socket apply the same
+policy as the joining socket. In a shared capture,
+the live transcript writer applies shrink-only dedupe for substantial text that
+matches after punctuation/case normalization and has nearly the same timeline;
+short backchannels and repeated text at different times remain distinct. The
+desktop client accepts a canonical ID different from its local client ID only
+when the versioned event carries both the shared marker and the local recording
+session identity, then persists the canonical ID for crash-safe finalization.
+
 The backend emits a `conversation_session` event carrying that recording
 identity:
 
@@ -109,14 +123,17 @@ identity:
   "status": "in_progress",
   "lifecycle_version": 1,
   "lifecycle_phase": "in_progress",
-  "lifecycle_sequence": 0
+  "lifecycle_sequence": 0,
+  "shared_capture": false
 }
 ```
 
 `conversation_session`, `memory_processing_started`, and `memory_created`
 carry the same versioned envelope. Clients must accept an envelope only when
 the recording and conversation IDs match their local session and the sequence
-is higher than the last accepted sequence. The phase is part of the contract:
+is higher than the last accepted sequence. For a paired Omi/desktop capture,
+`shared_capture: true` permits the canonical conversation ID to differ from the
+local client ID only with the local recording-session proof. The phase is part of the contract:
 `in_progress`, then `processing`, then a terminal `completed`/`failed`/
 `discarded`. Older events without the envelope retain the legacy identity and
 timestamp compatibility path only.

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -299,6 +299,9 @@ class Conversation(BaseModel):
     finished_at: Optional[datetime]
 
     source: Optional[ConversationSource] = ConversationSource.omi
+    # True when Omi hardware and the macOS desktop intentionally feed the same
+    # live capture into this conversation. It scopes transcript deduplication.
+    shared_capture: bool = False
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
 
     # True when this conversation was transcribed on a third-party (custom STT)

--- a/backend/models/message_event.py
+++ b/backend/models/message_event.py
@@ -33,6 +33,7 @@ class ConversationEvent(MessageEvent):
     lifecycle_version: Optional[int] = None
     lifecycle_phase: Optional[str] = None
     lifecycle_sequence: Optional[int] = None
+    shared_capture: bool = False
 
     def to_json(self):
         j = self.model_dump(mode="json")
@@ -114,6 +115,7 @@ class ConversationSessionEvent(MessageEvent):
     lifecycle_version: Optional[int] = None
     lifecycle_phase: Optional[str] = None
     lifecycle_sequence: Optional[int] = None
+    shared_capture: bool = False
 
     def to_json(self):
         j = self.model_dump(mode="json")

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -118,10 +118,45 @@ class TranscriptSegment(BaseModel):
 
     @staticmethod
     def combine_segments(
-        segments: List['TranscriptSegment'], new_segments: List['TranscriptSegment'], delta_seconds: int = 0
+        segments: List['TranscriptSegment'],
+        new_segments: List['TranscriptSegment'],
+        delta_seconds: int = 0,
+        *,
+        deduplicate_overlapping: bool = False,
     ) -> Tuple[List['TranscriptSegment'], List['TranscriptSegment'], List[str]]:
         if not new_segments or len(new_segments) == 0:
             return segments, [], []
+
+        if deduplicate_overlapping:
+
+            def _duplicate_text(text: str) -> str:
+                return re.sub(r'[^\w]+', ' ', text.casefold()).strip()
+
+            def _is_overlapping_duplicate(existing: 'TranscriptSegment', incoming: 'TranscriptSegment') -> bool:
+                # Provider IDs are not shared across paired sockets, so identity
+                # alone cannot deduplicate the second stream. Require a substantial
+                # text match and nearly the same timeline; this leaves short
+                # backchannels and genuinely repeated lines untouched.
+                existing_text = _duplicate_text(existing.text)
+                incoming_text = _duplicate_text(incoming.text)
+                if not existing_text or existing_text != incoming_text:
+                    return False
+                if len(existing_text) < 20 and len(existing_text.split()) < 4:
+                    return False
+                if existing.id == incoming.id:
+                    return True
+                return abs(existing.start - incoming.start) <= 2 and abs(existing.end - incoming.end) <= 2
+
+            deduped_new_segments: List[TranscriptSegment] = []
+            for new_segment in new_segments:
+                if any(
+                    _is_overlapping_duplicate(existing, new_segment) for existing in [*segments, *deduped_new_segments]
+                ):
+                    continue
+                deduped_new_segments.append(new_segment)
+            if not deduped_new_segments:
+                return segments, [], []
+            new_segments = deduped_new_segments
 
         def _extract_last_incomplete_sentence(text: str) -> Tuple[Optional[str], str]:
             text = text.strip()

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -128,35 +128,9 @@ class TranscriptSegment(BaseModel):
             return segments, [], []
 
         if deduplicate_overlapping:
-
-            def _duplicate_text(text: str) -> str:
-                return re.sub(r'[^\w]+', ' ', text.casefold()).strip()
-
-            def _is_overlapping_duplicate(existing: 'TranscriptSegment', incoming: 'TranscriptSegment') -> bool:
-                # Provider IDs are not shared across paired sockets, so identity
-                # alone cannot deduplicate the second stream. Require a substantial
-                # text match and nearly the same timeline; this leaves short
-                # backchannels and genuinely repeated lines untouched.
-                existing_text = _duplicate_text(existing.text)
-                incoming_text = _duplicate_text(incoming.text)
-                if not existing_text or existing_text != incoming_text:
-                    return False
-                if len(existing_text) < 20 and len(existing_text.split()) < 4:
-                    return False
-                if existing.id == incoming.id:
-                    return True
-                return abs(existing.start - incoming.start) <= 2 and abs(existing.end - incoming.end) <= 2
-
-            deduped_new_segments: List[TranscriptSegment] = []
-            for new_segment in new_segments:
-                if any(
-                    _is_overlapping_duplicate(existing, new_segment) for existing in [*segments, *deduped_new_segments]
-                ):
-                    continue
-                deduped_new_segments.append(new_segment)
-            if not deduped_new_segments:
+            new_segments = TranscriptSegment.deduplicate_overlapping_segments(segments, new_segments)
+            if not new_segments:
                 return segments, [], []
-            new_segments = deduped_new_segments
 
         def _extract_last_incomplete_sentence(text: str) -> Tuple[Optional[str], str]:
             text = text.strip()
@@ -301,6 +275,71 @@ class TranscriptSegment(BaseModel):
             )
 
         return segments, joined_similar_segments, removed_ids
+
+    @staticmethod
+    def deduplicate_overlapping_segments(
+        segments: List['TranscriptSegment'], new_segments: List['TranscriptSegment']
+    ) -> List['TranscriptSegment']:
+        """Drop only the same-text rows that overlap in the paired timelines.
+
+        The normalized-text index keeps the pairing check proportional to the
+        number of matching phrases instead of scanning the complete transcript
+        for every incoming segment.
+        """
+        if not new_segments:
+            return []
+
+        def _duplicate_text(text: str) -> str:
+            return re.sub(r'[^\w]+', ' ', text.casefold()).strip()
+
+        def _compact_script_char_count(text: str) -> int:
+            return sum(
+                1
+                for char in text
+                if (
+                    '\u0e00' <= char <= '\u0e7f'  # Thai
+                    or '\u3040' <= char <= '\u30ff'  # Hiragana/Katakana
+                    or '\u3400' <= char <= '\u9fff'  # CJK
+                    or '\uac00' <= char <= '\ud7af'  # Hangul
+                )
+            )
+
+        def _is_overlapping_duplicate(
+            existing: 'TranscriptSegment', incoming: 'TranscriptSegment', normalized_text: str
+        ) -> bool:
+            # Provider IDs are not shared across paired sockets, so identity
+            # alone cannot deduplicate the second stream. Require a substantial
+            # text match and nearly the same timeline; this leaves short
+            # backchannels and genuinely repeated lines untouched.
+            if not normalized_text or _duplicate_text(incoming.text) != normalized_text:
+                return False
+            if len(normalized_text) < 20 and len(normalized_text.split()) < 4:
+                # CJK/Thai and other compact scripts do not use spaces between
+                # words, so a long single token can still be a full sentence.
+                if _compact_script_char_count(normalized_text) < 4:
+                    return False
+            if existing.id == incoming.id:
+                return True
+            return abs(existing.start - incoming.start) <= 2 and abs(existing.end - incoming.end) <= 2
+
+        existing_by_text: dict[str, List[TranscriptSegment]] = {}
+        for existing in segments:
+            normalized_text = _duplicate_text(existing.text)
+            if normalized_text:
+                existing_by_text.setdefault(normalized_text, []).append(existing)
+
+        deduped_new_segments: List[TranscriptSegment] = []
+        for new_segment in new_segments:
+            normalized_text = _duplicate_text(new_segment.text)
+            if any(
+                _is_overlapping_duplicate(existing, new_segment, normalized_text)
+                for existing in existing_by_text.get(normalized_text, ())
+            ):
+                continue
+            deduped_new_segments.append(new_segment)
+            if normalized_text:
+                existing_by_text.setdefault(normalized_text, []).append(new_segment)
+        return deduped_new_segments
 
 
 class ImprovedTranscriptSegment(BaseModel):

--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -28,6 +28,7 @@ from utils.transcribe_decisions import (
     recording_session_id_for_lifecycle_event,
     select_recording_session_id,
     should_attach_to_existing_in_progress,
+    should_pair_omi_desktop_capture,
 )
 from utils.transcribe_store import calendar_db, conversations_db, redis_db
 
@@ -92,6 +93,7 @@ class LiveConversationController:
                 lifecycle_version=binding['lifecycle_version'],
                 lifecycle_phase=binding['lifecycle_phase'],
                 lifecycle_sequence=binding['lifecycle_sequence'],
+                shared_capture=binding.get('shared_capture', False),
             )
         )
 
@@ -123,6 +125,7 @@ class LiveConversationController:
                 lifecycle_version=envelope['lifecycle_version'],
                 lifecycle_phase=envelope['lifecycle_phase'],
                 lifecycle_sequence=envelope['lifecycle_sequence'],
+                shared_capture=envelope.get('shared_capture', False),
             )
         )
 
@@ -218,7 +221,9 @@ class LiveConversationController:
             latest and (latest.get('transcript_segments') or latest.get('has_content') or latest.get('photos'))
         ) and await self.schedule_finalization(conversation_id)
 
-    async def create_new_in_progress_conversation(self, *, rollover: bool = False) -> None:
+    async def create_new_in_progress_conversation(
+        self, *, rollover: bool = False, proposed_conversation_id: Optional[str] = None
+    ) -> None:
         request = self.host.request
         self.host.recording_session_id = select_recording_session_id(
             client_conversation_id=self.host.client_conversation_id,
@@ -231,18 +236,24 @@ class LiveConversationController:
         except ValueError:
             logger.error('Invalid conversation source %s; using omi', request.source)
             source = ConversationSource.omi
-        use_client_conversation_id = bool(self.host.client_conversation_id) and not rollover
-        proposed_id = self.host.client_conversation_id if use_client_conversation_id else str(uuid.uuid4())
-        proposed_id_is_server_generated = not use_client_conversation_id
+        use_client_conversation_id = (
+            bool(self.host.client_conversation_id) and not rollover and proposed_conversation_id is None
+        )
+        proposed_id = proposed_conversation_id or (
+            self.host.client_conversation_id if use_client_conversation_id else str(uuid.uuid4())
+        )
+        proposed_id_is_server_generated = not use_client_conversation_id and proposed_conversation_id is None
         binding = await self.host.persistence.call(
             lifecycle_service.open_live_recording_session,
             request.uid,
             self.host.recording_session_id,
             proposed_id,
+            shared_capture=proposed_conversation_id is not None,
         )
         if binding['requires_rollover']:
             await self.create_new_in_progress_conversation(rollover=True)
             return
+        self.host.shared_capture = binding.get('shared_capture', False)
         conversation_id = binding['conversation_id']
         self.host.recording_session_ids_by_conversation[conversation_id] = self.host.recording_session_id
         if proposed_id_is_server_generated and conversation_id == proposed_id:
@@ -350,6 +361,28 @@ class LiveConversationController:
             await self.create_new_in_progress_conversation()
             return None
         if self.host.client_conversation_id:
+            # Client IDs normally force a new conversation for idempotent client
+            # sessions. Omi hardware and the desktop app are the exception: if
+            # the other capture is already live, both sockets must fan into it.
+            existing = await self.host.persistence.call(retrieve_in_progress_conversation, self.host.request.uid)
+            existing_source = existing.get('source') if existing else None
+            if isinstance(existing_source, ConversationSource):
+                existing_source = existing_source.value
+            if existing and should_pair_omi_desktop_capture(
+                existing_source=existing_source if isinstance(existing_source, str) else None,
+                request_source=self.host.request.source,
+            ):
+                finished_at = datetime.fromisoformat(existing['finished_at'].isoformat())
+                seconds = (datetime.now(timezone.utc) - finished_at).total_seconds()
+                if (
+                    decide_existing_conversation_action(
+                        seconds_since_last_segment=seconds,
+                        conversation_creation_timeout=self.host.conversation_creation_timeout,
+                    )
+                    == ConversationLifecycleAction.continue_current
+                ):
+                    await self.create_new_in_progress_conversation(proposed_conversation_id=existing['id'])
+                    return None
             await self.create_new_in_progress_conversation()
             return None
         if self.host.request.onboarding_mode and self.host.onboarding_admitted:
@@ -369,9 +402,10 @@ class LiveConversationController:
             await self.create_new_in_progress_conversation()
             return None
         existing_source = existing.get('source')
-        if hasattr(existing_source, 'value'):
+        if isinstance(existing_source, ConversationSource):
             existing_source = existing_source.value
-        # Cross-source sockets (pendant + web meeting) must not share one conversation (#5388).
+        # Unrelated cross-source sockets (for example, pendant + web meeting)
+        # must not share one conversation; Omi + macOS is the explicit pair.
         if not should_attach_to_existing_in_progress(
             existing_source=existing_source if isinstance(existing_source, str) else None,
             request_source=self.host.request.source,
@@ -394,10 +428,15 @@ class LiveConversationController:
             self.host.request.uid,
             self.host.recording_session_id,
             existing['id'],
+            shared_capture=should_pair_omi_desktop_capture(
+                existing_source=existing_source if isinstance(existing_source, str) else None,
+                request_source=self.host.request.source,
+            ),
         )
         if binding['requires_rollover']:
             await self.create_new_in_progress_conversation(rollover=True)
             return None
+        self.host.shared_capture = binding.get('shared_capture', False)
         self.host.state.current_conversation_id = existing['id']
         self.host.recording_session_ids_by_conversation[existing['id']] = self.host.recording_session_id
         self.send_conversation_session(binding, self.host.recording_session_id)

--- a/backend/routers/listen/conversations.py
+++ b/backend/routers/listen/conversations.py
@@ -32,6 +32,8 @@ from utils.transcribe_decisions import (
 )
 from utils.transcribe_store import calendar_db, conversations_db, redis_db
 
+from .registry import mark_shared_capture
+
 logger = logging.getLogger(__name__)
 
 # Orphan threshold for stale in_progress recovery (#9809). Any live session
@@ -72,6 +74,7 @@ class LiveConversationController:
                 recording_session_id,
                 conversation_id,
                 phase,
+                shared_capture=bool(getattr(self.host, 'shared_capture', False)),
             )
         except Exception:
             logger.exception(
@@ -243,18 +246,21 @@ class LiveConversationController:
             self.host.client_conversation_id if use_client_conversation_id else str(uuid.uuid4())
         )
         proposed_id_is_server_generated = not use_client_conversation_id and proposed_conversation_id is None
+        shared_capture_requested = proposed_conversation_id is not None
         binding = await self.host.persistence.call(
             lifecycle_service.open_live_recording_session,
             request.uid,
             self.host.recording_session_id,
             proposed_id,
-            shared_capture=proposed_conversation_id is not None,
+            shared_capture=shared_capture_requested,
         )
         if binding['requires_rollover']:
             await self.create_new_in_progress_conversation(rollover=True)
             return
-        self.host.shared_capture = binding.get('shared_capture', False)
+        self.host.shared_capture = shared_capture_requested
         conversation_id = binding['conversation_id']
+        if shared_capture_requested and not binding.get('mapping_conflict'):
+            mark_shared_capture(request.uid, conversation_id)
         self.host.recording_session_ids_by_conversation[conversation_id] = self.host.recording_session_id
         if proposed_id_is_server_generated and conversation_id == proposed_id:
             # proposed_id was invented for this call and the binding adopted it
@@ -360,6 +366,11 @@ class LiveConversationController:
         if self.host.is_multi_channel:
             await self.create_new_in_progress_conversation()
             return None
+        if self.host.request.onboarding_mode and self.host.onboarding_admitted:
+            # An admitted speech-profile recording is its own conversation,
+            # even when the client also supplied an id from another flow.
+            await self.create_new_in_progress_conversation()
+            return None
         if self.host.client_conversation_id:
             # Client IDs normally force a new conversation for idempotent client
             # sessions. Omi hardware and the desktop app are the exception: if
@@ -383,18 +394,6 @@ class LiveConversationController:
                 ):
                     await self.create_new_in_progress_conversation(proposed_conversation_id=existing['id'])
                     return None
-            await self.create_new_in_progress_conversation()
-            return None
-        if self.host.request.onboarding_mode and self.host.onboarding_admitted:
-            # A speech-profile recording (onboarding step or Settings redo) is its
-            # own conversation. Attaching to a still-open one from a previous
-            # attempt makes combine_segments() merge the new speech into that
-            # conversation's last segment, and the client then shows the words
-            # from last time as soon as the user starts talking again.
-            # Admission, not the raw request flag, owns this decision: the
-            # runtime refuses onboarding provenance for completed accounts, and
-            # an unadmitted onboarding claim must keep the ordinary session's
-            # existing-conversation behavior instead of dodging it.
             await self.create_new_in_progress_conversation()
             return None
         existing = await self.host.persistence.call(retrieve_in_progress_conversation, self.host.request.uid)
@@ -423,20 +422,23 @@ class LiveConversationController:
         ):
             await self.create_new_in_progress_conversation()
             return existing['id']
+        shared_capture_requested = should_pair_omi_desktop_capture(
+            existing_source=existing_source if isinstance(existing_source, str) else None,
+            request_source=self.host.request.source,
+        )
         binding = await self.host.persistence.call(
             lifecycle_service.open_live_recording_session,
             self.host.request.uid,
             self.host.recording_session_id,
             existing['id'],
-            shared_capture=should_pair_omi_desktop_capture(
-                existing_source=existing_source if isinstance(existing_source, str) else None,
-                request_source=self.host.request.source,
-            ),
+            shared_capture=shared_capture_requested,
         )
         if binding['requires_rollover']:
             await self.create_new_in_progress_conversation(rollover=True)
             return None
-        self.host.shared_capture = binding.get('shared_capture', False)
+        self.host.shared_capture = shared_capture_requested
+        if shared_capture_requested and not binding.get('mapping_conflict'):
+            mark_shared_capture(self.host.request.uid, binding['conversation_id'])
         self.host.state.current_conversation_id = existing['id']
         self.host.recording_session_ids_by_conversation[existing['id']] = self.host.recording_session_id
         self.send_conversation_session(binding, self.host.recording_session_id)

--- a/backend/routers/listen/registry.py
+++ b/backend/routers/listen/registry.py
@@ -21,24 +21,75 @@ from models.message_event import ProactiveMessageEvent
 logger = logging.getLogger(__name__)
 
 _sessions: Dict[str, Set[Any]] = {}
+_shared_capture_conversations: Dict[str, Set[str]] = {}
 _lock = threading.Lock()
 
 PROACTIVE_MESSAGE_CHANNEL = "proactive_message:listen"
 
 
+def _conversation_id_for_session(session: Any) -> str | None:
+    current = getattr(getattr(session, 'state', None), 'current_conversation_id', None)
+    if current:
+        return current
+    return getattr(session, '_shared_capture_conversation_id', None)
+
+
 def register(session: Any) -> None:
     with _lock:
-        _sessions.setdefault(session.request.uid, set()).add(session)
+        uid = session.request.uid
+        _sessions.setdefault(uid, set()).add(session)
+        conversation_id = _conversation_id_for_session(session)
+        if conversation_id in _shared_capture_conversations.get(uid, set()):
+            session.shared_capture = True
 
 
 def unregister(session: Any) -> None:
     with _lock:
-        sessions = _sessions.get(session.request.uid)
+        uid = session.request.uid
+        sessions = _sessions.get(uid)
         if not sessions:
             return
         sessions.discard(session)
         if not sessions:
-            _sessions.pop(session.request.uid, None)
+            _sessions.pop(uid, None)
+        marked = _shared_capture_conversations.get(uid)
+        if marked:
+            active_conversations = {_conversation_id_for_session(active) for active in sessions}
+            marked.intersection_update(conversation for conversation in active_conversations if conversation)
+            if not marked:
+                _shared_capture_conversations.pop(uid, None)
+
+
+def mark_shared_capture(uid: str, conversation_id: str) -> None:
+    """Publish a pairing marker to already-registered sockets in this worker."""
+    if not uid or not conversation_id:
+        return
+    with _lock:
+        _shared_capture_conversations.setdefault(uid, set()).add(conversation_id)
+        for session in _sessions.get(uid, ()):
+            current = getattr(getattr(session, 'state', None), 'current_conversation_id', None)
+            source = getattr(getattr(session, 'request', None), 'source', None)
+            source = getattr(source, 'value', source)
+            if current == conversation_id or (current is None and source in {'omi', 'desktop'}):
+                session._shared_capture_conversation_id = conversation_id
+                session.shared_capture = True
+
+
+def is_shared_capture(uid: str, conversation_id: str | None) -> bool:
+    if not uid or not conversation_id:
+        return False
+    with _lock:
+        return conversation_id in _shared_capture_conversations.get(uid, set())
+
+
+def has_shared_capture_peer(uid: str, conversation_id: str | None) -> bool:
+    """Return whether another live socket still owns a paired conversation."""
+    if not uid or not conversation_id:
+        return False
+    with _lock:
+        if conversation_id not in _shared_capture_conversations.get(uid, set()):
+            return False
+        return any(_conversation_id_for_session(session) == conversation_id for session in _sessions.get(uid, ()))
 
 
 def _sessions_for(uid: str) -> List[Any]:

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -75,6 +75,7 @@ from .conversations import LiveConversationController
 from .persistence import ListenPersistence
 from .parity_capture import ListenParityCapture
 from .receiver import ListenReceiver
+from .registry import has_shared_capture_peer
 from .registry import register as register_listen_session
 from .registry import unregister as unregister_listen_session
 from .speakers import SpeakerMatcher
@@ -857,6 +858,9 @@ class ListenSessionRuntime:
             except Exception:
                 pass
         conversation_id = self.state.current_conversation_id
+        shared_capture_peer_active = bool(
+            conversation_id and has_shared_capture_peer(self.request.uid, conversation_id)
+        )
         if conversation_id and not owner_persistence_blocked:
             try:
                 if self.is_multi_channel:
@@ -886,6 +890,7 @@ class ListenSessionRuntime:
                         and self.state.close_code == 1000
                         and getattr(conversation.get('source'), 'value', conversation.get('source')) == 'desktop'
                         and (conversation.get('transcript_segments') or conversation.get('photos'))
+                        and not shared_capture_peer_active
                     ):
                         await self.transcripts.flush_speaker_assignments(conversation_id)
                         if await self.conversations.process_conversation(conversation_id):

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -122,6 +122,10 @@ class ListenSessionRuntime:
         self.session_id = str(uuid.uuid4())
         self.client_conversation_id = _normalize_client_conversation_id(request.client_conversation_id)
         self.recording_session_id = self.client_conversation_id or str(uuid.uuid4())
+        # Set by the conversation controller when this socket joins an
+        # Omi/desktop paired capture. Transcript-level dedupe is only safe for
+        # that explicitly shared lifecycle.
+        self.shared_capture = False
         self.recording_session_ids_by_conversation: Dict[str, str] = {}
         self.client_device_context = request.client_device_context or resolve_client_device_from_headers(
             request.websocket.headers

--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -33,6 +33,7 @@ from utils.transcribe_decisions import (
     is_user_self_match,
     person_id_for_client,
     resolve_photo_conversation_source,
+    should_pair_omi_desktop_capture,
     should_queue_speaker_embedding,
     should_skip_speaker_detection,
 )
@@ -88,6 +89,7 @@ class TranscriptProcessor:
         self.cache = ConversationCache(self._load_conversation)
         self.current_session_segments: Dict[str, bool] = {}
         self.suggested_segments: set[str] = set()
+
         self.speaker_id_allocator = ConversationSpeakerIdAllocator()
         self.language_cache = TranscriptSegmentLanguageCache()
         self.translation_service = TranslationService()
@@ -101,6 +103,15 @@ class TranscriptProcessor:
                 on_translation_ready=self._on_translation_ready,
                 language_state=ConversationLanguageState(host.translation_language or 'en'),
             )
+
+    def _is_shared_capture(self, source: Any, marker: bool = False) -> bool:
+        if marker or bool(getattr(self.host, 'shared_capture', False)):
+            return True
+        source_value = source.value if isinstance(source, ConversationSource) else source
+        return should_pair_omi_desktop_capture(
+            existing_source=source_value if isinstance(source_value, str) else None,
+            request_source=getattr(self.host.request, 'source', None),
+        )
 
     async def _load_conversation(self, conversation_id: str) -> Optional[Dict[str, Any]]:
         return await self.host.persistence.call(
@@ -191,9 +202,20 @@ class TranscriptProcessor:
         updated: List[TranscriptSegment] = []
         removed: List[str] = []
         if segments:
-            conversation.transcript_segments, updated, removed = TranscriptSegment.combine_segments(
-                conversation.transcript_segments, segments
+            deduplicate_overlapping = self._is_shared_capture(
+                conversation.source,
+                conversation.shared_capture,
             )
+            if deduplicate_overlapping:
+                conversation.transcript_segments, updated, removed = TranscriptSegment.combine_segments(
+                    conversation.transcript_segments,
+                    segments,
+                    deduplicate_overlapping=True,
+                )
+            else:
+                conversation.transcript_segments, updated, removed = TranscriptSegment.combine_segments(
+                    conversation.transcript_segments, segments
+                )
             sort_transcript_segments_in_place(conversation.transcript_segments)
             speaker = self.host.speakers
             targets = conversation.transcript_segments if self.host.state.speaker_map_dirty else updated
@@ -356,7 +378,12 @@ class TranscriptProcessor:
                 self.host.state.words_transcribed_since_last_record += len(
                     ' '.join(segment.text for segment in new_segments).split()
                 )
-            transcript_segments, _, _ = TranscriptSegment.combine_segments([], new_segments)
+            if self._is_shared_capture(data.get('source'), bool(data.get('shared_capture', False))):
+                transcript_segments, _, _ = TranscriptSegment.combine_segments(
+                    [], new_segments, deduplicate_overlapping=True
+                )
+            else:
+                transcript_segments, _, _ = TranscriptSegment.combine_segments([], new_segments)
             current = deserialize_conversation(data)
             result = await self._update_live_conversation(current, transcript_segments, photos, finished_at, started_at)
             rolled_over = False

--- a/backend/routers/listen/transcripts.py
+++ b/backend/routers/listen/transcripts.py
@@ -43,6 +43,8 @@ from utils.translation_cache import ConversationLanguageState, TranscriptSegment
 from utils.translation_coordinator import TranslationCoordinator
 from utils.product_telemetry import emit_product_event
 
+from .registry import is_shared_capture as is_registered_shared_capture
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,6 +91,7 @@ class TranscriptProcessor:
         self.cache = ConversationCache(self._load_conversation)
         self.current_session_segments: Dict[str, bool] = {}
         self.suggested_segments: set[str] = set()
+        self.last_accepted_segments: List[TranscriptSegment] = []
 
         self.speaker_id_allocator = ConversationSpeakerIdAllocator()
         self.language_cache = TranscriptSegmentLanguageCache()
@@ -104,8 +107,14 @@ class TranscriptProcessor:
                 language_state=ConversationLanguageState(host.translation_language or 'en'),
             )
 
-    def _is_shared_capture(self, source: Any, marker: bool = False) -> bool:
-        if marker or bool(getattr(self.host, 'shared_capture', False)):
+    def _is_shared_capture(self, source: Any) -> bool:
+        if bool(getattr(self.host, 'shared_capture', False)):
+            return True
+        state = getattr(self.host, 'state', None)
+        if is_registered_shared_capture(
+            getattr(getattr(self.host, 'request', None), 'uid', ''),
+            getattr(state, 'current_conversation_id', None),
+        ):
             return True
         source_value = source.value if isinstance(source, ConversationSource) else source
         return should_pair_omi_desktop_capture(
@@ -201,44 +210,42 @@ class TranscriptProcessor:
     ) -> Optional[tuple[Conversation, List[TranscriptSegment], List[str]]]:
         updated: List[TranscriptSegment] = []
         removed: List[str] = []
+        self.last_accepted_segments = []
         if segments:
-            deduplicate_overlapping = self._is_shared_capture(
-                conversation.source,
-                conversation.shared_capture,
+            deduplicate_overlapping = self._is_shared_capture(conversation.source)
+            accepted_segments = (
+                TranscriptSegment.deduplicate_overlapping_segments(conversation.transcript_segments, segments)
+                if deduplicate_overlapping
+                else list(segments)
             )
-            if deduplicate_overlapping:
+            self.last_accepted_segments = [segment.model_copy(deep=True) for segment in accepted_segments]
+            if accepted_segments:
                 conversation.transcript_segments, updated, removed = TranscriptSegment.combine_segments(
-                    conversation.transcript_segments,
-                    segments,
-                    deduplicate_overlapping=True,
+                    conversation.transcript_segments, accepted_segments
                 )
-            else:
-                conversation.transcript_segments, updated, removed = TranscriptSegment.combine_segments(
-                    conversation.transcript_segments, segments
+                sort_transcript_segments_in_place(conversation.transcript_segments)
+                speaker = self.host.speakers
+                targets = conversation.transcript_segments if self.host.state.speaker_map_dirty else updated
+                process_speaker_assigned_segments(targets, speaker.segment_assignments, speaker.speaker_to_person)
+                self._apply_speaker_identity_statuses(targets)
+                self.host.state.speaker_map_dirty = False
+                serialised = [segment.model_dump() for segment in conversation.transcript_segments]
+                written = await self.host.persistence.call(
+                    conversations_db.update_conversation_segments,
+                    self.host.request.uid,
+                    conversation.id,
+                    serialised,
+                    started_at=started_at,
+                    data_protection_level=self.cache.protection_level,
+                    # Opt out of the unconditional DELETE_FIELD sentinel so this ~0.6s
+                    # write loop stays cheap when no projection is present. The segment
+                    # transaction still clears a projection that is actually on the
+                    # document (a finalize overlapping capture).
+                    invalidate_client_processing=False,
                 )
-            sort_transcript_segments_in_place(conversation.transcript_segments)
-            speaker = self.host.speakers
-            targets = conversation.transcript_segments if self.host.state.speaker_map_dirty else updated
-            process_speaker_assigned_segments(targets, speaker.segment_assignments, speaker.speaker_to_person)
-            self._apply_speaker_identity_statuses(targets)
-            self.host.state.speaker_map_dirty = False
-            serialised = [segment.model_dump() for segment in conversation.transcript_segments]
-            written = await self.host.persistence.call(
-                conversations_db.update_conversation_segments,
-                self.host.request.uid,
-                conversation.id,
-                serialised,
-                started_at=started_at,
-                data_protection_level=self.cache.protection_level,
-                # Opt out of the unconditional DELETE_FIELD sentinel so this ~0.6s
-                # write loop stays cheap when no projection is present. The segment
-                # transaction still clears a projection that is actually on the
-                # document (a finalize overlapping capture).
-                invalidate_client_processing=False,
-            )
-            if not written:
-                return None
-            self.cache.update_segments(serialised)
+                if not written:
+                    return None
+                self.cache.update_segments(serialised)
         if photos:
             stored = await self.host.persistence.call(
                 conversations_db.store_conversation_photos, self.host.request.uid, conversation.id, photos
@@ -375,10 +382,7 @@ class TranscriptProcessor:
                     diarized_speaker_ids_by_conversation.setdefault(conversation_id, set()).update(
                         segment.speaker_id for segment in new_segments if isinstance(segment.speaker_id, int)
                     )
-                self.host.state.words_transcribed_since_last_record += len(
-                    ' '.join(segment.text for segment in new_segments).split()
-                )
-            if self._is_shared_capture(data.get('source'), bool(data.get('shared_capture', False))):
+            if self._is_shared_capture(data.get('source')):
                 transcript_segments, _, _ = TranscriptSegment.combine_segments(
                     [], new_segments, deduplicate_overlapping=True
                 )
@@ -403,21 +407,25 @@ class TranscriptProcessor:
             if not result or not result[0]:
                 continue
             conversation, updated, removed = result
+            accepted_segments = getattr(self, 'last_accepted_segments', transcript_segments)
             if removed:
                 self.host.send_event(SegmentsDeletedEvent(segment_ids=removed))
-            if not transcript_segments:
+            if not accepted_segments:
                 continue
+            self.host.state.words_transcribed_since_last_record += len(
+                ' '.join(segment.text for segment in accepted_segments).split()
+            )
             client_segments = [segment.model_dump() for segment in updated]
             delivered = await self._deliver_segments(client_segments)
             if delivered and client_segments:
                 self.host.complete_live_transcription()
             if self.host.transcript_send is not None and self.host.user_has_credits:
-                self.host.transcript_send([segment.model_dump() for segment in transcript_segments])
+                self.host.transcript_send([segment.model_dump() for segment in accepted_segments])
             elif not self.host.pusher_enabled and self.host.user_has_credits:
                 try:
                     await trigger_realtime_integrations(
                         self.host.request.uid,
-                        [segment.model_dump() for segment in transcript_segments],
+                        [segment.model_dump() for segment in accepted_segments],
                         self.host.state.current_conversation_id,
                         source=self.host.request.source,
                         client_kind=self.host.client_kind,
@@ -426,7 +434,7 @@ class TranscriptProcessor:
                     logger.error('Realtime integration trigger failed type=%s', type(error).__name__)
             if self.host.onboarding_handler and not self.host.onboarding_handler.completed:
                 self.host.onboarding_handler.on_segments_received(
-                    [segment.model_dump() for segment in transcript_segments]
+                    [segment.model_dump() for segment in accepted_segments]
                 )
             await self._translate(updated, conversation.id, removed)
             await self._speaker_detection(updated, offset)

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from database import conversations as conversations_db
 from routers.listen.contracts import ListenRequest
 from routers.listen.conversations import resolve_onboarding_provenance_marker
 from routers.listen.runtime import ListenSessionRuntime
@@ -104,6 +105,37 @@ async def test_teardown_rechecks_deletion_authority_before_owner_persistence():
     assert authority_reads[0][1] == ('newly-deleted-owner',)
     assert request.owner_persistence_blocked.is_set()
     _assert_deletion_teardown_skipped_owner_writes(runtime)
+
+
+@pytest.mark.anyio
+async def test_shared_desktop_teardown_waits_for_active_capture_peer(monkeypatch):
+    import routers.listen.runtime as runtime_module
+
+    request = ListenRequest(
+        websocket=SimpleNamespace(client_state=WebSocketState.DISCONNECTED),
+        uid='paired-user',
+    )
+
+    async def persistence_call(function, *_args, **_kwargs):
+        if function.__name__ == '_account_deletion_blocks_owner_persistence':
+            return False
+        if function is conversations_db.get_conversation:
+            return {
+                'id': 'conversation-1',
+                'source': 'desktop',
+                'transcript_segments': [{'id': 'segment-1'}],
+                'photos': [],
+            }
+        raise AssertionError(f'unexpected persistence call: {function}')
+
+    runtime = _deletion_teardown_runtime(request, persistence_call)
+    runtime.state.close_code = 1000
+    monkeypatch.setattr(runtime_module, 'has_shared_capture_peer', lambda *_args: True)
+
+    await runtime._teardown()
+
+    runtime.conversations.process_conversation.assert_not_awaited()
+    runtime.transcripts.flush_speaker_assignments.assert_not_awaited()
 
 
 def _runtime_for_periodic_usage(*, tracking, exhausted):
@@ -884,6 +916,28 @@ async def test_transcript_delivery_marks_live_transcription_success_only_after_a
     assert websocket.sent == [[{'id': 'segment-1', 'text': 'Hello'}]]
     assert delivered == [True]
     assert flushed == ['conversation-1']
+    assert processor.host.state.words_transcribed_since_last_record == 1
+
+
+@pytest.mark.anyio
+async def test_transcript_delivery_skips_segments_rejected_by_live_deduplication(monkeypatch):
+    class WebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send_json(self, payload):
+            self.sent.append(payload)
+
+    websocket = WebSocket()
+    processor, delivered, flushed = _transcript_processor_for_delivery(monkeypatch, websocket)
+    processor.last_accepted_segments = []
+
+    await processor.process_loop()
+
+    assert websocket.sent == []
+    assert delivered == []
+    assert flushed == ['conversation-1']
+    assert processor.host.state.words_transcribed_since_last_record == 0
 
 
 @pytest.mark.anyio

--- a/backend/tests/unit/test_listen_source_pairing.py
+++ b/backend/tests/unit/test_listen_source_pairing.py
@@ -1,0 +1,101 @@
+"""Regression coverage for the Omi-device and desktop capture pairing rule."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from routers.listen.conversations import LiveConversationController
+from routers.listen.transcripts import TranscriptProcessor
+
+
+class _Host:
+    def __init__(self, *, existing: dict, source: str = 'desktop') -> None:
+        self.request = SimpleNamespace(uid='uid-1', source=source, onboarding_mode=False)
+        self.client_conversation_id = 'desktop-client-id'
+        self.conversation_creation_timeout = 120
+        self.is_multi_channel = False
+        self.persistence = SimpleNamespace(call=self._call)
+        self.existing = existing
+
+    async def _call(self, _function, *_args, **_kwargs):
+        return self.existing
+
+
+async def test_client_id_session_pairs_with_live_omi_capture():
+    host = _Host(
+        existing={
+            'id': 'omi-conversation',
+            'source': 'omi',
+            'finished_at': datetime.now(timezone.utc),
+        }
+    )
+    controller = LiveConversationController(host)
+    controller.create_new_in_progress_conversation = AsyncMock()
+
+    await controller.prepare()
+
+    controller.create_new_in_progress_conversation.assert_awaited_once_with(proposed_conversation_id='omi-conversation')
+
+
+async def test_client_id_session_does_not_pair_stale_capture():
+    host = _Host(
+        existing={
+            'id': 'stale-omi-conversation',
+            'source': 'omi',
+            'finished_at': datetime.now(timezone.utc) - timedelta(seconds=121),
+        }
+    )
+    controller = LiveConversationController(host)
+    controller.create_new_in_progress_conversation = AsyncMock()
+
+    await controller.prepare()
+
+    controller.create_new_in_progress_conversation.assert_awaited_once_with()
+
+
+async def test_client_id_session_does_not_pair_web_capture():
+    host = _Host(
+        existing={
+            'id': 'omi-conversation',
+            'source': 'omi',
+            'finished_at': datetime.now(timezone.utc),
+        },
+        source='web',
+    )
+    controller = LiveConversationController(host)
+    controller.create_new_in_progress_conversation = AsyncMock()
+
+    await controller.prepare()
+
+    controller.create_new_in_progress_conversation.assert_awaited_once_with()
+
+
+async def test_client_id_session_keeps_same_source_idempotency_path():
+    host = _Host(
+        existing={
+            'id': 'omi-conversation',
+            'source': 'omi',
+            'finished_at': datetime.now(timezone.utc),
+        },
+        source='omi',
+    )
+    controller = LiveConversationController(host)
+    controller.create_new_in_progress_conversation = AsyncMock()
+
+    await controller.prepare()
+
+    controller.create_new_in_progress_conversation.assert_awaited_once_with()
+
+
+def test_transcript_writer_recognizes_pair_from_conversation_source_in_either_order():
+    processor = object.__new__(TranscriptProcessor)
+    processor.host = SimpleNamespace(
+        shared_capture=False,
+        request=SimpleNamespace(source='desktop'),
+    )
+
+    assert processor._is_shared_capture('omi') is True
+
+    processor.host.request.source = 'omi'
+    assert processor._is_shared_capture('desktop') is True
+    assert processor._is_shared_capture('web') is False

--- a/backend/tests/unit/test_listen_source_pairing.py
+++ b/backend/tests/unit/test_listen_source_pairing.py
@@ -5,15 +5,24 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from routers.listen.conversations import LiveConversationController
+from routers.listen import registry
 from routers.listen.transcripts import TranscriptProcessor
 
 
 class _Host:
-    def __init__(self, *, existing: dict, source: str = 'desktop') -> None:
-        self.request = SimpleNamespace(uid='uid-1', source=source, onboarding_mode=False)
+    def __init__(
+        self,
+        *,
+        existing: dict,
+        source: str = 'desktop',
+        onboarding_mode: bool = False,
+        onboarding_admitted: bool = False,
+    ) -> None:
+        self.request = SimpleNamespace(uid='uid-1', source=source, onboarding_mode=onboarding_mode)
         self.client_conversation_id = 'desktop-client-id'
         self.conversation_creation_timeout = 120
         self.is_multi_channel = False
+        self.onboarding_admitted = onboarding_admitted
         self.persistence = SimpleNamespace(call=self._call)
         self.existing = existing
 
@@ -87,6 +96,24 @@ async def test_client_id_session_keeps_same_source_idempotency_path():
     controller.create_new_in_progress_conversation.assert_awaited_once_with()
 
 
+async def test_admitted_onboarding_session_does_not_pair_client_id_with_live_capture():
+    host = _Host(
+        existing={
+            'id': 'omi-conversation',
+            'source': 'omi',
+            'finished_at': datetime.now(timezone.utc),
+        },
+        onboarding_mode=True,
+        onboarding_admitted=True,
+    )
+    controller = LiveConversationController(host)
+    controller.create_new_in_progress_conversation = AsyncMock()
+
+    await controller.prepare()
+
+    controller.create_new_in_progress_conversation.assert_awaited_once_with()
+
+
 def test_transcript_writer_recognizes_pair_from_conversation_source_in_either_order():
     processor = object.__new__(TranscriptProcessor)
     processor.host = SimpleNamespace(
@@ -99,3 +126,30 @@ def test_transcript_writer_recognizes_pair_from_conversation_source_in_either_or
     processor.host.request.source = 'omi'
     assert processor._is_shared_capture('desktop') is True
     assert processor._is_shared_capture('web') is False
+
+
+class _RegisteredSession:
+    def __init__(self, uid: str, conversation_id: str) -> None:
+        self.request = SimpleNamespace(uid=uid)
+        self.state = SimpleNamespace(current_conversation_id=conversation_id)
+        self.shared_capture = False
+
+
+def test_shared_capture_marker_reaches_active_peer_and_clears_after_last_socket():
+    first = _RegisteredSession('registry-user', 'paired-conversation')
+    second = _RegisteredSession('registry-user', 'paired-conversation')
+    registry.register(first)
+    registry.register(second)
+    try:
+        registry.mark_shared_capture('registry-user', 'paired-conversation')
+
+        assert first.shared_capture is True
+        assert second.shared_capture is True
+        assert registry.is_shared_capture('registry-user', 'paired-conversation') is True
+        registry.unregister(first)
+        assert registry.has_shared_capture_peer('registry-user', 'paired-conversation') is True
+    finally:
+        registry.unregister(first)
+        registry.unregister(second)
+
+    assert registry.is_shared_capture('registry-user', 'paired-conversation') is False

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -133,6 +133,20 @@ def test_shared_capture_marker_survives_binding_and_lifecycle_events(recording_s
     assert event['shared_capture'] is True
 
 
+def test_existing_recording_session_is_promoted_to_shared_capture(recording_store):
+    recording_sessions.create_or_get_recording_session(
+        'uid', 'desktop-session', 'omi-conversation', firestore_client=recording_store
+    )
+
+    binding = recording_sessions.create_or_get_recording_session(
+        'uid', 'desktop-session', 'omi-conversation', shared_capture=True, firestore_client=recording_store
+    )
+
+    assert binding['shared_capture'] is True
+    stored = recording_sessions.get_recording_session('uid', 'desktop-session', firestore_client=recording_store)
+    assert stored is not None and stored['shared_capture'] is True
+
+
 def test_shared_capture_marker_is_persisted_on_canonical_conversation(recording_store):
     path = ('users', 'uid', 'conversations', 'omi-conversation')
     recording_store.documents[path] = {'id': 'omi-conversation', 'source': 'omi'}
@@ -460,6 +474,22 @@ def test_shadow_mode_emits_legacy_envelope_when_durable_event_write_fails(monkey
         'shared_capture': False,
     }
     assert fallbacks[0]['to_mode'] == 'legacy_pointer'
+
+
+def test_shadow_mode_preserves_shared_capture_on_legacy_event_fallback(monkeypatch):
+    def fail(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError('unavailable')
+
+    monkeypatch.setattr(lifecycle_service, 'recording_session_mode', lambda: 'shadow')
+    monkeypatch.setattr(lifecycle_service.recording_sessions_db, 'record_lifecycle_event', fail)
+    monkeypatch.setattr(lifecycle_service, 'record_fallback', lambda **_kwargs: None)
+
+    event = lifecycle_service.record_recording_session_event(
+        'uid', 'session', 'conversation', 'processing', shared_capture=True
+    )
+
+    assert event is not None and event['shared_capture'] is True
 
 
 # ── Reuse the lifecycle-owner's conversation read instead of re-reading it ──

--- a/backend/tests/unit/test_recording_sessions.py
+++ b/backend/tests/unit/test_recording_sessions.py
@@ -119,6 +119,31 @@ def test_retry_keeps_one_canonical_recording_session_binding(recording_store):
     assert len(recording_store.documents) == 1
 
 
+def test_shared_capture_marker_survives_binding_and_lifecycle_events(recording_store):
+    binding = recording_sessions.create_or_get_recording_session(
+        'uid', 'desktop-session', 'omi-conversation', shared_capture=True, firestore_client=recording_store
+    )
+    event = recording_sessions.record_lifecycle_event(
+        'uid', 'desktop-session', 'omi-conversation', 'processing', firestore_client=recording_store
+    )
+    stored = recording_sessions.get_recording_session('uid', 'desktop-session', firestore_client=recording_store)
+
+    assert binding['shared_capture'] is True
+    assert stored is not None and stored['shared_capture'] is True
+    assert event['shared_capture'] is True
+
+
+def test_shared_capture_marker_is_persisted_on_canonical_conversation(recording_store):
+    path = ('users', 'uid', 'conversations', 'omi-conversation')
+    recording_store.documents[path] = {'id': 'omi-conversation', 'source': 'omi'}
+
+    assert (
+        conversations_db.mark_conversation_shared_capture('uid', 'omi-conversation', firestore_client=recording_store)
+        is True
+    )
+    assert recording_store.documents[path]['shared_capture'] is True
+
+
 def test_completed_retry_returns_its_canonical_terminal_envelope(recording_store):
     recording_sessions.create_or_get_recording_session(
         'uid', 'recording-one', 'conversation-one', firestore_client=recording_store
@@ -404,6 +429,7 @@ def test_dual_write_mismatch_keeps_legacy_processing_and_completion_events(recor
         'lifecycle_version': None,
         'lifecycle_phase': None,
         'lifecycle_sequence': None,
+        'shared_capture': False,
     }
     assert processing == expected_legacy_envelope
     assert completed == expected_legacy_envelope
@@ -431,6 +457,7 @@ def test_shadow_mode_emits_legacy_envelope_when_durable_event_write_fails(monkey
         'lifecycle_version': None,
         'lifecycle_phase': None,
         'lifecycle_sequence': None,
+        'shared_capture': False,
     }
     assert fallbacks[0]['to_mode'] == 'legacy_pointer'
 

--- a/backend/tests/unit/test_transcribe_decisions.py
+++ b/backend/tests/unit/test_transcribe_decisions.py
@@ -217,9 +217,11 @@ def test_conversation_lifecycle_actions():
     )
 
 
-def test_cross_source_in_progress_must_not_attach():
+def test_source_pairing_allows_only_omi_desktop_cross_source_capture():
     assert should_attach_to_existing_in_progress(existing_source='omi', request_source='omi') is True
     assert should_attach_to_existing_in_progress(existing_source='omi', request_source=None) is True
+    assert should_attach_to_existing_in_progress(existing_source='omi', request_source='desktop') is True
+    assert should_attach_to_existing_in_progress(existing_source='desktop', request_source='omi') is True
     assert should_attach_to_existing_in_progress(existing_source='omi', request_source='web') is False
     assert should_attach_to_existing_in_progress(existing_source='web', request_source='desktop') is False
     assert should_attach_to_existing_in_progress(existing_source=None, request_source='') is True

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -116,6 +116,15 @@ def test_short_overlapping_phrase_is_not_deduped():
     assert len(segments) == 2
 
 
+def test_compact_script_sentence_is_deduped_without_word_separators():
+    existing = _segment('これは重複する文章です。', speaker='SPEAKER_00', start=10.0, end=13.0)
+    incoming = _segment('これは重複する文章です。', speaker='SPEAKER_01', start=10.5, end=13.4)
+
+    segments, _, _ = TranscriptSegment.combine_segments([existing], [incoming], deduplicate_overlapping=True)
+
+    assert len(segments) == 1
+
+
 def test_non_overlapping_duplicate_text_is_preserved():
     existing = _segment(
         "The project review is scheduled for tomorrow morning.",

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -83,6 +83,58 @@ def test_updated_segments_returned_for_existing_merge():
     assert _concat_segments(segments) == input_concat
 
 
+def test_overlapping_duplicate_long_segment_from_paired_capture_is_dropped():
+    existing = _segment(
+        "The project review is scheduled for tomorrow morning.",
+        speaker="SPEAKER_00",
+        start=10.0,
+        end=13.0,
+    )
+    incoming = _segment(
+        "The project review is scheduled for tomorrow morning.",
+        speaker="SPEAKER_01",
+        start=10.6,
+        end=13.4,
+    )
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments(
+        [existing], [incoming], deduplicate_overlapping=True
+    )
+
+    assert len(segments) == 1
+    assert segments[0].text == existing.text
+    assert updated_segments == []
+    assert removed_ids == []
+
+
+def test_short_overlapping_phrase_is_not_deduped():
+    existing = _segment("Okay.", speaker="SPEAKER_00", start=10.0, end=11.0)
+    incoming = _segment("Okay.", speaker="SPEAKER_01", start=10.4, end=11.2)
+
+    segments, _, _ = TranscriptSegment.combine_segments([existing], [incoming], deduplicate_overlapping=True)
+
+    assert len(segments) == 2
+
+
+def test_non_overlapping_duplicate_text_is_preserved():
+    existing = _segment(
+        "The project review is scheduled for tomorrow morning.",
+        speaker="SPEAKER_00",
+        start=10.0,
+        end=13.0,
+    )
+    incoming = _segment(
+        "The project review is scheduled for tomorrow morning.",
+        speaker="SPEAKER_01",
+        start=20.0,
+        end=23.0,
+    )
+
+    segments, _, _ = TranscriptSegment.combine_segments([existing], [incoming], deduplicate_overlapping=True)
+
+    assert len(segments) == 2
+
+
 def test_forward_merge_trims_completed_prefix():
     a = _segment("First sentence. trailing", speaker="SPEAKER_00", start=0.0, end=4.0)
     b = _segment("continue here.", speaker="SPEAKER_01", start=4.0, end=6.0)

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -411,6 +411,7 @@ def open_recording_session(
     recording_session_id: str,
     proposed_conversation_id: str,
     *,
+    shared_capture: bool = False,
     firestore_client: Any = None,
 ) -> dict[str, Any]:
     """Open or resume a durable session through the single lifecycle owner.
@@ -423,6 +424,7 @@ def open_recording_session(
             uid,
             recording_session_id,
             proposed_conversation_id,
+            shared_capture=shared_capture,
             firestore_client=firestore_client,
         )
     except Exception:
@@ -448,6 +450,7 @@ def open_recording_session(
             'lifecycle_phase': None,
             'lifecycle_sequence': None,
             'mapping_conflict': False,
+            'shared_capture': shared_capture,
         }
     if binding['mapping_conflict']:
         record_fallback(
@@ -517,6 +520,7 @@ def record_recording_session_event(
             'lifecycle_version': None,
             'lifecycle_phase': None,
             'lifecycle_sequence': None,
+            'shared_capture': False,
         }
     if event['accepted']:
         return dict(event)
@@ -545,6 +549,7 @@ def record_recording_session_event(
             'lifecycle_version': None,
             'lifecycle_phase': None,
             'lifecycle_sequence': None,
+            'shared_capture': False,
         }
     return None
 
@@ -645,6 +650,7 @@ def open_live_recording_session(
     recording_session_id: str,
     proposed_conversation_id: str,
     *,
+    shared_capture: bool = False,
     firestore_client: Any = None,
 ) -> dict[str, Any]:
     """Open a live binding or require a fresh generation for a missing old row.
@@ -662,8 +668,24 @@ def open_live_recording_session(
         uid,
         recording_session_id,
         proposed_conversation_id,
+        shared_capture=shared_capture,
         firestore_client=firestore_client,
     )
+    if shared_capture and not binding['mapping_conflict']:
+        try:
+            conversations_db.mark_conversation_shared_capture(
+                uid,
+                binding['conversation_id'],
+                firestore_client=firestore_client,
+            )
+        except Exception:
+            # The session marker still protects the joining client, and the
+            # transcript writer also recognizes the explicit Omi/desktop pair.
+            logger.exception(
+                'shared capture marker persistence failed uid=%s conversation=%s',
+                uid,
+                binding['conversation_id'],
+            )
     if existing is None:
         return dict(binding) | {'requires_rollover': False}
 

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -487,6 +487,7 @@ def record_recording_session_event(
     conversation_id: str,
     phase: recording_sessions_db.RecordingPhase,
     *,
+    shared_capture: bool = False,
     firestore_client: Any = None,
 ) -> dict[str, Any] | None:
     """Persist and return an ordered client envelope, discarding stale callbacks."""
@@ -520,7 +521,7 @@ def record_recording_session_event(
             'lifecycle_version': None,
             'lifecycle_phase': None,
             'lifecycle_sequence': None,
-            'shared_capture': False,
+            'shared_capture': shared_capture,
         }
     if event['accepted']:
         return dict(event)
@@ -549,7 +550,7 @@ def record_recording_session_event(
             'lifecycle_version': None,
             'lifecycle_phase': None,
             'lifecycle_sequence': None,
-            'shared_capture': False,
+            'shared_capture': shared_capture,
         }
     return None
 

--- a/backend/utils/transcribe_decisions.py
+++ b/backend/utils/transcribe_decisions.py
@@ -186,18 +186,35 @@ def normalize_listen_source(value: Optional[str]) -> str:
     return ConversationSource(value.strip()).value
 
 
+def should_pair_omi_desktop_capture(
+    *,
+    existing_source: Optional[str],
+    request_source: Optional[str],
+) -> bool:
+    """Return whether two live sources are the explicit paired-capture case."""
+    existing = normalize_listen_source(existing_source)
+    request = normalize_listen_source(request_source)
+    return {existing, request} == {'omi', 'desktop'}
+
+
 def should_attach_to_existing_in_progress(
     *,
     existing_source: Optional[str],
     request_source: Optional[str],
 ) -> bool:
-    """Resume only when the live pointer and this socket share a source (#5388).
+    """Resume compatible live captures without merging unrelated sources (#5388).
 
     Device + web (or any other cross-source pair) must each own a conversation.
-    Attaching the second socket to the first pointer silently merges two audio
-    streams into one session and loses the web recording on stop.
+    The Omi device and the macOS desktop are the one intentional cross-source
+    exception: they are two clients for the same capture, so keeping a shared
+    conversation avoids presenting duplicate memories for one recording.
     """
-    return normalize_listen_source(existing_source) == normalize_listen_source(request_source)
+    existing = normalize_listen_source(existing_source)
+    request = normalize_listen_source(request_source)
+    return existing == request or should_pair_omi_desktop_capture(
+        existing_source=existing_source,
+        request_source=request_source,
+    )
 
 
 def decide_lifecycle_action(

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -97,11 +97,16 @@ enum DesktopConversationMatchPolicy {
     incomingBackendId: String,
     expectedBackendId: String? = nil,
     activeBackendId: String?,
-    ignoredRotatedBackendIds: Set<String>
+    ignoredRotatedBackendIds: Set<String>,
+    recordingSessionId: String? = nil,
+    sharedCapture: Bool = false
   ) -> Bool {
     guard !incomingBackendId.isEmpty else { return false }
     if let expectedBackendId, !expectedBackendId.isEmpty, incomingBackendId != expectedBackendId {
-      return false
+      // A paired capture has one durable recording-session identity but may be
+      // bound to the conversation opened by the other client. The session id
+      // is the proof; an unmarked or unrelated mismatch remains rejected.
+      guard sharedCapture, recordingSessionId == expectedBackendId else { return false }
     }
     if let activeBackendId, !activeBackendId.isEmpty {
       return incomingBackendId == activeBackendId
@@ -139,10 +144,14 @@ enum DesktopConversationMatchPolicy {
   static func lifecycleEventBelongsToRecording(
     memoryId: String,
     recordingSessionId: String?,
-    expectedBackendId: String?
+    expectedBackendId: String?,
+    sharedCapture: Bool = false
   ) -> Bool {
     guard let expectedBackendId, !expectedBackendId.isEmpty else { return true }
-    guard memoryId == expectedBackendId else { return false }
+    if memoryId != expectedBackendId {
+      guard sharedCapture, recordingSessionId == expectedBackendId else { return false }
+      return true
+    }
     return recordingSessionId == nil || recordingSessionId == expectedBackendId
   }
 
@@ -155,21 +164,23 @@ enum DesktopConversationMatchPolicy {
     memory: [String: Any]?,
     recordingSessionId: String?,
     expectedBackendId: String?,
-    finishedRecordingStartTime: Date?
+    finishedRecordingStartTime: Date?,
+    sharedCapture: Bool = false
   ) -> Bool {
     guard !memoryId.isEmpty, memoryId != "?" else { return false }
     guard
       lifecycleEventBelongsToRecording(
         memoryId: memoryId,
         recordingSessionId: recordingSessionId,
-        expectedBackendId: expectedBackendId
+        expectedBackendId: expectedBackendId,
+        sharedCapture: sharedCapture
       )
     else {
       return false
     }
 
     if let expectedBackendId, !expectedBackendId.isEmpty {
-      return memoryId == expectedBackendId
+      return memoryId == expectedBackendId || sharedCapture
     }
 
     guard let finishedRecordingStartTime else { return false }
@@ -180,7 +191,8 @@ enum DesktopConversationMatchPolicy {
     memoryId: String,
     memory: [String: Any]?,
     recordingSessionId: String?,
-    pending: [FinishedRecordingEnvelope]
+    pending: [FinishedRecordingEnvelope],
+    sharedCapture: Bool = false
   ) -> Int? {
     pending.firstIndex { envelope in
       acceptsCompletedLocalRecording(
@@ -188,7 +200,8 @@ enum DesktopConversationMatchPolicy {
         memory: memory,
         recordingSessionId: recordingSessionId,
         expectedBackendId: envelope.clientConversationId,
-        finishedRecordingStartTime: envelope.startedAt
+        finishedRecordingStartTime: envelope.startedAt,
+        sharedCapture: sharedCapture
       )
     }
   }
@@ -204,7 +217,8 @@ enum DesktopConversationMatchPolicy {
     lifecycleSequence: Int?,
     expectedLifecyclePhase: String,
     expectedBackendId: String?,
-    lastAcceptedSequence: Int?
+    lastAcceptedSequence: Int?,
+    sharedCapture: Bool = false
   ) -> Bool {
     guard lifecycleVersion != nil || lifecycleSequence != nil else { return true }
     guard lifecycleVersion == 1,
@@ -215,7 +229,8 @@ enum DesktopConversationMatchPolicy {
       lifecycleSequence >= 0
     else { return false }
     if let expectedBackendId, !expectedBackendId.isEmpty {
-      guard recordingSessionId == expectedBackendId, conversationId == expectedBackendId else { return false }
+      guard recordingSessionId == expectedBackendId else { return false }
+      guard conversationId == expectedBackendId || sharedCapture else { return false }
     }
     guard let lastAcceptedSequence else { return true }
     return lifecycleSequence > lastAcceptedSequence
@@ -225,9 +240,12 @@ enum DesktopConversationMatchPolicy {
     id conversationId: String,
     boundBackendId: String,
     status: ConversationStatus,
-    source: ConversationSource?
+    source: ConversationSource?,
+    localSource: ConversationSource? = nil
   ) -> Bool {
-    conversationId == boundBackendId && source == .desktop && status != .inProgress
+    conversationId == boundBackendId
+      && (source == .desktop || (localSource == .desktop && source == .omi))
+      && status != .inProgress
   }
 
   static func shouldFinalizeTimestampMatchedConversation(status: ConversationStatus) -> Bool {
@@ -582,7 +600,11 @@ class AppState: ObservableObject {
   /// The UUID created by desktop before opening an identified `/v4/listen` stream.
   /// In the current compatible protocol it is also the backend conversation id.
   var currentClientConversationId: String?
+  /// True when the backend bound this recording to a paired capture owned by
+  /// another client. The recording-session id remains the local identity.
+  var currentBackendConversationIsShared = false
   var pendingBackendConversationId: String?
+  var pendingBackendConversationIsShared = false
   /// Last accepted server event sequence per durable recording session. This
   /// is display state only; Firestore remains the authoritative sequence owner.
   var lifecycleSequenceByRecordingSession: [String: Int] = [:]

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -604,7 +604,6 @@ class AppState: ObservableObject {
   /// another client. The recording-session id remains the local identity.
   var currentBackendConversationIsShared = false
   var pendingBackendConversationId: String?
-  var pendingBackendConversationIsShared = false
   /// Last accepted server event sequence per durable recording session. This
   /// is display state only; Firestore remains the authoritative sequence owner.
   var lifecycleSequenceByRecordingSession: [String: Int] = [:]

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -237,13 +237,19 @@ extension AppState {
     }
   }
 
-  func bindActiveSessionToBackendConversation(_ backendId: String) {
+  func bindActiveSessionToBackendConversation(
+    _ backendId: String,
+    recordingSessionId: String? = nil,
+    sharedCapture: Bool = false
+  ) {
     guard
       DesktopConversationMatchPolicy.shouldBindConversationSession(
         incomingBackendId: backendId,
         expectedBackendId: currentClientConversationId,
         activeBackendId: currentBackendConversationId,
-        ignoredRotatedBackendIds: ignoredRotatedBackendConversationIds
+        ignoredRotatedBackendIds: ignoredRotatedBackendConversationIds,
+        recordingSessionId: recordingSessionId,
+        sharedCapture: sharedCapture
       )
     else {
       pendingBackendConversationId = nil
@@ -262,17 +268,25 @@ extension AppState {
 
     ignoredRotatedBackendConversationIds = []
     currentBackendConversationId = backendId
+    let acceptedSharedCapture = currentBackendConversationIsShared || sharedCapture
+    currentBackendConversationIsShared = acceptedSharedCapture
 
     guard let sessionId = currentSessionId else {
       pendingBackendConversationId = backendId
+      pendingBackendConversationIsShared = acceptedSharedCapture
       log("Transcription: Deferred backend conversation bind until local DB session exists (backend: \(backendId))")
       return
     }
 
     pendingBackendConversationId = nil
+    pendingBackendConversationIsShared = false
     Task {
       do {
-        try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+        try await TranscriptionStorage.shared.bindBackendConversation(
+          id: sessionId,
+          backendId: backendId,
+          adoptAsClientConversationId: acceptedSharedCapture
+        )
       } catch {
         logError(
           "Transcription: Failed to bind DB session \(sessionId) to backend conversation \(backendId)", error: error)
@@ -293,6 +307,7 @@ extension AppState {
     let lifecycleVersion = event.raw["lifecycle_version"] as? Int
     let lifecyclePhase = event.raw["lifecycle_phase"] as? String
     let lifecycleSequence = event.raw["lifecycle_sequence"] as? Int
+    let sharedCapture = event.raw["shared_capture"] as? Bool ?? false
     let lastAcceptedSequence = recordingSessionId.flatMap { lifecycleSequenceByRecordingSession[$0] }
     guard
       DesktopConversationMatchPolicy.acceptsLifecycleEnvelope(
@@ -303,7 +318,8 @@ extension AppState {
         lifecycleSequence: lifecycleSequence,
         expectedLifecyclePhase: expectedLifecyclePhase,
         expectedBackendId: expectedBackendId,
-        lastAcceptedSequence: lastAcceptedSequence
+        lastAcceptedSequence: lastAcceptedSequence,
+        sharedCapture: sharedCapture
       )
     else {
       log("Transcription: Ignoring stale or misbound versioned lifecycle event for \(conversationId)")
@@ -351,7 +367,11 @@ extension AppState {
       else {
         break
       }
-      bindActiveSessionToBackendConversation(backendId)
+      bindActiveSessionToBackendConversation(
+        backendId,
+        recordingSessionId: event.raw["recording_session_id"] as? String,
+        sharedCapture: event.raw["shared_capture"] as? Bool ?? false
+      )
 
     case "memory_processing_started":
       // ConversationEvent: conversation is nested under "memory"
@@ -373,7 +393,8 @@ extension AppState {
         DesktopConversationMatchPolicy.lifecycleEventBelongsToRecording(
           memoryId: processingId,
           recordingSessionId: recordingSessionId,
-          expectedBackendId: currentClientConversationId
+          expectedBackendId: currentClientConversationId,
+          sharedCapture: event.raw["shared_capture"] as? Bool ?? false
         )
       else {
         log("Transcription: Ignoring stale memory_processing_started \(processingId) for current recording")
@@ -398,7 +419,8 @@ extension AppState {
           memoryId: memoryId,
           memory: memory,
           recordingSessionId: recordingSessionId,
-          pending: pendingFinishedRecordings
+          pending: pendingFinishedRecordings,
+          sharedCapture: event.raw["shared_capture"] as? Bool ?? false
         )
       else {
         log("Transcription: Ignoring memory_created \(memoryId); no matching finished local recording")

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -273,13 +273,11 @@ extension AppState {
 
     guard let sessionId = currentSessionId else {
       pendingBackendConversationId = backendId
-      pendingBackendConversationIsShared = acceptedSharedCapture
       log("Transcription: Deferred backend conversation bind until local DB session exists (backend: \(backendId))")
       return
     }
 
     pendingBackendConversationId = nil
-    pendingBackendConversationIsShared = false
     Task {
       do {
         try await TranscriptionStorage.shared.bindBackendConversation(
@@ -408,6 +406,7 @@ extension AppState {
       let memory = event.raw["memory"] as? [String: Any]
       let memoryId = memory?["id"] as? String ?? "?"
       let recordingSessionId = event.raw["recording_session_id"] as? String
+      let sharedCapture = event.raw["shared_capture"] as? Bool ?? false
       log("Transcription: Backend created conversation: \(memoryId)")
 
       // Mark DB session as completed so TranscriptionRetryService won't re-upload.
@@ -420,7 +419,7 @@ extension AppState {
           memory: memory,
           recordingSessionId: recordingSessionId,
           pending: pendingFinishedRecordings,
-          sharedCapture: event.raw["shared_capture"] as? Bool ?? false
+          sharedCapture: sharedCapture
         )
       else {
         log("Transcription: Ignoring memory_created \(memoryId); no matching finished local recording")
@@ -448,7 +447,10 @@ extension AppState {
         Task {
           do {
             try await TranscriptionStorage.shared.markSessionCompleted(
-              id: sessionId, backendId: memoryId)
+              id: sessionId,
+              backendId: memoryId,
+              emitCreationTelemetry: !sharedCapture
+            )
             log("Transcription: Marked DB session \(sessionId) completed (backend: \(memoryId))")
           } catch {
             logError(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -227,6 +227,8 @@ extension AppState {
       recordingStartTime = Date()
       currentBackendConversationId = nil
       pendingBackendConversationId = nil
+      currentBackendConversationIsShared = false
+      pendingBackendConversationIsShared = false
       ignoredRotatedBackendConversationIds = []
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
@@ -294,10 +296,17 @@ extension AppState {
               incomingBackendId: candidate,
               expectedBackendId: self.currentClientConversationId,
               activeBackendId: self.currentBackendConversationId,
-              ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds
+              ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds,
+              recordingSessionId: self.currentBackendConversationIsShared
+                ? self.currentClientConversationId : nil,
+              sharedCapture: self.currentBackendConversationIsShared
             ) ? candidate : nil
           }) {
-            try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+            try await TranscriptionStorage.shared.bindBackendConversation(
+              id: sessionId,
+              backendId: backendId,
+              adoptAsClientConversationId: self.currentBackendConversationIsShared
+            )
             await MainActor.run {
               self.currentBackendConversationId = backendId
               self.pendingBackendConversationId = nil
@@ -1001,6 +1010,7 @@ extension AppState {
     // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil).
     let capturedSessionId = currentSessionId
     let capturedBackendId = currentBackendConversationId ?? pendingBackendConversationId
+    let capturedSharedCapture = currentBackendConversationIsShared || pendingBackendConversationIsShared
     captureCurrentFinishedRecordingForLifecycle()
     stopAudioCapture()
     clearTranscriptionState(
@@ -1016,7 +1026,11 @@ extension AppState {
         var persistedBackendId: String?
         if let backendId = capturedBackendId, !backendId.isEmpty {
           do {
-            try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+            try await TranscriptionStorage.shared.bindBackendConversation(
+              id: sessionId,
+              backendId: backendId,
+              adoptAsClientConversationId: capturedSharedCapture
+            )
             persistedBackendId = try await TranscriptionStorage.shared.getSession(id: sessionId)?.backendId
           } catch {
             logError(
@@ -1214,6 +1228,8 @@ extension AppState {
     }
     currentBackendConversationId = nil
     currentClientConversationId = nil
+    currentBackendConversationIsShared = false
+    pendingBackendConversationIsShared = false
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
 
@@ -1392,10 +1408,17 @@ extension AppState {
             incomingBackendId: candidate,
             expectedBackendId: self.currentClientConversationId,
             activeBackendId: self.currentBackendConversationId,
-            ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds
+            ignoredRotatedBackendIds: self.ignoredRotatedBackendConversationIds,
+            recordingSessionId: self.currentBackendConversationIsShared
+              ? self.currentClientConversationId : nil,
+            sharedCapture: self.currentBackendConversationIsShared
           ) ? candidate : nil
         }) {
-          try await TranscriptionStorage.shared.bindBackendConversation(id: sessionId, backendId: backendId)
+          try await TranscriptionStorage.shared.bindBackendConversation(
+            id: sessionId,
+            backendId: backendId,
+            adoptAsClientConversationId: self.currentBackendConversationIsShared
+          )
           await MainActor.run {
             guard self.isTranscribing, self.recordingGeneration == sessionGeneration else { return }
             self.currentBackendConversationId = backendId

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -228,7 +228,6 @@ extension AppState {
       currentBackendConversationId = nil
       pendingBackendConversationId = nil
       currentBackendConversationIsShared = false
-      pendingBackendConversationIsShared = false
       ignoredRotatedBackendConversationIds = []
       AudioLevelMonitor.shared.reset()
       RecordingTimer.shared.start()
@@ -1010,7 +1009,7 @@ extension AppState {
     // Capture session metadata BEFORE clearing state (clearTranscriptionState sets sessionId to nil).
     let capturedSessionId = currentSessionId
     let capturedBackendId = currentBackendConversationId ?? pendingBackendConversationId
-    let capturedSharedCapture = currentBackendConversationIsShared || pendingBackendConversationIsShared
+    let capturedSharedCapture = currentBackendConversationIsShared
     captureCurrentFinishedRecordingForLifecycle()
     stopAudioCapture()
     clearTranscriptionState(
@@ -1229,7 +1228,6 @@ extension AppState {
     currentBackendConversationId = nil
     currentClientConversationId = nil
     currentBackendConversationIsShared = false
-    pendingBackendConversationIsShared = false
     pendingBackendConversationId = nil
     RecordingTimer.shared.restart()
 

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -418,7 +418,10 @@ actor ConversationFinalizationService {
         try await TranscriptionStorage.shared.markSessionCompleted(
           id: sessionId,
           backendId: conversation.id,
-          conversationStatus: status
+          conversationStatus: status,
+          emitCreationTelemetry: !(
+            conversation.source == .omi && ConversationSource(rawValue: session.source) == .desktop
+          )
         )
         log("ConversationFinalization: Finalized cloud session \(sessionId) by backend id \(conversation.id)")
         return nil
@@ -619,7 +622,8 @@ actor ConversationFinalizationService {
       id: sessionId,
       backendId: conversation.id,
       conversationStatus: status,
-      allowBackendIdOverride: allowBackendIdOverride
+      allowBackendIdOverride: allowBackendIdOverride,
+      emitCreationTelemetry: !(conversation.source == .omi && localSource == .desktop)
     )
     log("ConversationFinalization: Reconciled cloud session \(sessionId) by conversation id \(conversation.id)")
     return true

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -393,7 +393,8 @@ actor ConversationFinalizationService {
           id: clientConversationId,
           sessionId: sessionId,
           allowForceProcess: allowForceProcess,
-          allowBackendIdOverride: true
+          allowBackendIdOverride: true,
+          localSource: ConversationSource(rawValue: session.source)
         ) {
           return nil
         }
@@ -410,7 +411,8 @@ actor ConversationFinalizationService {
         id: conversation.id,
         boundBackendId: backendId,
         status: conversation.status,
-        source: conversation.source
+        source: conversation.source,
+        localSource: ConversationSource(rawValue: session.source)
       ) {
         let status = LocalConversationStatus(rawValue: conversation.status.rawValue) ?? .processing
         try await TranscriptionStorage.shared.markSessionCompleted(
@@ -428,7 +430,8 @@ actor ConversationFinalizationService {
       if try await completeCloudConversation(
         id: clientConversationId,
         sessionId: sessionId,
-        allowForceProcess: true
+        allowForceProcess: true,
+        localSource: ConversationSource(rawValue: session.source)
       ) {
         return nil
       }
@@ -477,7 +480,8 @@ actor ConversationFinalizationService {
         if try await completeCloudConversation(
           id: clientConversationId,
           sessionId: sessionId,
-          allowForceProcess: true
+          allowForceProcess: true,
+          localSource: ConversationSource(rawValue: session.source)
         ) {
           return nil
         }
@@ -584,7 +588,8 @@ actor ConversationFinalizationService {
     id conversationId: String,
     sessionId: Int64,
     allowForceProcess: Bool,
-    allowBackendIdOverride: Bool = false
+    allowBackendIdOverride: Bool = false,
+    localSource: ConversationSource? = nil
   ) async throws -> Bool {
     let conversation: ServerConversation
     do {
@@ -602,7 +607,8 @@ actor ConversationFinalizationService {
         id: conversation.id,
         boundBackendId: conversationId,
         status: conversation.status,
-        source: conversation.source
+        source: conversation.source,
+        localSource: localSource
       )
     else {
       return false

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -1430,6 +1430,7 @@ public enum OmiAPI {
     public let processingMemoryId: String?
     public let processingState: ConversationProcessingState?
     public let screenshotSharingEnabled: Bool?
+    public let sharedCapture: Bool?
     public let source: ConversationSource?
     public let starred: Bool?
     public let startedAt: String?
@@ -1475,6 +1476,7 @@ public enum OmiAPI {
       case processingMemoryId = "processing_memory_id"
       case processingState = "processing_state"
       case screenshotSharingEnabled = "screenshot_sharing_enabled"
+      case sharedCapture = "shared_capture"
       case source
       case starred
       case startedAt = "started_at"
@@ -1522,6 +1524,7 @@ public enum OmiAPI {
       processingMemoryId = try c.decodeIfPresent(String.self, forKey: .processingMemoryId)
       processingState = try c.decodeIfPresent(ConversationProcessingState.self, forKey: .processingState)
       screenshotSharingEnabled = try c.decodeIfPresent(Bool.self, forKey: .screenshotSharingEnabled)
+      sharedCapture = try c.decodeIfPresent(Bool.self, forKey: .sharedCapture)
       source = try c.decodeIfPresent(ConversationSource.self, forKey: .source)
       starred = try c.decodeIfPresent(Bool.self, forKey: .starred)
       startedAt = try c.decodeIfPresent(String.self, forKey: .startedAt)
@@ -1535,7 +1538,7 @@ public enum OmiAPI {
       visibility = try c.decodeIfPresent(ConversationVisibility.self, forKey: .visibility)
     }
 
-    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, clientProcessing: ClientProcessing? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, imported: Bool? = nil, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, processingState: ConversationProcessingState? = nil, screenshotSharingEnabled: Bool? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
+    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, clientProcessing: ClientProcessing? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, imported: Bool? = nil, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, processingState: ConversationProcessingState? = nil, screenshotSharingEnabled: Bool? = nil, sharedCapture: Bool? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
       self.appId = appId
       self.appsResults = appsResults
       self.audioFiles = audioFiles
@@ -1568,6 +1571,7 @@ public enum OmiAPI {
       self.processingMemoryId = processingMemoryId
       self.processingState = processingState
       self.screenshotSharingEnabled = screenshotSharingEnabled
+      self.sharedCapture = sharedCapture
       self.source = source
       self.starred = starred
       self.startedAt = startedAt

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -219,7 +219,8 @@ actor TranscriptionStorage {
     id: Int64,
     backendId: String,
     conversationStatus: LocalConversationStatus = .completed,
-    allowBackendIdOverride: Bool = false
+    allowBackendIdOverride: Bool = false,
+    emitCreationTelemetry: Bool = true
   ) async throws -> Bool {
     let db = try await ensureInitialized()
 
@@ -253,7 +254,7 @@ actor TranscriptionStorage {
       record.updatedAt = completedAt
       try record.update(database)
       let telemetry =
-        wasAlreadyCompleted
+        wasAlreadyCompleted || !emitCreationTelemetry
         ? nil : ConversationCreatedTelemetry(session: record, conversationId: backendId)
       return (true, telemetry)
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/TranscriptionStorage.swift
@@ -135,7 +135,11 @@ actor TranscriptionStorage {
 
   /// Bind a local recording session to the backend conversation id announced by `/v4/listen`.
   /// This is not completion: the backend conversation may still be `in_progress` until stop/finalize.
-  func bindBackendConversation(id: Int64, backendId: String) async throws {
+  func bindBackendConversation(
+    id: Int64,
+    backendId: String,
+    adoptAsClientConversationId: Bool = false
+  ) async throws {
     let db = try await ensureInitialized()
 
     try await db.write { database in
@@ -151,6 +155,16 @@ actor TranscriptionStorage {
       }
 
       record.backendId = backendId
+      if adoptAsClientConversationId,
+        let clientConversationId = record.clientConversationId,
+        !clientConversationId.isEmpty,
+        clientConversationId != backendId
+      {
+        // A shared capture may use the other client's canonical conversation
+        // id. Keep the local recording pointed at that id for crash recovery
+        // and finalization; the recording-session id remains the event proof.
+        record.clientConversationId = backendId
+      }
       record.conversationStatus = .inProgress
       record.updatedAt = Date()
       try record.update(database)

--- a/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
+++ b/desktop/macos/Desktop/Tests/StopReconciliationTests.swift
@@ -328,6 +328,17 @@ final class StopReconciliationTests: XCTestCase {
       ))
   }
 
+  func testBoundBackendConversationCompletionAcceptsPairedOmiConversationForDesktopSession() {
+    XCTAssertTrue(
+      DesktopConversationMatchPolicy.canCompleteBoundBackendConversation(
+        id: "omi-conversation",
+        boundBackendId: "omi-conversation",
+        status: .completed,
+        source: .omi,
+        localSource: .desktop
+      ))
+  }
+
   func testRecordingSessionWithBackendIdCanStillBeFinishedForRetryReconciliation() {
     var session = TranscriptionSessionRecord(
       source: "desktop",
@@ -374,6 +385,39 @@ final class StopReconciliationTests: XCTestCase {
       ))
   }
 
+  func testSharedCaptureAcceptsCanonicalConversationWithLocalRecordingProof() {
+    XCTAssertTrue(
+      DesktopConversationMatchPolicy.shouldBindConversationSession(
+        incomingBackendId: "omi-conversation",
+        expectedBackendId: "desktop-recording",
+        activeBackendId: nil,
+        ignoredRotatedBackendIds: [],
+        recordingSessionId: "desktop-recording",
+        sharedCapture: true
+      ))
+  }
+
+  func testSharedCaptureRejectsCanonicalConversationWithoutMarkerOrProof() {
+    XCTAssertFalse(
+      DesktopConversationMatchPolicy.shouldBindConversationSession(
+        incomingBackendId: "omi-conversation",
+        expectedBackendId: "desktop-recording",
+        activeBackendId: nil,
+        ignoredRotatedBackendIds: [],
+        recordingSessionId: "desktop-recording",
+        sharedCapture: false
+      ))
+    XCTAssertFalse(
+      DesktopConversationMatchPolicy.shouldBindConversationSession(
+        incomingBackendId: "omi-conversation",
+        expectedBackendId: "desktop-recording",
+        activeBackendId: nil,
+        ignoredRotatedBackendIds: [],
+        recordingSessionId: "other-recording",
+        sharedCapture: true
+      ))
+  }
+
   func testLifecycleEventRejectsStaleRecordingIdentity() {
     XCTAssertFalse(
       DesktopConversationMatchPolicy.lifecycleEventBelongsToRecording(
@@ -398,6 +442,23 @@ final class StopReconciliationTests: XCTestCase {
         memoryId: "recording-conversation",
         recordingSessionId: nil,
         expectedBackendId: "recording-conversation"
+      ))
+  }
+
+  func testSharedLifecycleEventAcceptsCanonicalConversationWithLocalRecordingProof() {
+    XCTAssertTrue(
+      DesktopConversationMatchPolicy.lifecycleEventBelongsToRecording(
+        memoryId: "omi-conversation",
+        recordingSessionId: "desktop-recording",
+        expectedBackendId: "desktop-recording",
+        sharedCapture: true
+      ))
+    XCTAssertFalse(
+      DesktopConversationMatchPolicy.lifecycleEventBelongsToRecording(
+        memoryId: "omi-conversation",
+        recordingSessionId: "other-recording",
+        expectedBackendId: "desktop-recording",
+        sharedCapture: true
       ))
   }
 
@@ -538,6 +599,21 @@ final class StopReconciliationTests: XCTestCase {
         expectedLifecyclePhase: "processing",
         expectedBackendId: "recording-conversation",
         lastAcceptedSequence: 1
+      ))
+  }
+
+  func testVersionedSharedLifecycleEnvelopeAllowsCanonicalConversationId() {
+    XCTAssertTrue(
+      DesktopConversationMatchPolicy.acceptsLifecycleEnvelope(
+        recordingSessionId: "desktop-recording",
+        conversationId: "omi-conversation",
+        lifecycleVersion: 1,
+        lifecyclePhase: "processing",
+        lifecycleSequence: 2,
+        expectedLifecyclePhase: "processing",
+        expectedBackendId: "desktop-recording",
+        lastAcceptedSequence: 1,
+        sharedCapture: true
       ))
   }
 

--- a/desktop/macos/changelog/unreleased/20260911-3244-shared-capture.json
+++ b/desktop/macos/changelog/unreleased/20260911-3244-shared-capture.json
@@ -1,0 +1,3 @@
+{
+  "change": "Avoid duplicate conversations when an Omi device and the macOS app record together."
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1156,6 +1156,7 @@ export interface Conversation {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -1337,6 +1338,7 @@ export interface ConversationSearchItem {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -7426,6 +7426,11 @@
             "title": "Screenshot Sharing Enabled",
             "type": "boolean"
           },
+          "shared_capture": {
+            "default": false,
+            "title": "Shared Capture",
+            "type": "boolean"
+          },
           "source": {
             "anyOf": [
               {
@@ -8527,6 +8532,11 @@
           "screenshot_sharing_enabled": {
             "default": true,
             "title": "Screenshot Sharing Enabled",
+            "type": "boolean"
+          },
+          "shared_capture": {
+            "default": false,
+            "title": "Shared Capture",
             "type": "boolean"
           },
           "source": {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1156,6 +1156,7 @@ export interface Conversation {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -1337,6 +1338,7 @@ export interface ConversationSearchItem {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1156,6 +1156,7 @@ export interface Conversation {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -1337,6 +1338,7 @@ export interface ConversationSearchItem {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1156,6 +1156,7 @@ export interface Conversation {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;
@@ -1337,6 +1338,7 @@ export interface ConversationSearchItem {
   processing_memory_id?: string | null;
   processing_state?: ConversationProcessingState | null;
   screenshot_sharing_enabled?: boolean;
+  shared_capture?: boolean;
   source?: ConversationSource | null;
   starred?: boolean;
   started_at: string | null;


### PR DESCRIPTION
## What changed and why

Fixes #3244 by treating a fresh Omi hardware plus macOS desktop listen pair as
one capture. Both sockets bind to one canonical conversation, and shared-mode
transcript writes conservatively drop substantial same-timeline duplicates while
preserving short backchannels and repeated text at different times.

## Product invariants affected

none

## How it was verified

- `python3.11 -m compileall -q` passed for the changed backend modules.
- The focused backend suites and STT suite passed as listed below.
- Swift sources and regression tests passed `swiftc -frontend -parse` on Linux.
- The macOS `xcrun swift build`/XCTest and pinned Swift formatter could not run
  because this host is Linux and has no `xcrun`/Xcode.

## Tests

- `127 passed`: listen pairing, recording sessions, transcript merging, and
  listen runtime regressions.
- `61 passed`: conversation model and listen lifecycle tests.
- `94 passed`: Modulate STT tests.

## Failure class (fixes)

Failure-Class: none

## Line-count exceptions

Line-Count-Exception: backend/database/conversations.py | 2340 -> 2365 | shared-capture marker transaction
Line-Count-Exception: desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift | 1785 -> 1808 | shared-capture binding and crash-recovery state


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

