### PR TITLE
fix(app): give the live segment write a handle and an order

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:omi/services/capture/capture_controller.dart';
 import 'package:omi/services/capture/local_segment_store.dart';
+import 'package:omi/utils/logger.dart';
 
 class CaptureProvider extends CaptureController {
   CaptureProvider({
@@ -19,6 +20,9 @@ class CaptureProvider extends CaptureController {
 
   final LocalSegmentStore localSegmentStore;
   String? _lastPersistedFingerprint;
+  Future<void> _liveSegmentWrite = Future<void>.value();
+
+  Future<void> get pendingLiveSegmentWrite => _liveSegmentWrite;
 
   void _persistLiveSegments() {
     if (!localSegmentStore.enabled) return;
@@ -30,7 +34,12 @@ class CaptureProvider extends CaptureController {
         .join('\n');
     if (fingerprint == _lastPersistedFingerprint) return;
     _lastPersistedFingerprint = fingerprint;
-    unawaited(localSegmentStore.replaceSession(sessionId, List.of(segments)));
+    final pending = List.of(segments);
+    _liveSegmentWrite =
+        _liveSegmentWrite.then((_) => localSegmentStore.replaceSession(sessionId, pending)).catchError((Object e) {
+      Logger.debug('Error persisting live segments: $e');
+    });
+    unawaited(_liveSegmentWrite);
   }
 
   @override

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -38,6 +38,9 @@ class CaptureProvider extends CaptureController {
     _liveSegmentWrite =
         _liveSegmentWrite.then((_) => localSegmentStore.replaceSession(sessionId, pending)).catchError((Object e) {
       Logger.debug('Error persisting live segments: $e');
+      if (_lastPersistedFingerprint == fingerprint) {
+        _lastPersistedFingerprint = null;
+      }
     });
     unawaited(_liveSegmentWrite);
   }

--- a/app/test/unit/local_segment_store_test.dart
+++ b/app/test/unit/local_segment_store_test.dart
@@ -86,9 +86,26 @@ void main() {
     provider.testSessionStartSeconds = 1700000000;
     provider.segments = [_seg('a', 'I agree', speaker: 'Alice'), _seg('b', 'I refuse', speaker: 'Bob')];
     provider.notifyListeners();
-    await pumpEventQueue();
+    await provider.pendingLiveSegmentWrite;
 
     final loaded = await LocalSegmentStore.at(dir).loadSession('live-1700000000');
     expect(transcriptSha256(loaded), '6698e08ad93c92100b75e3ab279d15bfa3a70288b1693377841759a26e588d40');
+  });
+
+  test('the live segment write can be awaited and lands the last update', () async {
+    final store = LocalSegmentStore.at(dir);
+    final provider = CaptureProvider(localSegmentStore: store);
+    addTearDown(provider.dispose);
+    provider.testSessionStartSeconds = 1700000001;
+
+    provider.segments = [_seg('a', 'first')];
+    provider.notifyListeners();
+    provider.segments = [_seg('a', 'second')];
+    provider.notifyListeners();
+    await provider.pendingLiveSegmentWrite;
+
+    final loaded = await LocalSegmentStore.at(dir).loadSession('live-1700000001');
+
+    expect(loaded.map((s) => s.text), ['second']);
   });
 }

--- a/app/test/unit/local_segment_store_test.dart
+++ b/app/test/unit/local_segment_store_test.dart
@@ -108,4 +108,27 @@ void main() {
 
     expect(loaded.map((s) => s.text), ['second']);
   });
+
+  test('a failed write is retried on the next identical update', () async {
+    final blocked = File('${dir.path}/blocked');
+    await blocked.writeAsString('not a directory');
+    final store = LocalSegmentStore.at(Directory(blocked.path));
+    final provider = CaptureProvider(localSegmentStore: store);
+    addTearDown(provider.dispose);
+    provider.testSessionStartSeconds = 1700000002;
+
+    provider.segments = [_seg('a', 'only')];
+    provider.notifyListeners();
+    await provider.pendingLiveSegmentWrite;
+
+    expect(await LocalSegmentStore.at(Directory(blocked.path)).loadSession('live-1700000002'), isEmpty);
+
+    await blocked.delete();
+    provider.notifyListeners();
+    await provider.pendingLiveSegmentWrite;
+
+    final loaded = await LocalSegmentStore.at(Directory(blocked.path)).loadSession('live-1700000002');
+
+    expect(loaded.map((s) => s.text), ['only']);
+  });
 }


### PR DESCRIPTION
`_persistLiveSegments` fired `localSegmentStore.replaceSession(...)` unawaited, which leaves two problems. Two `notifyListeners` calls close together start overlapping writes to the same session file with no ordering, so the earlier segment list can land last. And nothing holds the future, so `dispose()` walks away from a write that is still in flight.

Writes now chain onto a single `pendingLiveSegmentWrite` future, so they run in the order they were queued and the last update is the one on disk. The dedup fingerprint used to advance before the write ran, so a failed write left every identical later update skipped and the file stale; it now resets on failure unless a newer update has already replaced it, and a test covers that retry by blocking the directory and freeing it again.

This also removes a real race in `local_segment_store_test`. The "CaptureProvider listener persists when a live session is active" case did `await pumpEventQueue()` and then read the session back, but `pumpEventQueue` drains microtasks and does not wait for the file write, so under full-suite load the read won and the assertion saw the hash of an empty transcript. It failed twice in my full-suite runs while passing 3 out of 3 on its own. It now awaits the write handle.

Verified by running, from `app/`:

```
$ flutter test test/unit/local_segment_store_test.dart
00:00 +7: All tests passed!

$ bash test.sh
04:31 +1880 ~5: All tests passed!

$ bash scripts/analyze_ratchet.sh
Analyzer ratchet passed.

$ make preflight          (repo root)
PR preflight passed: 14 checks
```

The full suite is green here, where the two runs before this change each failed on that one test.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


