### PR TITLE
fix(app): stop a corrupt stored device throwing on read

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -228,7 +228,15 @@ class SharedPreferencesUtil {
   BtDevice get btDevice {
     final String device = getString('btDevice');
     if (device.isEmpty) return BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0);
-    return BtDevice.fromJson(jsonDecode(device));
+    try {
+      final decoded = jsonDecode(device);
+      if (decoded is Map<String, dynamic>) {
+        return BtDevice.fromJson(decoded);
+      }
+    } catch (e) {
+      Logger.debug('Error decoding stored device: $e');
+    }
+    return BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0);
   }
 
   List<BtDevice> get btDevices {

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -233,6 +233,7 @@ class SharedPreferencesUtil {
       if (decoded is Map<String, dynamic>) {
         return BtDevice.fromJson(decoded);
       }
+      Logger.debug('Stored device is not a JSON object: ${decoded.runtimeType}');
     } catch (e) {
       Logger.debug('Error decoding stored device: $e');
     }

--- a/app/test/unit/stored_device_decode_test.dart
+++ b/app/test/unit/stored_device_decode_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> seed(Object value) async {
+    SharedPreferences.setMockInitialValues({'btDevice': value});
+    await SharedPreferencesUtil.init();
+  }
+
+  test('a corrupt stored device reads as empty instead of throwing', () async {
+    await seed('not-json');
+
+    expect(SharedPreferencesUtil().btDevice.id, isEmpty);
+  });
+
+  test('a stored device that decodes to a non-map reads as empty', () async {
+    await seed('[1,2,3]');
+
+    expect(SharedPreferencesUtil().btDevice.id, isEmpty);
+  });
+
+  test('btDevices still lists saved devices when the legacy entry is corrupt', () async {
+    await seed('not-json');
+    await SharedPreferencesUtil().btDeviceAdd(
+      BtDevice(id: 'AA:BB:CC:DD:EE:FF', name: 'Omi', type: DeviceType.omi, rssi: 0),
+    );
+    SharedPreferences.setMockInitialValues({
+      'btDevice': 'not-json',
+      'btDevices': SharedPreferencesUtil().getStringList('btDevices'),
+    });
+    await SharedPreferencesUtil.init();
+
+    final devices = SharedPreferencesUtil().btDevices;
+
+    expect(devices.map((d) => d.id), contains('AA:BB:CC:DD:EE:FF'));
+  });
+
+  test('a well formed stored device still round trips', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    await SharedPreferencesUtil().btDeviceSet(
+      BtDevice(id: '11:22:33:44:55:66', name: 'Omi DevKit 2', type: DeviceType.omi, rssi: 0),
+    );
+
+    expect(SharedPreferencesUtil().btDevice.id, '11:22:33:44:55:66');
+    expect(SharedPreferencesUtil().btDevice.name, 'Omi DevKit 2');
+  });
+}


### PR DESCRIPTION
`BtDevice.fromJson` is written so a stored device can never throw: every field is type checked and the comment above it says persisted values may be missing or mistyped. The `btDevice` getter runs `jsonDecode` before handing anything to it, outside that guard, so a malformed `btDevice` string throws a `FormatException` to all 20 call sites rather than reading as no device.

`btDevices` shows the intent. It wraps each saved entry in a try/catch precisely because stored device JSON can be bad, then reads the legacy `btDevice` entry outside that try, so one corrupt value defeats the guard the getter was written to provide.

The getter now decodes defensively, checks the decoded value is a map, logs whichever of those fails, and falls back to the empty device, which is what callers already handle for a device that was never paired.

Nine other decode sites in this file are unguarded the same way (`appsList`, `cachedMessages`, `cachedPeople`, `pendingMemories`, `modifiedConversationDetails` and the cached conversation helpers). I left them alone rather than widen this into a sweep of every cache; happy to follow up if you want them covered.

Verified by running, from `app/`:

```
$ flutter test test/unit/stored_device_decode_test.dart
00:00 +4: All tests passed!

$ bash test.sh
04:06 +1882 ~5: All tests passed!

$ bash scripts/analyze_ratchet.sh
Analyzer ratchet passed.

$ make preflight          (repo root)
PR preflight passed: 14 checks
```

`local_segment_store_test` can fail under full-suite load on a branch cut from main, because it races an unawaited write. That is unrelated to this change and fixed in #13490.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


