### PR TITLE
fix(app): stop an unreadable firmware version throwing the update check

### DIFF
--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -37,6 +37,15 @@ class DeviceUtils {
     }
   }
 
+  static Version? _tryParseVersion(Object? value) {
+    if (value is! String || value.isEmpty) return null;
+    try {
+      return Version.parse(value);
+    } catch (e) {
+      return null;
+    }
+  }
+
   static Future<(String, bool, String)> shouldUpdateFirmware({
     required String currentFirmware,
     required Map latestFirmwareDetails,
@@ -47,22 +56,36 @@ class DeviceUtils {
     if (latestFirmwareDetails.isEmpty || latestFirmwareDetails['version'] == null) {
       return ('Latest Version Not Available', false, '');
     }
-    if (latestFirmwareDetails['draft']) {
+    if (latestFirmwareDetails['draft'] == true) {
       return ('Latest Version Not Available', false, '');
     }
 
-    Version currentVersion = Version.parse(currentFirmware);
+    Version? currentVersion = _tryParseVersion(currentFirmware);
+    if (currentVersion == null) {
+      return ('Unable to determine current firmware version', false, '');
+    }
     String latestVersionStr = latestFirmwareDetails['version'];
-    Version latestVersion = Version.parse(latestVersionStr);
-    Version minVersion = Version.parse(latestFirmwareDetails['min_version']);
+    Version? latestVersion = _tryParseVersion(latestVersionStr);
+    Version? minVersion = _tryParseVersion(latestFirmwareDetails['min_version']);
+    if (latestVersion == null || minVersion == null) {
+      return ('Latest Version Not Available', false, '');
+    }
 
     if (currentVersion < minVersion) {
       return ('0', false, latestVersionStr);
     } else {
       if (latestVersion > currentVersion) {
         PackageInfo packageInfo = await PackageInfo.fromPlatform();
-        if (Version.parse(packageInfo.version) <= Version.parse(latestFirmwareDetails['min_app_version']) &&
-            int.parse(packageInfo.buildNumber) < int.parse(latestFirmwareDetails['min_app_version_code'])) {
+        final appVersion = _tryParseVersion(packageInfo.version);
+        final minAppVersion = _tryParseVersion(latestFirmwareDetails['min_app_version']);
+        final buildNumber = int.tryParse(packageInfo.buildNumber);
+        final minBuildNumber = int.tryParse('${latestFirmwareDetails['min_app_version_code']}');
+        if (appVersion != null &&
+            minAppVersion != null &&
+            buildNumber != null &&
+            minBuildNumber != null &&
+            appVersion <= minAppVersion &&
+            buildNumber < minBuildNumber) {
           return (
             'The latest version of firmware is not compatible with this version of App (${packageInfo.version}+${packageInfo.buildNumber}). Please update the app from ${Platform.isAndroid ? 'Play Store' : 'App Store'}',
             false,

--- a/app/test/unit/firmware_version_parse_test.dart
+++ b/app/test/unit/firmware_version_parse_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/utils/device.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const packageInfoChannel = MethodChannel('dev.fluttercommunity.plus/package_info');
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      packageInfoChannel,
+      (_) async => <String, dynamic>{
+        'appName': 'omi',
+        'packageName': 'com.friend.ios',
+        'version': '9.9.9',
+        'buildNumber': '9999',
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(packageInfoChannel, null);
+  });
+
+  const valid = {
+    'version': '2.0.0',
+    'min_version': '1.0.0',
+    'draft': false,
+    'min_app_version': '1.0.0',
+    'min_app_version_code': '1',
+  };
+
+  test('an unreadable firmware revision reports unknown instead of throwing', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(currentFirmware: 'Unknown', latestFirmwareDetails: valid);
+
+    expect(result.$1, 'Unable to determine current firmware version');
+    expect(result.$2, isFalse);
+  });
+
+  test('a missing min_version reports unavailable instead of throwing', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(
+      currentFirmware: '1.0.0',
+      latestFirmwareDetails: const {'version': '2.0.0', 'draft': false},
+    );
+
+    expect(result.$1, 'Latest Version Not Available');
+    expect(result.$2, isFalse);
+  });
+
+  test('a missing draft flag is treated as published', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(
+      currentFirmware: '1.0.0',
+      latestFirmwareDetails: const {'version': '2.0.0', 'min_version': '1.0.0'},
+    );
+
+    expect(result.$1, isNot('Latest Version Not Available'));
+  });
+
+  test('a newer published firmware still offers the update', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(currentFirmware: '1.5.0', latestFirmwareDetails: valid);
+
+    expect(result.$2, isTrue);
+    expect(result.$3, '2.0.0');
+  });
+
+  test('firmware below the minimum still reports the zero sentinel', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(
+      currentFirmware: '0.9.0',
+      latestFirmwareDetails: valid,
+    );
+
+    expect(result.$1, '0');
+    expect(result.$2, isFalse);
+  });
+
+  test('an up to date device is told so', () async {
+    final result = await DeviceUtils.shouldUpdateFirmware(currentFirmware: '2.0.0', latestFirmwareDetails: valid);
+
+    expect(result.$1, 'You are already on the latest version');
+    expect(result.$2, isFalse);
+  });
+}

--- a/app/test/unit/firmware_version_parse_test.dart
+++ b/app/test/unit/firmware_version_parse_test.dart
@@ -55,7 +55,9 @@ void main() {
       latestFirmwareDetails: const {'version': '2.0.0', 'min_version': '1.0.0'},
     );
 
-    expect(result.$1, isNot('Latest Version Not Available'));
+    expect(result.$1, 'A new version is available! Update your Omi now.');
+    expect(result.$2, isTrue);
+    expect(result.$3, '2.0.0');
   });
 
   test('a newer published firmware still offers the update', () async {


### PR DESCRIPTION
`BtDevice.firmwareRevision` returns the string `Unknown` when the GATT read fails, and `DeviceUtils.shouldUpdateFirmware` only rejects the empty string before passing it to `Version.parse`, which throws `FormatException: Not a properly formatted version string`. A response missing `min_version` throws `type 'Null' is not a subtype of type 'String'`, and `if (latestFirmwareDetails['draft'])` throws on a missing key rather than reading as not-draft.

`DeviceProvider.shouldUpdateFirmware` is called inside a try/catch so it retries, but `pages/home/firmware_update.dart` calls this from an `addPostFrameCallback` with no catch. The throw skips `setState(() => isLoading = false)`, so a device whose firmware revision could not be read leaves the Firmware Update page on its spinner with no way forward.

The parses are guarded at the source rather than at the call site, since the function's contract is to return a message tuple. An unreadable current version reports `Unable to determine current firmware version`, and an unusable latest/minimum reports `Latest Version Not Available`, both of which the callers already render.

Three of the six tests pin the existing behaviour so the guards cannot quietly change an outcome for a valid response: a newer published firmware still offers the update, a device below the minimum still gets the `0` sentinel, and an up to date device is still told so.

Verified by running, from `app/`:

```
$ flutter test test/unit/firmware_version_parse_test.dart
00:00 +6: All tests passed!

$ bash test.sh
02:57 +1884 ~5: All tests passed!

$ bash scripts/analyze_ratchet.sh
Analyzer ratchet passed.

$ make preflight          (repo root)
PR preflight passed: 14 checks
```

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

