### PR TITLE
fix(app): stop one malformed item dropping the whole conversation decode

### DIFF
--- a/app/lib/backend/schema/structured.dart
+++ b/app/lib/backend/schema/structured.dart
@@ -75,10 +75,13 @@ class Structured {
         if (item is String) {
           if (item.isEmpty) continue;
           structured.actionItems.add(ActionItem(item));
-        } else if (item is Map<String, dynamic>) {
-          structured.actionItems.add(ActionItem.fromJson(item));
         } else if (item is Map) {
-          structured.actionItems.add(ActionItem.fromJson(Map<String, dynamic>.from(item)));
+          final itemJson = item is Map<String, dynamic> ? item : Map<String, dynamic>.from(item);
+          try {
+            structured.actionItems.add(ActionItem.fromJson(itemJson));
+          } on FormatException {
+            continue;
+          }
         }
       }
     }
@@ -87,10 +90,13 @@ class Structured {
     if (events is List) {
       for (final event in events) {
         if (event is Map && event.isEmpty) continue;
-        if (event is Map<String, dynamic>) {
-          structured.events.add(Event.fromJson(event));
-        } else if (event is Map) {
-          structured.events.add(Event.fromJson(Map<String, dynamic>.from(event)));
+        if (event is Map) {
+          final eventJson = event is Map<String, dynamic> ? event : Map<String, dynamic>.from(event);
+          try {
+            structured.events.add(Event.fromJson(eventJson));
+          } on FormatException {
+            continue;
+          }
         }
       }
     }

--- a/app/lib/backend/schema/structured.dart
+++ b/app/lib/backend/schema/structured.dart
@@ -81,6 +81,8 @@ class Structured {
             structured.actionItems.add(ActionItem.fromJson(itemJson));
           } on FormatException {
             continue;
+          } on TypeError {
+            continue;
           }
         }
       }
@@ -95,6 +97,8 @@ class Structured {
           try {
             structured.events.add(Event.fromJson(eventJson));
           } on FormatException {
+            continue;
+          } on TypeError {
             continue;
           }
         }

--- a/app/test/unit/structured_decode_blast_radius_test.dart
+++ b/app/test/unit/structured_decode_blast_radius_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/structured.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Map<String, dynamic> payload({required List<dynamic> actionItems, List<dynamic> events = const []}) {
+    return {
+      'title': 'Team sync',
+      'overview': 'Notes from the call',
+      'emoji': '',
+      'category': 'other',
+      'actionItems': actionItems,
+      'events': events,
+    };
+  }
+
+  test('an action item with an unparseable due_at does not drop the conversation', () {
+    final structured = Structured.fromJson(payload(actionItems: [
+      {'id': 'a1', 'description': 'Good item', 'completed': false, 'due_at': '2026-08-20T16:00:00Z'},
+      {'id': 'a2', 'description': 'Garbage due date', 'completed': false, 'due_at': 'not-a-date'},
+      {'id': 'a3', 'description': 'Another good item', 'completed': false},
+    ]));
+
+    expect(structured.title, 'Team sync');
+    expect(structured.overview, 'Notes from the call');
+    expect(structured.actionItems.map((e) => e.description), ['Good item', 'Another good item']);
+  });
+
+  test('an action item with an empty due_at is skipped the same way', () {
+    final structured = Structured.fromJson(payload(actionItems: [
+      {'id': 'a1', 'description': 'Kept', 'completed': false},
+      {'id': 'a2', 'description': 'Dropped', 'completed': false, 'due_at': ''},
+    ]));
+
+    expect(structured.actionItems.map((e) => e.description), ['Kept']);
+  });
+
+  test('a malformed event does not drop the conversation or its action items', () {
+    final structured = Structured.fromJson(payload(
+      actionItems: [
+        {'id': 'a1', 'description': 'Kept', 'completed': false},
+      ],
+      events: [
+        {'title': 'Standup', 'startsAt': 'not-a-date', 'duration': 30},
+      ],
+    ));
+
+    expect(structured.title, 'Team sync');
+    expect(structured.actionItems.map((e) => e.description), ['Kept']);
+  });
+
+  test('well formed payloads still decode every item', () {
+    final structured = Structured.fromJson(payload(actionItems: [
+      {'id': 'a1', 'description': 'One', 'completed': false, 'due_at': '2026-08-20T16:00:00Z'},
+      {'id': 'a2', 'description': 'Two', 'completed': true},
+    ]));
+
+    expect(structured.actionItems.map((e) => e.description), ['One', 'Two']);
+    expect(structured.actionItems.last.completed, isTrue);
+  });
+
+  test('plain string action items are still supported', () {
+    final structured = Structured.fromJson(payload(actionItems: ['Legacy string item', '']));
+
+    expect(structured.actionItems.map((e) => e.description), ['Legacy string item']);
+  });
+}

--- a/app/test/unit/structured_decode_blast_radius_test.dart
+++ b/app/test/unit/structured_decode_blast_radius_test.dart
@@ -49,6 +49,31 @@ void main() {
 
     expect(structured.title, 'Team sync');
     expect(structured.actionItems.map((e) => e.description), ['Kept']);
+    expect(structured.events, isEmpty);
+  });
+
+  test('an action item whose deleted flag is not a bool is skipped, not fatal', () {
+    final structured = Structured.fromJson(payload(actionItems: [
+      {'id': 'a1', 'description': 'Kept', 'completed': false},
+      {'id': 'a2', 'description': 'Dropped', 'completed': false, 'deleted': 'yes'},
+    ]));
+
+    expect(structured.title, 'Team sync');
+    expect(structured.actionItems.map((e) => e.description), ['Kept']);
+  });
+
+  test('a legacy integer timestamp event with a mistyped field is skipped, not fatal', () {
+    final structured = Structured.fromJson(payload(
+      actionItems: [
+        {'id': 'a1', 'description': 'Kept', 'completed': false},
+      ],
+      events: [
+        {'title': 'Standup', 'startsAt': 1700000000, 'duration': 'long'},
+      ],
+    ));
+
+    expect(structured.actionItems.map((e) => e.description), ['Kept']);
+    expect(structured.events, isEmpty);
   });
 
   test('well formed payloads still decode every item', () {


### PR DESCRIPTION
`ActionItem.fromJson` throws `FormatException: Invalid field: due_at` when the server sends an unparseable or empty `due_at`, and the `actionItems` loop in `Structured.fromJson` had no guard around it. The exception escapes the whole factory, so one bad timestamp drops the entire conversation: title, overview, events, and every valid action item next to it. The `events` loop had the same gap.

Two paths throw `TypeError` rather than `FormatException`, so both need catching. `ActionItem.fromJson` passes `json['deleted']` straight into a `bool`, and `Event.fromJson` builds legacy integer timestamp events by hand from raw `duration`, `created` and `title`, skipping the generated reader. A `deleted` of `"yes"` failed with `type 'String' is not a subtype of type 'bool'`, a string `duration` with the same error for `int`, and each took the conversation down the same way. Both loops now skip an entry that raises either.

The `sections` loop directly above already skips a bad entry for this reason, and its comment says to skip "the way the actionItems and events loops below do". Those two loops did not do that. They do now.

This does not change what counts as a valid item. `contracts/parity/wire_action_item.json` pins Dart to `strict_decode` with `parses: false` for `""` and `"not-a-date"`, and that is still what happens: the bad item is rejected, only now on its own. `test/parity/parity_contracts_test.dart` passes unchanged at 35 cases. Whether Dart should converge on the tolerant decode Windows uses is the open question in divergence 4 of `contracts/parity/README.md`, and this PR deliberately does not answer it.

Verified by running, from `app/`:

```
$ flutter test test/unit/structured_decode_blast_radius_test.dart test/parity/parity_contracts_test.dart
00:08 +42 ~5: All tests passed!

$ bash test.sh
03:59 +1885 ~5: All tests passed!

$ bash scripts/analyze_ratchet.sh
Analyzer ratchet passed.

$ make preflight          (repo root)
PR preflight passed: 14 checks
```

The 42 are the 7 blast radius tests plus the 35 parity cases. Two of the seven pin unchanged behaviour: a well formed payload still decodes every item, and plain string action items still work.

Failure-Class: FC-batch-fault-domain-head-of-line-poison


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


