### PR TITLE
ci(python-cli): gate releases on a clean-install smoke test

### DIFF
--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check dist/*
 
+      - name: Clean-install smoke test (the artifact users actually get)
+        # Publish-blocking guard: installs the built wheel into a fresh venv
+        # and runs the console script. Catches the class of breakage shipped
+        # in omi-cli 0.2.3 (missing `click` runtime dep — invisible to
+        # `-e .[dev]` and to `twine check`) BEFORE it reaches PyPI.
+        run: bash verify-clean-install.sh dist
+
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -54,6 +54,7 @@ jobs:
         run: python -m pytest -q
 
       - name: Build wheel
+        shell: bash
         run: |
           rm -rf dist
           python -m build

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -52,3 +52,15 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -q
+
+      - name: Build wheel
+        run: |
+          rm -rf dist
+          python -m build
+
+      - name: Clean-install smoke test (PR-time guard)
+        # Same clean-install check as the publish workflow, run on every PR
+        # that touches sdks/python-cli: a missing runtime dependency is
+        # masked by the editable/dev install above and only shows up in a
+        # fresh `pip install` of the built wheel (see omi-cli 0.2.3 on PyPI).
+        run: bash verify-clean-install.sh dist

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -62,17 +62,19 @@ VENV_BIN="$work/venv/bin"
 
 run_omi() {
   # Windows: a freshly created venv .exe can transiently fail exec (defender /
-  # indexer lock). Retry once, then fall back to `python -m omi_cli`.
+  # indexer lock). Retry the direct launcher once. There is deliberately NO
+  # `python -m omi_cli` fallback: this gate exists to prove the console entry
+  # point users invoke works after a bare `pip install`, so a broken or
+  # missing entry point must fail the smoke test, not route around it.
   "$VENV_BIN/omi" "$@" && return 0
   sleep 2
-  "$VENV_BIN/omi" "$@" && return 0
-  echo "verify-clean-install: direct exe failed; retrying via python -m omi_cli" >&2
-  "$VENV_BIN/python" -m omi_cli "$@"
+  "$VENV_BIN/omi" "$@"
 }
 
 # The console script must exist and run with ONLY the wheel's declared deps.
 echo "verify-clean-install: omi --version"
-version_out="$(run_omi --version)"
+version_out="$(run_omi --version)" || \
+  fail "'omi' console script failed to execute after clean install (entry point broken or missing)"
 echo "verify-clean-install: got: $version_out"
 case "$version_out" in
   omi-cli*) ;;                       # e.g. "omi-cli 0.3.0"
@@ -80,6 +82,6 @@ case "$version_out" in
 esac
 
 echo "verify-clean-install: omi --help"
-run_omi --help > /dev/null
+run_omi --help > /dev/null || fail "'omi --help' exited non-zero"
 
 echo "verify-clean-install: PASS (clean install + console script OK)"

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Clean-install smoke test for omi-cli.
+#
+# Installs a BUILT omi-cli wheel into a throwaway virtual environment and runs
+# the console script there. This is the guard the published 0.2.3 release
+# needed: an editable/`-e .[dev]` install masks a missing runtime dependency
+# (the dev extra pulls it in), and `twine check` only validates metadata —
+# neither ever *imports* the wheel the way a fresh `pip install` + `omi`
+# invocation does.
+#
+# Build-agnostic: works with whatever wheel already sits in dist/ (or the path
+# given as $1), so the publish workflow can run it right after `twine check`,
+# and CI can run it right after `python -m build`.
+#
+# Usage:  bash verify-clean-install.sh [path/to/dist]
+# Exit codes: 0 = smoke passed, 1 = wheel missing/ambiguous or smoke failed.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dist_dir="${1:-$here/dist}"
+
+fail() { echo "verify-clean-install: FAIL: $*" >&2; exit 1; }
+
+# Pick a Python launcher that actually runs (Git-Bash on Windows exposes an
+# MS-Store `python3` stub that exists on PATH but prints an error and exits).
+PY=""
+for cand in python3 python py; do
+  if command -v "$cand" > /dev/null 2>&1 && "$cand" -c "import sys" > /dev/null 2>&1; then
+    PY="$cand"; break
+  fi
+done
+[ -n "$PY" ] || fail "no working python3/python/py on PATH"
+
+shopt -s nullglob
+wheels=("$dist_dir"/omi_cli-*.whl)
+shopt -u nullglob
+
+if [ "${#wheels[@]}" -eq 0 ]; then
+  fail "no omi_cli-*.whl found in '$dist_dir'. Build one first: python -m build"
+fi
+if [ "${#wheels[@]}" -ne 1 ]; then
+  fail "multiple wheels in '$dist_dir' (${wheels[*]}); keep exactly one build"
+fi
+wheel="${wheels[0]}"
+echo "verify-clean-install: wheel = $wheel"
+
+# Allocate the scratch dir via Python so the path is valid for the SAME
+# interpreter that creates the venv (Git-Bash /tmp is not visible to Windows
+# Python, which would otherwise create the venv in a phantom C:\tmp).
+work="$("$PY" -c "import tempfile; print(tempfile.mkdtemp())")"
+trap 'rm -rf "$work"' EXIT
+
+echo "verify-clean-install: creating clean venv at $work/venv"
+"$PY" -m venv "$work/venv"
+# Upgrade pip only inside the venv; the wheel's own dependencies must resolve
+# from the wheel metadata alone (this is the whole point of the guard).
+VENV_BIN="$work/venv/bin"
+[ -d "$VENV_BIN" ] || VENV_BIN="$work/venv/Scripts"   # Windows layout
+"$VENV_BIN/python" -m pip install --quiet --upgrade pip
+"$VENV_BIN/python" -m pip install --quiet "$wheel"
+
+run_omi() {
+  # Windows: a freshly created venv .exe can transiently fail exec (defender /
+  # indexer lock). Retry once, then fall back to `python -m omi_cli`.
+  "$VENV_BIN/omi" "$@" && return 0
+  sleep 2
+  "$VENV_BIN/omi" "$@" && return 0
+  echo "verify-clean-install: direct exe failed; retrying via python -m omi_cli" >&2
+  "$VENV_BIN/python" -m omi_cli "$@"
+}
+
+# The console script must exist and run with ONLY the wheel's declared deps.
+echo "verify-clean-install: omi --version"
+version_out="$(run_omi --version)"
+echo "verify-clean-install: got: $version_out"
+case "$version_out" in
+  omi-cli*) ;;                       # e.g. "omi-cli 0.3.0"
+  *) fail "unexpected 'omi --version' output: $version_out" ;;
+esac
+
+echo "verify-clean-install: omi --help"
+run_omi --help > /dev/null
+
+echo "verify-clean-install: PASS (clean install + console script OK)"

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
 # Clean-install smoke test for omi-cli.
 #
-# Installs a BUILT omi-cli wheel into a throwaway virtual environment and runs
+# Installs BUILT omi-cli artifacts into throwaway virtual environments and runs
 # the console script there. This is the guard the published 0.2.3 release
 # needed: an editable/`-e .[dev]` install masks a missing runtime dependency
 # (the dev extra pulls it in), and `twine check` only validates metadata —
-# neither ever *imports* the wheel the way a fresh `pip install` + `omi`
+# neither ever *imports* the artifact the way a fresh `pip install` + `omi`
 # invocation does.
 #
-# Build-agnostic: works with whatever wheel already sits in dist/ (or the path
-# given as $1), so the publish workflow can run it right after `twine check`,
-# and CI can run it right after `python -m build`.
+# Build-agnostic: works with whatever artifacts already sit in dist/ (or the
+# path given as $1), so the publish workflow can run it right after
+# `twine check`, and CI can run it right after `python -m build`.
+#
+# Coverage: the wheel is always smoked. If an sdist (omi_cli-*.tar.gz) sits in
+# the same dist dir, it is smoked too — a malformed sdist must not be able to
+# reach PyPI untested. For every artifact, the version the entry point prints
+# is cross-checked against the version declared in THAT artifact's own
+# metadata (wheel METADATA / sdist PKG-INFO), which rules out stale or
+# duplicate builds where an older artifact lingers in dist/.
 #
 # Usage:  bash verify-clean-install.sh [path/to/dist]
-# Exit codes: 0 = smoke passed, 1 = wheel missing/ambiguous or smoke failed.
+# Exit codes: 0 = smoke passed, 1 = artifact missing/ambiguous or smoke failed.
 
 set -euo pipefail
 
@@ -34,6 +41,7 @@ done
 
 shopt -s nullglob
 wheels=("$dist_dir"/omi_cli-*.whl)
+sdists=("$dist_dir"/omi_cli-*.tar.gz)
 shopt -u nullglob
 
 if [ "${#wheels[@]}" -eq 0 ]; then
@@ -42,23 +50,48 @@ fi
 if [ "${#wheels[@]}" -ne 1 ]; then
   fail "multiple wheels in '$dist_dir' (${wheels[*]}); keep exactly one build"
 fi
+if [ "${#sdists[@]}" -gt 1 ]; then
+  fail "multiple sdists in '$dist_dir' (${sdists[*]}); keep exactly one build"
+fi
 wheel="${wheels[0]}"
 echo "verify-clean-install: wheel = $wheel"
 
-# Allocate the scratch dir via Python so the path is valid for the SAME
-# interpreter that creates the venv (Git-Bash /tmp is not visible to Windows
+artifact_version() {
+  # $1 = path to a wheel or sdist; prints the version declared in its own
+  # metadata (wheel: *.dist-info/METADATA, sdist: PKG-INFO).
+  case "$1" in
+    *.whl)
+      "$PY" - "$1" <<'PYEOF'
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1]) as z:
+    meta = next(n for n in z.namelist() if n.endswith(".dist-info/METADATA"))
+    for line in z.read(meta).decode("utf-8", "replace").splitlines():
+        if line.startswith("Version:"):
+            print(line.split(":", 1)[1].strip())
+            break
+PYEOF
+      ;;
+    *.tar.gz)
+      "$PY" - "$1" <<'PYEOF'
+import sys, tarfile
+with tarfile.open(sys.argv[1], "r:gz") as t:
+    pkg = next(n for n in t.getnames() if n.endswith("/PKG-INFO"))
+    for line in t.extractfile(pkg).read().decode("utf-8", "replace").splitlines():
+        if line.startswith("Version:"):
+            print(line.split(":", 1)[1].strip())
+            break
+PYEOF
+      ;;
+  esac
+}
+
+# Scratch dir allocated via Python so the path is valid for the SAME
+# interpreter that creates the venvs (Git-Bash /tmp is not visible to Windows
 # Python, which would otherwise create the venv in a phantom C:\tmp).
 work="$("$PY" -c "import tempfile; print(tempfile.mkdtemp())")"
 trap 'rm -rf "$work"' EXIT
 
-echo "verify-clean-install: creating clean venv at $work/venv"
-"$PY" -m venv "$work/venv"
-# Upgrade pip only inside the venv; the wheel's own dependencies must resolve
-# from the wheel metadata alone (this is the whole point of the guard).
-VENV_BIN="$work/venv/bin"
-[ -d "$VENV_BIN" ] || VENV_BIN="$work/venv/Scripts"   # Windows layout
-"$VENV_BIN/python" -m pip install --quiet --upgrade pip
-"$VENV_BIN/python" -m pip install --quiet "$wheel"
+VENV_BIN=""
 
 run_omi() {
   # Windows: a freshly created venv .exe can transiently fail exec (defender /
@@ -71,17 +104,53 @@ run_omi() {
   "$VENV_BIN/omi" "$@"
 }
 
-# The console script must exist and run with ONLY the wheel's declared deps.
-echo "verify-clean-install: omi --version"
-version_out="$(run_omi --version)" || \
-  fail "'omi' console script failed to execute after clean install (entry point broken or missing)"
-echo "verify-clean-install: got: $version_out"
-case "$version_out" in
-  omi-cli*) ;;                       # e.g. "omi-cli 0.3.0"
-  *) fail "unexpected 'omi --version' output: $version_out" ;;
-esac
+smoke() {
+  # $1 = artifact (wheel or sdist). Installs it into a fresh venv and runs the
+  # console script with ONLY the artifact's declared dependencies.
+  local artifact="$1"
+  local declared expected version_out venv
+  declared="$(artifact_version "$artifact")" || \
+    fail "cannot read declared version from $artifact"
+  [ -n "$declared" ] || fail "no 'Version:' header found in $artifact metadata"
 
-echo "verify-clean-install: omi --help"
-run_omi --help > /dev/null || fail "'omi --help' exited non-zero"
+  venv="$work/venv-$(basename "$artifact" | tr -c 'A-Za-z0-9._-' '_')"
+  echo "verify-clean-install: creating clean venv at $venv"
+  "$PY" -m venv "$venv"
+  VENV_BIN="$venv/bin"
+  [ -d "$VENV_BIN" ] || VENV_BIN="$venv/Scripts"   # Windows layout
+  # Upgrade pip only inside the venv; the artifact's own dependencies must
+  # resolve from its metadata alone (this is the whole point of the guard).
+  "$VENV_BIN/python" -m pip install --quiet --upgrade pip
+  "$VENV_BIN/python" -m pip install --quiet "$artifact"
+
+  # The console script must exist and run with only the declared deps.
+  echo "verify-clean-install: omi --version ($artifact)"
+  version_out="$(run_omi --version)" || \
+    fail "'omi' console script failed to execute after clean install of $artifact (entry point broken or missing)"
+  echo "verify-clean-install: got: $version_out"
+  case "$version_out" in
+    omi-cli\ *) expected="${version_out#omi-cli }" ;;
+    omi-cli*)   expected="${version_out#omi-cli}" ;;
+    *) fail "unexpected 'omi --version' output: $version_out" ;;
+  esac
+  # Cross-check against the artifact's OWN metadata: catches stale or
+  # duplicate builds whose printed version drifts from what they declare.
+  if [ "$expected" != "$declared" ]; then
+    fail "'omi --version' prints '$expected' but $artifact declares '$declared' (stale or duplicate build?)"
+  fi
+
+  echo "verify-clean-install: omi --help ($artifact)"
+  run_omi --help > /dev/null || fail "'omi --help' exited non-zero ($artifact)"
+  echo "verify-clean-install: PASS ($artifact: clean install + console script OK, version $expected matches metadata)"
+}
+
+smoke "$wheel"
+
+if [ "${#sdists[@]}" -eq 1 ]; then
+  echo "verify-clean-install: sdist present in '$dist_dir' - smoking it too"
+  smoke "${sdists[0]}"
+else
+  echo "verify-clean-install: no sdist in '$dist_dir' - wheel-only smoke (build with 'python -m build' to cover both)"
+fi
 
 echo "verify-clean-install: PASS (clean install + console script OK)"


### PR DESCRIPTION
Closes the release-integrity gap described in #13410: the published `omi-cli` 0.2.3 wheel is broken for every new user (`ModuleNotFoundError: No module named 'click'` on `omi --version`), and nothing in CI can catch that class of breakage:

- `python-cli-ci.yml` installs `-e ".[dev]"` — the dev extras mask a missing runtime dependency.
- `publish_omi_cli.yml` runs `twine check` — metadata only, never imports the artifact it is about to publish.

## What this PR adds

**`sdks/python-cli/verify-clean-install.sh`** — a build-agnostic helper that installs the built wheel into a fresh virtual environment and runs the console script (`omi --version`, `omi --help`) with only the wheel's declared dependencies. Exit 0 = the artifact users actually get works; exit 1 = it does not.

**`publish_omi_cli.yml`** — runs the helper after `twine check`, before upload/publish. A broken dependency declaration can no longer reach PyPI.

**`python-cli-ci.yml`** — builds the wheel and runs the same check on every PR touching `sdks/python-cli`, so contributors see the failure at PR time instead of at release time.

No CLI behavior changes.

## Verification performed

- Helper passes 3/3 end-to-end runs against the current wheel (`omi_cli-0.3.0-py3-none-any.whl`): clean venv → deps resolve from wheel metadata → `omi --version` prints `omi-cli 0.3.0` → `omi --help` exits 0.
- The 0.2.3 incident reproduced in a clean venv for contrast: `pip install omi-cli==0.2.3 && omi --version` → `ModuleNotFoundError: No module named 'click'` (exit 1) — exactly what this guard blocks at the publish step.
- `bash -n` passes; both workflow files parse as valid YAML.

Refs #13410 (proposed $25 bounty — proposer confirmation of scope/reward pending, happy to stand down if they want to land their own branch; my branch is `ci/omi-cli-install-smoke`-equivalent work and I'll close this PR on request).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

