### PR TITLE
ci(omi-cli): gate releases on a clean-install wheel smoke test

### DIFF
--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -86,6 +86,14 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check dist/*
 
+      # Release-blocking install smoke: installs the built wheel into a clean
+      # venv and runs the console script. Guards against the omi-cli 0.2.3
+      # incident, where a wheel missing `click` from its declared requirements
+      # shipped to PyPI (editable/dev installs and `twine check` both mask
+      # that class of breakage).
+      - name: Clean-install smoke test (wheel only)
+        run: bash verify-clean-install.sh dist
+
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish_omi_cli.yml
+++ b/.github/workflows/publish_omi_cli.yml
@@ -86,12 +86,11 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check dist/*
 
-      # Release-blocking install smoke: installs the built wheel into a clean
-      # venv and runs the console script. Guards against the omi-cli 0.2.3
-      # incident, where a wheel missing `click` from its declared requirements
-      # shipped to PyPI (editable/dev installs and `twine check` both mask
-      # that class of breakage).
-      - name: Clean-install smoke test (wheel only)
+      - name: Clean-install smoke test (the artifact users actually get)
+        # Publish-blocking guard: installs the built wheel into a fresh venv
+        # and runs the console script. Catches the class of breakage shipped
+        # in omi-cli 0.2.3 (missing `click` runtime dep — invisible to
+        # `-e .[dev]` and to `twine check`) BEFORE it reaches PyPI.
         run: bash verify-clean-install.sh dist
 
       - name: Upload dist artifact

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -53,33 +53,15 @@ jobs:
       - name: Run tests
         run: python -m pytest -q
 
-  # PR-time smoke test on the built wheel: catches missing/over-pinned runtime
-  # dependencies that editable/dev installs hide (see omi-cli 0.2.3 incident).
-  install-smoke:
-    name: Install smoke / ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: windows-latest
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: sdks/python-cli
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: sdks/python-cli/pyproject.toml
-
       - name: Build wheel
+        shell: bash
         run: |
-          python -m pip install --upgrade pip build
+          rm -rf dist
           python -m build
 
-      - name: Clean-install smoke test (wheel only)
+      - name: Clean-install smoke test (PR-time guard)
+        # Same clean-install check as the publish workflow, run on every PR
+        # that touches sdks/python-cli: a missing runtime dependency is
+        # masked by the editable/dev install above and only shows up in a
+        # fresh `pip install` of the built wheel (see omi-cli 0.2.3 on PyPI).
         run: bash verify-clean-install.sh dist

--- a/.github/workflows/python-cli-ci.yml
+++ b/.github/workflows/python-cli-ci.yml
@@ -52,3 +52,34 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -q
+
+  # PR-time smoke test on the built wheel: catches missing/over-pinned runtime
+  # dependencies that editable/dev installs hide (see omi-cli 0.2.3 incident).
+  install-smoke:
+    name: Install smoke / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: sdks/python-cli
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: sdks/python-cli/pyproject.toml
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Clean-install smoke test (wheel only)
+        run: bash verify-clean-install.sh dist

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -1,76 +1,121 @@
 #!/usr/bin/env bash
-# verify-clean-install.sh — release-blocking install smoke test for omi-cli.
+# Clean-install smoke test for omi-cli.
 #
-# Guards against the omi-cli 0.2.3 incident: the published wheel omitted
-# `click` from its declared requirements, so EVERY fresh `pip install omi-cli`
-# crashed with `ModuleNotFoundError: No module named 'click'`. Editable/dev
-# installs and `twine check` (metadata-only) both mask that class of breakage.
+# Installs each BUILT omi-cli artifact into a throwaway virtual environment
+# and runs the console script there. This is the guard the published 0.2.3
+# release needed: an editable/`-e .[dev]` install masks a missing runtime
+# dependency (the dev extra pulls it in), and `twine check` only validates
+# metadata — neither ever *imports* the artifact the way a fresh
+# `pip install` + `omi` invocation does.
 #
-# What this does (build-agnostic — pass an already-built dist dir):
-#   1. Creates a throwaway virtual environment OUTSIDE the repo.
-#   2. Installs ONLY the built wheel into it (no extras, no dev deps, no
-#      editable source tree) — exactly what an end user gets from PyPI.
-#   3. Runs the console script: `omi --version` must print the packaged
-#      version and `omi --help` must exit 0.
+# Build-agnostic: works with whatever artifacts already sit in dist/ (or the
+# path given as $1), so the publish workflow can run it right after
+# `twine check`, and CI can run it right after `python -m build`.
 #
-# Usage: verify-clean-install.sh [dist-dir]   (default: ./dist)
+# Every artifact in the dist dir is verified (wheel AND sdist): the publish
+# job uploads both, so a malformed sdist must not reach PyPI untested. The
+# installed package must also report the artifact's own declared version,
+# ruling out accidental stale/duplicate builds.
+#
+# Usage:  bash verify-clean-install.sh [path/to/dist]
+# Exit codes: 0 = smoke passed, 1 = artifact missing/ambiguous or smoke failed.
+
 set -euo pipefail
 
-DIST_DIR="${1:-dist}"
-PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
-DIST_DIR="$(cd "$PKG_DIR" && cd "$DIST_DIR" && pwd)"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dist_dir="${1:-$here/dist}"
 
-WHEEL="$(ls "$DIST_DIR"/omi_cli-*.whl 2>/dev/null | head -n 1)"
-if [ -z "$WHEEL" ]; then
-    echo "ERROR: no omi_cli-*.whl found in $DIST_DIR (run 'python -m build' first)" >&2
-    exit 1
+fail() { echo "verify-clean-install: FAIL: $*" >&2; exit 1; }
+
+# Pick a Python launcher that actually runs (Git-Bash on Windows exposes an
+# MS-Store `python3` stub that exists on PATH but prints an error and exits).
+PY=""
+for cand in python3 python py; do
+  if command -v "$cand" > /dev/null 2>&1 && "$cand" -c "import sys" > /dev/null 2>&1; then
+    PY="$cand"; break
+  fi
+done
+[ -n "$PY" ] || fail "no working python3/python/py on PATH"
+
+shopt -s nullglob
+artifacts=("$dist_dir"/omi_cli-*.whl "$dist_dir"/omi_cli-*.tar.gz)
+shopt -u nullglob
+
+if [ "${#artifacts[@]}" -eq 0 ]; then
+  fail "no omi_cli-*.whl or omi_cli-*.tar.gz found in '$dist_dir'. Build first: python -m build"
 fi
-echo "== install smoke on $(basename "$WHEEL")"
 
-# Normalize the wheel path for the interpreter (MSYS/git-bash needs a
-# Windows path; no-op on Linux/macOS).
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*) WHEEL="$(cygpath -w "$WHEEL")" ;;
-esac
-
-# Read the version straight out of the wheel metadata — not the source tree —
-# so the check compares the artifact against itself.
-WHEEL_VERSION="$(python - "$WHEEL" <<'PY'
-import sys, zipfile
+# Print the version an artifact declares in its own metadata (wheel METADATA
+# / sdist PKG-INFO) without installing it. Paths are passed through this
+# helper so Windows Python never sees a Git-Bash-style /tmp/... argument.
+declared_version() {
+  "$PY" - "$1" <<'PYV'
+import sys, tarfile, zipfile
 from email.parser import Parser
-with zipfile.ZipFile(sys.argv[1]) as zf:
-    meta = next(n for n in zf.namelist() if n.endswith("METADATA"))
-    print(Parser().parsestr(zf.read(meta).decode())["Version"])
-PY
-)"
-echo "wheel version: $WHEEL_VERSION"
+path = sys.argv[1]
+if path.endswith(".whl"):
+    with zipfile.ZipFile(path) as zf:
+        meta = next(n for n in zf.namelist() if n.endswith("METADATA"))
+        print(Parser().parsestr(zf.read(meta).decode())["Version"])
+else:
+    with tarfile.open(path) as tf:
+        meta = next(n for n in tf.getnames() if n.endswith("PKG-INFO"))
+        print(Parser().parsestr(tf.extractfile(meta).read().decode())["Version"])
+PYV
+}
 
-SMOKE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-cli-smoke.XXXXXX")"
-trap 'rm -rf "$SMOKE_DIR"' EXIT
+for artifact in "${artifacts[@]}"; do
+  echo "verify-clean-install: artifact = $artifact"
 
-python -m venv "$SMOKE_DIR/venv"
-# shellcheck disable=SC1091
-PIP="$SMOKE_DIR/venv/bin/pip"
-OMI="$SMOKE_DIR/venv/bin/omi"
-if [ ! -f "$PIP" ]; then
-    # Windows-style venvs
-    PIP="$SMOKE_DIR/venv/Scripts/pip.exe"
-    OMI="$SMOKE_DIR/venv/Scripts/omi.exe"
-fi
+  # Resolve the artifact path to something the interpreter can open (MSYS
+  # /c/... paths are meaningless to Windows Python; no-op on Linux/macOS).
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) artifact_path="$(cygpath -w "$artifact")" ;;
+    *) artifact_path="$artifact" ;;
+  esac
+  declared="$(declared_version "$artifact_path")"
+  echo "verify-clean-install: declared version = $declared"
 
-echo "== clean install (wheel only, no extras)"
-"$PIP" install --no-cache-dir --no-input "$WHEEL" 1>&2
+  # Allocate the scratch dir via Python so the path is valid for the SAME
+  # interpreter that creates the venv (Git-Bash /tmp is not visible to Windows
+  # Python, which would otherwise create the venv in a phantom C:\tmp).
+  work="$("$PY" -c "import tempfile; print(tempfile.mkdtemp())")"
+  trap 'rm -rf "$work"' EXIT
 
-echo "== import + console-script check"
-VERSION_OUT="$("$OMI" --version)"
-echo "omi --version -> $VERSION_OUT"
-case "$VERSION_OUT" in
-    *"$WHEEL_VERSION"*) ;;
-    *)
-        echo "::error::install smoke FAILED: 'omi --version' printed '$VERSION_OUT' (expected it to contain wheel version $WHEEL_VERSION). The wheel's dependency declaration is likely broken — do not publish." >&2
-        exit 1
-        ;;
-esac
+  echo "verify-clean-install: creating clean venv at $work/venv"
+  "$PY" -m venv "$work/venv"
+  VENV_BIN="$work/venv/bin"
+  [ -d "$VENV_BIN" ] || VENV_BIN="$work/venv/Scripts"   # Windows layout
+  "$VENV_BIN/python" -m pip install --quiet --upgrade pip
+  "$VENV_BIN/python" -m pip install --quiet "$artifact_path"
 
-"$OMI" --help > /dev/null 2>&1
-echo "== install smoke PASSED (clean install -> omi --version + omi --help OK)"
+  run_omi() {
+    # Windows: a freshly created venv .exe can transiently fail exec (defender
+    # / indexer lock). Retry the direct launcher once. There is deliberately NO
+    # `python -m omi_cli` fallback: this gate exists to prove the console entry
+    # point users invoke works after a bare `pip install`, so a broken or
+    # missing entry point must fail the smoke test, not route around it.
+    "$VENV_BIN/omi" "$@" && return 0
+    sleep 2
+    "$VENV_BIN/omi" "$@"
+  }
+
+  # The console script must exist and run with ONLY the artifact's declared
+  # deps, and must report the artifact's own declared version.
+  echo "verify-clean-install: omi --version"
+  version_out="$(run_omi --version)" || \
+    fail "'omi' console script failed to execute after clean install of $(basename "$artifact") (entry point broken or missing)"
+  echo "verify-clean-install: got: $version_out"
+  case "$version_out" in
+    *"$declared"*) ;;                  # e.g. "omi-cli 0.3.0" with declared=0.3.0
+    *) fail "unexpected 'omi --version' output for $(basename "$artifact"): '$version_out' (declared version is $declared)" ;;
+  esac
+
+  echo "verify-clean-install: omi --help"
+  run_omi --help > /dev/null || fail "'omi --help' exited non-zero"
+
+  rm -rf "$work"
+  echo "verify-clean-install: PASS ($(basename "$artifact"))"
+done
+
+echo "verify-clean-install: PASS (all ${#artifacts[@]} artifact(s) clean-install and run)"

--- a/sdks/python-cli/verify-clean-install.sh
+++ b/sdks/python-cli/verify-clean-install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# verify-clean-install.sh — release-blocking install smoke test for omi-cli.
+#
+# Guards against the omi-cli 0.2.3 incident: the published wheel omitted
+# `click` from its declared requirements, so EVERY fresh `pip install omi-cli`
+# crashed with `ModuleNotFoundError: No module named 'click'`. Editable/dev
+# installs and `twine check` (metadata-only) both mask that class of breakage.
+#
+# What this does (build-agnostic — pass an already-built dist dir):
+#   1. Creates a throwaway virtual environment OUTSIDE the repo.
+#   2. Installs ONLY the built wheel into it (no extras, no dev deps, no
+#      editable source tree) — exactly what an end user gets from PyPI.
+#   3. Runs the console script: `omi --version` must print the packaged
+#      version and `omi --help` must exit 0.
+#
+# Usage: verify-clean-install.sh [dist-dir]   (default: ./dist)
+set -euo pipefail
+
+DIST_DIR="${1:-dist}"
+PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$(cd "$PKG_DIR" && cd "$DIST_DIR" && pwd)"
+
+WHEEL="$(ls "$DIST_DIR"/omi_cli-*.whl 2>/dev/null | head -n 1)"
+if [ -z "$WHEEL" ]; then
+    echo "ERROR: no omi_cli-*.whl found in $DIST_DIR (run 'python -m build' first)" >&2
+    exit 1
+fi
+echo "== install smoke on $(basename "$WHEEL")"
+
+# Normalize the wheel path for the interpreter (MSYS/git-bash needs a
+# Windows path; no-op on Linux/macOS).
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) WHEEL="$(cygpath -w "$WHEEL")" ;;
+esac
+
+# Read the version straight out of the wheel metadata — not the source tree —
+# so the check compares the artifact against itself.
+WHEEL_VERSION="$(python - "$WHEEL" <<'PY'
+import sys, zipfile
+from email.parser import Parser
+with zipfile.ZipFile(sys.argv[1]) as zf:
+    meta = next(n for n in zf.namelist() if n.endswith("METADATA"))
+    print(Parser().parsestr(zf.read(meta).decode())["Version"])
+PY
+)"
+echo "wheel version: $WHEEL_VERSION"
+
+SMOKE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/omi-cli-smoke.XXXXXX")"
+trap 'rm -rf "$SMOKE_DIR"' EXIT
+
+python -m venv "$SMOKE_DIR/venv"
+# shellcheck disable=SC1091
+PIP="$SMOKE_DIR/venv/bin/pip"
+OMI="$SMOKE_DIR/venv/bin/omi"
+if [ ! -f "$PIP" ]; then
+    # Windows-style venvs
+    PIP="$SMOKE_DIR/venv/Scripts/pip.exe"
+    OMI="$SMOKE_DIR/venv/Scripts/omi.exe"
+fi
+
+echo "== clean install (wheel only, no extras)"
+"$PIP" install --no-cache-dir --no-input "$WHEEL" 1>&2
+
+echo "== import + console-script check"
+VERSION_OUT="$("$OMI" --version)"
+echo "omi --version -> $VERSION_OUT"
+case "$VERSION_OUT" in
+    *"$WHEEL_VERSION"*) ;;
+    *)
+        echo "::error::install smoke FAILED: 'omi --version' printed '$VERSION_OUT' (expected it to contain wheel version $WHEEL_VERSION). The wheel's dependency declaration is likely broken — do not publish." >&2
+        exit 1
+        ;;
+esac
+
+"$OMI" --help > /dev/null 2>&1
+echo "== install smoke PASSED (clean install -> omi --version + omi --help OK)"


### PR DESCRIPTION
Closes #13410 — implements the proposed install-smoke scope (reward proposed by maintainer in the issue).

## What this adds

- **`sdks/python-cli/verify-clean-install.sh`** — build-agnostic helper that installs the built wheel into a throwaway venv (wheel only — no extras, no dev deps, no editable source) and runs the console script: `omi --version` must print the wheel's own version (read from its METADATA) and `omi --help` must exit 0.
- **`publish_omi_cli.yml`** — runs the smoke immediately after `twine check`, before the dist artifact is uploaded. A broken dependency declaration can no longer reach PyPI.
- **`python-cli-ci.yml`** — new `install-smoke` job (Linux + Windows) so contributors see the failure at PR time.

No CLI behavior changes.

## Verification performed

**Positive path (twice, fresh venvs):** built `omi_cli-0.3.0-py3-none-any.whl` from main; helper installs it clean → typer 0.25.1 (pin respected) → `omi --version` prints `omi-cli 0.3.0` → `omi --help` exits 0. Helper exits 0.

**Negative path (the guard actually fires):** rebuilt the wheel with the exact 0.2.3 incident recipe (click omitted from dependencies, typer un-pinned above 0.26) → clean install → `omi --version` reproduces `ModuleNotFoundError: No module named 'click'` (exit 1). The smoke helper fails non-zero on that wheel, so the publish workflow would have blocked 0.2.3.

**Lint:** `bash -n` passes on the helper; both workflow files parse as valid YAML.

Also verified MSYS/git-bash compatibility of the helper (cygpath path normalization), since contributors on Windows may run it locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

