### PR TITLE
fix(cli): preserve raw text when SQL results contain pipes or newlines (#13432)

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -302,16 +302,45 @@ def _normalize_sql_result(result: Any) -> Any:
     if result.startswith("OK:"):
         return {"ok": True, "message": result}
 
-    footer = non_empty[-1]
+    # Find first non-empty line (header) and last non-empty line (footer)
+    header_idx = None
+    for idx, line in enumerate(lines):
+        if line.strip():
+            header_idx = idx
+            break
+
+    footer_idx = None
+    for idx in range(len(lines) - 1, -1, -1):
+        if lines[idx].strip():
+            footer_idx = idx
+            break
+
+    if header_idx is None or footer_idx is None or header_idx >= footer_idx:
+        return {"text": result}
+
+    footer = lines[footer_idx].strip()
     row_count_match = re.match(r"^(\d+) row\(s\)$", footer)
-    header = non_empty[0]
-    separator_index = 1 if len(non_empty) > 1 and set(non_empty[1]) <= {"-", " "} else None
-    if separator_index is None or not row_count_match:
+    if not row_count_match:
+        return {"text": result}
+
+    header = lines[header_idx].strip()
+    sep_idx = header_idx + 1
+    if sep_idx >= footer_idx or not set(lines[sep_idx].strip()) <= {"-", " "}:
         return {"text": result}
 
     expected_count = int(row_count_match.group(1))
-    data_lines = non_empty[2:-1]
+
+    # Extract raw data lines between separator line and footer line
+    data_lines = lines[sep_idx + 1 : footer_idx]
+    # Strip optional trailing blank line before footer
+    if data_lines and not data_lines[-1].strip():
+        data_lines.pop()
+
     if len(data_lines) != expected_count:
+        return {"text": result}
+
+    # Verify no embedded empty continuation lines inside data_lines
+    if any(not line.strip() for line in data_lines):
         return {"text": result}
 
     columns = [part.strip() for part in header.split("|")] if "|" in header else [header.strip()]

--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -309,16 +309,23 @@ def _normalize_sql_result(result: Any) -> Any:
     if separator_index is None or not row_count_match:
         return {"text": result}
 
+    expected_count = int(row_count_match.group(1))
+    data_lines = non_empty[2:-1]
+    if len(data_lines) != expected_count:
+        return {"text": result}
+
     columns = [part.strip() for part in header.split("|")] if "|" in header else [header.strip()]
     rows = []
-    for line in non_empty[2:-1]:
+    for line in data_lines:
         values = [part.strip() for part in line.split("|")] if "|" in line else [line.strip()]
-        rows.append({column: values[index] if index < len(values) else "" for index, column in enumerate(columns)})
+        if len(values) != len(columns):
+            return {"text": result}
+        rows.append({column: values[index] for index, column in enumerate(columns)})
 
     return {
         "columns": columns,
         "rows": rows,
-        "row_count": int(row_count_match.group(1)),
+        "row_count": expected_count,
     }
 
 

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -331,6 +331,27 @@ def test_sql_json_structures_single_column_table_text(config_path: Path, cli_run
     }
 
 
+def test_sql_json_falls_back_to_raw_text_when_cells_contain_pipes_or_newlines(config_path: Path, cli_runner) -> None:
+    _configure_local_profile(config_path)
+    # Cell with pipe delimiter in single column output
+    sql_text_pipe = "value\n-----\na|b\n\n1 row(s)"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(sql_text_pipe)))
+        result = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 'a|b' AS value"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"text": sql_text_pipe}
+
+    # Multiline cell resulting in row count mismatch
+    sql_text_newline = "value\n-----\na\nb\n\n1 row(s)"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(sql_text_newline)))
+        result_nl = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 'a\\nb' AS value"])
+
+    assert result_nl.exit_code == 0, result_nl.output
+    assert json.loads(result_nl.stdout) == {"text": sql_text_newline}
+
+
 def test_task_commands_route_to_local_tools(config_path: Path, cli_runner) -> None:
     _configure_local_profile(config_path)
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -346,10 +346,21 @@ def test_sql_json_falls_back_to_raw_text_when_cells_contain_pipes_or_newlines(co
     sql_text_newline = "value\n-----\na\nb\n\n1 row(s)"
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
         router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(sql_text_newline)))
-        result_nl = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 'a\\nb' AS value"])
+        result_nl = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 'a' || char(10) || 'b' AS value"])
 
     assert result_nl.exit_code == 0, result_nl.output
     assert json.loads(result_nl.stdout) == {"text": sql_text_newline}
+
+    # Multiline cell containing an empty continuation line
+    sql_text_empty_cont = "value\n-----\na\n\nb\n\n2 row(s)"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(sql_text_empty_cont)))
+        result_empty_cont = cli_runner.invoke(
+            app, ["--json", "local", "sql", "SELECT 'a' || char(10) || char(10) || 'b' AS value"]
+        )
+
+    assert result_empty_cont.exit_code == 0, result_empty_cont.output
+    assert json.loads(result_empty_cont.stdout) == {"text": sql_text_empty_cont}
 
 
 def test_task_commands_route_to_local_tools(config_path: Path, cli_runner) -> None:


### PR DESCRIPTION
Fixes #13432

### Summary
Prevents silent data truncation and table corruption when `omi --json local sql` receives query results containing pipe (`|`) delimiters or multiline text cells.

### Changes Made
- Updated `_normalize_sql_result` in `sdks/python-cli/omi_cli/commands/local.py` to verify that the parsed row count matches `expected_count` from the footer and that every line splits into exactly `len(columns)` values. If a line contains extra pipe delimiters or multiline text, `_normalize_sql_result` falls back to `{"text": result}` to preserve raw text without discarding data.
- Added regression tests in `sdks/python-cli/tests/test_local.py` validating raw text fallback when single-column output contains pipe characters or multiline strings.

### Verification
- Executed `uv run pytest tests/test_local.py` (49 passed).
- Executed full test suite `uv run pytest` (372 passed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

