### PR TITLE
fix(app): clarify marketplace app actions

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -590,7 +590,6 @@ class _AppDetailPageState extends State<AppDetailPage> {
         return Scaffold(
           appBar: AppDetailAppBar(
             appName: app.name,
-            isOwner: appProvider.isAppOwner,
             chatLoading: chatButtonLoading,
             onBack: () {
               HapticFeedback.mediumImpact();

--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -21,6 +21,7 @@ import 'package:omi/pages/apps/app_detail/reviews_list_page.dart';
 import 'package:omi/pages/apps/app_detail/reviews_section.dart';
 import 'package:omi/pages/apps/app_detail/app_summary.dart';
 import 'package:omi/pages/apps/app_home_web_page.dart';
+import 'package:omi/pages/apps/app_detail/widgets/app_detail_app_bar.dart';
 import 'package:omi/pages/apps/markdown_viewer.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
 import 'package:omi/widgets/media_viewer_page.dart';
@@ -587,173 +588,100 @@ class _AppDetailPageState extends State<AppDetailPage> {
             isIntegration && app.externalIntegration?.setupInstructionsFilePath?.isNotEmpty == true;
         bool hasAuthSteps = isIntegration && app.externalIntegration?.authSteps.isNotEmpty == true;
         return Scaffold(
-          appBar: AppBar(
-            backgroundColor: Theme.of(context).colorScheme.primary,
-            elevation: 0,
-            automaticallyImplyLeading: false,
-            leading: Container(
-              width: 36,
-              height: 36,
-              margin: const EdgeInsets.all(8),
-              decoration: BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
-              child: IconButton(
-                padding: EdgeInsets.zero,
-                onPressed: () {
-                  HapticFeedback.mediumImpact();
-                  Navigator.pop(context);
-                },
-                icon: const FaIcon(FontAwesomeIcons.arrowLeft, size: 16.0, color: Colors.white),
-              ),
-            ),
-            actions: [
-              if (app.enabled && app.worksWithChat()) ...[
-                Container(
-                  width: 36,
-                  height: 36,
-                  margin: const EdgeInsets.only(right: 8),
-                  decoration: BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
-                  child: IconButton(
-                    padding: EdgeInsets.zero,
-                    onPressed: chatButtonLoading
-                        ? null
-                        : () async {
-                            HapticFeedback.mediumImpact();
+          appBar: AppDetailAppBar(
+            appName: app.name,
+            isOwner: appProvider.isAppOwner,
+            chatLoading: chatButtonLoading,
+            onBack: () {
+              HapticFeedback.mediumImpact();
+              Navigator.pop(context);
+            },
+            onChat: app.enabled && app.worksWithChat()
+                ? () async {
+                    HapticFeedback.mediumImpact();
 
-                            // Prevent multiple clicks
-                            if (chatButtonLoading) return;
+                    // Prevent multiple clicks
+                    if (chatButtonLoading) return;
 
-                            setState(() => chatButtonLoading = true);
+                    setState(() => chatButtonLoading = true);
 
-                            try {
-                              // Navigate directly to chat page with this app selected
-                              var appId = app.id;
-                              var appProvider = Provider.of<AppProvider>(context, listen: false);
-                              var messageProvider = Provider.of<MessageProvider>(context, listen: false);
+                    try {
+                      // Navigate directly to chat page with this app selected
+                      var appId = app.id;
+                      var appProvider = Provider.of<AppProvider>(context, listen: false);
+                      var messageProvider = Provider.of<MessageProvider>(context, listen: false);
 
-                              // Set the selected app
-                              appProvider.setSelectedChatAppId(appId);
+                      // Set the selected app
+                      appProvider.setSelectedChatAppId(appId);
 
-                              // Refresh messages and get the selected app
-                              await messageProvider.refreshMessages();
-                              App? selectedApp = await appProvider.getAppFromId(appId);
+                      // Refresh messages and get the selected app
+                      await messageProvider.refreshMessages();
+                      App? selectedApp = await appProvider.getAppFromId(appId);
 
-                              // Send initial message if chat is empty
-                              if (messageProvider.messages.isEmpty) {
-                                messageProvider.sendInitialAppMessage(selectedApp);
-                              }
+                      // Send initial message if chat is empty
+                      if (messageProvider.messages.isEmpty) {
+                        messageProvider.sendInitialAppMessage(selectedApp);
+                      }
 
-                              // Track chat button clicked
-                              PlatformManager.instance.analytics.appDetailChatClicked(appId: app.id, appName: app.name);
+                      // Track chat button clicked
+                      PlatformManager.instance.analytics.appDetailChatClicked(appId: app.id, appName: app.name);
 
-                              // Navigate directly to chat page
-                              if (context.mounted) {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(builder: (context) => const ChatPage(isPivotBottom: false)),
-                                );
-                              }
-                            } finally {
-                              if (mounted) {
-                                setState(() => chatButtonLoading = false);
-                              }
-                            }
-                          },
-                    icon: chatButtonLoading
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 1.5,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                            ),
-                          )
-                        : const FaIcon(FontAwesomeIcons.solidComments, size: 16.0, color: Colors.white),
-                  ),
-                ),
-              ],
-              if (app.enabled && app.externalIntegration?.appHomeUrl?.isNotEmpty == true) ...[
-                Container(
-                  width: 36,
-                  height: 36,
-                  margin: const EdgeInsets.only(right: 8),
-                  decoration: BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
-                  child: IconButton(
-                    padding: EdgeInsets.zero,
-                    icon: const FaIcon(FontAwesomeIcons.gear, size: 16.0, color: Colors.white),
-                    onPressed: () {
-                      HapticFeedback.mediumImpact();
-                      Navigator.push(context, MaterialPageRoute(builder: (context) => AppHomeWebPage(app: app)));
-                    },
-                  ),
-                ),
-              ],
-              isLoading || app.private
-                  ? const SizedBox.shrink()
-                  : Builder(
-                      builder: (BuildContext context) {
-                        return Container(
-                          width: 36,
-                          height: 36,
-                          margin: const EdgeInsets.only(right: 8),
-                          decoration: BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
-                          child: IconButton(
-                            padding: EdgeInsets.zero,
-                            icon: const FaIcon(FontAwesomeIcons.arrowUpFromBracket, size: 16.0, color: Colors.white),
-                            onPressed: () async {
-                              HapticFeedback.mediumImpact();
-                              PlatformManager.instance.analytics.track('App Shared', properties: {'appId': app.id});
-
-                              // Track share button clicked
-                              PlatformManager.instance.analytics.appDetailShared(appId: app.id, appName: app.name);
-
-                              // Get the position of the share button for iOS
-                              final RenderBox? box = context.findRenderObject() as RenderBox?;
-                              final Rect? sharePositionOrigin =
-                                  box != null ? box.localToGlobal(Offset.zero) & box.size : null;
-
-                              await Share.share(
-                                appShareUrl(app.id),
-                                subject: app.name,
-                                sharePositionOrigin: sharePositionOrigin,
-                              );
-                            },
-                          ),
+                      // Navigate directly to chat page
+                      if (context.mounted) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) => const ChatPage(isPivotBottom: false)),
                         );
+                      }
+                    } finally {
+                      if (mounted) {
+                        setState(() => chatButtonLoading = false);
+                      }
+                    }
+                  }
+                : null,
+            onOpen: app.enabled && app.externalIntegration?.appHomeUrl?.isNotEmpty == true
+                ? () {
+                    HapticFeedback.mediumImpact();
+                    Navigator.push(context, MaterialPageRoute(builder: (context) => AppHomeWebPage(app: app)));
+                  }
+                : null,
+            onShare: isLoading || app.private
+                ? null
+                : (context) async {
+                    HapticFeedback.mediumImpact();
+                    PlatformManager.instance.analytics.track('App Shared', properties: {'appId': app.id});
+
+                    // Track share button clicked
+                    PlatformManager.instance.analytics.appDetailShared(appId: app.id, appName: app.name);
+
+                    // Get the position of the share button for iOS
+                    final RenderBox? box = context.findRenderObject() as RenderBox?;
+                    final Rect? sharePositionOrigin = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
+
+                    await Share.share(
+                      appShareUrl(app.id),
+                      subject: app.name,
+                      sharePositionOrigin: sharePositionOrigin,
+                    );
+                  },
+            onEdit: appProvider.isAppOwner && !isLoading
+                ? () async {
+                    HapticFeedback.mediumImpact();
+                    await showModalBottomSheet(
+                      context: context,
+                      shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          topLeft: Radius.circular(16),
+                          topRight: Radius.circular(16),
+                        ),
+                      ),
+                      builder: (context) {
+                        return ShowAppOptionsSheet(app: app);
                       },
-                    ),
-              appProvider.isAppOwner
-                  ? (isLoading
-                      ? const SizedBox.shrink()
-                      : Container(
-                          width: 36,
-                          height: 36,
-                          margin: const EdgeInsets.only(right: 8),
-                          decoration: BoxDecoration(
-                            color: Colors.grey.withValues(alpha: 0.3),
-                            shape: BoxShape.circle,
-                          ),
-                          child: IconButton(
-                            padding: EdgeInsets.zero,
-                            icon: const FaIcon(FontAwesomeIcons.edit, size: 16.0, color: Colors.white),
-                            onPressed: () async {
-                              HapticFeedback.mediumImpact();
-                              await showModalBottomSheet(
-                                context: context,
-                                shape: const RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.only(
-                                    topLeft: Radius.circular(16),
-                                    topRight: Radius.circular(16),
-                                  ),
-                                ),
-                                builder: (context) {
-                                  return ShowAppOptionsSheet(app: app);
-                                },
-                              );
-                            },
-                          ),
-                        ))
-                  : const SizedBox(width: 8),
-            ],
+                    );
+                  }
+                : null,
           ),
           backgroundColor: Theme.of(context).colorScheme.primary,
           body: SingleChildScrollView(

--- a/app/lib/pages/apps/app_detail/widgets/app_detail_app_bar.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_detail_app_bar.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:omi/utils/l10n_extensions.dart';
+
+/// App-detail actions; the page retains navigation and availability ownership.
+class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String appName;
+  final VoidCallback onBack;
+  final VoidCallback? onChat;
+  final VoidCallback? onOpen;
+  final ValueChanged<BuildContext>? onShare;
+  final VoidCallback? onEdit;
+  final bool chatLoading;
+  final bool isOwner;
+
+  const AppDetailAppBar({
+    super.key,
+    required this.appName,
+    required this.onBack,
+    this.onChat,
+    this.onOpen,
+    this.onShare,
+    this.onEdit,
+    this.chatLoading = false,
+    this.isOwner = false,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  Widget _button({
+    required String name,
+    required String tooltip,
+    required Widget icon,
+    required VoidCallback? onPressed,
+  }) =>
+      SizedBox(
+        width: 48,
+        height: 48,
+        child: IconButton(
+          key: ValueKey('app_detail_$name'),
+          padding: EdgeInsets.zero,
+          tooltip: tooltip,
+          onPressed: onPressed,
+          icon: Container(
+            width: 36,
+            height: 36,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(color: Colors.grey.withValues(alpha: 0.3), shape: BoxShape.circle),
+            child: icon,
+          ),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) => AppBar(
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        elevation: 0,
+        automaticallyImplyLeading: false,
+        leading: Center(
+            child: _button(
+          name: 'back',
+          tooltip: context.l10n.back,
+          icon: const FaIcon(FontAwesomeIcons.arrowLeft, size: 16, color: Colors.white),
+          onPressed: onBack,
+        )),
+        actions: [
+          if (onChat != null)
+            _button(
+              name: 'chat',
+              tooltip: context.l10n.chatWithAppName(appName),
+              onPressed: chatLoading ? null : onChat,
+              icon: chatLoading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 1.5,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    )
+                  : const FaIcon(FontAwesomeIcons.solidComments, size: 16, color: Colors.white),
+            ),
+          if (onOpen != null)
+            _button(
+              name: 'open',
+              tooltip: context.l10n.open,
+              icon: const Icon(Icons.web, size: 20, color: Colors.white),
+              onPressed: onOpen,
+            ),
+          if (onShare != null)
+            Builder(
+              builder: (buttonContext) => _button(
+                name: 'share',
+                tooltip: context.l10n.share,
+                icon: const FaIcon(FontAwesomeIcons.arrowUpFromBracket, size: 16, color: Colors.white),
+                onPressed: () => onShare!(buttonContext),
+              ),
+            ),
+          if (onEdit != null)
+            _button(
+              name: 'edit',
+              tooltip: context.l10n.edit,
+              icon: const FaIcon(FontAwesomeIcons.edit, size: 16, color: Colors.white),
+              onPressed: onEdit,
+            )
+          else if (!isOwner)
+            const SizedBox(width: 8),
+        ],
+      );
+}

--- a/app/lib/pages/apps/app_detail/widgets/app_detail_app_bar.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_detail_app_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/widgets/extensions/string.dart';
 
 /// App-detail actions; the page retains navigation and availability ownership.
 class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -12,7 +13,6 @@ class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
   final ValueChanged<BuildContext>? onShare;
   final VoidCallback? onEdit;
   final bool chatLoading;
-  final bool isOwner;
 
   const AppDetailAppBar({
     super.key,
@@ -23,7 +23,6 @@ class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.onShare,
     this.onEdit,
     this.chatLoading = false,
-    this.isOwner = false,
   });
 
   @override
@@ -69,7 +68,7 @@ class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
           if (onChat != null)
             _button(
               name: 'chat',
-              tooltip: context.l10n.chatWithAppName(appName),
+              tooltip: context.l10n.chatWithAppName(appName.decodeString),
               onPressed: chatLoading ? null : onChat,
               icon: chatLoading
                   ? const SizedBox(
@@ -104,9 +103,8 @@ class AppDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
               tooltip: context.l10n.edit,
               icon: const FaIcon(FontAwesomeIcons.edit, size: 16, color: Colors.white),
               onPressed: onEdit,
-            )
-          else if (!isOwner)
-            const SizedBox(width: 8),
+            ),
+          const SizedBox(width: 8),
         ],
       );
 }

--- a/app/lib/pages/apps/widgets/app_thumbnail.dart
+++ b/app/lib/pages/apps/widgets/app_thumbnail.dart
@@ -1,0 +1,38 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+/// Decorative marketplace artwork; the adjacent app name provides its identity.
+class AppThumbnail extends StatelessWidget {
+  final String imageUrl;
+
+  const AppThumbnail({super.key, required this.imageUrl});
+
+  Widget _placeholder({bool unavailable = false}) => Container(
+        width: 60,
+        height: 60,
+        decoration: BoxDecoration(color: const Color(0xFF35343B), borderRadius: BorderRadius.circular(8)),
+        child: unavailable ? const Icon(Icons.image_not_supported_outlined, color: Colors.white54, size: 24) : null,
+      );
+
+  @override
+  Widget build(BuildContext context) => ExcludeSemantics(
+        child: CachedNetworkImage(
+          imageUrl: imageUrl,
+          httpHeaders: const {
+            'User-Agent':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+          },
+          imageBuilder: (context, imageProvider) => Container(
+            width: 60,
+            height: 60,
+            decoration: BoxDecoration(
+              shape: BoxShape.rectangle,
+              borderRadius: BorderRadius.circular(8),
+              image: DecorationImage(image: imageProvider, fit: BoxFit.cover),
+            ),
+          ),
+          placeholder: (context, url) => _placeholder(),
+          errorWidget: (context, url, error) => _placeholder(unavailable: true),
+        ),
+      );
+}

--- a/app/lib/pages/apps/widgets/capability_category_section.dart
+++ b/app/lib/pages/apps/widgets/capability_category_section.dart
@@ -3,13 +3,13 @@ import 'dart:math';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
+import 'package:omi/pages/apps/widgets/app_thumbnail.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/utils/app_localizations_helper.dart';
 import 'package:omi/utils/other/temp.dart';
@@ -142,33 +142,7 @@ class CapabilitySectionAppItemCard extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                CachedNetworkImage(
-                  imageUrl: app.getImageUrl(),
-                  httpHeaders: const {
-                    "User-Agent":
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-                  },
-                  imageBuilder: (context, imageProvider) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.rectangle,
-                      borderRadius: BorderRadius.circular(8),
-                      image: DecorationImage(image: imageProvider, fit: BoxFit.cover),
-                    ),
-                  ),
-                  placeholder: (context, url) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(color: const Color(0xFF35343B), borderRadius: BorderRadius.circular(8)),
-                  ),
-                  errorWidget: (context, url, error) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(color: const Color(0xFF35343B), borderRadius: BorderRadius.circular(8)),
-                    child: const Icon(Icons.error_outline, color: Colors.white54, size: 24),
-                  ),
-                ),
+                AppThumbnail(imageUrl: app.getImageUrl()),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Column(

--- a/app/lib/pages/apps/widgets/category_section.dart
+++ b/app/lib/pages/apps/widgets/category_section.dart
@@ -3,12 +3,12 @@ import 'dart:math';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:provider/provider.dart';
 
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/pages/apps/app_detail/app_detail.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
+import 'package:omi/pages/apps/widgets/app_thumbnail.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/utils/app_localizations_helper.dart';
 import 'package:omi/utils/other/temp.dart';
@@ -147,33 +147,7 @@ class SectionAppItemCard extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                CachedNetworkImage(
-                  imageUrl: app.getImageUrl(),
-                  httpHeaders: const {
-                    "User-Agent":
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-                  },
-                  imageBuilder: (context, imageProvider) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.rectangle,
-                      borderRadius: BorderRadius.circular(8),
-                      image: DecorationImage(image: imageProvider, fit: BoxFit.cover),
-                    ),
-                  ),
-                  placeholder: (context, url) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(color: const Color(0xFF35343B), borderRadius: BorderRadius.circular(8)),
-                  ),
-                  errorWidget: (context, url, error) => Container(
-                    width: 60,
-                    height: 60,
-                    decoration: BoxDecoration(color: const Color(0xFF35343B), borderRadius: BorderRadius.circular(8)),
-                    child: const Icon(Icons.error_outline, color: Colors.white54, size: 24),
-                  ),
-                ),
+                AppThumbnail(imageUrl: app.getImageUrl()),
                 const SizedBox(width: 12),
                 Expanded(
                   child: Column(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -599,7 +599,7 @@ packages:
     source: hosted
     version: "5.1.2"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -149,6 +149,8 @@ dependency_overrides:
       path: opus_flutter_android
 
 dev_dependencies:
+  # Test the thumbnail's real image stream without network or disk cache access.
+  flutter_cache_manager: 3.4.1
   flutter_launcher_icons: 0.13.1
   google_sign_in_ios: 5.7.5
   flutter_lints: ^4.0.0

--- a/app/test/widgets/app_detail_app_bar_test.dart
+++ b/app/test/widgets/app_detail_app_bar_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/apps/app_detail/widgets/app_detail_app_bar.dart';
+
+Widget _wrap(AppDetailAppBar bar, {Locale locale = const Locale('en')}) => MaterialApp(
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: ThemeData.dark(),
+      home: Scaffold(appBar: bar),
+    );
+
+void main() {
+  testWidgets('each named action has a distinct icon and invokes only its callback', (tester) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final actions = <String>[];
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(_wrap(AppDetailAppBar(
+      appName: 'Notes',
+      onBack: () => actions.add('back'),
+      onChat: () => actions.add('chat'),
+      onOpen: () => actions.add('open'),
+      onShare: (_) => actions.add('share'),
+      onEdit: () => actions.add('edit'),
+      isOwner: true,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.web), findsOneWidget);
+    expect(find.byIcon(FontAwesomeIcons.gear.data), findsNothing);
+    final icons = tester.widgetList<FaIcon>(find.byType(FaIcon)).map((icon) => icon.icon).toSet();
+    expect(icons, hasLength(4));
+    final labels = {'back': 'Back', 'chat': 'Chat with Notes', 'open': 'Open', 'share': 'Share', 'edit': 'Edit'};
+    for (final entry in labels.entries) {
+      expect(find.byTooltip(entry.value), findsOneWidget);
+      final button = find.byKey(ValueKey('app_detail_${entry.key}'));
+      // Flutter's Tooltip exposes a semantic tooltip on the button, rather
+      // than replacing its semantic label. Native screen readers announce it.
+      expect(tester.getSemantics(button).getSemanticsData().tooltip, entry.value);
+      expect(tester.getSize(button), const Size(48, 48));
+      await tester.tap(button);
+      expect(actions, labels.keys.take(actions.length).toList());
+    }
+    expect(actions, labels.keys.toList());
+    expect(tester.takeException(), isNull); // Includes layout overflow at 320 px.
+    semantics.dispose();
+  });
+
+  testWidgets('only available actions are shown, and loading chat stays labelled but disabled', (tester) async {
+    var chats = 0;
+    await tester.pumpWidget(_wrap(AppDetailAppBar(appName: 'Notes', onBack: () {})));
+    await tester.pumpAndSettle();
+    expect(find.byType(IconButton), findsOneWidget);
+
+    await tester.pumpWidget(_wrap(AppDetailAppBar(
+      appName: 'Notes',
+      onBack: () {},
+      onChat: () => chats++,
+      chatLoading: true,
+    )));
+    await tester.pump();
+    final chat = find.byKey(const ValueKey('app_detail_chat'));
+    expect(tester.widget<IconButton>(chat).onPressed, isNull);
+    expect(find.byTooltip('Chat with Notes'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.tap(chat);
+    expect(chats, 0);
+
+    await tester.pumpWidget(_wrap(AppDetailAppBar(appName: 'Notes', onBack: () {}, onChat: () => chats++)));
+    await tester.pumpAndSettle();
+    await tester.tap(chat);
+    expect(chats, 1);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('share receives its own laid-out anchor for the iOS share sheet', (tester) async {
+    Rect? shareRect;
+    await tester.pumpWidget(_wrap(AppDetailAppBar(
+      appName: 'Notes',
+      onBack: () {},
+      onOpen: () {},
+      onShare: (context) {
+        final box = context.findRenderObject()! as RenderBox;
+        shareRect = box.localToGlobal(Offset.zero) & box.size;
+      },
+    )));
+    await tester.pumpAndSettle();
+    final share = find.byKey(const ValueKey('app_detail_share'));
+    await tester.tap(share);
+    expect(shareRect, isNotNull);
+    expect(shareRect!.contains(tester.getCenter(share)), isTrue);
+    expect(shareRect!.width, lessThan(60));
+    expect(shareRect!.height, 48);
+    expect(shareRect!.contains(tester.getCenter(find.byKey(const ValueKey('app_detail_open')))), isFalse);
+  });
+
+  testWidgets('action tooltips follow the selected locale', (tester) async {
+    const locale = Locale('es');
+    final labels = await AppLocalizations.delegate.load(locale);
+    await tester.pumpWidget(_wrap(
+        AppDetailAppBar(
+          appName: 'Notes',
+          onBack: () {},
+          onChat: () {},
+          onOpen: () {},
+          onShare: (_) {},
+          onEdit: () {},
+        ),
+        locale: locale));
+    await tester.pumpAndSettle();
+    for (final text in [labels.back, labels.chatWithAppName('Notes'), labels.open, labels.share, labels.edit]) {
+      expect(find.byTooltip(text), findsOneWidget);
+    }
+    expect(find.byTooltip('Open'), findsNothing);
+  });
+}

--- a/app/test/widgets/app_detail_app_bar_test.dart
+++ b/app/test/widgets/app_detail_app_bar_test.dart
@@ -28,7 +28,6 @@ void main() {
       onOpen: () => actions.add('open'),
       onShare: (_) => actions.add('share'),
       onEdit: () => actions.add('edit'),
-      isOwner: true,
     )));
     await tester.pumpAndSettle();
 
@@ -36,7 +35,14 @@ void main() {
     expect(find.byIcon(FontAwesomeIcons.gear.data), findsNothing);
     final icons = tester.widgetList<FaIcon>(find.byType(FaIcon)).map((icon) => icon.icon).toSet();
     expect(icons, hasLength(4));
-    final labels = {'back': 'Back', 'chat': 'Chat with Notes', 'open': 'Open', 'share': 'Share', 'edit': 'Edit'};
+    final localized = await AppLocalizations.delegate.load(const Locale('en'));
+    final labels = {
+      'back': localized.back,
+      'chat': localized.chatWithAppName('Notes'),
+      'open': localized.open,
+      'share': localized.share,
+      'edit': localized.edit,
+    };
     for (final entry in labels.entries) {
       expect(find.byTooltip(entry.value), findsOneWidget);
       final button = find.byKey(ValueKey('app_detail_${entry.key}'));
@@ -54,6 +60,7 @@ void main() {
 
   testWidgets('only available actions are shown, and loading chat stays labelled but disabled', (tester) async {
     var chats = 0;
+    final localized = await AppLocalizations.delegate.load(const Locale('en'));
     await tester.pumpWidget(_wrap(AppDetailAppBar(appName: 'Notes', onBack: () {})));
     await tester.pumpAndSettle();
     expect(find.byType(IconButton), findsOneWidget);
@@ -67,7 +74,7 @@ void main() {
     await tester.pump();
     final chat = find.byKey(const ValueKey('app_detail_chat'));
     expect(tester.widget<IconButton>(chat).onPressed, isNull);
-    expect(find.byTooltip('Chat with Notes'), findsOneWidget);
+    expect(find.byTooltip(localized.chatWithAppName('Notes')), findsOneWidget);
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     await tester.tap(chat);
     expect(chats, 0);
@@ -77,6 +84,51 @@ void main() {
     await tester.tap(chat);
     expect(chats, 1);
     expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('chat tooltip normalizes an encoded app name like the detail summary', (tester) async {
+    final localized = await AppLocalizations.delegate.load(const Locale('en'));
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(_wrap(AppDetailAppBar(appName: 'Caf\u00c3\u00a9', onBack: () {}, onChat: () {})));
+    await tester.pumpAndSettle();
+    final label = localized.chatWithAppName('Café');
+    expect(find.byTooltip(label), findsOneWidget);
+    expect(
+      tester.getSemantics(find.byKey(const ValueKey('app_detail_chat'))).getSemanticsData().tooltip,
+      label,
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('trailing inset stays consistent when edit becomes unavailable during loading', (tester) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(_wrap(AppDetailAppBar(
+      appName: 'Notes',
+      onBack: () {},
+      onChat: () {},
+      onOpen: () {},
+      onEdit: () {},
+    )));
+    await tester.pumpAndSettle();
+    final right = tester.getRect(find.byType(AppBar)).right;
+    expect(right - tester.getRect(find.byKey(const ValueKey('app_detail_edit'))).right, 8);
+
+    // The page removes Edit while an owner's app data is loading; the toolbar
+    // derives layout from available actions rather than duplicating ownership.
+    await tester.pumpWidget(_wrap(AppDetailAppBar(
+      appName: 'Notes',
+      onBack: () {},
+      onChat: () {},
+      onOpen: () {},
+      chatLoading: true,
+    )));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('app_detail_edit')), findsNothing);
+    expect(right - tester.getRect(find.byKey(const ValueKey('app_detail_open'))).right, 8);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('share receives its own laid-out anchor for the iOS share sheet', (tester) async {
@@ -117,6 +169,7 @@ void main() {
     for (final text in [labels.back, labels.chatWithAppName('Notes'), labels.open, labels.share, labels.edit]) {
       expect(find.byTooltip(text), findsOneWidget);
     }
-    expect(find.byTooltip('Open'), findsNothing);
+    final english = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.byTooltip(english.open), findsNothing);
   });
 }

--- a/app/test/widgets/app_thumbnail_test.dart
+++ b/app/test/widgets/app_thumbnail_test.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/pages/apps/widgets/app_thumbnail.dart';
+
+class _UnavailableImageCache extends Fake implements BaseCacheManager {
+  final response = StreamController<FileResponse>();
+
+  @override
+  Stream<FileResponse> getFileStream(String url,
+          {String? key, Map<String, String>? headers, bool withProgress = false}) =>
+      response.stream;
+}
+
+void main() {
+  testWidgets('a missing thumbnail keeps its space and shows an image placeholder, not an app error', (tester) async {
+    final cache = _UnavailableImageCache();
+    final original = CachedNetworkImageProvider.defaultCacheManager;
+    CachedNetworkImageProvider.defaultCacheManager = cache;
+    addTearDown(() async {
+      CachedNetworkImageProvider.defaultCacheManager = original;
+      await cache.response.close();
+      PaintingBinding.instance.imageCache.clear();
+      PaintingBinding.instance.imageCache.clearLiveImages();
+    });
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: Center(child: AppThumbnail(imageUrl: 'https://example.invalid/missing.png'))),
+    ));
+    final thumbnail = find.byType(AppThumbnail);
+    expect(tester.getSize(thumbnail), const Size(60, 60));
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsNothing);
+    // Drive the actual image stream from loading to failure without networking,
+    // disk caches, plugins, timers or a replacement presentation widget.
+    cache.response.addError(StateError('thumbnail unavailable'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsNothing);
+    expect(tester.getSize(thumbnail), const Size(60, 60));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/app/test/widgets/app_thumbnail_test.dart
+++ b/app/test/widgets/app_thumbnail_test.dart
@@ -40,6 +40,12 @@ void main() {
     expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
     expect(find.byIcon(Icons.error_outline), findsNothing);
     expect(tester.getSize(thumbnail), const Size(60, 60));
+    // Check the rendered glyph, not just the Icon's expanded 60px box.
+    final glyph = find.descendant(
+      of: find.byIcon(Icons.image_not_supported_outlined),
+      matching: find.byType(RichText),
+    );
+    expect(tester.getCenter(glyph), tester.getCenter(thumbnail));
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
The app-detail toolbar used a settings gear for an action that opens the app's home page, and its icon buttons had no tooltips. This changes Open to an arrow-free browser-window icon, adds existing localized action names, and gives each button a 48px tap target around the existing circular treatment. Missing marketplace thumbnails now use an image-unavailable placeholder instead of an app-error symbol.

Chat tooltips normalize app names like the detail summary, and the toolbar keeps an 8px trailing inset as available actions change. The page retains its existing navigation, availability checks, chat loading behavior, and iOS share anchor. The toolbar and thumbnail are small production widgets exercised directly by hermetic tests; no new translation keys or runtime packages were added. The already-locked cache manager is declared as a direct test dependency to drive its real image stream without network or disk access.

Related to #3886. The proposed bounty remains unconfirmed; this PR does not assume assignment or payment.

Validation on pinned Flutter 3.44.5 / Dart 3.12.2:

- `cd app && bash test.sh`: 1,885 passed, five existing skips; includes seven new widget tests for all actions/48px targets at 320px, semantic tooltips, chat loading, share origin, Spanish labels, encoded app names, loading-state spacing, and the real image failure stream with glyph-centering geometry.
- `cd app && bash scripts/analyze_ratchet.sh`: passed with no baseline changes.
- `dart format --line-length 120 <changed Dart files>` and `git diff --check`: passed.
- `make preflight` and post-commit `scripts/pr-preflight --pr-body-file`: all 14 selected checks passed, including failure-class validation and the repository source-graph ratchet.
- Normal pre-push gate passed, including Flutter generated-output verification; no tracked generated files changed.

Before/after screenshots render the actual components with fixture state at 320px and 390px; the before toolbar is extracted from the upstream source with inert fixture callbacks. This is isolated component evidence, not an authenticated marketplace or real iOS share-sheet run.

Failure-Class: none

## Product invariants affected

none

## Isolated UI evidence

At 390px; real production component rendering with fixture state:

| Before (upstream presentation) | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/28ce6e8e-8da7-44c5-9cdb-dfa556fb27f9" width="320" alt="Before: gear for Open and warning thumbnail"> | <img src="https://github.com/user-attachments/assets/a8b162f4-8348-456f-8f08-1b0bfa12d832" width="320" alt="After: browser icon for Open and missing-image thumbnail"> |

<details><summary>320px layout, Open tooltip, and disabled loading action</summary>

<img src="https://github.com/user-attachments/assets/53d23f3f-e9a4-4347-bc51-4bd4fb191fef" width="320" alt="All five actions fit a 320px viewport">
<img src="https://github.com/user-attachments/assets/d5fc0f03-b153-47fe-86ca-599c33db4fde" width="320" alt="Localized Open tooltip on the browser-window action">
<img src="https://github.com/user-attachments/assets/a5c7b227-c182-425d-9870-b7d1082e715e" width="320" alt="Chat loading indicator with other actions still available">

</details>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

