### PR TITLE
fix(app): skip unreadable entries in cached preference lists

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -684,10 +684,22 @@ class SharedPreferencesUtil {
 
   set showGetOmiCard(bool value) => saveBool('showGetOmiCard', value);
 
-  List<App> get appsList {
-    final apps = getStringList('appsList');
-    return App.fromJsonList(apps.map((e) => jsonDecode(e)).toList());
+  List<T> _decodeCachedList<T>(String key, T Function(Map<String, dynamic> json) fromJson) {
+    final items = <T>[];
+    for (final encoded in getStringList(key)) {
+      try {
+        final decoded = jsonDecode(encoded);
+        if (decoded is Map<String, dynamic>) {
+          items.add(fromJson(decoded));
+        }
+      } catch (e) {
+        Logger.debug('Skipping unreadable ${key.split(':').first} entry: ${e.runtimeType}');
+      }
+    }
+    return items;
   }
+
+  List<App> get appsList => _decodeCachedList('appsList', (json) => App.fromJson(json));
 
   set appsList(List<App> value) {
     final List<String> apps = value.map((e) => jsonEncode(e.toJson())).toList();
@@ -728,13 +740,11 @@ class SharedPreferencesUtil {
     if (getBool('migratedMemories')) {
       final cachedMemories = getStringList('cachedMemories');
       if (cachedMemories.isNotEmpty) {
-        final conversations = cachedMemories.map((e) => ServerConversation.fromJson(jsonDecode(e))).toList();
-        cachedConversations = conversations;
+        cachedConversations = _decodeCachedList('cachedMemories', (json) => ServerConversation.fromJson(json));
         saveBool('migratedMemories', true);
       }
     }
-    final conversations = getStringList('cachedConversations');
-    return conversations.map((e) => ServerConversation.fromJson(jsonDecode(e))).toList();
+    return _decodeCachedList('cachedConversations', (json) => ServerConversation.fromJson(json));
   }
 
   set cachedConversations(List<ServerConversation> value) {
@@ -742,10 +752,7 @@ class SharedPreferencesUtil {
     saveStringList('cachedConversations', conversations);
   }
 
-  List<ServerMessage> get cachedMessages {
-    final messages = getStringList('cachedMessages');
-    return messages.map((e) => ServerMessage.fromJson(jsonDecode(e))).toList();
-  }
+  List<ServerMessage> get cachedMessages => _decodeCachedList('cachedMessages', (json) => ServerMessage.fromJson(json));
 
   set cachedMessages(List<ServerMessage> value) {
     final List<String> messages = value.map((e) => jsonEncode(e.toJson())).toList();
@@ -757,8 +764,9 @@ class SharedPreferencesUtil {
     final ownerUid = uid;
     if (ownerUid.isEmpty) return [];
     _scopeLegacyUserData(ownerUid);
-    final memories = getStringList(_userScopedKey('pendingMemories', ownerUid));
-    return memories.map((e) => Memory.fromJson(jsonDecode(e))).where((memory) => memory.uid == ownerUid).toList();
+    return _decodeCachedList(_userScopedKey('pendingMemories', ownerUid), (json) => Memory.fromJson(json))
+        .where((memory) => memory.uid == ownerUid)
+        .toList();
   }
 
   set pendingMemories(List<Memory> value) {
@@ -777,13 +785,10 @@ class SharedPreferencesUtil {
   void removePendingMemory(String memoryId, {String? ownerUid}) {
     final owner = ownerUid ?? uid;
     if (owner.isEmpty) return;
-    final encoded = getStringList(_userScopedKey('pendingMemories', owner));
-    final memories = encoded.map((e) => Memory.fromJson(jsonDecode(e))).toList();
+    final key = _userScopedKey('pendingMemories', owner);
+    final memories = _decodeCachedList(key, (json) => Memory.fromJson(json));
     memories.removeWhere((m) => m.id == memoryId);
-    saveStringList(
-      _userScopedKey('pendingMemories', owner),
-      memories.map((memory) => jsonEncode(memory.toJson())).toList(),
-    );
+    saveStringList(key, memories.map((memory) => jsonEncode(memory.toJson())).toList());
   }
 
   void clearPendingMemories() {
@@ -792,10 +797,7 @@ class SharedPreferencesUtil {
     saveStringList(_userScopedKey('pendingMemories', ownerUid), []);
   }
 
-  List<Person> get cachedPeople {
-    final people = getStringList('cachedPeople');
-    return people.map((e) => Person.fromJson(jsonDecode(e))).toList();
-  }
+  List<Person> get cachedPeople => _decodeCachedList('cachedPeople', (json) => Person.fromJson(json));
 
   Person? getPersonById(String id) {
     return cachedPeople.firstWhereOrNull((element) => element.id == id);
@@ -834,7 +836,13 @@ class SharedPreferencesUtil {
   ServerConversation? get modifiedConversationDetails {
     final String conversation = getString('modifiedConversationDetails');
     if (conversation.isEmpty) return null;
-    return ServerConversation.fromJson(jsonDecode(conversation));
+    try {
+      final decoded = jsonDecode(conversation);
+      if (decoded is Map<String, dynamic>) return ServerConversation.fromJson(decoded);
+    } catch (e) {
+      Logger.debug('Skipping unreadable modifiedConversationDetails: ${e.runtimeType}');
+    }
+    return null;
   }
 
   set modifiedConversationDetails(ServerConversation? value) {

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -691,6 +691,8 @@ class SharedPreferencesUtil {
         final decoded = jsonDecode(encoded);
         if (decoded is Map<String, dynamic>) {
           items.add(fromJson(decoded));
+        } else {
+          Logger.debug('Skipping unreadable ${key.split(':').first} entry: ${decoded.runtimeType}');
         }
       } catch (e) {
         Logger.debug('Skipping unreadable ${key.split(':').first} entry: ${e.runtimeType}');
@@ -848,6 +850,7 @@ class SharedPreferencesUtil {
     try {
       final decoded = jsonDecode(conversation);
       if (decoded is Map<String, dynamic>) return ServerConversation.fromJson(decoded);
+      Logger.debug('Skipping unreadable modifiedConversationDetails: ${decoded.runtimeType}');
     } catch (e) {
       Logger.debug('Skipping unreadable modifiedConversationDetails: ${e.runtimeType}');
     }

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -777,18 +777,27 @@ class SharedPreferencesUtil {
   }
 
   void addPendingMemory(Memory memory) {
-    final List<Memory> memories = pendingMemories;
-    memories.add(memory);
-    pendingMemories = memories;
+    final ownerUid = uid;
+    if (ownerUid.isEmpty) return;
+    _scopeLegacyUserData(ownerUid);
+    final key = _userScopedKey('pendingMemories', ownerUid);
+    saveStringList(key, [...getStringList(key), jsonEncode(memory.toJson())]);
   }
 
   void removePendingMemory(String memoryId, {String? ownerUid}) {
     final owner = ownerUid ?? uid;
     if (owner.isEmpty) return;
     final key = _userScopedKey('pendingMemories', owner);
-    final memories = _decodeCachedList(key, (json) => Memory.fromJson(json));
-    memories.removeWhere((m) => m.id == memoryId);
-    saveStringList(key, memories.map((memory) => jsonEncode(memory.toJson())).toList());
+    saveStringList(key, getStringList(key).where((encoded) => !_hasId(encoded, memoryId)).toList());
+  }
+
+  bool _hasId(String encoded, String id) {
+    try {
+      final decoded = jsonDecode(encoded);
+      return decoded is Map<String, dynamic> && decoded['id'] == id;
+    } catch (e) {
+      return false;
+    }
   }
 
   void clearPendingMemories() {

--- a/app/lib/backend/schema/app.dart
+++ b/app/lib/backend/schema/app.dart
@@ -659,8 +659,6 @@ class App {
     };
   }
 
-  static List<App> fromJsonList(List<dynamic> jsonList) => jsonList.map((e) => App.fromJson(e)).toList();
-
   List<NotificationScope> getNotificationScopesFromIds(List<NotificationScope> allScopes) {
     if (proactiveNotification == null) {
       return [];

--- a/app/test/unit/preferences_cache_decode_test.dart
+++ b/app/test/unit/preferences_cache_decode_test.dart
@@ -115,12 +115,21 @@ void main() {
     expect(prefs.getStringList('cachedPeople'), hasLength(1));
   });
 
-  test('removePendingMemory removes the target when an unreadable entry is present', () async {
+  test('addPendingMemory works after a bad entry and keeps it', () async {
+    final prefs = await _prefs({'uid': 'user-1', 'pendingMemories:user-1': _unreadable});
+    prefs.addPendingMemory(_memory('pending-1'));
+    expect(prefs.pendingMemories.map((m) => m.id), ['pending-1']);
+    expect(prefs.getStringList('pendingMemories:user-1'), hasLength(_unreadable.length + 1));
+    expect(prefs.getStringList('pendingMemories:user-1'), containsAll(_unreadable));
+  });
+
+  test('removePendingMemory removes only the target and keeps unreadable entries', () async {
     final prefs = await _prefs({'uid': 'user-1'});
     prefs.pendingMemories = [_memory('pending-1'), _memory('pending-2')];
     await _appendUnreadable(prefs, 'pendingMemories:user-1');
     prefs.removePendingMemory('pending-1');
     expect(prefs.pendingMemories.map((m) => m.id), ['pending-2']);
+    expect(prefs.getStringList('pendingMemories:user-1'), containsAll(_unreadable));
   });
 
   group('modifiedConversationDetails', () {

--- a/app/test/unit/preferences_cache_decode_test.dart
+++ b/app/test/unit/preferences_cache_decode_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/app.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/memory.dart';
+import 'package:omi/backend/schema/message.dart';
+import 'package:omi/backend/schema/person.dart';
+import 'package:omi/backend/schema/structured.dart';
+
+const _unreadable = ['not-json', '[]', '{"id": 42}'];
+
+Person _person(String id) => Person(id: id, name: 'Alex', createdAt: DateTime.utc(2026), updatedAt: DateTime.utc(2026));
+
+Memory _memory(String id) => Memory(
+      id: id,
+      uid: 'user-1',
+      content: 'unsynced',
+      category: MemoryCategory.manual,
+      createdAt: DateTime.utc(2026),
+      updatedAt: DateTime.utc(2026),
+      visibility: MemoryVisibility.private,
+    );
+
+ServerConversation _conversation(String id) =>
+    ServerConversation(id: id, createdAt: DateTime.utc(2026), structured: Structured('Title', 'Overview'));
+
+ServerMessage _message(String id) => ServerMessage(
+      id,
+      DateTime.utc(2026),
+      'hello',
+      MessageSender.ai,
+      MessageType.text,
+      null,
+      false,
+      const [],
+      const [],
+      const [],
+    );
+
+App _app(String id) => App.fromJson({
+      'id': id,
+      'uid': 'user-1',
+      'name': 'Test App',
+      'author': 'Author',
+      'description': 'Desc',
+      'image': 'https://example.com/icon.png',
+      'capabilities': ['chat'],
+      'status': 'approved',
+      'approved': true,
+      'rating_count': 0,
+      'enabled': true,
+      'deleted': false,
+      'is_paid': false,
+      'category': 'productivity-and-organization',
+    });
+
+Future<SharedPreferencesUtil> _prefs([Map<String, Object> values = const {}]) async {
+  SharedPreferences.setMockInitialValues(values);
+  await SharedPreferencesUtil.init();
+  return SharedPreferencesUtil();
+}
+
+Future<void> _appendUnreadable(SharedPreferencesUtil prefs, String key) =>
+    prefs.saveStringList(key, [...prefs.getStringList(key), ..._unreadable]);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('cached list getters skip unreadable entries', () {
+    test('cachedPeople', () async {
+      final prefs = await _prefs();
+      prefs.cachedPeople = [_person('p1')];
+      await _appendUnreadable(prefs, 'cachedPeople');
+      expect(prefs.cachedPeople.map((p) => p.id), ['p1']);
+      expect(prefs.getPersonById('p1')?.name, 'Alex');
+    });
+
+    test('cachedConversations', () async {
+      final prefs = await _prefs();
+      prefs.cachedConversations = [_conversation('c1')];
+      await _appendUnreadable(prefs, 'cachedConversations');
+      expect(prefs.cachedConversations.map((c) => c.id), ['c1']);
+    });
+
+    test('cachedMessages', () async {
+      final prefs = await _prefs();
+      prefs.cachedMessages = [_message('m1')];
+      await _appendUnreadable(prefs, 'cachedMessages');
+      expect(prefs.cachedMessages.map((m) => m.id), ['m1']);
+    });
+
+    test('appsList', () async {
+      final prefs = await _prefs();
+      prefs.appsList = [_app('app-1')];
+      await _appendUnreadable(prefs, 'appsList');
+      expect(prefs.appsList.map((a) => a.id), ['app-1']);
+    });
+
+    test('pendingMemories', () async {
+      final prefs = await _prefs({'uid': 'user-1'});
+      prefs.pendingMemories = [_memory('pending-1')];
+      await _appendUnreadable(prefs, 'pendingMemories:user-1');
+      expect(prefs.pendingMemories.map((m) => m.id), ['pending-1']);
+    });
+  });
+
+  test('addCachedPerson still works after a bad entry and rewrites the cache clean', () async {
+    final prefs = await _prefs({'cachedPeople': _unreadable});
+    prefs.addCachedPerson(_person('p1'));
+    expect(prefs.cachedPeople.map((p) => p.id), ['p1']);
+    expect(prefs.getStringList('cachedPeople'), hasLength(1));
+  });
+
+  test('removePendingMemory removes the target when an unreadable entry is present', () async {
+    final prefs = await _prefs({'uid': 'user-1'});
+    prefs.pendingMemories = [_memory('pending-1'), _memory('pending-2')];
+    await _appendUnreadable(prefs, 'pendingMemories:user-1');
+    prefs.removePendingMemory('pending-1');
+    expect(prefs.pendingMemories.map((m) => m.id), ['pending-2']);
+  });
+
+  group('modifiedConversationDetails', () {
+    test('returns null for an unreadable value', () async {
+      for (final value in _unreadable) {
+        final prefs = await _prefs({'modifiedConversationDetails': value});
+        expect(prefs.modifiedConversationDetails, isNull, reason: value);
+      }
+    });
+
+    test('still returns a readable value', () async {
+      final prefs = await _prefs({'modifiedConversationDetails': jsonEncode(_conversation('c1').toJson())});
+      expect(prefs.modifiedConversationDetails?.id, 'c1');
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #13491. That one fixed the stored device; the same bare `jsonDecode` is behind five cached lists in `SharedPreferencesUtil` (`cachedPeople`, `cachedConversations`, `cachedMessages`, `appsList`, `pendingMemories`) and the single `modifiedConversationDetails` value. One bad string in any of them makes the whole getter throw, so callers lose the entire cache instead of one entry. #13491 and #13493 were this same bug in two other places, so this adds one shared helper instead of six more try/catch blocks.

The worst case is `cachedPeople`. `capture_controller.dart` reads it during live transcription (`_hasMissingPerson` and `getPersonById`) and `transcript_segment.dart` reads it to resolve speaker names. It also never heals, because `addCachedPerson` reads through the same getter before writing, so every later save throws as well. `addPendingMemory` and `removePendingMemory` have the same shape.

`_decodeCachedList` decodes each entry on its own and skips anything that is not JSON, not a map, or fails `fromJson` (a `TypeError` from a wrong field type, same as #13493 had to handle). The five getters use it, so `addCachedPerson`, `enableApp` and `disableApp` stop throwing and their next write leaves the bad entry out. Those lists are overwritten from the server on every refresh (`apps.dart`, `app_provider.dart`, `home_provider.dart`), so nothing is lost that the next fetch would not replace. Pending memories only exist on the phone until they sync, so `addPendingMemory` now appends to the stored list and `removePendingMemory` drops only the matching id, and an entry this build cannot read is kept. `modifiedConversationDetails` returns null instead of throwing. The debug log records the key and the error type only, never the stored content. `appsList` was the only caller of `App.fromJsonList`, so a separate commit removes it.

`test/unit/preferences_cache_decode_test.dart` seeds a valid entry plus `not-json`, `[]` and `{"id": 42}` into each key. Against main, 9 of the 10 tests fail with `FormatException: Unexpected character (at character 1)`; the tenth is the readable-value control. With the fix all 10 pass.

```
cd app
flutter test test/unit/preferences_cache_decode_test.dart   # +10: All tests passed!
bash test.sh                                                 # +1911 ~5: All tests passed!
bash scripts/analyze_ratchet.sh                              # Analyzer ratchet passed.
```

Failure-Class: FC-batch-fault-domain-head-of-line-poison
