### PR TITLE
test(backend): anchor the belief-band test to the clock it is measured against

### DIFF
--- a/backend/tests/unit/test_memories_archive_and_read_contracts.py
+++ b/backend/tests/unit/test_memories_archive_and_read_contracts.py
@@ -378,9 +378,20 @@ def test_memory_item_to_memorydb_preserves_canonical_alias_for_portability():
 
 
 def test_memory_item_to_memorydb_attaches_belief_view_only_when_flag_on(monkeypatch):
-    now = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+    # `captured_at` is anchored to the real clock because the band is too: the adapter
+    # calls `public_belief_overlay(item, now=datetime.now(timezone.utc))`, and takes no
+    # `now` a test could pin. A fixed capture date therefore ages every day the suite is
+    # not run, and this test did exactly that -- pinned at 2026-07-13T12:00Z against a
+    # 30-day half-life, it read `fading` until real time crossed two half-lives at
+    # 2026-09-11T12:00Z, then read `history` and failed for good.
+    #
+    # 45 days is one and a half half-lives: currency 0.354, which sits mid-band rather
+    # than on either edge. 30 days would land exactly on the current/fading boundary
+    # (currency 0.5, and `current` needs strictly greater), which is a coin flip on
+    # sub-second timing rather than a test.
+    now = datetime.now(timezone.utc)
     item = _item("mem-state", tier=MemoryLayer.short_term, content="in a meeting", updated_at=now).model_copy(
-        update={"half_life_days": 30, "captured_at": now - timedelta(days=30)}
+        update={"half_life_days": 30, "captured_at": now - timedelta(days=45)}
     )
     monkeypatch.delenv("MEMORY_BELIEF_MODEL_ENABLED", raising=False)
     off = memory_item_to_memorydb(item)


### PR DESCRIPTION
## What changed

`test_memory_item_to_memorydb_attaches_belief_view_only_when_flag_on` now anchors `captured_at` to the real clock instead of a fixed date.

## Why

The test was a time bomb, and it went off at **2026-09-11 12:00:00 UTC**.

It pinned `captured_at` to `2026-08-12T12:00Z − 30 days = 2026-07-13T12:00Z` with `half_life_days=30`, then asserted the band reads `fading`. But the band is not computed against that pinned date — `memory_item_to_memorydb` calls `public_belief_overlay(item, now=datetime.now(timezone.utc))` (`canonical_memory_adapter.py:410`) and takes no `now` a test can supply. So elapsed time grows every day the suite is not run:

```
captured_at   : 2026-07-13 12:00 UTC
half_life_days: 30
currency      : 0.5 ** (days_elapsed / 30)
fading needs  : currency >= 0.25   ->   days_elapsed <= 60
60 days after : 2026-09-11 12:00:00 UTC
```

At exactly two half-lives the currency is 0.25 and the band is still `fading`. One second later it is `history`, and the assertion fails — permanently, on every run from then on. Measured on this branch at 14:52 UTC today: 60.120 days elapsed, currency 0.249311, band `history`.

Nothing is wrong with the band logic or the read path. Both are correct; the test was measuring them against a clock it could not hold still.

## Why 45 days

45 days is one and a half half-lives — currency 0.354, mid-band. 30 days would sit exactly on the `current`/`fading` boundary (currency 0.5, and `current` requires strictly greater), making the result depend on sub-second timing between constructing the fixture and reading the clock.

## Verification

- The full file passes: **11 passed**, including the previously failing test.
- Mutation-checked in both directions rather than trusting a green run: raising `FADING_BAND_MIN` to 0.4 (so 0.354 falls into `history`) fails the test; restoring it passes. The assertion still catches a real band regression.

## Impact

This one test reddens `Backend Unit Tests` on every PR that merges current main — it is currently failing on #12409 (shard 3/4) and #11183 (shard 4/4), neither of which touches memory code.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

