### PR TITLE
fix(cli): clean up temp config file when atomic replace fails

### DIFF
--- a/.github/failure-classes/FC-temp-file-cleanup-excludes-final-replace.json
+++ b/.github/failure-classes/FC-temp-file-cleanup-excludes-final-replace.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "id": "FC-temp-file-cleanup-excludes-final-replace",
+  "violated_contract": "A write-to-temp-then-atomic-replace primitive that cleans up its own temp file on failure must cover every failure point after the temp file is created, including the final os.replace/os.rename, not only the preceding serialization step. Omi CLI's config save() wrapped tomli_w.dump() in a try/except that unlinked the temp file on failure, but called os.replace() after that block exited, so a replace failure (e.g. the destination transiently locked on Windows) propagated the exception with no cleanup — leaving the fully serialized, credential-bearing temp file on disk indefinitely.",
+  "canonical_prevention": "Keep the entire write-then-replace sequence, from temp-file creation through the final replace, inside one try/except whose except clause unlinks only the temp file this invocation created (never another concurrent writer's) and re-raises the original error unmasked.",
+  "canonical_prevention_artifact": [
+    "sdks/python-cli/tests/test_config.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "sdks/python-cli/omi_cli/config.py",
+    "backend/database/google_credentials.py"
+  ],
+  "status": "open"
+}

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -209,7 +209,7 @@ def load(path: Optional[Path] = None) -> Config:
         )
 
     profiles_data = data.get("profiles", {})
-    
+
     # Validate that profiles is a table (dict), not a string or other scalar.
     if not isinstance(profiles_data, dict):
         return Config(
@@ -218,7 +218,7 @@ def load(path: Optional[Path] = None) -> Config:
             profiles={},
             load_error=f"'profiles' must be a table, got {type(profiles_data).__name__}",
         )
-    
+
     # Validate each profile value is a table before constructing Profile objects.
     profiles = {}
     for name, raw in profiles_data.items():
@@ -249,8 +249,7 @@ def save(config: Config) -> None:
     """
     if config.load_error is not None:
         raise PermissionError(
-            f"refusing to overwrite {config.path}: {config.load_error}. "
-            "Fix or remove the config file and try again."
+            f"refusing to overwrite {config.path}: {config.load_error}. " "Fix or remove the config file and try again."
         )
     config.path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir perms too — credentials live underneath. Best-effort:
@@ -286,8 +285,12 @@ def save(config: Config) -> None:
         try:
             with os.fdopen(fd, "wb") as fh:
                 tomli_w.dump(payload, fh)
+            # Atomic rename. The destination inherits the temp's 0o600 mode.
+            os.replace(tmp_path, config.path)
         except Exception:
-            # Best-effort cleanup if the dump itself failed mid-write.
+            # Best-effort cleanup of our own temp file, whether the dump or
+            # the replace failed. A failed replace (e.g. destination locked
+            # on Windows) must not leave a credential-bearing temp behind.
             try:
                 os.unlink(tmp_path)
             except FileNotFoundError:
@@ -295,9 +298,6 @@ def save(config: Config) -> None:
             raise
     finally:
         os.umask(old_umask)
-
-    # Atomic rename. The destination inherits the temp's 0o600 mode.
-    os.replace(tmp_path, config.path)
 
 
 def resolve_profile_name(cli_flag: Optional[str], config: Config) -> str:

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -282,6 +282,36 @@ def test_save_retries_when_unique_temp_name_collides(config_path: Path, monkeypa
     assert reloaded.api_key == "omi_dev_retry"
 
 
+def test_save_cleans_up_temp_file_when_replace_fails(config_path: Path, monkeypatch) -> None:
+    """A failed os.replace() (e.g. the destination is locked on Windows) must
+    not leave the fully serialized, credential-bearing temp file on disk."""
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.auth_method = "api_key"
+    profile.api_key = "omi_dev_secret"
+    config.set_profile(profile)
+
+    written_tmp_path: list[Path] = []
+    original_replace = cfg.os.replace
+
+    def failing_replace(src, dst):
+        written_tmp_path.append(Path(src))
+        raise PermissionError("destination is locked")
+
+    monkeypatch.setattr(cfg.os, "replace", failing_replace)
+
+    with pytest.raises(PermissionError, match="destination is locked"):
+        cfg.save(config)
+
+    assert written_tmp_path
+    assert not written_tmp_path[0].exists()
+    assert not config_path.exists()
+
+    monkeypatch.setattr(cfg.os, "replace", original_replace)
+    cfg.save(config)
+    assert cfg.load().get_profile().api_key == "omi_dev_secret"
+
+
 def test_save_concurrent_writers_retry_on_unique_name_collision(config_path: Path) -> None:
     """Real interleaving: a nested save() inside the first writer's dump
     claims a temp path; the outer writer's own path cannot collide with it
@@ -429,9 +459,7 @@ def test_no_profiles_section(config_path: Path) -> None:
         ("[active_profile]\nname = 'work'\n", "dict"),
     ],
 )
-def test_active_profile_non_string_records_load_error(
-    config_path: Path, invalid_toml: str, expected_type: str
-) -> None:
+def test_active_profile_non_string_records_load_error(config_path: Path, invalid_toml: str, expected_type: str) -> None:
     """active_profile must be a string; non-string values should set load_error instead of crashing."""
     config_path.write_text(invalid_toml, encoding="utf-8")
     config = cfg.load()
@@ -444,7 +472,9 @@ def test_active_profile_non_string_records_load_error(
 
 def test_active_profile_non_string_refuses_save_overwrite(config_path: Path) -> None:
     """A config with invalid active_profile type must not be overwritten by save()."""
-    config_path.write_text('active_profile = ["work"]\n[profiles.work]\napi_base = "https://api.omi.me"\n', encoding="utf-8")
+    config_path.write_text(
+        'active_profile = ["work"]\n[profiles.work]\napi_base = "https://api.omi.me"\n', encoding="utf-8"
+    )
     config = cfg.load()
     assert config.was_load_error
 


### PR DESCRIPTION
## What

`save()` in `sdks/python-cli/omi_cli/config.py` writes the new config to a
temp file (with credentials, created owner-only), then calls `os.replace()`
**outside** the `try/except` that cleans up on failure. If the replace fails
(e.g. the destination is open/locked, which is common on Windows), the temp
file — containing the newly-serialized credentials — is left on disk. The
original config file is untouched and the caller sees the replace error, but
never learns about the orphaned temp file.

Fix: move `os.replace()` inside the existing try block so a failed replace
hits the same cleanup path that already unlinks the current invocation's own
temp file (never another writer's) and re-raises the original error.

## Why

Reported in #13421: leftover credential-bearing temp files accumulate in
`~/.omi/` whenever a save's atomic replace fails, e.g. an antivirus scanner
or another process transiently holding the config file open on Windows.

## Testing

- Added `test_save_cleans_up_temp_file_when_replace_fails`, which forces
  `os.replace` to raise and asserts the temp file is gone, the original
  config file was never created, and a normal `save()` afterward still
  round-trips correctly.
- `pytest sdks/python-cli/tests/` — full suite, 335 passed, 1 pre-existing
  skip (Windows-only DACL test on this Linux/macOS runner).

Failure-Class: new

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

