### PR TITLE
fix(app): stop a crash during WAL save from wiping the offline index

### DIFF
--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
+import 'package:pool/pool.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
@@ -16,6 +17,7 @@ class WalFileManager {
 
   static File? _walFile;
   static File? _walBackupFile;
+  static final _saveLock = Pool(1);
 
   static Future<void> init() async {
     final directory = await getApplicationDocumentsDirectory();
@@ -55,7 +57,9 @@ class WalFileManager {
     return Wal.fromJsonList(walsList);
   }
 
-  static Future<bool> saveWals(List<Wal> wals) async {
+  static Future<bool> saveWals(List<Wal> wals) => _saveLock.withResource(() => _saveWals(wals));
+
+  static Future<bool> _saveWals(List<Wal> wals) async {
     if (_walFile == null) {
       await init();
     }
@@ -85,10 +89,15 @@ class WalFileManager {
   static Future<void> _createBackup() async {
     try {
       if (_walFile != null && _walFile!.existsSync() && _walBackupFile != null) {
+        final content = await _walFile!.readAsString();
+        if (content.isEmpty) return;
+        jsonDecode(content);
         await _walFile!.copy(_walBackupFile!.path);
       }
     } on FileSystemException catch (e) {
       Logger.debug('WalFileManager: Failed to create backup: $e');
+    } on FormatException catch (e) {
+      Logger.debug('WalFileManager: Not backing up unreadable WAL file: $e');
     }
   }
 

--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -35,8 +35,8 @@ class WalFileManager {
 
     final content = await _walFile!.readAsString();
     if (content.isEmpty) {
-      Logger.debug('WAL file is empty, returning empty list');
-      return [];
+      Logger.debug('WAL file is empty, trying backup');
+      return await _loadFromBackup();
     }
 
     dynamic jsonData;
@@ -74,7 +74,9 @@ class WalFileManager {
     };
 
     final jsonString = jsonEncode(jsonData);
-    await _walFile!.writeAsString(jsonString);
+    final tmp = File('${_walFile!.path}.tmp');
+    await tmp.writeAsString(jsonString, flush: true);
+    await tmp.rename(_walFile!.path);
 
     Logger.debug('Successfully saved ${wals.length} WALs to file');
     return true;

--- a/app/test/unit/wal_file_manager_torn_write_test.dart
+++ b/app/test/unit/wal_file_manager_torn_write_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/utils/wal_file_manager.dart';
+
+class _TornWriteFile implements File {
+  _TornWriteFile(this._real);
+
+  final File _real;
+
+  @override
+  String get path => _real.path;
+
+  @override
+  bool existsSync() => _real.existsSync();
+
+  @override
+  Future<File> copy(String newPath) => _real.copy(newPath);
+
+  @override
+  Future<File> rename(String newPath) => _real.rename(newPath);
+
+  @override
+  Future<File> writeAsString(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) async {
+    await _real.writeAsString('');
+    throw const FileSystemException('simulated crash mid-write');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Wal _wal(int timerStart) => Wal(
+    timerStart: timerStart, codec: BleAudioCodec.opus, seconds: 60, status: WalStatus.miss, storage: WalStorage.disk);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late File walFile;
+  late File backupFile;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('wal_torn_write_test_');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall methodCall) async {
+        if (methodCall.method == 'getApplicationDocumentsDirectory') return tempDir.path;
+        return null;
+      },
+    );
+    await WalFileManager.init();
+    walFile = File('${tempDir.path}/wals.json');
+    backupFile = File('${tempDir.path}/wals_backup.json');
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('a save that dies mid-write leaves the stored index readable', () async {
+    await WalFileManager.saveWals([_wal(1000)]);
+    final before = walFile.readAsStringSync();
+
+    await IOOverrides.runZoned(() async {
+      await WalFileManager.init();
+      await expectLater(WalFileManager.saveWals([_wal(1000), _wal(2000)]), throwsA(isA<FileSystemException>()));
+    }, createFile: (path) => _TornWriteFile(Zone.root.run(() => File(path))));
+
+    await WalFileManager.init();
+    expect(walFile.readAsStringSync(), before);
+    expect((await WalFileManager.loadWals()).map((w) => w.timerStart), [1000]);
+  });
+
+  test('an empty index falls back to the backup instead of dropping every WAL', () async {
+    await WalFileManager.saveWals([_wal(1000)]);
+    await WalFileManager.saveWals([_wal(1000), _wal(2000)]);
+    walFile.writeAsStringSync('');
+
+    expect((await WalFileManager.loadWals()).map((w) => w.timerStart), [1000]);
+  });
+
+  test('a half written index falls back to the backup', () async {
+    await WalFileManager.saveWals([_wal(1000)]);
+    await WalFileManager.saveWals([_wal(1000), _wal(2000)]);
+    final full = walFile.readAsStringSync();
+    walFile.writeAsStringSync(full.substring(0, full.length ~/ 2));
+
+    expect((await WalFileManager.loadWals()).map((w) => w.timerStart), [1000]);
+  });
+
+  test('an empty index with no backup still loads as empty', () async {
+    walFile.writeAsStringSync('');
+    expect(backupFile.existsSync(), isFalse);
+
+    expect(await WalFileManager.loadWals(), isEmpty);
+  });
+}

--- a/app/test/unit/wal_file_manager_torn_write_test.dart
+++ b/app/test/unit/wal_file_manager_torn_write_test.dart
@@ -21,6 +21,9 @@ class _TornWriteFile implements File {
   bool existsSync() => _real.existsSync();
 
   @override
+  Future<String> readAsString({Encoding encoding = utf8}) => _real.readAsString(encoding: encoding);
+
+  @override
   Future<File> copy(String newPath) => _real.copy(newPath);
 
   @override
@@ -109,5 +112,26 @@ void main() {
     expect(backupFile.existsSync(), isFalse);
 
     expect(await WalFileManager.loadWals(), isEmpty);
+  });
+
+  test('overlapping saves both complete and the later one wins', () async {
+    await Future.wait([
+      WalFileManager.saveWals([_wal(1000)]),
+      WalFileManager.saveWals([_wal(1000), _wal(2000)]),
+    ]);
+
+    expect((await WalFileManager.loadWals()).map((w) => w.timerStart), [1000, 2000]);
+  });
+
+  test('saving after an empty index keeps the good backup', () async {
+    await WalFileManager.saveWals([_wal(1000)]);
+    await WalFileManager.saveWals([_wal(1000), _wal(2000)]);
+    walFile.writeAsStringSync('');
+
+    final recovered = await WalFileManager.loadWals();
+    await WalFileManager.saveWals([...recovered, _wal(3000)]);
+
+    final backup = jsonDecode(backupFile.readAsStringSync()) as Map<String, dynamic>;
+    expect((backup['wals'] as List).map((w) => w['timer_start']), [1000]);
   });
 }


### PR DESCRIPTION
`WalFileManager.saveWals` rewrites `wals.json` in place with `writeAsString`, which truncates the file before writing the new contents. If the app is killed or the phone loses power in that window, `wals.json` can be left empty. `loadWals` treats an empty file as "no WALs" and returns `[]` without looking at the backup, and the next flush then runs `_createBackup`, which copies the empty file over the good backup. So one badly timed crash drops every offline recording that was still waiting to sync from the index. The `.bin` audio stays on disk, but the only rescan (`LocalRecordingsProvider.refresh`) skips offline-sync WALs on purpose, so nothing picks them up again. `saveWals` runs from the periodic flush in `LocalWalSyncImpl`, so this write happens often.

The index is now written to `wals.json.tmp` with `flush: true` and renamed over `wals.json`, so a save that dies partway leaves the previous index as it was. An empty `wals.json` also falls back to the backup, the same way a corrupted one already does, which covers anyone who already has an empty file on disk. `_createBackup` skips an empty or undecodable `wals.json`, so recovering from a torn index doesn't overwrite the good backup on the next save. `LocalWalSyncImpl` calls `_saveWalsToFile` from 19 places (flush timer, upload loop, deletes), so saves can overlap; they now go through a `Pool(1)` so two saves never share the temp file.

`test/unit/wal_file_manager_torn_write_test.dart` uses `IOOverrides` to make a save die mid-write (the file is truncated, then the write throws). Against main, 3 of the 6 tests fail: after the torn save `wals.json` is `''`, an empty `wals.json` loads as `[]` even though the backup has the WAL, and saving after that leaves the backup empty. The half-written and no-backup cases pass on both as controls. The overlapping-save test passes on main (it writes in place) and failed on this branch's first commit with `PathNotFoundException` on the rename, which is what the `Pool(1)` fixes.

```
cd app
flutter test test/unit/wal_file_manager_torn_write_test.dart   # +6: All tests passed!
flutter test test/unit/wal_file_manager_torn_write_test.dart test/unit/wal_recovery_test.dart \
  test/unit/session_wal_sync_test.dart test/unit/wal_upload_resilience_test.dart \
  test/unit/sync_manifest_claim_drain_test.dart test/providers/sync_provider_terminal_wal_state_test.dart \
  test/widgets/sync_row_recovery_window_test.dart               # +57: All tests passed!
bash test.sh                                                    # +1907 ~5: All tests passed!
bash scripts/analyze_ratchet.sh                                 # Analyzer ratchet passed.
```

Failure-Class: FC-destructive-replace-precedes-derivation
