### PR TITLE
test(backend): keep memory belief-view half-life fixture clock-relative

### DIFF
--- a/backend/tests/unit/test_memories_archive_and_read_contracts.py
+++ b/backend/tests/unit/test_memories_archive_and_read_contracts.py
@@ -378,9 +378,12 @@ def test_memory_item_to_memorydb_preserves_canonical_alias_for_portability():
 
 
 def test_memory_item_to_memorydb_attaches_belief_view_only_when_flag_on(monkeypatch):
-    now = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
-    item = _item("mem-state", tier=MemoryLayer.short_term, content="in a meeting", updated_at=now).model_copy(
-        update={"half_life_days": 30, "captured_at": now - timedelta(days=30)}
+    # Anchor to the wall clock: exactly one half-life old keeps currency at 0.5
+    # (the fading band floor) regardless of when CI runs. A fixed calendar date
+    # rots into the history band once 60 days elapse.
+    captured_at = datetime.now(timezone.utc) - timedelta(days=30)
+    item = _item("mem-state", tier=MemoryLayer.short_term, content="in a meeting", updated_at=captured_at).model_copy(
+        update={"half_life_days": 30, "captured_at": captured_at}
     )
     monkeypatch.delenv("MEMORY_BELIEF_MODEL_ENABLED", raising=False)
     off = memory_item_to_memorydb(item)


### PR DESCRIPTION
## Summary
- Extract the date-sensitive memory belief-view unit fixture from #13456.
- The production path uses wall-clock `now`; a frozen `2026-08-12` captured_at ages into the history band ~60 days later and fails otherwise-sound backend CI.
- Anchor `captured_at` to `now - 30d` so one half-life still yields currency 0.5.

## Test Plan
- [x] `pytest backend/tests/unit/test_memories_archive_and_read_contracts.py` — 11 passed
- [x] focused: `test_memory_item_to_memorydb_attaches_belief_view_only_when_flag_on`

## Failure-Class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

