### PR TITLE
fix(app): stop deleting a recording from clearing the device's SD card

### DIFF
--- a/.github/failure-classes/FC-fanout-delete-skips-ownership-check.json
+++ b/.github/failure-classes/FC-fanout-delete-skips-ownership-check.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "id": "FC-fanout-delete-skips-ownership-check",
-  "violated_contract": "When one user action is fanned out to every handler regardless of which one owns the target, each handler must confirm it owns that exact target before doing anything irreversible. WalSyncs.deleteWal sends every recording delete to all five sub-syncs. The ring sync checks membership since #7218, but the SD card and storage syncs still sent their device delete for any wal, so deleting a phone recording with a DevKit connected cleared the audio on the DevKit's SD card.",
+  "violated_contract": "When one user action is fanned out to every handler regardless of which one owns the target, each handler must confirm it owns that exact target before doing anything irreversible. WalSyncs.deleteWal sends every recording delete to all five sub-syncs. The ring sync checks membership since #7218, but the SD card, storage and flash page syncs still ran their device action for any wal, so deleting a phone recording with a DevKit connected cleared the audio on the DevKit's SD card.",
   "canonical_prevention": "Guard each fan-out receiver's destructive path on ownership of the exact target, including the kind of storage it manages, because a copy can share the original's id. Cover it with a test that sends a target the receiver does not own and asserts the device or store is never touched, next to a control showing its own target still is.",
   "canonical_prevention_artifact": [
     "app/test/unit/wal_delete_cascade_test.dart"

--- a/.github/failure-classes/FC-fanout-delete-skips-ownership-check.json
+++ b/.github/failure-classes/FC-fanout-delete-skips-ownership-check.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-fanout-delete-skips-ownership-check",
+  "violated_contract": "When one user action is fanned out to every handler regardless of which one owns the target, each handler must confirm it owns that exact target before doing anything irreversible. WalSyncs.deleteWal sends every recording delete to all five sub-syncs. The ring sync checks membership since #7218, but the SD card and storage syncs still sent their device delete for any wal, so deleting a phone recording with a DevKit connected cleared the audio on the DevKit's SD card.",
+  "canonical_prevention": "Guard each fan-out receiver's destructive path on ownership of the exact target, including the kind of storage it manages, because a copy can share the original's id. Cover it with a test that sends a target the receiver does not own and asserts the device or store is never touched, next to a control showing its own target still is.",
+  "canonical_prevention_artifact": [
+    "app/test/unit/wal_delete_cascade_test.dart"
+  ],
+  "evidence_prs": [
+    7218
+  ],
+  "scope_hints": [
+    "app/lib/services/wals/**"
+  ],
+  "status": "open"
+}

--- a/app/lib/services/wals/flash_page_wal_sync.dart
+++ b/app/lib/services/wals/flash_page_wal_sync.dart
@@ -43,6 +43,12 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   FlashPageWalSyncImpl(this.listener);
 
+  @visibleForTesting
+  set testWals(List<Wal> wals) => _wals = wals;
+
+  @visibleForTesting
+  set testDevice(BtDevice? device) => _device = device;
+
   @override
   void setLocalSync(LocalWalSync localSync) {
     _localSync = localSync;
@@ -123,9 +129,10 @@ class FlashPageWalSyncImpl implements FlashPageWalSync {
 
   @override
   Future deleteWal(Wal wal) async {
+    if (wal.storage != WalStorage.flashPage || !_wals.any((w) => w.id == wal.id)) return;
     _wals.removeWhere((w) => w.id == wal.id);
 
-    if (_device != null && wal.status == WalStatus.synced) {
+    if (_device != null && wal.device == _device!.id && wal.status == WalStatus.synced) {
       await _acknowledgeProcessedData(_device!.id, wal.storageTotalBytes);
     }
 

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -116,7 +116,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
     if (wal.storage != WalStorage.sdcard || !_wals.any((w) => w.id == wal.id)) return;
     _wals.removeWhere((w) => w.id == wal.id);
 
-    if (_device != null) {
+    if (_device != null && wal.device == _device!.id) {
       await _writeToStorage(_device!.id, wal.fileNum, 1, 0);
     }
 

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:version/version.dart';
@@ -47,6 +48,12 @@ class SDCardWalSyncImpl implements SDCardWalSync {
   }
 
   SDCardWalSyncImpl(this.listener);
+
+  @visibleForTesting
+  set testWals(List<Wal> wals) => _wals = wals;
+
+  @visibleForTesting
+  set testDevice(BtDevice? device) => _device = device;
 
   bool _supportsTimestampMarkers() {
     if (_device == null) return false;
@@ -106,6 +113,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
   @override
   Future deleteWal(Wal wal) async {
+    if (wal.storage != WalStorage.sdcard || !_wals.any((w) => w.id == wal.id)) return;
     _wals.removeWhere((w) => w.id == wal.id);
 
     if (_device != null) {

--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -224,7 +224,7 @@ class StorageSyncImpl implements StorageSync {
   @override
   Future deleteWal(Wal wal) async {
     if (wal.storage != WalStorage.sdcard || !_wals.any((w) => w.id == wal.id)) return;
-    await _deleteWalsOnDevice([wal]);
+    if (wal.device == _device?.id) await _deleteWalsOnDevice([wal]);
     _wals = _wals.where((w) => w.id != wal.id).toList();
     listener.onWalUpdated();
   }

--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:path_provider/path_provider.dart';
@@ -42,6 +43,9 @@ class StorageSyncImpl implements StorageSync {
   double get currentSpeedKBps => _currentSpeedKBps;
 
   StorageSyncImpl(this.listener);
+
+  @visibleForTesting
+  set testWals(List<Wal> wals) => _wals = wals;
 
   @override
   void setLocalSync(LocalWalSync localSync) {
@@ -219,6 +223,7 @@ class StorageSyncImpl implements StorageSync {
 
   @override
   Future deleteWal(Wal wal) async {
+    if (wal.storage != WalStorage.sdcard || !_wals.any((w) => w.id == wal.id)) return;
     await _deleteWalsOnDevice([wal]);
     _wals = _wals.where((w) => w.id != wal.id).toList();
     listener.onWalUpdated();

--- a/app/test/unit/wal_delete_cascade_test.dart
+++ b/app/test/unit/wal_delete_cascade_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/wals/sdcard_wal_sync.dart';
+import 'package:omi/services/wals/storage_sync.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/services/wals/wal_interfaces.dart';
+
+class _Listener implements IWalSyncListener {
+  @override
+  void onWalUpdated() {}
+
+  @override
+  void onWalSynced(Wal wal, {ServerConversation? conversation}) {}
+}
+
+final _device = BtDevice(id: 'omi-1', name: 'Omi', type: DeviceType.omi, rssi: -40);
+
+Wal _sdWal() => Wal(
+      timerStart: 2000,
+      codec: BleAudioCodec.opus,
+      seconds: 60,
+      status: WalStatus.miss,
+      storage: WalStorage.sdcard,
+      device: 'omi-1',
+      fileNum: 1,
+    );
+
+Wal _phoneWal() =>
+    Wal(timerStart: 1000, codec: BleAudioCodec.opus, seconds: 60, status: WalStatus.miss, storage: WalStorage.disk);
+
+Wal _phoneCopyOf(Wal wal) => Wal(
+      timerStart: wal.timerStart,
+      codec: wal.codec,
+      seconds: 60,
+      status: WalStatus.miss,
+      storage: WalStorage.disk,
+      device: wal.device,
+      originalStorage: WalStorage.sdcard,
+    );
+
+final _reachedDevice = throwsA(predicate((e) => '$e'.contains('Service manager is not initiated')));
+
+void main() {
+  group('SDCardWalSyncImpl.deleteWal', () {
+    SDCardWalSyncImpl sync() => SDCardWalSyncImpl(_Listener())
+      ..testDevice = _device
+      ..testWals = [_sdWal()];
+
+    test('leaves the device alone when a phone recording is deleted', () async {
+      final s = sync();
+      await s.deleteWal(_phoneWal());
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('leaves the device alone when the phone copy of an SD recording is deleted', () async {
+      final s = sync();
+      expect(_phoneCopyOf(_sdWal()).id, _sdWal().id);
+      await s.deleteWal(_phoneCopyOf(_sdWal()));
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('still sends the delete to the device for its own recording', () async {
+      await expectLater(sync().deleteWal(_sdWal()), _reachedDevice);
+    });
+  });
+
+  group('StorageSyncImpl.deleteWal', () {
+    StorageSyncImpl sync() => StorageSyncImpl(_Listener())
+      ..setDevice(_device)
+      ..testWals = [_sdWal()];
+
+    test('leaves the device alone when a phone recording is deleted', () async {
+      final s = sync();
+      await s.deleteWal(_phoneWal());
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('leaves the device alone when the phone copy of a device recording is deleted', () async {
+      final s = sync();
+      await s.deleteWal(_phoneCopyOf(_sdWal()));
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('still sends the delete to the device for its own recording', () async {
+      await expectLater(sync().deleteWal(_sdWal()), _reachedDevice);
+    });
+  });
+}

--- a/app/test/unit/wal_delete_cascade_test.dart
+++ b/app/test/unit/wal_delete_cascade_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/services/wals/flash_page_wal_sync.dart';
 import 'package:omi/services/wals/sdcard_wal_sync.dart';
 import 'package:omi/services/wals/storage_sync.dart';
 import 'package:omi/services/wals/wal.dart';
@@ -17,18 +18,27 @@ class _Listener implements IWalSyncListener {
 
 final _device = BtDevice(id: 'omi-1', name: 'Omi', type: DeviceType.omi, rssi: -40);
 
-Wal _sdWal() => Wal(
-      timerStart: 2000,
+Wal _sdWal({String device = 'omi-1', int timerStart = 2000}) => Wal(
+      timerStart: timerStart,
       codec: BleAudioCodec.opus,
       seconds: 60,
       status: WalStatus.miss,
       storage: WalStorage.sdcard,
-      device: 'omi-1',
+      device: device,
       fileNum: 1,
     );
 
-Wal _phoneWal() =>
-    Wal(timerStart: 1000, codec: BleAudioCodec.opus, seconds: 60, status: WalStatus.miss, storage: WalStorage.disk);
+Wal _flashWal() => Wal(
+      timerStart: 4000,
+      codec: BleAudioCodec.opus,
+      seconds: 60,
+      status: WalStatus.synced,
+      storage: WalStorage.flashPage,
+      device: 'omi-1',
+    );
+
+Wal _phoneWal({WalStatus status = WalStatus.miss}) =>
+    Wal(timerStart: 1000, codec: BleAudioCodec.opus, seconds: 60, status: status, storage: WalStorage.disk);
 
 Wal _phoneCopyOf(Wal wal) => Wal(
       timerStart: wal.timerStart,
@@ -37,16 +47,16 @@ Wal _phoneCopyOf(Wal wal) => Wal(
       status: WalStatus.miss,
       storage: WalStorage.disk,
       device: wal.device,
-      originalStorage: WalStorage.sdcard,
+      originalStorage: wal.storage,
     );
 
 final _reachedDevice = throwsA(predicate((e) => '$e'.contains('Service manager is not initiated')));
 
 void main() {
   group('SDCardWalSyncImpl.deleteWal', () {
-    SDCardWalSyncImpl sync() => SDCardWalSyncImpl(_Listener())
+    SDCardWalSyncImpl sync({List<Wal>? wals}) => SDCardWalSyncImpl(_Listener())
       ..testDevice = _device
-      ..testWals = [_sdWal()];
+      ..testWals = wals ?? [_sdWal()];
 
     test('leaves the device alone when a phone recording is deleted', () async {
       final s = sync();
@@ -61,15 +71,28 @@ void main() {
       expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
     });
 
+    test('leaves the device alone for an SD recording it does not list', () async {
+      final s = sync();
+      await s.deleteWal(_sdWal(timerStart: 3000));
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('drops a recording from the previous device without deleting on the new one', () async {
+      final stale = _sdWal(device: 'omi-0');
+      final s = sync(wals: [stale]);
+      await s.deleteWal(stale);
+      expect(await s.getMissingWals(), isEmpty);
+    });
+
     test('still sends the delete to the device for its own recording', () async {
       await expectLater(sync().deleteWal(_sdWal()), _reachedDevice);
     });
   });
 
   group('StorageSyncImpl.deleteWal', () {
-    StorageSyncImpl sync() => StorageSyncImpl(_Listener())
+    StorageSyncImpl sync({List<Wal>? wals}) => StorageSyncImpl(_Listener())
       ..setDevice(_device)
-      ..testWals = [_sdWal()];
+      ..testWals = wals ?? [_sdWal()];
 
     test('leaves the device alone when a phone recording is deleted', () async {
       final s = sync();
@@ -83,8 +106,35 @@ void main() {
       expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
     });
 
+    test('leaves the device alone for a device recording it does not list', () async {
+      final s = sync();
+      await s.deleteWal(_sdWal(timerStart: 3000));
+      expect((await s.getMissingWals()).map((w) => w.id), [_sdWal().id]);
+    });
+
+    test('drops a recording from the previous device without deleting on the new one', () async {
+      final stale = _sdWal(device: 'omi-0');
+      final s = sync(wals: [stale]);
+      await s.deleteWal(stale);
+      expect(await s.getMissingWals(), isEmpty);
+    });
+
     test('still sends the delete to the device for its own recording', () async {
       await expectLater(sync().deleteWal(_sdWal()), _reachedDevice);
+    });
+  });
+
+  group('FlashPageWalSyncImpl.deleteWal', () {
+    FlashPageWalSyncImpl sync() => FlashPageWalSyncImpl(_Listener())
+      ..testDevice = _device
+      ..testWals = [_flashWal()];
+
+    test('does not acknowledge the pendant when a synced phone recording is deleted', () async {
+      await sync().deleteWal(_phoneWal(status: WalStatus.synced));
+    });
+
+    test('still acknowledges the pendant for its own synced recording', () async {
+      await expectLater(sync().deleteWal(_flashWal()), _reachedDevice);
     });
   });
 }


### PR DESCRIPTION
`WalSyncs.deleteWal` sends every recording delete to all five sub-syncs, whichever one owns it. The ring sync already checks membership first (the guard added in #7218, whose comment calls out exactly this cascade), but the SD card, storage and flash page syncs don't. So deleting any recording from the sync page, the auto-sync page or a recording's detail page while a device is connected also runs their device-side action.

For the SD card sync that is `writeToStorage(fileNum, 1, 0)`. The DevKit firmware handles command 1 as `DELETE_COMMAND` and runs `clear_audio_file(1)` and `save_offset(0)` whatever file number was sent (`omi/firmware/devkit/src/storage.c`). Phone recordings default to `fileNum = 1`, so deleting a phone recording with a DevKit connected wipes the audio still waiting on its SD card. The storage sync sends `[0x12, fileIndex]`; the current Omi firmware reads `0x12` as ring advance and rejects a 2-byte write, so CV1 on the ring firmware isn't hit by either path. The flash page sync acknowledges the Limitless pendant up to `wal.storageTotalBytes` for any synced wal. Phone recordings carry 0 there, so I couldn't show that ack frees anything, but it shouldn't run for a recording that sync doesn't own.

All three now return early unless the wal is one of their own device recordings (the storage type they manage and listed in `_wals`), the same way the ring sync does. The storage type matters because a chunk copied to the phone keeps the original `device` and `timerStart`, and `Wal.id` is `'${device}_$timerStart'`, so an id-only check would still clear the card when that phone copy is deleted. The device command also only goes out when `wal.device` is the connected device: the storage sync keeps its list across a device switch, so a stale recording from the previous device would otherwise be deleted by file number on the new one. The stale entry is still dropped from the list. Bulk deletes aren't affected because those only walk each sync's own list.

`test/unit/wal_delete_cascade_test.dart` builds each sync with a connected device and one of its own recordings, then deletes a phone recording, the phone copy of a device recording, a device recording it doesn't list, and a recording from a previous device. These classes can't take a fake connection, so reaching the device shows up in the test as `ServiceManager` throwing "Service manager is not initiated"; a control per sync deletes its own recording and expects exactly that. Against main with only the `@visibleForTesting` setters added, 9 of the 12 fail (every case where the sync doesn't own the recording) and the three controls pass. With the fix all 12 pass.

```
cd app
flutter test test/unit/wal_delete_cascade_test.dart   # +12: All tests passed!
flutter test test/unit/*wal*_test.dart test/unit/sdcard*_test.dart test/providers/*wal*_test.dart \
  test/widgets/sync_row_recovery_window_test.dart test/unit/sync_manifest_claim_drain_test.dart   # +173: All tests passed!
bash test.sh                          # +1913 ~5: All tests passed!
bash scripts/analyze_ratchet.sh       # Analyzer ratchet passed.
```

No existing class covers a fan-out receiver acting on a target it doesn't own, so this adds `FC-fanout-delete-skips-ownership-check` with #7218 as the earlier instance.

Failure-Class: new
