### PR TITLE
fix(backend): gate /v1/dev abuse, canonical invalid_patch visibility race, embeddings-400 degrade

### DIFF
--- a/backend/database/dev_api_key.py
+++ b/backend/database/dev_api_key.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, List, Optional, Tuple, cast
@@ -28,6 +29,10 @@ from utils.dev_api_keys import generate_dev_api_key, hash_dev_api_key
 from utils.scopes import AVAILABLE_SCOPES, READ_ONLY_SCOPES, Scopes
 
 DEV_API_KEY_APP_ID = "developer_api"
+
+# Every issued Developer API key is ``omi_dev_`` + secrets.token_hex(16):
+# 32 lowercase hex characters (see utils.dev_api_keys.generate_dev_api_key).
+_DEV_API_KEY_PATTERN = re.compile(r"omi_dev_[0-9a-f]{32}")
 
 
 def _db() -> Any:
@@ -199,7 +204,11 @@ def get_api_key_auth_result(api_key: str) -> ApiKeyAuthLookupResult:
     Returns dict with 'user_id' and 'scopes' keys, or None if invalid.
     If scopes don't exist in the database, returns None (treated as read-only by has_scope).
     """
-    if not api_key.startswith("omi_dev_"):
+    # Keys are always issued as ``omi_dev_`` + 32 lowercase hex chars
+    # (generate_dev_api_key); anything else can never match a stored key, so
+    # reject it before the Redis read and Firestore query. Scripted abuse of
+    # /v1/dev/* presents junk Bearer tokens — those must cost nothing.
+    if not _DEV_API_KEY_PATTERN.fullmatch(api_key or ""):
         return ApiKeyAuthLookupResult(context=None)
     secret_part = api_key.replace("omi_dev_", "", 1)
     hashed_key = hash_dev_api_key(secret_part)

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -910,26 +910,45 @@ def upsert_action_item_vectors_batch(uid: str, items: List[Dict[str, Any]]) -> i
         return 0
 
 
+# Embedding input for action-item similarity is scraped/untrusted text. The
+# embeddings gateway rejects empty or oversized input with a 400, so validate
+# and clip before spending the call; callers degrade to "no candidates".
+_ACTION_ITEM_QUERY_MAX_CHARS = 8000
+
+
+def _prepare_action_item_query(query: str) -> Optional[str]:
+    """Strip, reject empty, and clip untrusted action-item query text."""
+    prepared = (query or "").strip()
+    if not prepared:
+        return None
+    return prepared[:_ACTION_ITEM_QUERY_MAX_CHARS]
+
+
 def search_action_items_by_vector(uid: str, query: str, limit: int = 10, min_score: float = 0.3) -> List[str]:
-    if index is None:
-        logger.warning('Pinecone index not initialized, skipping action item search')
+    prepared_query = _prepare_action_item_query(query)
+    if index is None or prepared_query is None:
+        logger.warning('Pinecone index not initialized or empty query, skipping action item search')
         return []
 
-    vector = embeddings.embed_query(query)
-    filter_data: Dict[str, Any] = {'uid': uid}
+    try:
+        vector = embeddings.embed_query(prepared_query)
+        filter_data: Dict[str, Any] = {'uid': uid}
 
-    xc = index.query(
-        vector=vector, top_k=limit, include_metadata=True, filter=filter_data, namespace=ACTION_ITEMS_NAMESPACE
-    )
+        xc = index.query(
+            vector=vector, top_k=limit, include_metadata=True, filter=filter_data, namespace=ACTION_ITEMS_NAMESPACE
+        )
 
-    matches: List[Any] = xc.get('matches', [])
-    top_score = matches[0]['score'] if matches else None
-    kept = [m for m in matches if m.get('score', 0.0) >= min_score]
-    logger.info(
-        f'search_action_items_by_vector uid={uid} matches={len(matches)} kept={len(kept)} '
-        f'top_score={top_score} min_score={min_score}'
-    )
-    return [m['metadata'].get('action_item_id') for m in kept]
+        matches: List[Any] = xc.get('matches', [])
+        top_score = matches[0]['score'] if matches else None
+        kept = [m for m in matches if m.get('score', 0.0) >= min_score]
+        logger.info(
+            f'search_action_items_by_vector uid={uid} matches={len(matches)} kept={len(kept)} '
+            f'top_score={top_score} min_score={min_score}'
+        )
+        return [m['metadata'].get('action_item_id') for m in kept]
+    except Exception as e:
+        logger.exception(f'search_action_items_by_vector failed uid={uid}: {e}')
+        return []
 
 
 def find_similar_action_items(uid: str, query: str, threshold: float = 0.6, limit: int = 10) -> List[Dict[str, Any]]:
@@ -944,11 +963,12 @@ def find_similar_action_items(uid: str, query: str, threshold: float = 0.6, limi
     caller treats "no candidates" as "user has nothing relevant," which is
     the same behavior as a brand-new user.
     """
-    if index is None:
+    prepared_query = _prepare_action_item_query(query)
+    if index is None or prepared_query is None:
         return []
 
     try:
-        vector = embeddings.embed_query(query)
+        vector = embeddings.embed_query(prepared_query)
         xc = index.query(
             vector=vector,
             top_k=limit,

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -28,6 +28,7 @@ from models.conversation_metadata import ConversationMetadataKeys, metadata_list
 from models.product_memory import MemoryItem
 from models.memory_search_gateway import SearchMode, SearchVectorHit
 from utils.llm.clients import embeddings
+from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -948,6 +949,16 @@ def search_action_items_by_vector(uid: str, query: str, limit: int = 10, min_sco
         return [m['metadata'].get('action_item_id') for m in kept]
     except Exception as e:
         logger.exception(f'search_action_items_by_vector failed uid={uid}: {e}')
+        # Degrade telemetry: without this, a provider outage is indistinguishable
+        # from a genuine no-match search in the empty-list result.
+        record_fallback(
+            component='other',
+            from_mode='action_item_vector_search',
+            to_mode='no_candidates',
+            reason='other',
+            outcome='degraded',
+            log=logger,
+        )
         return []
 
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -643,9 +643,19 @@ async def get_developer_memory_default_memory_write_context(
         key_id=auth_context.key_id,
         policy_name="dev:memories",
     )
-    # Burst ceiling: the hourly dev:memories window alone admits the whole
-    # quota inside one minute (the 2026-09-11 scripted-abuse shape), so the
-    # per-minute cap is what actually stops 69/min bursts.
+    return auth_context
+
+
+async def get_developer_memory_default_memory_create_context(
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_context),
+) -> ProductAuthorizationContext:
+    """POST-only memory-create context: shared hourly ceiling plus burst cap.
+
+    The per-minute ``dev:memories_write_burst`` ceiling exists to stop scripted
+    create bursts (the 2026-09-11 69/min shape), so it must ride only the POST
+    create route — PATCH/DELETE share the hourly write context and must not
+    drain a POST-specific bucket.
+    """
     await _check_api_key_rate_limit_async(
         prefix="dev",
         uid=auth_context.uid,

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -437,6 +437,27 @@ async def get_uid_with_conversations_write(auth: ApiKeyAuth = Depends(get_api_ke
     return auth.uid
 
 
+async def get_uid_with_conversations_from_segments_write(
+    auth: ApiKeyAuth = Depends(get_auth_with_conversations_write),
+    request: Request = None,
+) -> str:
+    """conversations:write plus the dedicated from-segments budget for the dev route.
+
+    POST /v1/dev/user/conversations/from-segments mirrors the first-party
+    route's dedicated conversations:from-segments policy (30/hour) on top of
+    the shared dev:conversations write ceiling — the same shared-plus-per-route
+    composition as _check_conversation_read_budgets_async, so per-route tuning
+    can never raise the aggregate conversation-write limit. Failure logging
+    includes remote IP and user agent: this route is a scripted-abuse target.
+    """
+    await _check_dev_api_key_rate_limit_async(
+        request=request,
+        auth=auth,
+        policy_name="dev:conversations_from_segments",
+    )
+    return auth.uid
+
+
 async def get_auth_with_memories_read(auth: ApiKeyAuth = Depends(get_api_key_auth)) -> ApiKeyAuth:
     if not has_scope(auth.scopes, Scopes.MEMORIES_READ):
         raise HTTPException(status_code=403, detail=f"Insufficient permissions. Required scope: {Scopes.MEMORIES_READ}")
@@ -621,6 +642,16 @@ async def get_developer_memory_default_memory_write_context(
         app_id=auth_context.app_id,
         key_id=auth_context.key_id,
         policy_name="dev:memories",
+    )
+    # Burst ceiling: the hourly dev:memories window alone admits the whole
+    # quota inside one minute (the 2026-09-11 scripted-abuse shape), so the
+    # per-minute cap is what actually stops 69/min bursts.
+    await _check_api_key_rate_limit_async(
+        prefix="dev",
+        uid=auth_context.uid,
+        app_id=auth_context.app_id,
+        key_id=auth_context.key_id,
+        policy_name="dev:memories_write_burst",
     )
     return auth_context
 

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -46,6 +46,7 @@ from dependencies import (
     get_auth_with_conversations_read,
     get_uid_with_conversations_read,
     get_uid_with_conversations_read_ask,
+    get_uid_with_conversations_from_segments_write,
     get_uid_with_conversations_write,
     get_developer_memory_default_memory_batch_write_context,
     get_developer_memory_default_memory_read_context,
@@ -1197,6 +1198,20 @@ class CreateConversationFromTranscriptRequest(BaseModel):
             raise ValueError('client_session_id cannot be empty')
         return value
 
+    @field_validator('started_at', 'finished_at')
+    @classmethod
+    def require_timezone_offset(cls, value: Optional[datetime]) -> Optional[datetime]:
+        """Reject offset-naive timestamps with a 422 instead of a 500.
+
+        A naive ``finished_at`` against the tz-aware ``started_at`` default (or
+        the reverse) makes the handler's ``finished_at <= started_at`` check
+        raise TypeError — an uncaught 500 on a malformed body. Both from-segments
+        routes (developer and first-party) share this model, so both get the 422.
+        """
+        if value is not None and value.tzinfo is None:
+            raise ValueError('must include a timezone offset (e.g. 2026-09-11T12:00:00Z)')
+        return value
+
 
 class DeveloperFolder(BaseModel):
     model_config = ConfigDict(title='DeveloperFolder')
@@ -2102,7 +2117,7 @@ def create_conversation_from_segments_user(
 def create_conversation_from_segments(
     request: CreateConversationFromTranscriptRequest,
     http_request: Request,
-    uid: str = Depends(get_uid_with_conversations_write),
+    uid: str = Depends(get_uid_with_conversations_from_segments_write),
 ):
     """
     Create a new conversation from structured transcript segments.

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -51,6 +51,7 @@ from dependencies import (
     get_developer_memory_default_memory_batch_write_context,
     get_developer_memory_default_memory_read_context,
     get_developer_memory_default_memory_write_context,
+    get_developer_memory_default_memory_create_context,
     get_uid_with_action_items_read,
     get_uid_with_action_items_write,
     get_uid_with_goals_read,
@@ -482,7 +483,7 @@ def search_memories_vector(
 @router.post("/v1/dev/user/memories", response_model=DeveloperMemory, tags=["Memories"], operation_id="createMemory")
 def create_memory(
     request: CreateMemoryRequest,
-    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_write_context),
+    auth_context: ProductAuthorizationContext = Depends(get_developer_memory_default_memory_create_context),
 ):
     """
     Create a new memory for the authenticated user.

--- a/backend/tests/unit/test_action_item_dedup.py
+++ b/backend/tests/unit/test_action_item_dedup.py
@@ -22,7 +22,9 @@ from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
+
 
 from testing.import_isolation import load_module_fresh, stub_modules
 
@@ -196,14 +198,17 @@ class TestFindSimilarActionItems:
 
         assert result == []
 
-    def test_empty_query_still_calls_pinecone(self, monkeypatch, vector_db):
-        """The helper itself doesn't gate on empty query — that's the caller's concern.
-        Embedding an empty string is harmless; Pinecone returns no matches; helper returns []."""
-        _setup_mocks(monkeypatch, vector_db, query_response={'matches': []})
+    def test_empty_or_blank_query_skips_the_embedding_call(self, monkeypatch, vector_db):
+        """GH #13505: empty input is exactly what the embeddings gateway 400s on.
 
-        result = vector_db.find_similar_action_items('uid-abc', '')
+        The helper validates before embedding — an empty or blank query returns
+        "no candidates" without spending the gateway call.
+        """
+        _, fake_embeddings = _setup_mocks(monkeypatch, vector_db, query_response={'matches': []})
 
-        assert result == []
+        assert vector_db.find_similar_action_items('uid-abc', '') == []
+        assert vector_db.find_similar_action_items('uid-abc', '   ') == []
+        fake_embeddings.embed_query.assert_not_called()
 
     def test_preserves_pinecone_match_order(self, monkeypatch, vector_db):
         """Pinecone returns matches sorted by relevance; we must not re-order."""
@@ -239,6 +244,71 @@ class TestFindSimilarActionItems:
 
         assert [r['action_item_id'] for r in result] == ['good-1', 'good-2']
         assert all(r['action_item_id'] for r in result)
+
+
+def _gateway_400() -> Exception:
+    request = httpx.Request('POST', 'http://llm-gateway.internal/v1/embeddings')
+    response = httpx.Response(400, request=request)
+    return httpx.HTTPStatusError(
+        "Client error '400 Bad Request' for url '.../v1/embeddings'", request=request, response=response
+    )
+
+
+class TestActionItemEmbeddingGateway400:
+    """GH #13505: the embeddings gateway answers 400 on empty/oversized/invalid
+    input, and that 400 propagates out of ``embed_query`` as
+    ``httpx.HTTPStatusError``. ``search_action_items_by_vector`` (backing
+    GET /v1/action-items/search and the MCP search path) had no guard at all —
+    the 400 surfaced as a 500 on a real user request. Both similarity helpers
+    must degrade to "no candidates": validate and clip the query before the
+    call, and swallow the gateway failure when it still rejects it.
+    """
+
+    def test_search_returns_empty_on_gateway_400(self, monkeypatch, vector_db):
+        _setup_mocks(monkeypatch, vector_db, embed_raises=_gateway_400())
+
+        assert vector_db.search_action_items_by_vector('uid-abc', 'buy milk') == []
+
+    def test_search_returns_empty_on_pinecone_failure(self, monkeypatch, vector_db):
+        _setup_mocks(monkeypatch, vector_db, query_raises=RuntimeError('pinecone is down'))
+
+        assert vector_db.search_action_items_by_vector('uid-abc', 'buy milk') == []
+
+    def test_search_empty_query_skips_the_embedding_call(self, monkeypatch, vector_db):
+        _, fake_embeddings = _setup_mocks(monkeypatch, vector_db, query_response={'matches': []})
+
+        assert vector_db.search_action_items_by_vector('uid-abc', '') == []
+        fake_embeddings.embed_query.assert_not_called()
+
+    def test_search_clips_oversized_query_before_embedding(self, monkeypatch, vector_db):
+        """A scraped/oversized action-item string must not reach the gateway raw."""
+        _, fake_embeddings = _setup_mocks(monkeypatch, vector_db, query_response={'matches': []})
+        oversized = 'x' * (vector_db._ACTION_ITEM_QUERY_MAX_CHARS * 3)
+
+        vector_db.search_action_items_by_vector('uid-abc', oversized)
+
+        sent = fake_embeddings.embed_query.call_args.args[0]
+        assert len(sent) == vector_db._ACTION_ITEM_QUERY_MAX_CHARS
+
+    def test_search_returns_kept_match_ids(self, monkeypatch, vector_db):
+        response = {
+            'matches': [
+                {'metadata': {'action_item_id': 'a1'}, 'score': 0.9},
+                {'metadata': {'action_item_id': 'a2'}, 'score': 0.1},  # below default 0.3
+            ]
+        }
+        _setup_mocks(monkeypatch, vector_db, query_response=response)
+
+        assert vector_db.search_action_items_by_vector('uid-abc', 'buy milk') == ['a1']
+
+    def test_find_similar_clips_oversized_query_before_embedding(self, monkeypatch, vector_db):
+        _, fake_embeddings = _setup_mocks(monkeypatch, vector_db, query_response={'matches': []})
+        oversized = 'y' * (vector_db._ACTION_ITEM_QUERY_MAX_CHARS * 3)
+
+        vector_db.find_similar_action_items('uid-abc', oversized)
+
+        sent = fake_embeddings.embed_query.call_args.args[0]
+        assert len(sent) == vector_db._ACTION_ITEM_QUERY_MAX_CHARS
 
 
 class TestQueryConversationVectors:

--- a/backend/tests/unit/test_api_key_listability_contract.py
+++ b/backend/tests/unit/test_api_key_listability_contract.py
@@ -396,6 +396,37 @@ def test_developer_key_authentication_metadata_projection_and_revocation_share_d
     assert dev_api_key_db.get_user_and_scopes_by_api_key(raw_token) is None
 
 
+def test_malformed_dev_api_keys_are_rejected_before_any_redis_or_firestore_io(monkeypatch):
+    """GH #13505: junk Bearer tokens on /v1/dev/* must cost nothing.
+
+    Every issued Developer API key is ``omi_dev_`` + 32 lowercase hex chars, so
+    anything else can never match a stored row. Scripted abuse presents
+    prefixed junk; rejecting it at the format gate keeps the Redis read and the
+    Firestore ``where(hashed_key)`` query off the hot path entirely.
+    """
+
+    def _forbidden_lookup() -> None:
+        raise AssertionError("malformed key must not reach the Firestore client")
+
+    monkeypatch.setattr(dev_api_key_db, "get_firestore_client", _forbidden_lookup)
+    monkeypatch.setattr(dev_api_key_db, "redis_db", MagicMock())
+
+    malformed = [
+        "",  # no credential at all
+        "omi_dev_secret",  # right family, not hex, wrong length
+        "omi_dev_0123456789ABCDEF0123456789ABCDEF",  # uppercase is never issued
+        "omi_dev_" + "0" * 31,  # one char short
+        "omi_dev_" + "0" * 33,  # one char long
+        "omi_mcp_" + "0" * 32,  # wrong family
+        "firebase-id-token",  # not an API key
+    ]
+    for token in malformed:
+        assert dev_api_key_db.get_api_key_auth_result(token).context is None, token
+
+    well_formed = "omi_dev_0123456789abcdef0123456789abcdef"
+    assert dev_api_key_db._DEV_API_KEY_PATTERN.fullmatch(well_formed)
+
+
 def test_mcp_present_poisoned_app_identity_fails_auth_but_remains_safely_listable(monkeypatch):
     raw_token = "omi_mcp_fedcba9876543210fedcba9876543210"
     overflowing_datetime = datetime.max.replace(tzinfo=timezone(-timedelta(hours=23)))

--- a/backend/tests/unit/test_api_key_listability_contract.py
+++ b/backend/tests/unit/test_api_key_listability_contract.py
@@ -409,7 +409,15 @@ def test_malformed_dev_api_keys_are_rejected_before_any_redis_or_firestore_io(mo
         raise AssertionError("malformed key must not reach the Firestore client")
 
     monkeypatch.setattr(dev_api_key_db, "get_firestore_client", _forbidden_lookup)
-    monkeypatch.setattr(dev_api_key_db, "redis_db", MagicMock())
+    # A plain MagicMock would silently absorb Redis reads, so the test could
+    # pass even if a regression routed malformed tokens through the cache. The
+    # Redis handle must be a MagicMock (attribute access works) whose read
+    # method fails loudly: the format gate has to short-circuit before any IO.
+    forbidden_redis = MagicMock()
+    forbidden_redis.read_cached_dev_api_key_data.side_effect = AssertionError(
+        "malformed key must not reach the Redis cache"
+    )
+    monkeypatch.setattr(dev_api_key_db, "redis_db", forbidden_redis)
 
     malformed = [
         "",  # no credential at all

--- a/backend/tests/unit/test_dependency_async_boundaries.py
+++ b/backend/tests/unit/test_dependency_async_boundaries.py
@@ -328,6 +328,7 @@ def test_all_api_key_scope_dependencies_route_rate_limits_through_the_critical_e
             'dev:goals_write',
             'dev:memories_read',
             'dev:memories',
+            'dev:memories_write_burst',
             'dev:memories_batch',
         ]
         assert len(executor_calls) == len(policies)
@@ -467,3 +468,55 @@ def test_authentication_and_scope_failures_preserve_public_http_semantics() -> N
             asyncio.run(dependencies.get_auth_with_goals_write(no_scope))
         assert scope_exc.value.status_code == 403
         assert dependencies.Scopes.GOALS_WRITE in scope_exc.value.detail
+
+
+def test_dev_write_paths_check_burst_and_dedicated_rate_budgets() -> None:
+    """GH #13505: the abused /v1/dev/* write paths must ride dedicated limits.
+
+    - POST /v1/dev/user/memories: hourly dev:memories plus the per-minute
+      dev:memories_write_burst ceiling — the hourly window alone admits the
+      whole quota inside one minute (the scripted 69/min burst shape).
+    - POST /v1/dev/user/conversations/from-segments: shared dev:conversations
+      plus the dedicated dev:conversations_from_segments budget, mirroring the
+      first-party route's conversations:from-segments policy.
+    """
+    with _loaded_dependencies() as (dependencies, _firebase_auth, _mcp_db, _dev_db):
+        policies: list[str] = []
+
+        def check_rate_limit(**kwargs: Any) -> None:
+            policies.append(kwargs['policy_name'])
+
+        async def inline_run_blocking(_executor: Any, fn: Any, *args: Any, **kwargs: Any) -> Any:
+            return fn(*args, **kwargs)
+
+        dependencies.check_api_key_rate_limit = check_rate_limit
+        dependencies.run_blocking = inline_run_blocking
+
+        auth = dependencies.ApiKeyAuth(
+            uid='user-1',
+            scopes=[dependencies.Scopes.CONVERSATIONS_WRITE],
+            app_id='developer_api',
+            key_id='key-1',
+        )
+
+        async def exercise() -> None:
+            write_context = dependencies.ProductAuthorizationContext(
+                uid='user-1', app_id='developer_api', key_id='key-1'
+            )
+            assert await dependencies.get_developer_memory_default_memory_write_context(write_context) is (
+                write_context
+            )
+            # The route's Depends() chain resolves get_auth_with_conversations_write
+            # (shared ceiling) before the from-segments wrapper adds its per-route
+            # budget; exercise them in that order.
+            assert await dependencies.get_auth_with_conversations_write(auth) is auth
+            assert await dependencies.get_uid_with_conversations_from_segments_write(auth) == 'user-1'
+
+        asyncio.run(exercise())
+
+        assert policies == [
+            'dev:memories',
+            'dev:memories_write_burst',
+            'dev:conversations',
+            'dev:conversations_from_segments',
+        ]

--- a/backend/tests/unit/test_dependency_async_boundaries.py
+++ b/backend/tests/unit/test_dependency_async_boundaries.py
@@ -304,6 +304,7 @@ def test_all_api_key_scope_dependencies_route_rate_limits_through_the_critical_e
             write_context = dependencies.get_developer_memory_default_memory_write_auth_context(auth)
             assert write_context.surface == 'developer_default_memory_write'
             assert await dependencies.get_developer_memory_default_memory_write_context(write_context) is write_context
+            assert await dependencies.get_developer_memory_default_memory_create_context(write_context) is write_context
             assert (
                 await dependencies.get_developer_memory_default_memory_batch_write_context(write_context)
                 is write_context
@@ -475,7 +476,8 @@ def test_dev_write_paths_check_burst_and_dedicated_rate_budgets() -> None:
 
     - POST /v1/dev/user/memories: hourly dev:memories plus the per-minute
       dev:memories_write_burst ceiling — the hourly window alone admits the
-      whole quota inside one minute (the scripted 69/min burst shape).
+      whole quota inside one minute (the scripted 69/min burst shape). The
+      burst budget is POST-only: PATCH/DELETE ride just the hourly context.
     - POST /v1/dev/user/conversations/from-segments: shared dev:conversations
       plus the dedicated dev:conversations_from_segments budget, mirroring the
       first-party route's conversations:from-segments policy.
@@ -499,16 +501,29 @@ def test_dev_write_paths_check_burst_and_dedicated_rate_budgets() -> None:
             key_id='key-1',
         )
 
+        # Verify the declared Depends() composition itself, not a hand-picked
+        # call order: the POST create context must chain the shared hourly
+        # write context (so PATCH/DELETE never touch the burst budget), and
+        # the from-segments wrapper must chain get_auth_with_conversations_write.
+        create_default = dependencies.get_developer_memory_default_memory_create_context.__defaults__[0]
+        assert create_default.dependency is dependencies.get_developer_memory_default_memory_write_context
+        write_default = dependencies.get_developer_memory_default_memory_write_context.__defaults__[0]
+        assert write_default.dependency is dependencies.get_developer_memory_default_memory_write_auth_context
+        from_segments_default = dependencies.get_uid_with_conversations_from_segments_write.__defaults__[0]
+        assert from_segments_default.dependency is dependencies.get_auth_with_conversations_write
+
         async def exercise() -> None:
             write_context = dependencies.ProductAuthorizationContext(
                 uid='user-1', app_id='developer_api', key_id='key-1'
             )
-            assert await dependencies.get_developer_memory_default_memory_write_context(write_context) is (
-                write_context
-            )
-            # The route's Depends() chain resolves get_auth_with_conversations_write
-            # (shared ceiling) before the from-segments wrapper adds its per-route
-            # budget; exercise them in that order.
+            # PATCH/DELETE path: shared hourly ceiling only, no burst budget.
+            hourly = await dependencies.get_developer_memory_default_memory_write_context(write_context)
+            assert hourly is write_context
+            # POST path: the create context composes on top of the hourly one.
+            assert await dependencies.get_developer_memory_default_memory_create_context(hourly) is write_context
+            # POST /v1/dev/user/conversations/from-segments: the wrapper's
+            # Depends(get_auth_with_conversations_write) resolves the shared
+            # ceiling before adding its per-route budget.
             assert await dependencies.get_auth_with_conversations_write(auth) is auth
             assert await dependencies.get_uid_with_conversations_from_segments_write(auth) == 'user-1'
 

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -702,3 +702,46 @@ def test_from_segments_renews_processing_lease_during_live_processing(monkeypatc
     developer._create_conversation_from_segments('uid1', _request(client_session_id='local-session-lease'))
 
     assert lease_renewed.is_set()
+
+
+def test_from_segments_rejects_timezone_naive_timestamps_with_422():
+    """GH #13505: a naive finished_at against the tz-aware started_at default made
+    the handler's finished_at <= started_at check raise TypeError — an uncaught
+    500 on a malformed body (the scripted-client failure shape). The shared model
+    now rejects offset-naive timestamps at validation, so both the developer and
+    first-party from-segments routes answer 422 instead."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match='timezone offset'):
+        developer.CreateConversationFromTranscriptRequest.model_validate(
+            {**_request_data(), 'finished_at': '2026-01-01T00:00:01'}
+        )
+
+    with pytest.raises(ValidationError, match='timezone offset'):
+        developer.CreateConversationFromTranscriptRequest.model_validate(
+            {**_request_data(), 'started_at': '2026-01-01T00:00:00'}
+        )
+
+    # Offset-aware values still validate.
+    assert developer.CreateConversationFromTranscriptRequest.model_validate(_request_data()).finished_at is not None
+
+
+def _request_data():
+    return {
+        'transcript_segments': [_segment()],
+        'source': 'desktop',
+        'started_at': NOW,
+        'finished_at': NOW.replace(second=2),
+        'language': 'en',
+    }
+
+
+def test_dev_from_segments_route_uses_the_dedicated_rate_limited_dependency():
+    """GH #13505: the developer from-segments route must not ride the bare
+    conversations:write dependency — it needs the dedicated
+    dev:conversations_from_segments budget on top of the shared ceiling."""
+    import inspect
+
+    parameter = inspect.signature(developer.create_conversation_from_segments).parameters['uid']
+    # fastapi.Depends is a factory, so assert on the resolved dependency itself.
+    assert parameter.default.dependency is developer.get_uid_with_conversations_from_segments_write

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -180,6 +180,27 @@ class TestBoostExemption(unittest.TestCase):
     def test_action_items_list_is_exempt_by_default(self):
         self.assertIn("action_items:list", BOOST_EXEMPT_POLICIES)
 
+    def test_dev_abuse_ceilings_are_exempt_by_default(self):
+        """GH #13505: the /v1/dev/* abuse ceilings are decisions, not defaults.
+
+        RATE_LIMIT_BOOST exists to widen limits for events; at the documented
+        production value 100 it would turn the 30/min memories burst ceiling
+        into 3,000/min and the 30/hour from-segments budget into 3,000/hour —
+        exactly the scripted-abuse shape these policies exist to stop. The
+        shared hourly ceilings (dev:memories, dev:conversations) ride the same
+        exemption so the dedicated budgets always compose with real caps.
+        """
+        for policy in (
+            "dev:memories",
+            "dev:memories_write_burst",
+            "dev:conversations",
+            "dev:conversations_from_segments",
+        ):
+            self.assertIn(policy, BOOST_EXEMPT_POLICIES)
+            base = RATE_POLICIES[policy]
+            for boost in (2.0, 100.0, 1000.0):
+                self.assertEqual(get_effective_limit(policy, boost=boost), base)
+
     def test_exempt_policy_ignores_the_boost(self):
         """(b) The exempt policy enforces its base limit under any boost."""
         base = RATE_POLICIES["action_items:list"]

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -1031,6 +1031,106 @@ def test_reusing_a_row_id_for_different_content_still_fails(monkeypatch, canonic
     assert canonical_db.docs[f"users/{uid}/memory_items/{first_id}"] == before
 
 
+class _LaggingSnapshotDb:
+    """Fake Firestore wrapper that hides one document for the first plain reads.
+
+    Emulates the losing side of the concurrent identical-add race (GH #13505):
+    the apply transaction observed the colliding row inside its own snapshot,
+    but the duplicate-resolution read that follows lands before the winning
+    write is readable. Reads inside a transaction (``transaction=``) always see
+    the row — that is what produced ``invalid_patch`` in the first place.
+    """
+
+    def __init__(self, inner: "_FakeDb", hidden_path: str, misses: int):
+        self._inner = inner
+        self._hidden_path = hidden_path
+        self._misses_left = misses
+
+    def document(self, path):
+        ref = self._inner.document(path)
+        if path != self._hidden_path:
+            return ref
+        wrapper = self
+
+        class _LaggingDocRef:
+            def get(self, transaction=None):
+                if transaction is None and wrapper._misses_left > 0:
+                    wrapper._misses_left -= 1
+                    return _Snapshot(None, exists=False, doc_id=path.rsplit("/", 1)[-1])
+                return ref.get(transaction=transaction)
+
+            def __getattr__(self, name):
+                return getattr(ref, name)
+
+        return _LaggingDocRef()
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def test_identical_resubmission_resolves_once_the_row_becomes_readable(monkeypatch, canonical_db):
+    """GH #13505 residual: concurrent/retry identical adds must not 500.
+
+    The 2026-09-11 prod family (12x ``canonical write failed: invalid_patch
+    (add patch new_memory_id already exists)`` in one SLI window) is the case
+    #12524's resolver misses: the apply transaction sees the colliding row, but
+    its single follow-up snapshot read still cannot. Without the visibility
+    retry this raises and fails the user-visible chat/extraction write; with it,
+    the resubmission resolves to the existing row once the row is readable.
+    """
+    uid = "uid-canonical-ws-j"
+    _stub_delete_side_effects(monkeypatch)
+    monkeypatch.setattr("utils.memory.canonical_memory_adapter.time.sleep", lambda _seconds: None)
+
+    payload = _sample_memory_payload(uid=uid, conversation_id="conv-race", content="User rows every morning")
+    first_id = write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+    # An unrelated write advances the account head so the resubmission cannot
+    # be recognized as a replay of the first operation.
+    write_canonical_external_memory(
+        uid, _external_memory_payload(uid, "Unrelated head-advancing fact"), db_client=canonical_db
+    )
+    before = copy.deepcopy(canonical_db.docs[f"users/{uid}/memory_items/{first_id}"])
+
+    # Same row id and same content, but a distinct idempotency identity: the
+    # winning write came from a converging operation, not a byte-identical
+    # replay, so the apply surfaces the row-id collision instead of a skip.
+    resubmission = dict(payload, subject_entity_id="person-race")
+    lagging_db = _LaggingSnapshotDb(
+        canonical_db,
+        hidden_path=f"users/{uid}/memory_items/{first_id}",
+        misses=1,
+    )
+
+    resubmitted_id = write_canonical_extraction_memory(uid, resubmission, db_client=lagging_db)
+
+    assert resubmitted_id == first_id
+    assert canonical_db.docs[f"users/{uid}/memory_items/{first_id}"] == before
+
+
+def test_row_that_never_becomes_readable_still_fails_closed(monkeypatch, canonical_db):
+    """The visibility retry must stay bounded: a row that never appears is an
+    error, not an idempotent success."""
+    uid = "uid-canonical-ws-j"
+    _stub_delete_side_effects(monkeypatch)
+    monkeypatch.setattr("utils.memory.canonical_memory_adapter.time.sleep", lambda _seconds: None)
+
+    payload = _sample_memory_payload(uid=uid, conversation_id="conv-race", content="User rows every morning")
+    first_id = write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+    write_canonical_external_memory(
+        uid, _external_memory_payload(uid, "Unrelated head-advancing fact"), db_client=canonical_db
+    )
+
+    resubmission = dict(payload, subject_entity_id="person-race")
+    never_visible_db = _LaggingSnapshotDb(
+        canonical_db,
+        hidden_path=f"users/{uid}/memory_items/{first_id}",
+        misses=99,  # every plain read misses: the row never becomes readable
+    )
+
+    with pytest.raises(RuntimeError, match="canonical write failed"):
+        write_canonical_extraction_memory(uid, resubmission, db_client=never_visible_db)
+
+
 def test_conversation_sourced_evidence_is_never_reissued_after_delete(monkeypatch, canonical_db):
     uid = "uid-canonical-ws-j"
     conversation_id = "conv-deleted-source"

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -1510,6 +1510,40 @@ def _existing_identical_add_row(
     return item
 
 
+_DUPLICATE_ADD_SNAPSHOT_RETRY_DELAYS: tuple[float, ...] = (0.05, 0.15, 0.3)
+
+
+def _resolve_duplicate_add_row(
+    uid: str,
+    *,
+    result: ApplyResult,
+    memory_id: str,
+    data: Dict[str, Any],
+    db_client: Any,
+) -> Optional[MemoryItem]:
+    """Resolve an add collision, retrying briefly while the row is not readable yet.
+
+    The apply transaction observed the colliding row inside its own snapshot, but
+    a concurrent identical submission can return ``invalid_patch`` while the
+    winning write is still landing for a plain read — the exact residue behind
+    the 2026-09-11 ``canonical write failed`` family on chat/extraction writes.
+    Re-read briefly before failing so an identical resubmission resolves to the
+    existing row instead of surfacing a 500. Definitive conflicts — a row that
+    is not active, user-rejected, or carrying different content — return None on
+    every re-read and stay fail-closed.
+    """
+    duplicate = _existing_identical_add_row(uid, result=result, memory_id=memory_id, data=data, db_client=db_client)
+    if duplicate is not None:
+        return duplicate
+    for delay in _DUPLICATE_ADD_SNAPSHOT_RETRY_DELAYS:
+        time.sleep(delay)
+        snapshot = db_client.document(f"{MemoryCollections(uid=uid).memory_items}/{memory_id}").get()
+        if not getattr(snapshot, "exists", False):
+            continue
+        return _existing_identical_add_row(uid, result=result, memory_id=memory_id, data=data, db_client=db_client)
+    return None
+
+
 def write_canonical_extraction_memory(
     uid: str,
     data: Dict[str, Any],
@@ -1565,7 +1599,7 @@ def write_canonical_extraction_memory(
             break
     assert result is not None
     if result.status not in {ApplyStatus.committed, ApplyStatus.idempotent_skip}:
-        duplicate_row = _existing_identical_add_row(
+        duplicate_row = _resolve_duplicate_add_row(
             uid,
             result=result,
             memory_id=memory_id,

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -1532,6 +1532,11 @@ def _resolve_duplicate_add_row(
     is not active, user-rejected, or carrying different content — return None on
     every re-read and stay fail-closed.
     """
+    # Only the duplicate-add collision shape can ever be resolved by a re-read;
+    # any other failure (admission, inactive-source, payload mismatch,
+    # exhausted-head-retry) pays nothing here and fails immediately.
+    if result.status != ApplyStatus.invalid_patch or result.reason != _DUPLICATE_ADD_ROW_REASON:
+        return None
     duplicate = _existing_identical_add_row(uid, result=result, memory_id=memory_id, data=data, db_client=db_client)
     if duplicate is not None:
         return duplicate

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -67,7 +67,17 @@ ACTION_ITEMS_LIST_HOT_CLIENT_MAX: int = _hot_client_max()
 
 # Policies the boost must not touch. Env-overridable (see module docstring);
 # resolved against RATE_POLICIES below so a typo is dropped, not enforced.
-_BOOST_EXEMPT_DEFAULT = "action_items:list,action_items:list_hot_client,static_map:get"
+# The abuse ceilings below are decisions, not defaults: RATE_LIMIT_BOOST exists
+# to temporarily widen limits for events, and a boosted event window is exactly
+# when scripted abuse would exploit a multiplied dev-write budget (boost=100
+# would turn 30/min into 3,000/min). dev:memories and dev:conversations are
+# exempt too — they are the shared hourly ceilings the dedicated policies
+# compose with; exempting only the dedicated budgets would leave the aggregate
+# hourly caps boosted into no-ops.
+_BOOST_EXEMPT_DEFAULT = (
+    "action_items:list,action_items:list_hot_client,static_map:get,"
+    "dev:memories,dev:memories_write_burst,dev:conversations,dev:conversations_from_segments"
+)
 _RATE_LIMIT_BOOST_EXEMPT_RAW: str = os.getenv("RATE_LIMIT_BOOST_EXEMPT", _BOOST_EXEMPT_DEFAULT)
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -207,11 +207,22 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "dev:conversation_transcript_read": (25, 3600),
     "dev:goals_read": (120, 3600),
     "dev:conversations": (25, 3600),
+    # Dedicated per-route budget for POST /v1/dev/user/conversations/from-segments,
+    # mirroring the first-party conversations:from-segments (30/hour) sizing.
+    # Composed on top of the shared dev:conversations ceiling so per-route
+    # tuning can never raise the aggregate conversation-write limit.
+    "dev:conversations_from_segments": (30, 3600),
     # Ask (/v1/dev/user/ask): one qa_rag LLM call per request over the caller's
     # conversations — billable like a conversation create, so it carries its own
     # low per-key cap instead of riding the cheap dev:conversations_read list limit.
     "dev:ask": (25, 3600),
     "dev:memories": (120, 3600),
+    # Per-minute burst ceiling on POST /v1/dev/user/memories, composed with
+    # dev:memories above. The hourly window alone admits the whole 120-request
+    # quota inside a single minute, which is exactly the scripted-burst shape
+    # seen on 2026-09-11 (69/min from one client). 30/min stays well above
+    # legitimate app/integration traffic while capping bursts far below it.
+    "dev:memories_write_burst": (30, 60),
     "dev:memories_batch": (15, 3600),
     "dev:action_items_write": (120, 3600),
     "dev:goals_write": (120, 3600),


### PR DESCRIPTION
## What changed and why

Three residuals from the 2026-09-11 chat-SLI triage, all in one theme — stop unauthenticated junk from burning budgeted reads and stop two real error families that failed user-visible chat journeys. Closes #13505. Closes SCA-466.

1. **Canonical write `invalid_patch` visibility race** (`backend/utils/memory/canonical_memory_adapter.py`): the duplicate-add resolver from #12524 read the colliding row exactly once. A concurrent/retry submission whose row is not readable yet at that single read raised `canonical write failed: ApplyStatus.invalid_patch (add patch new_memory_id already exists)` — the 12× family in the SLI window. The resolver now re-reads briefly (bounded ~0.5s, only on the miss path) before failing. Different-content id reuse, user-rejected rows, privacy-deleted ids, and never-visible rows still raise exactly as before.
2. **Embeddings gateway 400 on action-item similarity** (`backend/database/vector_db.py`): `search_action_items_by_vector` had no guard at all — an `httpx.HTTPStatusError` 400 from `embed_query` surfaced as a 500 on `GET /v1/action-items/search` and the MCP search path. Both similarity helpers now strip/clip the query before embedding (empty short-circuits, oversized input clipped at 8000 chars) and degrade to `[]` on embed/query failure, matching the established best-effort contract of `find_similar_action_items`.
3. **`/v1/dev/*` scripted abuse hardening**: junk `omi_dev_`-prefixed Bearer tokens now fail a zero-IO format gate in `database/dev_api_key.py` (every issued key is `omi_dev_` + 32 lowercase hex) instead of costing a Redis read plus a Firestore `where(hashed_key)` query; `POST /v1/dev/user/memories` gains a per-minute burst ceiling `dev:memories_write_burst` (30/min — the hourly `dev:memories` 120/h window alone admits the whole quota inside one minute, which is the observed 69/min burst shape); `POST /v1/dev/user/conversations/from-segments` gains a dedicated `dev:conversations_from_segments` (30/hour) budget mirroring the first-party route, composed with the shared `dev:conversations` ceiling the same way conversation reads compose shared+per-route budgets; naive `started_at`/`finished_at` values on from-segments now 422 at validation instead of raising `TypeError` (uncaught 500) inside the handler on both the developer and first-party routes.

## Product invariants affected

- INV-MEM-4 — the duplicate-add visibility retry still resolves only to an
  identical, active, non-user-rejected row and returns its existing id;
  promotion authority and every fail-closed collision case are untouched.
- INV-MEM-1 — no tier vocabulary or tier-transition behavior changes; the
  resolver returns the existing row's id unchanged.

## How it was verified

- All touched suites green in per-file sessions (the repo's contract — see backend-unit-tests.yml): `test_ws_j_delete_privacy.py` (43), `test_action_item_dedup.py` (23), `test_dependency_async_boundaries.py` (10), `test_api_key_listability_contract.py` (26), `test_api_key_family_errors.py` (4), `test_developer_from_segments_idempotency.py` (19).
- Adjacent suites still green: `test_memory_apply_store.py` (45), `test_developer_memory_adapter.py` (15), `test_rate_limiting.py` (85), `test_dev_ask_endpoint.py` (9), `test_action_items_conversation_list_malformed.py` + `test_task_sharing.py` (33).
- Sabotage-proven: with each fix reverted in turn, every new regression fails — the canonical race test reproduces the exact prod `RuntimeError`, the embeddings 400 propagates out of `search_action_items_by_vector`, the malformed-key test reaches the Firestore client, the wiring tests miss the new policies/dependency, and the naive-datetime validation does not raise. Restored, all pass.
- `scripts/pr-preflight` and `make preflight` with this body file from the final commit.

## Tests

- `test_ws_j_delete_privacy.py::test_identical_resubmission_resolves_once_the_row_becomes_readable` — the race regression (fails without the fix with the exact prod error); `test_row_that_never_becomes_readable_still_fails_closed` — the retry stays bounded. Existing fail-closed tests (`test_reusing_a_row_id_for_different_content_still_fails`, privacy-delete) unchanged and passing.
- `test_action_item_dedup.py::TestActionItemEmbeddingGateway400` — real `httpx.HTTPStatusError` 400 degrade, empty-query short-circuit, clip-before-embed, Pinecone failure, and the previously untested happy path of `search_action_items_by_vector`; empty/blank/oversized handling for `find_similar_action_items`.
- `test_api_key_listability_contract.py::test_malformed_dev_api_keys_are_rejected_before_any_redis_or_firestore_io`.
- `test_dependency_async_boundaries.py::test_dev_write_paths_check_burst_and_dedicated_rate_budgets` (plus the updated executor-routing sequence test).
- `test_developer_from_segments_idempotency.py::test_from_segments_rejects_timezone_naive_timestamps_with_422` and `::test_dev_from_segments_route_uses_the_dedicated_rate_limited_dependency`.

## Failure class (fixes)

Failure-Class: FC-replay-idempotency-keyed-on-advancing-state

<!-- The canonical residual extends this class's coverage: #12524 resolved the
sequential identical resubmission; this PR covers the same class's remaining
concurrent/visibility shape and keeps different-content and non-active
collisions failing (same regression file the class cites). The embeddings and
dev-abuse fixes are degrade/hardening instances of the same user-visible
failure surface. -->

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 3734 -> 3773 | bounded snapshot-visibility retry wrapper for the duplicate-add resolver (~30 lines incl. contract docstring) plus the review-fix early gate that skips the retry for every non-duplicate failure; no new branching surface elsewhere in the file
Line-Count-Exception: backend/routers/developer.py | 2511 -> 2527 | tz-aware field validator on the shared from-segments request model (422 instead of TypeError 500) plus the dedicated rate-limited dependencies for the dev from-segments route and the POST-only memory-create burst context


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


