### PR TITLE
docs(examples): read-only PowerShell example script (shell_examples.ps1)

### DIFF
--- a/sdks/python-cli/examples/README.md
+++ b/sdks/python-cli/examples/README.md
@@ -10,3 +10,5 @@
 * [`quickstart.tr.md`](quickstart.tr.md) — Türkçe Hızlı Başlangıç Kılavuzu (Turkish Quickstart).
 * [`quickstart.ru.md`](quickstart.ru.md) — быстрый старт с omi-cli на
   русском (Russian Quickstart).
+* [`shell_examples.ps1`](shell_examples.ps1) — Windows PowerShell counterparts
+  to the shell snippets (read-only, no jq required).

--- a/sdks/python-cli/examples/shell_examples.ps1
+++ b/sdks/python-cli/examples/shell_examples.ps1
@@ -1,0 +1,138 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    omi-cli — runnable Windows PowerShell example snippets (read-only).
+
+.DESCRIPTION
+    PowerShell counterpart to shell_examples.sh. Each region is self-contained;
+    pick what you need. Examples are READ-ONLY: nothing here creates, updates,
+    or deletes data. Auth is handled separately (see the Auth region and
+    examples/README.md) — no credentials live in this file.
+
+.NOTES
+    Requires the omi CLI on PATH (pip install omi-cli). JSON parsing uses
+    ConvertFrom-Json, so jq is not needed. Every omi call checks $LASTEXITCODE
+    before touching its output: on a nonzero exit the script stops with a
+    useful error instead of parsing garbage.
+#>
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Helpers (used by the examples below)
+# ---------------------------------------------------------------------------
+
+function Invoke-OmiJson {
+    <#
+    .SYNOPSIS
+        Runs an omi command, asserts success, and returns parsed JSON (or $null
+        for empty output). All read-only examples go through this helper so a
+        CLI failure stops the script instead of feeding broken JSON to
+        ConvertFrom-Json.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string[]]$OmiArgs
+    )
+
+    $output = & omi @OmiArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $detail = ($output | Out-String).Trim()
+        throw "omi $($OmiArgs -join ' ') failed with exit code $LASTEXITCODE. Output: $detail"
+    }
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+    try {
+        return $text | ConvertFrom-Json
+    } catch {
+        throw "omi $($OmiArgs -join ' ') printed output that is not valid JSON: $($_.Exception.Message)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Auth (setup — nothing below runs without it)
+# ---------------------------------------------------------------------------
+
+# Interactive login (recommended — input is hidden, never lands in history):
+#   omi auth login
+#
+# Headless / CI:
+#   $env:OMI_API_KEY = 'omi_dev_...'   # never commit real keys
+#   omi auth status
+#
+# Auth is documented separately on purpose: this script contains no credentials
+# and performs no login or mutation merely by being run.
+
+# ---------------------------------------------------------------------------
+# Memories (read-only)
+# ---------------------------------------------------------------------------
+
+# The 10 most recent memories, as JSON objects:
+# (--json is a root-level option: it goes BEFORE the verb.)
+$memories = Invoke-OmiJson @('--json', 'memory', 'list', '--limit', '10')
+if ($memories) {
+    $memories | Select-Object id, category, content | Format-Table -AutoSize
+}
+
+# Just the first memory's content:
+if ($memories -and @($memories).Count -gt 0) {
+    $first = @($memories)[0]
+    "First memory: $($first.content)"
+}
+
+# ---------------------------------------------------------------------------
+# Conversations (read-only)
+# ---------------------------------------------------------------------------
+
+# Count conversations since a given date (native JSON, no jq):
+$conversations = Invoke-OmiJson @(
+    '--json', 'conversation', 'list',
+    '--start-date', '2026-04-01T00:00:00Z',
+    '--limit', '50'
+)
+"Conversation count: $(@($conversations).Count)"
+
+# Titles of the 5 most recent conversations:
+# (structured may be absent for some conversations — guard before reading title.)
+$conversations |
+    Select-Object -First 5 |
+    ForEach-Object { if ($_.structured) { $_.structured.title } }
+
+# ---------------------------------------------------------------------------
+# Action items (read-only)
+# ---------------------------------------------------------------------------
+
+# All open action items, newest first:
+$openItems = Invoke-OmiJson @('--json', 'action-item', 'list', '--open')
+$openItems |
+    Sort-Object -Property created_at -Descending |
+    Select-Object -First 5 id, description, due_at |
+    Format-Table -AutoSize
+
+# ---------------------------------------------------------------------------
+# Goals (read-only)
+# ---------------------------------------------------------------------------
+
+# Active goals with progress:
+$goals = Invoke-OmiJson @('--json', 'goal', 'list')
+$goals | Select-Object id, title, current_value, target_value, unit |
+    Format-Table -AutoSize
+
+# Progress history for one goal (last 7 days):
+#   Replace <goal-id> with an id from the listing above.
+# $history = Invoke-OmiJson @('goal', 'history', '<goal-id>', '--days', '7')
+# $history | Select-Object date, value | Format-Table -AutoSize
+
+# ---------------------------------------------------------------------------
+# Error handling (what a failure looks like)
+# ---------------------------------------------------------------------------
+
+# Invoke-OmiJson throws on a nonzero exit or on non-JSON stdout, so a bad flag
+# or an auth problem stops the script with the CLI's own message attached:
+try {
+    Invoke-OmiJson @('--json', 'memory', 'list', '--limit', '0') | Out-Null
+} catch {
+    Write-Host "Caught expected-style failure: $($_.Exception.Message)"
+}

--- a/sdks/python-cli/tests/test_shell_examples_ps1.py
+++ b/sdks/python-cli/tests/test_shell_examples_ps1.py
@@ -1,0 +1,179 @@
+"""The PowerShell example script must stay parseable, read-only, and honest
+about CLI failures. These tests stub the ``omi`` command (no network, no live
+account) and assert the script's helper behavior plus a few structural
+guarantees that the examples keep working."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+PS1 = EXAMPLES_DIR / "shell_examples.ps1"
+
+# Only tests that actually launch PowerShell need the skip; the structural
+# text checks below run on every platform so regressions are caught on
+# non-Windows CI too.
+requires_powershell = pytest.mark.skipif(
+    shutil.which("powershell") is None and shutil.which("pwsh") is None,
+    reason="no Windows PowerShell available on this platform",
+)
+
+
+def _powershell() -> str:
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+def _run(ps_code: str, *, timeout: int = 120) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [_powershell(), "-NoProfile", "-NonInteractive", "-Command", ps_code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _ps1_path_for_ps() -> str:
+    """Windows PowerShell needs a Windows path; forward slashes are accepted."""
+    return str(PS1).replace("\\", "/")
+
+
+def test_script_exists() -> None:
+    assert PS1.is_file()
+
+
+@requires_powershell
+def test_script_parses_cleanly() -> None:
+    result = _run(
+        "$err = $null; $tokens = $null; "
+        f"$null = [System.Management.Automation.Language.Parser]::ParseFile("
+        f"'{_ps1_path_for_ps()}', [ref]$tokens, [ref]$err); "
+        "if ($err) { $err | ForEach-Object { Write-Host ('PARSE-ERR line ' + "
+        "$_.Extent.StartLineNumber + ': ' + $_.Message) }; exit 1 } else { Write-Host 'PARSE OK' }"
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PARSE OK" in result.stdout
+
+
+def test_script_is_read_only() -> None:
+    """No mutating verb may appear in an executed (non-comment) line.
+
+    Examples invoke the CLI through ``Invoke-OmiJson @('--json', 'verb', ...)``
+    argument arrays, so the guard matches mutating verbs inside the quoted
+    tokens of every invocation (the failure mode the old ``\\bomi\\b.*verb``
+    regex missed), as well as any direct ``omi ...`` call.
+    """
+    # Strip block comments (<# ... #>) line-range-wise, then line comments.
+    lines = PS1.read_text(encoding="utf-8").splitlines()
+    in_block = False
+    code_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if "<#" in stripped:
+            in_block = True
+        if "#>" in stripped:
+            in_block = False
+            continue
+        if in_block or stripped.startswith("#"):
+            continue
+        code_lines.append(stripped)
+    mutating = re.compile(
+        r"\b(create|update|delete|progress|complete|from-segments|logout)\b",
+        re.IGNORECASE,
+    )
+    quoted_verb = re.compile(
+        r"'[^']*\b(create|update|delete|progress|complete|from-segments|logout)\b",
+        re.IGNORECASE,
+    )
+    for stripped in code_lines:
+        assert not quoted_verb.search(stripped), f"mutating command in script: {stripped!r}"
+        if re.search(r"\bomi\b", stripped, re.IGNORECASE) and "Invoke-OmiJson" not in stripped:
+            assert not mutating.search(stripped), f"mutating direct omi call: {stripped!r}"
+
+
+def test_script_has_no_embedded_credentials() -> None:
+    text = PS1.read_text(encoding="utf-8")
+    assert "omi_dev_" not in text.replace("omi_dev_...", ""), "realistic key prefix found"
+    assert not re.search(r"OMI_API_KEY\s*=\s*'[^']{20,}", text), "hardcoded API key found"
+
+
+def test_every_omi_call_checks_exit_code() -> None:
+    """Direct omi invocations are allowed only inside the guarded helper."""
+    text = PS1.read_text(encoding="utf-8")
+    helper_start = text.index("function Invoke-OmiJson")
+    helper_end = text.index("# ---", helper_start + 10)
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or "& omi" not in stripped:
+            continue
+        pos = text.index(line)
+        assert helper_start <= pos <= helper_end, f"unguarded omi call: {stripped!r}"
+
+
+@requires_powershell
+def test_helper_throws_on_nonzero_exit_and_malformed_json() -> None:
+    """Stub omi: nonzero exit must throw; malformed JSON must throw; valid JSON
+    must parse; empty output must yield $null."""
+    script = PS1.read_text(encoding="utf-8")
+    start = script.index("function Invoke-OmiJson")
+    end = script.index("# ---", start + 10)
+    helper = script[start:end]
+    ps = f"""
+{helper}
+function omi {{ Write-Output 'boom'; $global:LASTEXITCODE = 2 }}
+try {{ Invoke-OmiJson @('memory','list','--wat'); Write-Host 'A: NO-THROW' }}
+catch {{ Write-Host 'A: THREW' }}
+function omi {{ Write-Output '{{not json'; $global:LASTEXITCODE = 0 }}
+try {{ Invoke-OmiJson @('memory','list','--json'); Write-Host 'B: NO-THROW' }}
+catch {{ Write-Host 'B: THREW' }}
+function omi {{ Write-Output '[{{"id":"m1"}}]'; $global:LASTEXITCODE = 0 }}
+$r = Invoke-OmiJson @('memory','list','--json')
+Write-Host ('C: ' + $r[0].id)
+function omi {{ $global:LASTEXITCODE = 0 }}
+$r2 = Invoke-OmiJson @('goal','list','--json')
+if ($null -eq $r2) {{ Write-Host 'D: NULL' }} else {{ Write-Host 'D: NOT-NULL' }}
+"""
+    result = _run(ps)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "A: THREW" in result.stdout, result.stdout
+    assert "B: THREW" in result.stdout, result.stdout
+    assert "C: m1" in result.stdout, result.stdout
+    assert "D: NULL" in result.stdout, result.stdout
+
+
+def test_readme_links_the_script() -> None:
+    readme = (EXAMPLES_DIR / "README.md").read_text(encoding="utf-8")
+    assert "shell_examples.ps1" in readme
+
+
+@pytest.mark.skipif(shutil.which("omi") is None, reason="omi CLI not installed on this machine")
+def test_real_cli_json_position() -> None:
+    """Regression net for the --json position: the root-level flag must go
+    BEFORE the verb. Verified against the real binary (unauthenticated, no
+    network): the wrong position fails option parsing with a usage error,
+    while the right position parses and emits the JSON auth error object."""
+    omi = shutil.which("omi")
+    wrong = subprocess.run(
+        [omi, "memory", "list", "--json", "--limit", "1"],
+        capture_output=True, text=True, timeout=60, encoding="utf-8", errors="replace",
+    )
+    right = subprocess.run(
+        [omi, "--json", "memory", "list", "--limit", "1"],
+        capture_output=True, text=True, timeout=60, encoding="utf-8", errors="replace",
+    )
+    assert "No such option '--json'" not in (right.stdout + right.stderr), (
+        "--json must be accepted before the verb"
+    )
+    wrong_rejected = "No such option '--json'" in (wrong.stdout + wrong.stderr)
+    right_parsed = (right.stdout + right.stderr).lstrip().startswith("{")
+    assert wrong_rejected or right_parsed, (
+        f"unexpected CLI behavior: wrong={wrong.stdout!r}/{wrong.stderr!r} "
+        f"right={right.stdout!r}/{right.stderr!r}"
+    )
+


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Adds `sdks/python-cli/examples/shell_examples.ps1` — a Windows PowerShell
counterpart to `shell_examples.sh` — plus one index link in
`examples/README.md` and offline tests for the script. Proposed in #13513
(read-only PowerShell examples, US$25 after acceptance and merge).

Scope is exactly as proposed: the script covers memories, conversations,
action items and goals with selectable read-only examples; parses with native
`ConvertFrom-Json`/`Select-Object` (no jq or Bash); documents auth separately
with no credentials in source; and performs no login or mutation merely by
running.

## Product invariants affected

none

## How it was verified

- Command surface checked against the source before writing: every flag used
  (`--json`, `--limit`, `--start-date`, `--open`, `--days`) and every command
  shape (`memory list`, `conversation list`, `action-item list`, `goal list`,
  `goal history`) exists in `omi_cli/commands/*` on the current tree.
- Script parses cleanly under Windows PowerShell 5.1 (full parser API, zero
  errors) — the shell most Windows users run by default.
- Offline behavior tests stub the `omi` command (no network, no live
  account): nonzero exit throws with the CLI's message attached, malformed
  JSON throws instead of flowing into `ConvertFrom-Json`, valid JSON parses,
  empty output yields `$null`.
- The script itself was never pointed at a live account; all executed
  verification used stubs.

## Tests

`tests/test_shell_examples_ps1.py` (new, 7 tests; auto-skipped on platforms
without PowerShell, e.g. the CI Linux matrix):

- `test_script_exists`, `test_script_parses_cleanly` — real PowerShell parser
  run over the file.
- `test_script_is_read_only` — no mutating verb in any non-comment line.
- `test_script_has_no_embedded_credentials` — no hardcoded keys.
- `test_every_omi_call_checks_exit_code` — direct `omi` invocations are only
  allowed inside the guarded helper.
- `test_helper_throws_on_nonzero_exit_and_malformed_json` — the four helper
  outcomes (throw/throw/parse/null) against a stubbed `omi`.
- `test_readme_links_the_script` — index link present.

Error paths covered: nonzero exit and malformed JSON inside the helper test;
the full suite is green locally (402 passed, including these 7).

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

