### PR TITLE
feat(cli): allow clearing goal min/max bounds

### DIFF
--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -242,7 +242,7 @@ omi
     ├── list [--limit N] [--include-inactive]
     ├── get <id>
     ├── create <title> --target N [--type ...] [--current N] [--unit ...]
-    ├── update <id> [--unit ... | --clear-unit] [...]
+    ├── update <id> [--unit ... | --clear-unit] [--min N | --clear-min] [--max N | --clear-max] [...]
     ├── progress <id> <value>
     ├── history <id> [--days N]
     └── delete <id> [-y]

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -132,10 +132,16 @@ def update_goal(
     max_value: Optional[float] = typer.Option(None, "--max"),
     unit: Optional[str] = typer.Option(None, "--unit"),
     clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
+    clear_min: bool = typer.Option(False, "--clear-min", help="Remove the existing minimum bound."),
+    clear_max: bool = typer.Option(False, "--clear-max", help="Remove the existing maximum bound."),
 ) -> None:
     ctx = _ctx(typer_ctx)
     if clear_unit and unit is not None:
         raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
+    if clear_min and min_value is not None:
+        raise UsageError(message="Conflicting options", detail="--min and --clear-min are mutually exclusive.")
+    if clear_max and max_value is not None:
+        raise UsageError(message="Conflicting options", detail="--max and --clear-max are mutually exclusive.")
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -143,9 +149,13 @@ def update_goal(
         body["target_value"] = target_value
     if current_value is not None:
         body["current_value"] = current_value
-    if min_value is not None:
+    if clear_min:
+        body["min_value"] = None
+    elif min_value is not None:
         body["min_value"] = min_value
-    if max_value is not None:
+    if clear_max:
+        body["max_value"] = None
+    elif max_value is not None:
         body["max_value"] = max_value
     if clear_unit:
         body["unit"] = None
@@ -154,7 +164,10 @@ def update_goal(
     if not body:
         raise UsageError(
             message="No fields to update",
-            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit.",
+            detail=(
+                "Provide one of --title/--target/--current/--min/--max/--unit/"
+                "--clear-unit/--clear-min/--clear-max."
+            ),
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -185,6 +185,11 @@ def test_goal_delete(authed_profile, respx_mock, cli_runner) -> None:
         (["--clear-unit"], {"unit": None}),
         (["--title", "drink water"], {"title": "drink water"}),
         (["--clear-unit", "--current", "2"], {"unit": None, "current_value": 2.0}),
+        (["--clear-min"], {"min_value": None}),
+        (["--clear-max"], {"max_value": None}),
+        (["--clear-min", "--clear-max"], {"min_value": None, "max_value": None}),
+        (["--clear-min", "--max", "20"], {"min_value": None, "max_value": 20.0}),
+        (["--min", "1", "--clear-max"], {"min_value": 1.0, "max_value": None}),
     ],
 )
 def test_goal_update_unit_patch(authed_profile, respx_mock, cli_runner, options, expected) -> None:
@@ -206,4 +211,26 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     error = json.loads(output.err)
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
+    assert not respx_mock.calls
+
+
+@pytest.mark.parametrize(
+    ("argv_suffix", "flag", "clear_flag"),
+    [
+        (["--min", "1", "--clear-min"], "--min", "--clear-min"),
+        (["--max", "20", "--clear-max"], "--max", "--clear-max"),
+    ],
+)
+def test_goal_update_rejects_set_and_clear_bounds(
+    authed_profile, respx_mock, monkeypatch, capsys, argv_suffix, flag, clear_flag
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", *argv_suffix])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert flag in error["detail"]
+    assert clear_flag in error["detail"]
     assert not respx_mock.calls


### PR DESCRIPTION
## What

`omi goal update` can set `--min` and `--max` but cannot clear either bound. The Developer API `UpdateGoalRequest` already accepts explicit null `min_value`/`max_value`.

This adds:

- `--clear-min` sends `min_value: null`
- `--clear-max` sends `max_value: null`
- set+clear conflicts rejected the same way as `--unit` / `--clear-unit`

## Why

Closes #13393. Callers who created a scale goal with bounds and later want a qualitative or unbounded metric have no CLI path today.

## Test plan

- [x] `pytest tests/test_goal.py -q` (24 passed)
- [x] Regression: `--clear-min`, `--clear-max`, both together, and mixed set+clear
- [x] Regression: `--min` + `--clear-min` and `--max` + `--clear-max` exit 1 with usage error

```
pytest sdks/python-cli/tests/test_goal.py -q
# 24 passed
```

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

