### PR TITLE
fix(stack-overflow): label accepted answers via accepted_answer_id

### DIFF
--- a/plugins/omi-stack-overflow-app/main.py
+++ b/plugins/omi-stack-overflow-app/main.py
@@ -170,7 +170,9 @@ def _format_question(item: dict[str, Any], index: int, site: str) -> str:
     score = item.get("score", 0)
     answers = item.get("answer_count", 0)
     views = item.get("view_count", 0)
-    accepted = "accepted" if item.get("is_answered") else "not accepted"
+    # Stack Exchange distinguishes "has any answer" (is_answered) from
+    # "has an accepted answer" (accepted_answer_id). Label only the latter.
+    accepted = "accepted" if item.get("accepted_answer_id") else "not accepted"
     tags = ", ".join(item.get("tags", [])) or "no tags"
     link = item.get("link") or _question_url(site, question_id)
 

--- a/plugins/omi-stack-overflow-app/test_format_question.py
+++ b/plugins/omi-stack-overflow-app/test_format_question.py
@@ -1,0 +1,38 @@
+"""Unit tests for accepted-answer labeling (issue #13246)."""
+
+from main import _format_question
+
+
+def test_format_question_uses_accepted_answer_id_not_is_answered():
+    item = {
+        "title": "How do I parse JSON?",
+        "question_id": 1,
+        "score": 3,
+        "answer_count": 2,
+        "view_count": 10,
+        # Answered, but nobody accepted an answer.
+        "is_answered": True,
+        "accepted_answer_id": None,
+        "tags": ["python"],
+        "link": "https://stackoverflow.com/q/1",
+    }
+    out = _format_question(item, 1, "stackoverflow")
+    assert "| not accepted" in out
+    assert out.count("accepted") == 1  # only inside "not accepted"
+
+
+def test_format_question_marks_accepted_when_id_present():
+    item = {
+        "title": "How do I parse JSON?",
+        "question_id": 1,
+        "score": 3,
+        "answer_count": 2,
+        "view_count": 10,
+        "is_answered": True,
+        "accepted_answer_id": 99,
+        "tags": ["python"],
+        "link": "https://stackoverflow.com/q/1",
+    }
+    out = _format_question(item, 1, "stackoverflow")
+    assert "accepted" in out
+    assert "not accepted" not in out


### PR DESCRIPTION
## What
`search_questions` labeled any question with answers as "accepted"
using `is_answered`. Stack Exchange reserves that label for
`accepted_answer_id`.

## Why
Closes #13246. Answered-but-unaccepted questions were reported as
accepted.

## Test plan
- [x] New unit tests for answered-but-unaccepted vs accepted
- [x] `pytest test_format_question.py` (2 passed)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

