### PR TITLE
fix(shipbob): treat empty-body HTTP errors as cancel failures

### DIFF
--- a/plugins/omi-shipbob-app/main.py
+++ b/plugins/omi-shipbob-app/main.py
@@ -806,7 +806,10 @@ async def tool_cancel_wro(request: Request):
         if result is None:
             return ChatToolResponse(error=f"Failed to cancel WRO: no response from ShipBob")
         if isinstance(result, dict) and ("error" in result or "status_code" in result):
-            detail = result.get("error") or f"HTTP {result.get('status_code')}"
+            detail = result.get("error")
+            if not detail:
+                status = result.get("status_code")
+                detail = f"HTTP {status}" if status is not None else "ShipBob request failed"
             return ChatToolResponse(error=f"Failed to cancel WRO: {detail}")
 
         return ChatToolResponse(result=f"**WRO #{wro_id} has been cancelled.**")

--- a/plugins/omi-shipbob-app/main.py
+++ b/plugins/omi-shipbob-app/main.py
@@ -801,8 +801,13 @@ async def tool_cancel_wro(request: Request):
 
         result = make_shipbob_request(uid, "POST", f"/2.0/receiving/{wro_id}/cancel")
 
-        if result and isinstance(result, dict) and result.get("error"):
-            return ChatToolResponse(error=f"Failed to cancel WRO: {result.get('error')}")
+        # Failed requests return {"error": ..., "status_code": ...}. An empty
+        # error string is still a failure (e.g. HTTP 500 with a blank body).
+        if result is None:
+            return ChatToolResponse(error=f"Failed to cancel WRO: no response from ShipBob")
+        if isinstance(result, dict) and ("error" in result or "status_code" in result):
+            detail = result.get("error") or f"HTTP {result.get('status_code')}"
+            return ChatToolResponse(error=f"Failed to cancel WRO: {detail}")
 
         return ChatToolResponse(result=f"**WRO #{wro_id} has been cancelled.**")
 

--- a/plugins/omi-shipbob-app/test_main.py
+++ b/plugins/omi-shipbob-app/test_main.py
@@ -1,11 +1,30 @@
 """Regression tests for cancel_wro error classification (#13183)."""
 
-from unittest.mock import patch
+import sys
+import types
+from unittest.mock import MagicMock, patch
 
-from fastapi.testclient import TestClient
+# Shipbob main imports models -> omi_plugin_sdk. Stub the SDK for hermetic tests.
+if "omi_plugin_sdk" not in sys.modules:
+    sdk = types.ModuleType("omi_plugin_sdk")
+    sdk_models = types.ModuleType("omi_plugin_sdk.models")
 
-from main import app
+    class _Dummy:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
 
+    sdk_models.Conversation = _Dummy
+    sdk_models.EndpointResponse = _Dummy
+    sdk_models.Structured = _Dummy
+    sdk_models.TranscriptSegment = _Dummy
+    sdk.models = sdk_models
+    sys.modules["omi_plugin_sdk"] = sdk
+    sys.modules["omi_plugin_sdk.models"] = sdk_models
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from main import app  # noqa: E402
 
 client = TestClient(app)
 
@@ -33,7 +52,7 @@ def test_cancel_empty_body_500_is_error(mock_post, _refresh, _headers):
     assert resp.status_code == 200
     body = resp.json()
     assert body.get("error")
-    assert "123" not in str(body.get("result") or "")
+    assert "cancelled" not in str(body.get("result") or "").lower()
 
 
 @patch("main.get_shipbob_headers", return_value=_headers_ok())

--- a/plugins/omi-shipbob-app/test_main.py
+++ b/plugins/omi-shipbob-app/test_main.py
@@ -1,0 +1,64 @@
+"""Regression tests for cancel_wro error classification (#13183)."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+class FakeResp:
+    def __init__(self, status_code=200, text="", json_data=None):
+        self.status_code = status_code
+        self.text = text
+        self._json = json_data if json_data is not None else {}
+
+    def json(self):
+        return self._json
+
+
+def _headers_ok():
+    return {"Authorization": "Bearer t", "Content-Type": "application/json"}
+
+
+@patch("main.get_shipbob_headers", return_value=_headers_ok())
+@patch("main.refresh_token_if_needed")
+@patch("main.requests.post")
+def test_cancel_empty_body_500_is_error(mock_post, _refresh, _headers):
+    mock_post.return_value = FakeResp(status_code=500, text="")
+    resp = client.post("/tools/cancel_wro", json={"uid": "u1", "wro_id": "123"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("error")
+    assert "123" not in str(body.get("result") or "")
+
+
+@patch("main.get_shipbob_headers", return_value=_headers_ok())
+@patch("main.refresh_token_if_needed")
+@patch("main.make_shipbob_request", return_value=None)
+def test_cancel_none_result_is_error(mock_req, _refresh, _headers):
+    resp = client.post("/tools/cancel_wro", json={"uid": "u1", "wro_id": "123"})
+    body = resp.json()
+    assert body.get("error")
+
+
+@patch("main.get_shipbob_headers", return_value=_headers_ok())
+@patch("main.refresh_token_if_needed")
+@patch("main.make_shipbob_request", return_value={"error": "forbidden", "status_code": 403})
+def test_cancel_nonempty_error_is_surfaced(mock_req, _refresh, _headers):
+    resp = client.post("/tools/cancel_wro", json={"uid": "u1", "wro_id": "123"})
+    body = resp.json()
+    assert "forbidden" in body.get("error", "")
+
+
+@patch("main.get_shipbob_headers", return_value=_headers_ok())
+@patch("main.refresh_token_if_needed")
+@patch("main.make_shipbob_request", return_value={"id": 123, "status": "cancelled"})
+def test_cancel_success_200_object(mock_req, _refresh, _headers):
+    resp = client.post("/tools/cancel_wro", json={"uid": "u1", "wro_id": "123"})
+    body = resp.json()
+    assert body.get("error") in (None, "")
+    assert "cancelled" in (body.get("result") or "").lower()


### PR DESCRIPTION
## What
`cancel_wro` treated a failed request as success when the error
message was an empty string (HTTP error with blank body). It now
fails on any error/status_code key and on a null response.

## Why
Closes #13183.

## Test plan
- [x] Manual review of empty-string error path
- [x] No new public API

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

