### PR TITLE
fix(pubmed): fetch abstracts via efetch instead of ESummary

### DIFF
--- a/plugins/omi-pubmed-app/main.py
+++ b/plugins/omi-pubmed-app/main.py
@@ -1,4 +1,5 @@
 import html
+import xml.etree.ElementTree as ET
 from typing import Any
 
 import httpx
@@ -10,7 +11,7 @@ from models import ChatToolResponse
 app = FastAPI(
     title="Omi PubMed App",
     description="PubMed chat tools for Omi",
-    version="1.0.1",
+    version="1.0.2",
 )
 
 EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
@@ -31,6 +32,35 @@ def _clamp_max_results(value: Any, default: int = 5) -> int:
     except (TypeError, ValueError):
         return default
     return max(1, min(parsed, 10))
+
+
+def _extract_abstract_from_efetch_xml(xml_text: str) -> str:
+    """Parse efetch XML and return the abstract text for the first article."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return ""
+    abstract_parts = root.findall(".//AbstractText")
+    if not abstract_parts:
+        return ""
+    chunks = []
+    for part in abstract_parts:
+        label = (part.get("Label") or "").strip()
+        text = "".join(part.itertext()).strip()
+        if not text:
+            continue
+        chunks.append(f"{label}: {text}" if label else text)
+    return " ".join(chunks).strip()
+
+
+async def _fetch_abstract(client: httpx.AsyncClient, pmid: str) -> str:
+    """ESummary has no abstract field; efetch XML does."""
+    resp = await client.get(
+        f"{EUTILS}/efetch.fcgi",
+        params={"db": "pubmed", "id": pmid, "retmode": "xml"},
+    )
+    resp.raise_for_status()
+    return _extract_abstract_from_efetch_xml(resp.text)
 
 
 def _extract_article_fields(record: dict) -> dict:
@@ -206,6 +236,11 @@ async def get_pubmed_article(request: Request):
 
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
             summaries = await _fetch_summaries(client, [pmid])
+            if pmid in summaries:
+                # Prefer a real efetch abstract; ESummary never includes one.
+                abstract = await _fetch_abstract(client, pmid)
+                if abstract:
+                    summaries[pmid]["abstract"] = abstract
 
         if pmid not in summaries:
             return ChatToolResponse(error=f"No PubMed record found for PMID {pmid}")

--- a/plugins/omi-pubmed-app/main.py
+++ b/plugins/omi-pubmed-app/main.py
@@ -238,7 +238,11 @@ async def get_pubmed_article(request: Request):
             summaries = await _fetch_summaries(client, [pmid])
             if pmid in summaries:
                 # Prefer a real efetch abstract; ESummary never includes one.
-                abstract = await _fetch_abstract(client, pmid)
+                # Abstract enrichment is optional so ESummary still works if efetch fails.
+                try:
+                    abstract = await _fetch_abstract(client, pmid)
+                except Exception:
+                    abstract = ""
                 if abstract:
                     summaries[pmid]["abstract"] = abstract
 

--- a/plugins/omi-pubmed-app/test_abstract.py
+++ b/plugins/omi-pubmed-app/test_abstract.py
@@ -1,0 +1,45 @@
+"""Unit tests for efetch abstract extraction (issue #13199)."""
+
+from main import _extract_abstract_from_efetch_xml
+
+
+def test_extracts_unlabeled_abstract():
+    xml = """<?xml version="1.0"?>
+    <PubmedArticleSet>
+      <PubmedArticle>
+        <MedlineCitation>
+          <Article>
+            <Abstract>
+              <AbstractText>This paper studies sleep.</AbstractText>
+            </Abstract>
+          </Article>
+        </MedlineCitation>
+      </PubmedArticle>
+    </PubmedArticleSet>
+    """
+    assert _extract_abstract_from_efetch_xml(xml) == "This paper studies sleep."
+
+
+def test_extracts_labeled_abstract_sections():
+    xml = """<?xml version="1.0"?>
+    <PubmedArticleSet>
+      <PubmedArticle>
+        <MedlineCitation>
+          <Article>
+            <Abstract>
+              <AbstractText Label="BACKGROUND">Prior work.</AbstractText>
+              <AbstractText Label="METHODS">We measured X.</AbstractText>
+            </Abstract>
+          </Article>
+        </MedlineCitation>
+      </PubmedArticle>
+    </PubmedArticleSet>
+    """
+    out = _extract_abstract_from_efetch_xml(xml)
+    assert "BACKGROUND: Prior work." in out
+    assert "METHODS: We measured X." in out
+
+
+def test_returns_empty_for_missing_or_bad_xml():
+    assert _extract_abstract_from_efetch_xml("<not-closed") == ""
+    assert _extract_abstract_from_efetch_xml("<PubmedArticleSet></PubmedArticleSet>") == ""


### PR DESCRIPTION
## What
`get_pubmed_article` only called ESummary, which has no abstract
field, so available abstracts were omitted. It now fetches efetch
XML and merges the abstract into the summary record.

## Why
Closes #13199. The tool advertises abstract retrieval.

## Test plan
- [x] Unit tests for unlabeled, labeled, and missing abstracts
- [x] `pytest test_abstract.py` (3 passed)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

