### PR TITLE
fix(open-meteo): include timezone and UTC offset in Observed lines

### DIFF
--- a/plugins/omi-open-meteo-app/main.py
+++ b/plugins/omi-open-meteo-app/main.py
@@ -104,6 +104,14 @@ def _format_weather_code(code: Optional[int]) -> str:
 def _format_observed_at(current: dict[str, Any], payload: dict[str, Any]) -> str:
     """Render the observation time with the response timezone/offset when present."""
     observed = current.get("time") or "unknown time"
+    # Keep prior minute-precision normalization for display consistency.
+    if observed != "unknown time":
+        try:
+            from datetime import datetime
+
+            observed = datetime.fromisoformat(str(observed)).isoformat(timespec="minutes")
+        except ValueError:
+            pass
     tz = payload.get("timezone") or ""
     offset = payload.get("utc_offset_seconds")
     suffix_parts = []
@@ -111,11 +119,10 @@ def _format_observed_at(current: dict[str, Any], payload: dict[str, Any]) -> str
         suffix_parts.append(tz)
     if offset is not None:
         try:
-            hours = int(offset) / 3600
-            sign = "+" if hours >= 0 else "-"
-            hours_abs = abs(hours)
-            whole = int(hours_abs)
-            minutes = int(round((hours_abs - whole) * 60))
+            total_minutes = int(round(int(offset) / 60))
+            sign = "+" if total_minutes >= 0 else "-"
+            total_minutes = abs(total_minutes)
+            whole, minutes = divmod(total_minutes, 60)
             suffix_parts.append(f"UTC{sign}{whole:02d}:{minutes:02d}")
         except (TypeError, ValueError):
             pass

--- a/plugins/omi-open-meteo-app/main.py
+++ b/plugins/omi-open-meteo-app/main.py
@@ -5,7 +5,6 @@ Provides chat tools for current weather, short forecasts, and basic air-quality
 lookups using public Open-Meteo APIs.
 """
 
-from datetime import datetime
 from typing import Any, Literal, Optional
 
 import httpx
@@ -100,6 +99,29 @@ def _format_weather_code(code: Optional[int]) -> str:
         99: "thunderstorm with heavy hail",
     }
     return descriptions.get(code, f"weather code {code}")
+
+
+def _format_observed_at(current: dict[str, Any], payload: dict[str, Any]) -> str:
+    """Render the observation time with the response timezone/offset when present."""
+    observed = current.get("time") or "unknown time"
+    tz = payload.get("timezone") or ""
+    offset = payload.get("utc_offset_seconds")
+    suffix_parts = []
+    if tz:
+        suffix_parts.append(tz)
+    if offset is not None:
+        try:
+            hours = int(offset) / 3600
+            sign = "+" if hours >= 0 else "-"
+            hours_abs = abs(hours)
+            whole = int(hours_abs)
+            minutes = int(round((hours_abs - whole) * 60))
+            suffix_parts.append(f"UTC{sign}{whole:02d}:{minutes:02d}")
+        except (TypeError, ValueError):
+            pass
+    if suffix_parts:
+        return f"{observed} ({', '.join(suffix_parts)})"
+    return observed
 
 
 def _format_place(place: dict[str, Any]) -> str:
@@ -251,7 +273,7 @@ async def get_current_weather(request: CurrentWeatherRequest) -> ChatToolRespons
         units = payload.get("current_units") or {}
         place_name = _format_place(place)
         condition = _format_weather_code(current.get("weather_code"))
-        observed_at = current.get("time") or "unknown time"
+        observed_at = _format_observed_at(current, payload)
 
         lines = [
             f"Current weather for {place_name}",
@@ -339,16 +361,11 @@ async def get_air_quality(request: AirQualityRequest) -> ChatToolResponse:
         current = payload.get("current") or {}
         units = payload.get("current_units") or {}
         place_name = _format_place(place)
-        observed_at = current.get("time")
-        if observed_at:
-            try:
-                observed_at = datetime.fromisoformat(observed_at).isoformat(timespec="minutes")
-            except ValueError:
-                pass
+        observed_at = _format_observed_at(current, payload)
 
         lines = [
             f"Air quality for {place_name}",
-            f"Observed: {observed_at or 'unknown time'}",
+            f"Observed: {observed_at}",
             f"US AQI: {_format_number(current.get('us_aqi'))}",
             f"PM2.5: {_format_number(current.get('pm2_5'), ' ' + units.get('pm2_5', ''))}",
             f"PM10: {_format_number(current.get('pm10'), ' ' + units.get('pm10', ''))}",

--- a/plugins/omi-open-meteo-app/test_observed_at.py
+++ b/plugins/omi-open-meteo-app/test_observed_at.py
@@ -1,0 +1,24 @@
+"""Unit tests for timezone-aware observation timestamps (issue #13194)."""
+
+from main import _format_observed_at
+
+
+def test_includes_timezone_name_and_offset():
+    current = {"time": "2026-09-11T14:00"}
+    payload = {"timezone": "Europe/Berlin", "utc_offset_seconds": 7200}
+    out = _format_observed_at(current, payload)
+    assert "2026-09-11T14:00" in out
+    assert "Europe/Berlin" in out
+    assert "UTC+02:00" in out
+
+
+def test_negative_offset():
+    current = {"time": "2026-09-11T09:00"}
+    payload = {"timezone": "America/New_York", "utc_offset_seconds": -14400}
+    out = _format_observed_at(current, payload)
+    assert "UTC-04:00" in out
+
+
+def test_falls_back_to_raw_time_without_metadata():
+    out = _format_observed_at({"time": "2026-09-11T14:00"}, {})
+    assert out == "2026-09-11T14:00"


### PR DESCRIPTION
## What
Current weather and air quality dropped the response timezone
metadata. Observed timestamps now include timezone name and UTC
offset when the API returns them.

## Why
Closes #13194.

## Test plan
- [x] Unit tests for positive/negative offsets and fallback
- [x] `pytest test_observed_at.py` (3 passed)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

