### PR TITLE
fix(cli): continue action-item get after short pages

### DIFF
--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -89,7 +89,13 @@ def get_action_item(
                 if item.get("id") == action_item_id:
                     ctx.renderer.emit(item, title="action item")
                     return
-            if len(page) < page_size:
+            # The API filters locked records after pagination, so a short page
+            # does not mean the result set is exhausted. Only stop on empty.
+            if len(page) == 0:
+                break
+            # Guard against a pathological infinite cursor if the server never
+            # advances offset semantics; 10k items matches the documented cap.
+            if offset >= 10_000:
                 break
             offset += page_size
     # Exit code 5 (NotFoundError) — same contract as a server-side 404,

--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -81,7 +81,11 @@ def get_action_item(
         # A fixed page cap would report existing older items as not found.
         page_size = 200
         offset = 0
-        while True:
+        # The API filters locked records after pagination, so a short page
+        # does not mean the result set is exhausted. Continue until empty
+        # or the documented 10k scan cap (checked before the next request).
+        max_offset = 10_000
+        while offset <= max_offset:
             page = client.get("/v1/dev/user/action-items", params={"limit": page_size, "offset": offset})
             if not page:
                 break
@@ -89,14 +93,6 @@ def get_action_item(
                 if item.get("id") == action_item_id:
                     ctx.renderer.emit(item, title="action item")
                     return
-            # The API filters locked records after pagination, so a short page
-            # does not mean the result set is exhausted. Only stop on empty.
-            if len(page) == 0:
-                break
-            # Guard against a pathological infinite cursor if the server never
-            # advances offset semantics; 10k items matches the documented cap.
-            if offset >= 10_000:
-                break
             offset += page_size
     # Exit code 5 (NotFoundError) — same contract as a server-side 404,
     # whether or not the dev API exposed a direct GET for this noun.

--- a/sdks/python-cli/tests/test_action_item.py
+++ b/sdks/python-cli/tests/test_action_item.py
@@ -83,8 +83,29 @@ def test_action_item_get_searches_beyond_five_pages(authed_profile, respx_mock, 
         assert json.loads(result.stdout) == {"id": "target"}
 
 
-def test_action_item_get_stops_after_short_page(authed_profile, respx_mock, cli_runner) -> None:
-    route = respx_mock.get("/v1/dev/user/action-items").respond(json=[{"id": "other"}])
+def test_action_item_get_continues_past_short_pages(authed_profile, respx_mock, cli_runner) -> None:
+    """A short page is not exhaustion: the API filters locked records after paging (#13214)."""
+    offsets = []
+
+    def respond(request):
+        offset = int(request.url.params["offset"])
+        offsets.append(offset)
+        if offset == 0:
+            # 199 items after one locked record was filtered from a 200-row page.
+            return httpx.Response(200, json=[{"id": f"a{i}"} for i in range(199)])
+        if offset == 200:
+            return httpx.Response(200, json=[{"id": "target"}])
+        return httpx.Response(200, json=[])
+
+    respx_mock.get("/v1/dev/user/action-items").mock(side_effect=respond)
+    result = cli_runner.invoke(app, ["--json", "action-item", "get", "target"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"id": "target"}
+    assert offsets == [0, 200]
+
+
+def test_action_item_get_stops_on_empty_page(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.get("/v1/dev/user/action-items").respond(json=[])
     result = cli_runner.invoke(app, ["--json", "action-item", "get", "missing"])
     assert result.exit_code == 5
     assert route.call_count == 1


### PR DESCRIPTION
## What
`action-item get` treated a short page as exhaustion. The API
filters locked records after paging, so a 199-item page does not
mean no further accessible records exist. Scan continues until an
empty page or a 10k safety cap.

## Why
Closes #13214.

## Test plan
- [x] `pytest tests/test_action_item.py` (passed)
- [x] New regression: short page then target on next offset

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

