### PR TITLE
fix(cli): map deeply nested JSON RecursionError to ValueError

### DIFF
--- a/sdks/python-cli/omi_cli/json_input.py
+++ b/sdks/python-cli/omi_cli/json_input.py
@@ -22,9 +22,14 @@ def load_json_input(value: str | bytes) -> Any:
     """Reject non-finite numbers and strings that cannot be encoded as UTF-8.
 
     JSON strings are unchanged, and bytes retain json.loads' encoding detection.
-    Invalid input raises ValueError (including JSONDecodeError and UnicodeError).
+    Invalid input raises ValueError (including JSONDecodeError, UnicodeError,
+    and RecursionError from extreme nesting, which callers already map to
+    UsageError via the ValueError contract).
     """
-    parsed = json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    try:
+        parsed = json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    except RecursionError:
+        raise ValueError("JSON nesting depth exceeds the supported limit") from None
     pending = [parsed]
     while pending:
         item = pending.pop()

--- a/sdks/python-cli/tests/test_json_input_recursion.py
+++ b/sdks/python-cli/tests/test_json_input_recursion.py
@@ -1,0 +1,21 @@
+"""Deeply nested JSON must raise ValueError, not RecursionError (#13507)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omi_cli.json_input import load_json_input
+
+
+def test_load_json_input_maps_recursion_error_to_value_error():
+    raw = '{"a":' * 20000 + "1" + "}" * 20000
+    with pytest.raises(ValueError) as exc:
+        load_json_input(raw)
+    assert "nesting" in str(exc.value).lower() or "recursion" in str(exc.value).lower()
+
+
+def test_load_json_input_still_rejects_malformed_json_as_value_error():
+    with pytest.raises(ValueError):
+        load_json_input("{not json")


### PR DESCRIPTION
## What
`load_json_input` lets RecursionError escape for extreme nesting.
Callers only catch ValueError, so the CLI exits with a traceback
instead of a usage error. RecursionError is now mapped to ValueError.

## Why
Closes #13507.

## Test plan
- [x] `pytest tests/test_json_input_recursion.py` (passed)
- [x] Existing non-finite and malformed-JSON tests still pass

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

