### PR TITLE
chore(failure-classes): extend, don't cap, in FC-concurrent-ptt-strea…

### DIFF
--- a/.github/failure-classes/FC-concurrent-ptt-stream-budget-overspend.json
+++ b/.github/failure-classes/FC-concurrent-ptt-stream-budget-overspend.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "id": "FC-concurrent-ptt-stream-budget-overspend",
   "violated_contract": "Concurrent /v2/voice-message/transcribe-stream sessions for the same uid must not each admit against the same remaining daily STT duration slice. Probe-only check_budget at connect plus force-record at end lets N sessions freeze identical remaining_ms and overspend the shared voice_duration budget after the fact.",
-  "canonical_prevention": "Atomically reserve up to MAX_SESSION_DURATION_S at WS connect via try_reserve_session_budget (Lua force=2 consume-up-to). Cap mid-session audio to the reserved amount. On successful drain, settle_reserved_duration(reserved, actual); on terminal provider failure, refund the full reservation. Pin with fakeredis Lua tests that show probe+force overspend and reserve-up-to mutual exclusion.",
+  "canonical_prevention": "Atomically reserve up to MAX_SESSION_DURATION_S at WS connect via try_reserve_session_budget (Lua force=2 consume-up-to). Never admit mid-session audio past the cumulative reservation: when a stream outgrows it, atomically reserve another slice the same way and close only when that reservation is denied (one slice is an admission unit, not a cap on stream length — see FC-stream-budget-slice-treated-as-daily-cap). On successful drain, settle_reserved_duration(cumulative_reserved, actual); on terminal provider failure, refund the full reservation. Pin with fakeredis Lua tests that show probe+force overspend and reserve-up-to mutual exclusion.",
   "canonical_prevention_artifact": [
     "backend/tests/unit/test_voice_duration_limiter.py",
     "backend/tests/unit/test_desktop_transcribe.py"


### PR DESCRIPTION
…m-budget-overspend

The class's canonical_prevention said to cap mid-session audio at the connect-time reservation. That cap was the defect behind FC-stream-budget-slice-treated-as-daily-cap: every long-lived transcribe-stream session (Windows meeting/screen system audio) was closed after one 120s slice with a false "Daily transcription budget exhausted". The concurrency guarantee this class protects only needs "never admit audio past the cumulative reservation"; extending the reservation in atomic force=2 slices keeps it and removes the length cap.

Registry-only change: no status, evidence or artifact edits. It pairs with the backend fix branch fix/backend-transcribe-stream-budget-slices and should merge after it.

<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

<!-- One or two sentences. Link the issue if there is one. -->

## Product invariants affected

<!-- Name locked invariant IDs this PR touches (e.g. INV-CHAT-1), or "none".
     Registry: product/invariants/ — required when changing paths listed
     on a locked invariant. -->

## How it was verified

<!-- The commands you ran and what they showed. Exercising the real user-facing
     path counts as verification; compiling or lint passing does not.
     If something could not be verified, say so explicitly. -->

## Tests

<!-- Bug fix: point to the regression test that would have caught the bug.
     Feature: point to the tests for the core path and main error path.
     No test change: explain why none was needed. -->

## Failure class (fixes)

<!-- Every `fix:` commit needs this exact, machine-validated declaration. Write one
     of these three lines, exactly — the value is a single token, never a list:
         Failure-Class: FC-<lower-kebab-slug>
         Failure-Class: new
         Failure-Class: none
     `scripts/failure-class prepare` lists the classes whose scope_hints overlap your
     change (add --all-candidates for the whole registry); `explain <id>` prints one.
     `harden:` commits may cite a class but do not need a declaration. -->

Failure-Class: none

## Failure-class transition narrative (only when needed)

<!-- Required only when declaring `new`, changing a class's canonical prevention
     primitive/owner, or making a registry-only lifecycle transition.

     Declaring `new` means adding exactly one
     .github/failure-classes/FC-<lower-kebab-slug>.json in THIS PR, alongside the fix.
     Its `evidence_prs` may be `[]` — this PR is the evidence, and its number does not
     exist yet.

     Every OTHER registry transition — dormant, reopen, or changing an existing class's
     canonical prevention — goes in a separate registry-only PR, never in the
     instance-fix PR. A dormant transition sets `status: dormant` and an ISO-8601
     `dormant_since`; a reopen sets `status: open` and removes `dormant_since`.

     State the violated contract, the canonical guard, and the supporting evidence.
     Delete this section for an ordinary instance fix. -->

## New guards (only when adding a check or ratchet)

<!-- Cite the real merged PR or incident this guard would have caught, then answer
     in one sentence: why is this not a shared primitive instead? Delete this
     section when no check or ratchet is added. -->

## Scoped cleanups (optional)

<!-- Related fixes you made along the way (see AGENTS.md → "Leave It Better
     Than You Found It"). Each should be its own commit and verifiable. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

