### PR TITLE
fix(crossref): strip JATS markup from abstracts

### DIFF
--- a/plugins/omi-crossref-app/main.py
+++ b/plugins/omi-crossref-app/main.py
@@ -23,8 +23,10 @@ def clamp_max_results(value: int) -> int:
 
 
 _JATS_TAG = re.compile(r"</?jats:[^>]+>")
-# Require a non-word char before "<" so inequalities like a<b are preserved.
-_HTML_TAG = re.compile(r"(?<![A-Za-z0-9_])</?[a-zA-Z][^>]*>")
+# Closing tags are never inequalities; strip them unconditionally.
+_CLOSE_TAG = re.compile(r"</[a-zA-Z][^>]*>")
+# Open tags need a non-word char before "<" so inequalities like a<b survive.
+_OPEN_TAG = re.compile(r"(?<![A-Za-z0-9_])<[a-zA-Z][^>]*>")
 
 
 def clean(text: Any) -> str:
@@ -33,7 +35,8 @@ def clean(text: Any) -> str:
     value = html.unescape(str(text)).strip()
     # Crossref abstracts often carry JATS markup; chat tools want plain text.
     value = _JATS_TAG.sub("", value)
-    value = _HTML_TAG.sub("", value)
+    value = _CLOSE_TAG.sub("", value)
+    value = _OPEN_TAG.sub("", value)
     return value.strip()
 
 

--- a/plugins/omi-crossref-app/main.py
+++ b/plugins/omi-crossref-app/main.py
@@ -23,6 +23,8 @@ def clamp_max_results(value: int) -> int:
 
 
 _JATS_TAG = re.compile(r"</?jats:[^>]+>")
+# Require a non-word char before "<" so inequalities like a<b are preserved.
+_HTML_TAG = re.compile(r"(?<![A-Za-z0-9_])</?[a-zA-Z][^>]*>")
 
 
 def clean(text: Any) -> str:
@@ -31,7 +33,7 @@ def clean(text: Any) -> str:
     value = html.unescape(str(text)).strip()
     # Crossref abstracts often carry JATS markup; chat tools want plain text.
     value = _JATS_TAG.sub("", value)
-    value = re.sub(r"</?[a-zA-Z][^>]*>", "", value)
+    value = _HTML_TAG.sub("", value)
     return value.strip()
 
 

--- a/plugins/omi-crossref-app/main.py
+++ b/plugins/omi-crossref-app/main.py
@@ -1,4 +1,5 @@
 import html
+import re
 from typing import Any
 from urllib.parse import quote
 
@@ -13,7 +14,7 @@ TIMEOUT = 20.0
 app = FastAPI(
     title="Crossref Omi Integration",
     description="No-auth Crossref chat tools for paper metadata search and lookup",
-    version="1.0.0",
+    version="1.0.1",
 )
 
 
@@ -21,10 +22,17 @@ def clamp_max_results(value: int) -> int:
     return max(1, min(10, value))
 
 
+_JATS_TAG = re.compile(r"</?jats:[^>]+>")
+
+
 def clean(text: Any) -> str:
     if text is None:
         return ""
-    return html.unescape(str(text)).strip()
+    value = html.unescape(str(text)).strip()
+    # Crossref abstracts often carry JATS markup; chat tools want plain text.
+    value = _JATS_TAG.sub("", value)
+    value = re.sub(r"</?[a-zA-Z][^>]*>", "", value)
+    return value.strip()
 
 
 def extract_year(item: dict[str, Any]) -> str:

--- a/plugins/omi-crossref-app/test_clean.py
+++ b/plugins/omi-crossref-app/test_clean.py
@@ -14,3 +14,8 @@ def test_clean_unescapes_entities_and_strips_generic_tags():
 
 def test_clean_preserves_inequality_operators():
     assert clean("If a<b, then c>d.") == "If a<b, then c>d."
+
+
+def test_clean_strips_closing_tags_after_word_chars():
+    assert clean("text</p> tail") == "text tail"
+    assert clean("A &amp; B <b>bold</b>") == "A & B bold"

--- a/plugins/omi-crossref-app/test_clean.py
+++ b/plugins/omi-crossref-app/test_clean.py
@@ -1,0 +1,12 @@
+"""JATS abstracts must be plain text (#13242)."""
+
+from main import clean
+
+
+def test_clean_strips_jats_paragraph_tags():
+    raw = "<jats:p>Sleep quality improved <jats:italic>slightly</jats:italic>.</jats:p>"
+    assert clean(raw) == "Sleep quality improved slightly."
+
+
+def test_clean_unescapes_entities_and_strips_generic_tags():
+    assert clean("A &amp; B <b>bold</b>") == "A & B bold"

--- a/plugins/omi-crossref-app/test_clean.py
+++ b/plugins/omi-crossref-app/test_clean.py
@@ -10,3 +10,7 @@ def test_clean_strips_jats_paragraph_tags():
 
 def test_clean_unescapes_entities_and_strips_generic_tags():
     assert clean("A &amp; B <b>bold</b>") == "A & B bold"
+
+
+def test_clean_preserves_inequality_operators():
+    assert clean("If a<b, then c>d.") == "If a<b, then c>d."


### PR DESCRIPTION
Closes #13242.

`clean()` now removes jats tags and generic HTML tags from Crossref abstracts.

- [x] Unit tests
- Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

