### PR TITLE
fix(openfoodfacts): per-100g nutrients only + full-text search

### DIFF
--- a/plugins/omi-openfoodfacts-app/main.py
+++ b/plugins/omi-openfoodfacts-app/main.py
@@ -106,11 +106,16 @@ def _invalid_body_response(message: str) -> ChatToolResponse:
 
 
 def _nutrient(product: Dict[str, Any], key: str) -> Optional[Any]:
+    """Return the per-100g nutrient only.
+
+    Unsuffixed nutriment keys depend on nutrition_data_per (often serving).
+    Falling back to them and labeling the result per_100g is wrong.
+    """
     nutriments = product.get("nutriments") or {}
     per_100g_key = f"{key}_100g"
     if per_100g_key in nutriments:
         return nutriments[per_100g_key]
-    return nutriments.get(key)
+    return None
 
 
 def _summarize_product(product: Dict[str, Any]) -> Dict[str, Any]:
@@ -185,10 +190,14 @@ async def _search_foods(query: str, page_size: int) -> Dict[str, Any]:
     if not query:
         return {"error": "query is required"}
 
+    # CGI search is the full-text product search; /api/v2/search is not.
     payload = await _openfoodfacts_get_async(
-        "/api/v2/search",
+        "/cgi/search.pl",
         {
+            "action": "process",
             "search_terms": query,
+            "search_simple": 1,
+            "json": 1,
             "page_size": page_size,
             "fields": PRODUCT_FIELDS,
         },

--- a/plugins/omi-openfoodfacts-app/test_nutrient_basis.py
+++ b/plugins/omi-openfoodfacts-app/test_nutrient_basis.py
@@ -1,0 +1,20 @@
+"""Only per-100g nutriments may be labeled nutrition_per_100g (#13272)."""
+
+from main import _nutrient, _summarize_product
+
+
+def test_serving_only_nutrient_is_not_reported_as_per_100g():
+    product = {
+        "code": "1",
+        "product_name": "Oat milk",
+        "nutriments": {
+            # serving-only, no _100g key
+            "fat": 1.5,
+            "fat_100g": 0.2,
+        },
+    }
+    assert _nutrient(product, "fat") == 0.2
+    # Serving-only key must not leak into nutrition_per_100g.
+    product2 = {"code": "2", "product_name": "X", "nutriments": {"fat": 1.5}}
+    summary = _summarize_product(product2)
+    assert summary["nutrition_per_100g"]["fat_g"] is None

--- a/plugins/omi-openfoodfacts-app/test_search_endpoint.py
+++ b/plugins/omi-openfoodfacts-app/test_search_endpoint.py
@@ -1,0 +1,23 @@
+"""Full-text search endpoint contract (#13190)."""
+
+import asyncio
+
+
+def test_search_foods_uses_cgi_fulltext_endpoint(monkeypatch):
+    import main
+
+    captured = {}
+
+    async def fake_get_async(path, params=None):
+        captured["path"] = path
+        captured["params"] = params or {}
+        return {"products": [{"code": "1", "product_name": "Oat milk"}], "count": 1}
+
+    monkeypatch.setattr(main, "_openfoodfacts_get_async", fake_get_async)
+
+    result = asyncio.get_event_loop().run_until_complete(main._search_foods("oat milk", 5))
+    assert captured["path"] == "/cgi/search.pl"
+    assert captured["params"]["search_terms"] == "oat milk"
+    assert captured["params"]["json"] == 1
+    assert result["count"] == 1
+    assert result["products"][0]["name"] == "Oat milk"


### PR DESCRIPTION
Closes #13272 and closes #13190.

1. _nutrient only returns *_100g values so serving data is not labeled per 100g.
2. Plain-text search uses /cgi/search.pl (full-text) instead of /api/v2/search.

- [x] Unit tests for nutrient basis
- Failure-Class: none
