### PR TITLE
fix(shopify): stop double-subtracting discounts from net sales

### DIFF
--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -489,8 +489,9 @@ async def tool_get_analytics(request: Request):
                     for transaction in refund.get("transactions", []):
                         total_refunds += float(transaction.get("amount", 0))
         
-        # Net sales (gross - discounts - refunds)
-        net_sales = gross_sales - total_discounts - total_refunds
+        # Shopify subtotal_price is already after discounts. Do not subtract
+        # total_discounts again or discounts are applied twice.
+        net_sales = gross_sales - total_refunds
         
         # Total collected (what was actually charged - includes tax & shipping)
         total_collected = sum(float(o.get("total_price", 0)) for o in orders)

--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -472,8 +472,8 @@ async def tool_get_analytics(request: Request):
         # Calculate detailed financial analytics
         total_orders = len(orders)
         
-        # Gross sales (subtotal before discounts, taxes, shipping)
-        gross_sales = sum(float(o.get("subtotal_price", 0)) for o in orders)
+        # Shopify subtotal_price is already after line-item discounts.
+        post_discount_subtotal = sum(float(o.get("subtotal_price", 0)) for o in orders)
         
         # Total discounts applied
         total_discounts = sum(float(o.get("total_discounts", 0)) for o in orders)
@@ -489,9 +489,10 @@ async def tool_get_analytics(request: Request):
                     for transaction in refund.get("transactions", []):
                         total_refunds += float(transaction.get("amount", 0))
         
-        # Shopify subtotal_price is already after discounts. Do not subtract
-        # total_discounts again or discounts are applied twice.
-        net_sales = gross_sales - total_refunds
+        # Present a true pre-discount gross so the Discounts row reconciles:
+        # gross_sales - total_discounts - total_refunds == net_sales
+        gross_sales = post_discount_subtotal + total_discounts
+        net_sales = post_discount_subtotal - total_refunds
         
         # Total collected (what was actually charged - includes tax & shipping)
         total_collected = sum(float(o.get("total_price", 0)) for o in orders)


### PR DESCRIPTION
Closes #13180.

Shopify `subtotal_price` is already after discounts; net sales no longer subtract `total_discounts` again.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

