### PR TITLE
fix(google-calendar): convert ISO offsets to UTC wall time

### DIFF
--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -7,7 +7,7 @@ and chat tools for managing calendar events.
 import os
 import sys
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List
 from urllib.parse import urlencode
 
@@ -221,8 +221,12 @@ def parse_datetime(dt_str: str) -> tuple[datetime, bool]:
     # Default: try to parse as ISO format
     try:
         parsed = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+        if parsed.tzinfo is not None:
+            # Convert the instant to UTC wall time before dropping tzinfo so
+            # callers that attach timeZone: UTC do not shift the event.
+            parsed = parsed.astimezone(timezone.utc)
         return parsed.replace(tzinfo=None), False
-    except:
+    except Exception:
         pass
 
     raise ValueError(f"Could not parse datetime: {dt_str}")

--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -212,6 +212,11 @@ def parse_datetime(dt_str: str) -> tuple[datetime, bool]:
             # If no year in format, use current year
             if "%Y" not in fmt:
                 parsed = parsed.replace(year=today.year)
+            # Normalize any explicit offset to UTC wall time before callers
+            # attach timeZone: UTC.
+            if parsed.tzinfo is not None:
+                parsed = parsed.astimezone(timezone.utc)
+                parsed = parsed.replace(tzinfo=None)
             # If no time in format, it's an all-day event
             is_all_day = "%H" not in fmt and "%I" not in fmt
             return parsed, is_all_day


### PR DESCRIPTION
Closes #13149.

ISO datetimes with an explicit offset are converted to UTC before tzinfo is dropped, so `timeZone: UTC` does not shift the instant.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

