### PR TITLE
fix(cli): emit JSON for config mutations

### DIFF
--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -93,6 +93,8 @@ def set_value(
         f"Set [bold]{escape(key)}[/bold] = {escape(display_value)} "
         f"on profile [bold]{escape(profile.name)}[/bold]."
     )
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"ok": True, "profile": profile.name, "key": key, "value": display_value})
 
 
 @profile_app.command("list", help="List all configured profiles.")
@@ -134,6 +136,8 @@ def profile_use(
     config.active_profile = name
     cfg.save(config)
     ctx.renderer.success(f"Active profile: [bold]{escape(name)}[/bold].")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"ok": True, "active_profile": name})
 
 
 @profile_app.command("delete", help="Delete a profile and its credentials.")
@@ -151,3 +155,5 @@ def profile_delete(
     config.delete_profile(name)
     cfg.save(config)
     ctx.renderer.success(f"Deleted profile [bold]{escape(name)}[/bold].")
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit({"ok": True, "deleted_profile": name})

--- a/sdks/python-cli/tests/test_next_batch.py
+++ b/sdks/python-cli/tests/test_next_batch.py
@@ -1,0 +1,76 @@
+"""CLI regressions for the next PR batch."""
+import json
+import sys
+
+import pytest
+
+from omi_cli.main import app, main
+
+
+def test_config_set_emits_json(authed_profile, cli_runner, monkeypatch):
+    result = cli_runner.invoke(app, ["--json", "config", "set", "api_base", "https://example.test"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["key"] == "api_base"
+
+
+def test_config_profile_use_emits_json(authed_profile, cli_runner):
+    result = cli_runner.invoke(app, ["--json", "config", "profile", "use", "work"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["active_profile"] == "work"
+
+
+def test_list_ids_are_not_truncated(authed_profile, respx_mock, cli_runner):
+    full_id = "12345678-1234-4234-8234-123456789abc"
+    respx_mock.get("/v1/dev/user/memories").respond(
+        json=[{"id": full_id, "content": "hello world", "category": "note", "tags": []}]
+    )
+    result = cli_runner.invoke(app, ["memory", "list"])
+    assert result.exit_code == 0
+    assert full_id in result.stdout
+    assert "12345678-1234…" not in result.stdout
+
+
+def test_goal_update_horizon_and_context(authed_profile, respx_mock, cli_runner):
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1"})
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "goal",
+            "update",
+            "g1",
+            "--horizon-at",
+            "2026-12-01T00:00:00",
+            "--desired-outcome",
+            "ship",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body["horizon_at"].startswith("2026-12-01")
+    assert body["desired_outcome"] == "ship"
+
+
+def test_goal_update_clear_horizon(authed_profile, respx_mock, cli_runner):
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1"})
+    result = cli_runner.invoke(app, ["--json", "goal", "update", "g1", "--clear-horizon"])
+    assert result.exit_code == 0, result.output
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"horizon_at": None}
+
+
+def test_goal_update_rejects_conflicting_horizon(authed_profile, respx_mock, monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["omi", "--json", "goal", "update", "g1", "--horizon-at", "2026-12-01T00:00:00", "--clear-horizon"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    err = json.loads(capsys.readouterr().err)
+    assert "horizon" in err["detail"].lower()
+    assert not respx_mock.calls

--- a/sdks/python-cli/tests/test_next_batch.py
+++ b/sdks/python-cli/tests/test_next_batch.py
@@ -1,13 +1,10 @@
-"""CLI regressions for the next PR batch."""
+"""Config mutations must emit JSON in --json mode (#13044)."""
 import json
-import sys
-
-import pytest
-
-from omi_cli.main import app, main
 
 
-def test_config_set_emits_json(authed_profile, cli_runner, monkeypatch):
+def test_config_set_emits_json(authed_profile, cli_runner):
+    from omi_cli.main import app
+
     result = cli_runner.invoke(app, ["--json", "config", "set", "api_base", "https://example.test"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
@@ -16,61 +13,9 @@ def test_config_set_emits_json(authed_profile, cli_runner, monkeypatch):
 
 
 def test_config_profile_use_emits_json(authed_profile, cli_runner):
+    from omi_cli.main import app
+
     result = cli_runner.invoke(app, ["--json", "config", "profile", "use", "work"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     assert payload["active_profile"] == "work"
-
-
-def test_list_ids_are_not_truncated(authed_profile, respx_mock, cli_runner):
-    full_id = "12345678-1234-4234-8234-123456789abc"
-    respx_mock.get("/v1/dev/user/memories").respond(
-        json=[{"id": full_id, "content": "hello world", "category": "note", "tags": []}]
-    )
-    result = cli_runner.invoke(app, ["memory", "list"])
-    assert result.exit_code == 0
-    assert full_id in result.stdout
-    assert "12345678-1234…" not in result.stdout
-
-
-def test_goal_update_horizon_and_context(authed_profile, respx_mock, cli_runner):
-    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1"})
-    result = cli_runner.invoke(
-        app,
-        [
-            "--json",
-            "goal",
-            "update",
-            "g1",
-            "--horizon-at",
-            "2026-12-01T00:00:00",
-            "--desired-outcome",
-            "ship",
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    body = json.loads(route.calls.last.request.content)
-    assert body["horizon_at"].startswith("2026-12-01")
-    assert body["desired_outcome"] == "ship"
-
-
-def test_goal_update_clear_horizon(authed_profile, respx_mock, cli_runner):
-    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1"})
-    result = cli_runner.invoke(app, ["--json", "goal", "update", "g1", "--clear-horizon"])
-    assert result.exit_code == 0, result.output
-    body = json.loads(route.calls.last.request.content)
-    assert body == {"horizon_at": None}
-
-
-def test_goal_update_rejects_conflicting_horizon(authed_profile, respx_mock, monkeypatch, capsys):
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["omi", "--json", "goal", "update", "g1", "--horizon-at", "2026-12-01T00:00:00", "--clear-horizon"],
-    )
-    with pytest.raises(SystemExit) as exc:
-        main()
-    assert exc.value.code == 1
-    err = json.loads(capsys.readouterr().err)
-    assert "horizon" in err["detail"].lower()
-    assert not respx_mock.calls


### PR DESCRIPTION
Closes #13044.

`config set`, `profile use`, and `profile delete` emit a JSON payload in `--json` mode instead of empty stdout.

- [x] `pytest tests/test_next_batch.py`
- Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

