### PR TITLE
fix(uber-call): reject out-of-range coordinates

### DIFF
--- a/plugins/uber_call/test_coord_bounds.py
+++ b/plugins/uber_call/test_coord_bounds.py
@@ -1,0 +1,20 @@
+"""Coordinate bounds for Uber deep links (#13291)."""
+
+import pytest
+
+from uber_links import build_location
+
+
+def test_accepts_valid_bounds():
+    loc = build_location(latitude=90, longitude=-180)
+    assert loc.latitude == 90
+    assert loc.longitude == -180
+
+
+@pytest.mark.parametrize(
+    ("lat", "lng"),
+    [(91, 0), (0, 181), (-91, 0), (0, -181)],
+)
+def test_rejects_out_of_range(lat, lng):
+    with pytest.raises(ValueError, match="Invalid coordinates"):
+        build_location(latitude=lat, longitude=lng)

--- a/plugins/uber_call/test_coord_bounds.py
+++ b/plugins/uber_call/test_coord_bounds.py
@@ -1,20 +1,27 @@
 """Coordinate bounds for Uber deep links (#13291)."""
 
-import pytest
+import unittest
 
 from uber_links import build_location
 
 
-def test_accepts_valid_bounds():
-    loc = build_location(latitude=90, longitude=-180)
-    assert loc.latitude == 90
-    assert loc.longitude == -180
+class TestCoordinateBounds(unittest.TestCase):
+    def test_accepts_valid_bounds(self):
+        loc = build_location(latitude=90, longitude=-180)
+        self.assertEqual(loc.latitude, 90)
+        self.assertEqual(loc.longitude, -180)
+
+    def test_rejects_out_of_range_pair(self):
+        for lat, lng in [(91, 0), (0, 181), (-91, 0), (0, -181)]:
+            with self.assertRaises(ValueError):
+                build_location(latitude=lat, longitude=lng)
+
+    def test_rejects_out_of_range_single_coordinate(self):
+        with self.assertRaises(ValueError):
+            build_location(latitude=200, longitude=None)
+        with self.assertRaises(ValueError):
+            build_location(latitude=None, longitude=181)
 
 
-@pytest.mark.parametrize(
-    ("lat", "lng"),
-    [(91, 0), (0, 181), (-91, 0), (0, -181)],
-)
-def test_rejects_out_of_range(lat, lng):
-    with pytest.raises(ValueError, match="Invalid coordinates"):
-        build_location(latitude=lat, longitude=lng)
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/uber_call/uber_links.py
+++ b/plugins/uber_call/uber_links.py
@@ -43,9 +43,12 @@ def _normalize_float(value: float | int | str | None) -> float | None:
 
 
 def _valid_lat_lng(lat: float | None, lng: float | None) -> bool:
-    if lat is None or lng is None:
-        return True
-    return -90.0 <= lat <= 90.0 and -180.0 <= lng <= 180.0
+    # Validate each supplied coordinate independently.
+    if lat is not None and not (-90.0 <= lat <= 90.0):
+        return False
+    if lng is not None and not (-180.0 <= lng <= 180.0):
+        return False
+    return True
 
 
 def build_location(

--- a/plugins/uber_call/uber_links.py
+++ b/plugins/uber_call/uber_links.py
@@ -42,6 +42,12 @@ def _normalize_float(value: float | int | str | None) -> float | None:
     return float(value)
 
 
+def _valid_lat_lng(lat: float | None, lng: float | None) -> bool:
+    if lat is None or lng is None:
+        return True
+    return -90.0 <= lat <= 90.0 and -180.0 <= lng <= 180.0
+
+
 def build_location(
     *,
     latitude: float | int | str | None = None,
@@ -51,6 +57,11 @@ def build_location(
 ) -> UberLocation:
     lat = _normalize_float(latitude)
     lng = _normalize_float(longitude)
+    if not _valid_lat_lng(lat, lng):
+        raise ValueError(
+            f"Invalid coordinates: latitude={lat}, longitude={lng}. "
+            "Latitude must be in [-90, 90] and longitude in [-180, 180]."
+        )
     return UberLocation(
         latitude=lat,
         longitude=lng,


### PR DESCRIPTION
Closes #13291.

`build_location` rejects latitude outside [-90,90] and longitude outside [-180,180]. The existing handler already maps `ValueError` to HTTP 400.

- [x] `pytest test_coord_bounds.py test_uber_links.py`
- Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

