### PR TITLE
fix(ms365): honour Graph Retry-After instead of shortening it

### DIFF
--- a/plugins/omi-ms365-app/services/graph_client.py
+++ b/plugins/omi-ms365-app/services/graph_client.py
@@ -59,7 +59,8 @@ class GraphClient:
                 if attempt == MAX_RETRIES - 1:
                     raise GraphError(resp.status_code, resp.text)
                 retry_after = int(resp.headers.get("Retry-After", "2"))
-                backoff = min(retry_after, 2 ** attempt + 1)
+                # Honour the server cooldown; do not shorten a long Retry-After.
+                backoff = max(retry_after, min(2 ** attempt + 1, 30))
                 log.warning("Graph %s on %s — backing off %ss", resp.status_code, path, backoff)
                 await asyncio.sleep(backoff)
                 continue
@@ -119,7 +120,8 @@ class GraphClient:
                 if attempt == MAX_RETRIES - 1:
                     raise GraphError(resp.status_code, resp.text)
                 retry_after = int(resp.headers.get("Retry-After", "2"))
-                backoff = min(retry_after, 2 ** attempt + 1)
+                # Honour the server cooldown; do not shorten a long Retry-After.
+                backoff = max(retry_after, min(2 ** attempt + 1, 30))
                 log.warning("Graph %s on %s — backing off %ss", resp.status_code, path, backoff)
                 await asyncio.sleep(backoff)
                 continue


### PR DESCRIPTION
Closes #13176.

Backoff is `max(Retry-After, min(2**attempt+1, 30))` so a 60s cooldown is respected.

- Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

