### PR TITLE
fix(shopify): fail analytics when a later orders page errors

### DIFF
--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -463,7 +463,10 @@ async def tool_get_analytics(request: Request):
             params["since_id"] = last_order_id
             orders_result = shopify_api_request(uid, "GET", "/orders.json", params=params)
             if "error" in orders_result:
-                break
+                # Later-page failures must not look like complete analytics.
+                return ChatToolResponse(
+                    error=f"Failed to get analytics after {len(all_orders)} orders: {orders_result['error']}"
+                )
             all_orders.extend(orders_result.get("orders", []))
             page_count += 1
         


### PR DESCRIPTION
Closes #13278.

A later-page `/orders.json` error now returns a tool error instead of partial totals as success.

- Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

