### PR TITLE
Fix #13507: Python CLI: deeply nested JSON escapes shared input validation as Recu

### DIFF
--- a/sdks/python-cli/omi_cli/json_input.py
+++ b/sdks/python-cli/omi_cli/json_input.py
@@ -24,7 +24,10 @@ def load_json_input(value: str | bytes) -> Any:
     JSON strings are unchanged, and bytes retain json.loads' encoding detection.
     Invalid input raises ValueError (including JSONDecodeError and UnicodeError).
     """
-    parsed = json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    try:
+        parsed = json.loads(value, parse_constant=_reject_constant, parse_float=_finite_float)
+    except RecursionError as exc:
+        raise ValueError("JSON input is nested too deeply") from exc
     pending = [parsed]
     while pending:
         item = pending.pop()

--- a/sdks/python-cli/tests/test_issue_13507.py
+++ b/sdks/python-cli/tests/test_issue_13507.py
@@ -1,0 +1,27 @@
+import unittest
+from omi_cli.json_input import load_json_input
+
+
+class TestRecursionErrorFix(unittest.TestCase):
+    def test_deeply_nested_json_raises_value_error(self):
+        raw = '{"child":' * 10_000 + '0' + '}' * 10_000
+        with self.assertRaises(ValueError) as ctx:
+            load_json_input(raw)
+        self.assertIn("nested too deeply", str(ctx.exception))
+
+    def test_normal_nested_json_still_works(self):
+        raw = '{"a":{"b":{"c":1}}}'
+        result = load_json_input(raw)
+        self.assertEqual(result["a"]["b"]["c"], 1)
+
+    def test_malformed_json_still_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            load_json_input('{"unclosed"}')
+
+    def test_non_finite_number_still_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            load_json_input('{"x": Infinity}')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/python-cli/tests/test_issue_13507.py
+++ b/sdks/python-cli/tests/test_issue_13507.py
@@ -1,27 +1,25 @@
-import unittest
+"""Regression tests for #13507: deeply nested JSON must raise ValueError, not RecursionError."""
+
+import pytest
+
 from omi_cli.json_input import load_json_input
 
 
-class TestRecursionErrorFix(unittest.TestCase):
-    def test_deeply_nested_json_raises_value_error(self):
-        raw = '{"child":' * 10_000 + '0' + '}' * 10_000
-        with self.assertRaises(ValueError) as ctx:
-            load_json_input(raw)
-        self.assertIn("nested too deeply", str(ctx.exception))
-
-    def test_normal_nested_json_still_works(self):
-        raw = '{"a":{"b":{"c":1}}}'
-        result = load_json_input(raw)
-        self.assertEqual(result["a"]["b"]["c"], 1)
-
-    def test_malformed_json_still_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            load_json_input('{"unclosed"}')
-
-    def test_non_finite_number_still_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            load_json_input('{"x": Infinity}')
+def test_deeply_nested_json_raises_value_error():
+    raw = '{"child":' * 10_000 + "0" + "}" * 10_000
+    with pytest.raises(ValueError, match="nested too deeply"):
+        load_json_input(raw)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_normal_nested_json_still_works():
+    assert load_json_input('{"a":{"b":{"c":1}}}')["a"]["b"]["c"] == 1
+
+
+def test_malformed_json_still_raises_value_error():
+    with pytest.raises(ValueError):
+        load_json_input('{"unclosed"}')
+
+
+def test_non_finite_number_still_raises_value_error():
+    with pytest.raises(ValueError):
+        load_json_input('{"x": Infinity}')


### PR DESCRIPTION
Closes #13507

`load_json_input()` documents invalid input as `ValueError`, but JSON nested beyond the decoder's capacity raised `RecursionError`, escaping the shared validation boundary (`local call` did not turn it into a `UsageError`).

This wraps `json.loads` and re-raises `RecursionError` as `ValueError("JSON input is nested too deeply")`, keeping normal nested JSON, malformed JSON and non-finite numbers unchanged. Regression tests in `sdks/python-cli/tests/test_issue_13507.py`; the whole `sdks/python-cli` suite passes.

/claim #13507


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

