### PR TITLE
ci(desktop): size the batch watchdog cap against the step budget it has to fit

### DIFF
--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -219,7 +219,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         # the whole ceiling before the bisect that clears it, so the step
         # pays healthy-run + ceiling + bisect. At a 1500s ceiling that was
         # ~2400s against an 1800s guard, and three runs failed exactly there
-        # (34609469561, 34641438446, 34655499561) with zero failing suites.
+        # (34609469609, 34641438446, 34655499561) with zero failing suites.
         ordinary_healthy_step_seconds = 900  # 780s and 873s on green runs
         bisect_allowance_seconds = 200  # two halves, measured 48-57s each
         pr_step_budget_seconds = 1800

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -206,6 +206,30 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             f"left for its bisect fallback",
         )
 
+        # The job timeout is not the binding constraint — the step's own
+        # regression budget is, and it is far tighter. A wedged batch spends
+        # the whole ceiling before the bisect that clears it, so the step
+        # pays healthy-run + ceiling + bisect. At a 1500s ceiling that was
+        # ~2400s against an 1800s guard, and three runs failed exactly there
+        # (34609469561, 34641438446, 34655499561) with zero failing suites.
+        measured_healthy_step_seconds = 900  # 780s and 873s on green runs
+        bisect_allowance_seconds = 200  # two halves, measured 48-57s each
+        pr_step_budget_seconds = 1800
+        self.assertIn(
+            "'pr' && '1800'",
+            self.jobs["desktop-swift-verify"],
+            "the PR lane's step budget moved; re-derive the ceiling bound "
+            "below against the new number",
+        )
+        self.assertLessEqual(
+            measured_healthy_step_seconds + ceiling + bisect_allowance_seconds,
+            pr_step_budget_seconds,
+            f"ceiling {ceiling}s does not fit the PR lane's "
+            f"{pr_step_budget_seconds}s step budget: one wedged batch on top "
+            f"of a healthy ~{measured_healthy_step_seconds}s run would fail "
+            f"the step with nothing wrong in the suite",
+        )
+
     def test_no_closed_pull_request_runs_exist(self):
         """No closure run can publish a skipped check onto the merge SHA."""
         workflow = _workflow_text()

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -167,6 +167,14 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         """
         job = self.jobs["desktop-swift-verify"]
         self.assertIn('OMI_SWIFT_TEST_SUITE_BATCH_SIZE: "100"', job)
+        suite_timeout_match = re.search(
+            r'OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS: "(\d+)"', job
+        )
+        if suite_timeout_match is None:
+            self.fail(
+                "desktop-swift-verify must set OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS"
+            )
+        suite_timeout_seconds = int(suite_timeout_match.group(1))
         match = re.search(
             r'OMI_SWIFT_TEST_BATCH_CEILING_SECONDS: "(\d+)"', job
         )
@@ -212,22 +220,50 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         # pays healthy-run + ceiling + bisect. At a 1500s ceiling that was
         # ~2400s against an 1800s guard, and three runs failed exactly there
         # (34609469561, 34641438446, 34655499561) with zero failing suites.
-        measured_healthy_step_seconds = 900  # 780s and 873s on green runs
+        ordinary_healthy_step_seconds = 900  # 780s and 873s on green runs
         bisect_allowance_seconds = 200  # two halves, measured 48-57s each
         pr_step_budget_seconds = 1800
+        # The workflow's own budget comment: the PR lane measures ~12m at
+        # batch 100, and ~24m worst case for auth PRs that wake the deferred
+        # serial cluster.
+        serial_wake_healthy_step_seconds = 24 * 60
         self.assertIn(
             "'pr' && '1800'",
             self.jobs["desktop-swift-verify"],
-            "the PR lane's step budget moved; re-derive the ceiling bound "
+            "the PR lane's step budget moved; re-derive the ceiling bounds "
             "below against the new number",
         )
         self.assertLessEqual(
-            measured_healthy_step_seconds + ceiling + bisect_allowance_seconds,
+            ordinary_healthy_step_seconds + ceiling + bisect_allowance_seconds,
             pr_step_budget_seconds,
             f"ceiling {ceiling}s does not fit the PR lane's "
             f"{pr_step_budget_seconds}s step budget: one wedged batch on top "
-            f"of a healthy ~{measured_healthy_step_seconds}s run would fail "
+            f"of an ordinary ~{ordinary_healthy_step_seconds}s run would fail "
             f"the step with nothing wrong in the suite",
+        )
+
+        # Scope, stated as an assertion rather than left implicit: the bound
+        # above covers the ordinary PR-lane run, which is where all three
+        # observed failures happened. It does NOT cover a PR that wakes the
+        # serial cluster. There, the step is already ~1440s, so a wedge plus
+        # its bisect has ~160s of headroom — less than one suite's own 300s
+        # budget, i.e. below any ceiling a batch of 100 could honestly carry.
+        # No value of this ceiling rescues that case; only not wedging does.
+        # If this assertion ever fails, a ceiling CAN cover the serial-wake
+        # case and the bound above should be re-derived against it instead.
+        serial_wake_headroom_seconds = (
+            pr_step_budget_seconds
+            - serial_wake_healthy_step_seconds
+            - bisect_allowance_seconds
+        )
+        self.assertLess(
+            serial_wake_headroom_seconds,
+            suite_timeout_seconds,
+            f"a serial-cluster PR now leaves {serial_wake_headroom_seconds}s "
+            f"for a wedged batch, at or above the {suite_timeout_seconds}s "
+            f"per-suite budget: the ceiling can cover that case too, so bound "
+            f"it against the ~{serial_wake_healthy_step_seconds}s worst case "
+            f"rather than the ordinary run",
         )
 
     def test_no_closed_pull_request_runs_exist(self):

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -292,12 +292,20 @@ jobs:
           # zero failing suites and one `exit=143` batch at the cap, whose
           # halves then passed in under 60s apiece.
           #
-          # 600s keeps a wedged run inside the step guard (870 + 600 + the
-          # ~105s bisect) while staying ~9x the slowest healthy batch of 100
-          # observed (67s). A batch that genuinely needs more is not killed,
-          # only re-run in halves. The local default stays 25 and every
-          # invocation logs its wall seconds, so a regression is visible in
-          # the run log.
+          # 600s keeps a wedged ORDINARY run inside the step guard (870 +
+          # 600 + the ~105s bisect) while staying ~9x the slowest healthy
+          # batch of 100 observed (67s). A batch that genuinely needs more is
+          # not killed, only re-run in halves.
+          #
+          # Scope, because it is not universal: a PR that wakes the deferred
+          # serial cluster already spends ~24m of the 30m step, so a wedge
+          # there has ~160s of room — less than one suite's own 300s budget,
+          # which no ceiling for a batch of 100 can honestly sit below. That
+          # case is not rescued by any value here; it needs the wedge itself
+          # fixed. All three observed failures were ordinary runs.
+          #
+          # The local default stays 25 and every invocation logs its wall
+          # seconds, so a regression is visible in the run log.
           OMI_SWIFT_TEST_SUITE_BATCH_SIZE: "100"
           OMI_SWIFT_TEST_BATCH_CEILING_SECONDS: "600"
           # PRs defer ratcheted slow suites (swift-test-slow-suites.json) to

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -280,13 +280,26 @@ jobs:
           # overhead). The uncapped scaled budget (300s + 30s/suite) would
           # be 3270s at batch 100 — 54.5 minutes inside this job's
           # 60-minute ceiling, leaving a wedged batch no room for its
-          # bisect fallback — so the batch watchdog is independently capped
-          # at 25 minutes: a stalled batch fails over to isolation with
-          # half the job still ahead of it. The local default stays 25 and
-          # every invocation logs its wall seconds, so a regression is
-          # visible in the run log.
+          # bisect fallback — so the batch watchdog is independently
+          # capped.
+          #
+          # The cap is sized against the STEP budget, not the job timeout.
+          # 1500s cleared the job ceiling and still failed the step: a
+          # wedged batch spends the full cap before the bisect that clears
+          # it, and 1500s on top of a healthy ~870s step is 2400s against
+          # an 1800s guard. Three runs failed exactly that way — 34609469561
+          # (2414s), 34641438446 (2505s), 34655499561 (2511s) — each with
+          # zero failing suites and one `exit=143` batch at the cap, whose
+          # halves then passed in under 60s apiece.
+          #
+          # 600s keeps a wedged run inside the step guard (870 + 600 + the
+          # ~105s bisect) while staying ~9x the slowest healthy batch of 100
+          # observed (67s). A batch that genuinely needs more is not killed,
+          # only re-run in halves. The local default stays 25 and every
+          # invocation logs its wall seconds, so a regression is visible in
+          # the run log.
           OMI_SWIFT_TEST_SUITE_BATCH_SIZE: "100"
-          OMI_SWIFT_TEST_BATCH_CEILING_SECONDS: "1500"
+          OMI_SWIFT_TEST_BATCH_CEILING_SECONDS: "600"
           # PRs defer ratcheted slow suites (swift-test-slow-suites.json) to
           # the full lane unless this diff touches their own inputs; pushes,
           # scheduled health runs, and manual dispatch always run everything.

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -287,7 +287,7 @@ jobs:
           # 1500s cleared the job ceiling and still failed the step: a
           # wedged batch spends the full cap before the bisect that clears
           # it, and 1500s on top of a healthy ~870s step is 2400s against
-          # an 1800s guard. Three runs failed exactly that way — 34609469561
+          # an 1800s guard. Three runs failed exactly that way — 34609469609
           # (2414s), 34641438446 (2505s), 34655499561 (2511s) — each with
           # zero failing suites and one `exit=143` batch at the cap, whose
           # halves then passed in under 60s apiece.
@@ -304,8 +304,10 @@ jobs:
           # case is not rescued by any value here; it needs the wedge itself
           # fixed. All three observed failures were ordinary runs.
           #
-          # The local default stays 25 and every invocation logs its wall
-          # seconds, so a regression is visible in the run log.
+          # Local runs are unaffected by either number: the script's own
+          # defaults are a batch of 25 with the ceiling disabled (0), so this
+          # cap exists only for CI's batch of 100. Every invocation logs its
+          # wall seconds, so a regression stays visible in the run log.
           OMI_SWIFT_TEST_SUITE_BATCH_SIZE: "100"
           OMI_SWIFT_TEST_BATCH_CEILING_SECONDS: "600"
           # PRs defer ratcheted slow suites (swift-test-slow-suites.json) to


### PR DESCRIPTION
## Summary

A wedged batch currently fails the Desktop Swift suite step by construction, and it fails it as if a test broke.

`swift-test-suites.sh` gives each batch a watchdog cap, and CI sets it to 1500s. When a batch wedges, the invocation spends that entire cap before the bisect that clears it, so the step pays `healthy run + cap + bisect`. A healthy PR-lane step is ~870s. 870 + 1500 is already 2370s against the lane's 1800s step guard, so *any* wedged batch overruns it — there is no run in which that arithmetic works.

Three runs failed exactly that way, each with 823–824 suites executed and **zero test failures**:

| run | branch | wedged invocation | step wall |
| --- | --- | --- | --- |
| [34609469609](https://github.com/BasedHardware/omi/actions/runs/34609469609) | `codex/9518-notification-dispatch` | `batch worker-2-0 x100 wall=1649s exit=143` | 2414s |
| [34641438446](https://github.com/BasedHardware/omi/actions/runs/34641438446) | `fix/audio-reconfig-retry` | `batch worker-1-0 x100 wall=1648s exit=143` | 2505s |
| [34655499561](https://github.com/BasedHardware/omi/actions/runs/34655499561) | `local-llm-provider-macos` | `batch worker-2-0 x100 wall=1648s exit=143` | 2511s |

`exit=143` is the watchdog's own SIGTERM at the cap. In all three the log then goes quiet for ~23 minutes with the machine otherwise idle, and the halves of that same batch pass immediately afterwards — 56s and 48s in the second run. Every other invocation in those runs exited 0 in 16–67s.

The failure surfaces as `FAIL: the Desktop Swift suite step took 2505s, over its 1800s regression budget`, which reads as a performance regression in the diff under test. It is not: it is one batch hanging, and the diffs in question were three unrelated files, a `#if DEBUG` guard, and a notification refactor.

## What this changes

`OMI_SWIFT_TEST_BATCH_CEILING_SECONDS`: 1500 → 600, and the contract test now bounds it against the step budget rather than the job timeout.

The existing guard in `test_ci_batch_ceiling_leaves_fallback_headroom` bounded the cap at half the **60-minute job timeout**. 1500s passes that comfortably. But the job timeout was never the binding constraint — the step's 1800s regression budget is, and it is less than a third of it. The two numbers were never checked against each other, which is how a cap that guarantees a red step passed review.

The new assertion writes the arithmetic down with its measured inputs, so they cannot drift apart again:

```python
measured_healthy_step_seconds = 900  # 780s and 873s on green runs
bisect_allowance_seconds = 200       # two halves, measured 48-57s each
self.assertLessEqual(
    measured_healthy_step_seconds + ceiling + bisect_allowance_seconds,
    pr_step_budget_seconds,
    ...
)
```

Mutation-checked: restoring 1500 fails it with `2600 not less than or equal to 1800`; 600 passes. It also asserts the PR lane's `'pr' && '1800'` literal still exists, so moving the step budget fails here rather than silently invalidating the bound.

## Why 600

The slowest healthy batch of 100 I found in any run is 67s; the bisect halves run 48–57s. 600s is ~9x the slowest healthy batch. And the cap is not a failure — a batch that genuinely needs longer is re-run in halves on the per-suite path, which is the harness's existing behaviour and is what already rescues these runs today. So the downside of being wrong here is a slower run, not a false red.

## What this does not do

- **It does not explain the wedge.** Something hangs an entire SwiftPM process for the full cap. It is not one bad suite: it is always a worker's *first* batch, and the two wedged batches I could compare share **zero** suites. This change bounds the cost so the wedge stops failing unrelated PRs; the hang itself deserves its own investigation.
- **It does not touch the release lane.** `Desktop Swift Release Compile` sitting at ~95% of its own 60-minute cap (#12735) is a separate problem in a separate job, and nothing here moves it.
- It weakens nothing. The step budget stays 1800s, the per-suite budget stays 300s, and the batch size stays 100.

## Verification

```
.github/scripts/test_desktop_swift_ci_contract.py   Ran 35 tests — OK
same, with the ceiling reverted to 1500             FAILED (failures=1)
```

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


