### PR TITLE
feat(desktop): enforce automation effects and isolate test state

### DIFF
--- a/.github/agent-docs/desktop-automation-effects.md
+++ b/.github/agent-docs/desktop-automation-effects.md
@@ -1,0 +1,32 @@
+# Explicit automation effects
+
+Every `DesktopAutomationActionRegistry.register` call requires an `effects` set.
+Include every effect reachable through its parameters or asynchronously started
+work. `[]` is reserved for side-effect-free observations and pure fixtures.
+Names such as `probe`, `state`, or `snapshot` never determine safety: #13208
+found an import probe and a state-clearing action mislabeled as read-only.
+
+- `.localState`: changes app/UI state, defaults, local storage, or active work.
+- `.localArtifact`: writes/export files, including screenshots.
+- `.networkOrModel`: invokes the agent runtime, network services, or a model, including API reads.
+- `.remoteWrite`: may modify remote user data, directly or through queued work.
+
+Declare the union for parameter-dependent actions. Dynamic chat/tool dispatch
+may reach all four effects. Incidental logging/analytics is outside this
+product-effect contract. Existing handler authorization stays in force.
+
+Discovery returns the stable, sorted `effects` array and derives the existing
+coarse `safety` field from it. Mandatory effect descriptions come from the typed declaration; optional
+specific descriptions supplement them. Surface
+and category hints are not authorization decisions.
+
+Use `./scripts/omi-ctl action about_snapshot --read-only` for an observation-only
+invocation, or send `"readOnly": true` in the top-level `POST /action` JSON.
+The registry rejects any declared effect before invoking the handler, including
+handlers that launch asynchronous work. Invalid policy values fail before
+dispatch. Ordinary invocations keep their existing behavior.
+
+This is a declaration and dispatch contract, not a sandbox for arbitrary Swift
+code. Review the actual handler/callees when assigning effects. Tests use injected
+mutation handlers to prove pre-dispatch refusal and pin historical import,
+delete, loading-snapshot, and artifact-writing cases without invoking services.

--- a/.github/agent-docs/desktop-automation-effects.md
+++ b/.github/agent-docs/desktop-automation-effects.md
@@ -11,6 +11,8 @@ found an import probe and a state-clearing action mislabeled as read-only.
 - `.networkOrModel`: invokes the agent runtime, network services, or a model, including API reads.
 - `.remoteWrite`: may modify remote user data, directly or through queued work.
 
+Include cold initialization and work queued by mounted views: `dump_tasks` can
+initialize/migrate SQLite, and opening Tasks can retry queued uploads/deletions.
 Declare the union for parameter-dependent actions. Dynamic chat/tool dispatch
 may reach all four effects. Incidental logging/analytics is outside this
 product-effect contract. Existing handler authorization stays in force.

--- a/.github/agent-docs/desktop-test-isolation.md
+++ b/.github/agent-docs/desktop-test-isolation.md
@@ -1,0 +1,30 @@
+# Desktop test isolation
+
+Regressions #13260 and #13468 showed that auth defaults and repeating timers
+can poison unrelated desktop suites sharing a runner. These helpers live in
+the existing desktop Swift test target; no additional test runner is required.
+
+- Use `makeIsolatedDefaults()` from `desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift`
+  and inject the returned defaults into the subject. The helper owns a unique
+  domain and registers XCTest teardown; shared auth domains raced in #13260.
+  New direct `UserDefaults.standard` mutations are ratcheted. Only singleton
+  integration tests lacking an injection seam may annotate an individual site:
+  `// omi-test-quality: shared-defaults -- integration: <why the shared domain is required>`.
+  Preserve/restore the affected keys for those exceptions; the annotation does
+  not provide isolation. The static check counts direct calls, not aliases.
+- For chat repeating timers, use `OwnedRunLoopTimer` and retain explicit stop
+  calls. The token invalidates on release; callbacks must capture feature owners
+  weakly. `ManualRunLoopTimerScheduler` drives unscheduled timers and a fixed
+  date in tests, so cancellation and elapsed-time behavior need no sleeps.
+- `python3 desktop/macos/scripts/check_desktop_test_quality.py` ratchets legacy source
+  inspection, wall-clock waits, and direct shared defaults mutations; its
+  baselines may only decrease. The check and its fixture tests run in the
+  existing desktop suite and the local/CI check manifest.
+
+Run `python3 desktop/macos/scripts/tests/test_check_desktop_test_quality.py` to
+exercise the static check and its no-increase CLI boundary. Focused Swift
+coverage is `IsolatedTestDefaultsTests`, `KernelTurnRecordedProjectionTests`,
+and `UserScrollDetectorTests` (including the chat glide and pinner guards).
+Preserve the actual run-loop deinit regressions alongside the manually driven
+scheduler cases: unscheduled timers prove cancellation and elapsed-time
+behavior, while the real scheduler cases prove production wiring.

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -771,6 +771,11 @@ checks:
     triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "desktop/macos/Desktop/Tests/**/*.swift", "desktop/macos/scripts/check_desktop_test_quality.py", "desktop/macos/scripts/swift-test-suites.sh"]
     lanes: ["local", "ci"]
     reason: "desktop Swift production or test structure changed"
+  - id: desktop-test-quality-fixtures
+    command: ["python3", "desktop/macos/scripts/tests/test_check_desktop_test_quality.py"]
+    triggers: ["desktop/macos/scripts/check_desktop_test_quality.py", "desktop/macos/scripts/tests/test_check_desktop_test_quality.py", "desktop/macos/scripts/tests/fixtures/desktop_test_quality/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "fixture and CLI regressions prove desktop quality ratchets reject new shared defaults mutations and malformed exceptions"
   - id: desktop-chat-selection-boundary
     command: ["python3", ".github/scripts/check_chat_selection_boundary.py"]
     triggers: ["desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift", "desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift", "desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift", ".github/scripts/check_chat_selection_boundary.py", ".github/failure-classes/FC-selection-overlay-layout-loop.json", ".github/checks-manifest.yaml"]

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -326,7 +326,7 @@ Fast path (skips web login and sidebar click-through):
 2. **Prefer the local bridge — it never touches the cursor.** It calls the app's real code in-process (no synthetic mouse events). Use it before reaching for `agent-swift click`/`cliclick`/computer-use. Auto-enables on non-prod bundles; run several at once via distinct `OMI_AUTOMATION_PORT` (default 47777). Navigation stays backgrounded unless `--show` is passed.
    - `./scripts/omi-ctl state` — app-state snapshot (selected tab, auth, onboarding).
    - `./scripts/omi-ctl navigate <screen> [settings-section]` — jump straight to a screen in ~150ms (`omi-ctl screens` lists targets).
-   - `./scripts/omi-ctl actions` then `./scripts/omi-ctl action <name> [k=v …]` — semantic actions (e.g. `refresh_all_data`). Add new ones in `DesktopAutomationActionRegistry`. See `e2e/SKILL.md` §2b.
+   - `./scripts/omi-ctl actions` discovers semantic actions; `action <name> [k=v …]` runs them. Registrations require [effects](../../.github/agent-docs/desktop-automation-effects.md); `--read-only` rejects effectful actions.
    - `agent-swift` only for UI the bridge can't reach yet (`click` moves the cursor).
 3. **Read logs to confirm behavior:** app + chat bridge in the exact path from
    `./scripts/omi-ctl log-path` (named dev bundles) or `/private/tmp/omi.log`

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -197,22 +197,8 @@ do not hand-edit those paths to match a specific machine.
   callback/continuation, or await a deterministic state signal. An unavoidable
   real-scheduler integration wait needs
   `// omi-test-quality: wall-clock-wait -- <why injection cannot test this boundary>`.
-- Use `makeIsolatedDefaults()` from `Tests/Support/IsolatedTestDefaults.swift`
-  and inject the returned defaults into the subject. The helper owns a unique
-  domain and registers XCTest teardown; shared auth domains raced in #13260.
-  New direct `UserDefaults.standard` mutations are ratcheted. Only singleton
-  integration tests lacking an injection seam may annotate an individual site:
-  `// omi-test-quality: shared-defaults -- integration: <why the shared domain is required>`.
-  Preserve/restore the affected keys for those exceptions; the annotation does
-  not provide isolation. The static check counts direct calls, not aliases.
-- For chat repeating timers, use `OwnedRunLoopTimer` and retain explicit stop
-  calls. The token invalidates on release; callbacks must capture feature owners
-  weakly. `ManualRunLoopTimerScheduler` drives unscheduled timers and a fixed
-  date in tests, so cancellation and elapsed-time behavior need no sleeps.
-- `python3 scripts/check_desktop_test_quality.py` ratchets legacy source
-  inspection, wall-clock waits, and direct shared defaults mutations; its
-  baselines may only decrease. The check and its fixture tests run in the
-  existing desktop suite and the local/CI check manifest.
+- The [test isolation guide](../../.github/agent-docs/desktop-test-isolation.md)
+  covers shared fixtures and the test-quality ratchet.
 
 ## Key Architecture Notes
 

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -197,8 +197,22 @@ do not hand-edit those paths to match a specific machine.
   callback/continuation, or await a deterministic state signal. An unavoidable
   real-scheduler integration wait needs
   `// omi-test-quality: wall-clock-wait -- <why injection cannot test this boundary>`.
-- `python3 scripts/check_desktop_test_quality.py` ratchets both legacy
-  source-inspection sites and wall-clock waits; its baselines may only decrease.
+- Use `makeIsolatedDefaults()` from `Tests/Support/IsolatedTestDefaults.swift`
+  and inject the returned defaults into the subject. The helper owns a unique
+  domain and registers XCTest teardown; shared auth domains raced in #13260.
+  New direct `UserDefaults.standard` mutations are ratcheted. Only singleton
+  integration tests lacking an injection seam may annotate an individual site:
+  `// omi-test-quality: shared-defaults -- integration: <why the shared domain is required>`.
+  Preserve/restore the affected keys for those exceptions; the annotation does
+  not provide isolation. The static check counts direct calls, not aliases.
+- For chat repeating timers, use `OwnedRunLoopTimer` and retain explicit stop
+  calls. The token invalidates on release; callbacks must capture feature owners
+  weakly. `ManualRunLoopTimerScheduler` drives unscheduled timers and a fixed
+  date in tests, so cancellation and elapsed-time behavior need no sleeps.
+- `python3 scripts/check_desktop_test_quality.py` ratchets legacy source
+  inspection, wall-clock waits, and direct shared defaults mutations; its
+  baselines may only decrease. The check and its fixture tests run in the
+  existing desktop suite and the local/CI check manifest.
 
 ## Key Architecture Notes
 

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActionEffect.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActionEffect.swift
@@ -1,0 +1,27 @@
+/// Effects an automation action may have, including work it starts asynchronously.
+/// Registration must declare the union of all supported parameter paths. An empty
+/// set means a read-only observation; a name containing `probe` proves nothing.
+/// Incidental diagnostic logging/analytics is outside this product-effect contract.
+enum DesktopAutomationActionEffect: String, Codable, CaseIterable, Sendable {
+  case localState = "local_ui_state"
+  case localArtifact = "local_artifact"
+  case networkOrModel = "network_or_model"
+  case remoteWrite = "remote_write"
+
+  var description: String {
+    switch self {
+    case .localState: return "mutates local app, UI, or stored state"
+    case .localArtifact: return "writes local artifact file"
+    case .networkOrModel: return "may call agent runtime, model, or backend services"
+    case .remoteWrite: return "may mutate remote user data"
+    }
+  }
+
+  /// Preserve the coarse discovery field while exposing every effect separately.
+  static func safety(for effects: Set<Self>) -> String {
+    for effect in [Self.remoteWrite, .networkOrModel, .localArtifact, .localState] {
+      if effects.contains(effect) { return effect.rawValue }
+    }
+    return "read_only"
+  }
+}

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
@@ -21,6 +21,31 @@ extension DesktopAutomationActionRegistry {
 
   func registerActivationActions() {
     register(
+      name: "chat_timer_lifetime_probe",
+      effects: [.localState],
+      summary: "Verify common-runloop timer cancellation and invalidation when its owner is released",
+      category: "chat",
+      surfaces: ["main_chat"]
+    ) { _ in
+      let cancelled = OwnedRunLoopTimer.schedule(interval: 60) {}
+      var released: OwnedRunLoopTimer? = OwnedRunLoopTimer.schedule(interval: 60) {}
+      let releasedTimer = released?.timer
+      let scheduled = cancelled.timer.isValid && releasedTimer?.isValid == true
+      // Keep even a failing probe from leaving a source attached to the run loop.
+      defer {
+        cancelled.timer.invalidate()
+        releasedTimer?.invalidate()
+      }
+      cancelled.cancel()
+      released = nil
+      return [
+        "scheduled": String(scheduled),
+        "cancelledValid": String(cancelled.timer.isValid),
+        "releasedValid": String(releasedTimer?.isValid ?? true),
+      ]
+    }
+
+    register(
       name: "daily_summary_snapshot",
       effects: [],
       summary: "Shape-only state of the shared daily-summary store (has summary, date, stat presence; no text)",

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationActivationActions.swift
@@ -22,10 +22,10 @@ extension DesktopAutomationActionRegistry {
   func registerActivationActions() {
     register(
       name: "daily_summary_snapshot",
+      effects: [],
       summary: "Shape-only state of the shared daily-summary store (has summary, date, stat presence; no text)",
       category: "chat",
-      surfaces: ["main_chat"],
-      safety: "read_only"
+      surfaces: ["main_chat"]
     ) { _ in
       guard AppBuild.isNonProduction else {
         return ["error": "daily_summary_snapshot is disabled on production bundles"]
@@ -61,6 +61,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "open_daily_recap_page",
+      effects: [.localState, .networkOrModel],
       summary:
         "Open the dedicated daily-recap page for a summary id through the typed recap route "
         + "(same `ChatFirstShellNavigation.openDailyRecap` the recap rows call)",
@@ -86,6 +87,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "open_chat_prefilled",
+      effects: [.localState],
       summary: "Open the main chat with `query` prefilled and focused, NOT sent (the first-real-app card path)",
       params: ["query"],
       category: "chat",
@@ -109,11 +111,11 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "recent_screen_frames_snapshot",
+      effects: [.localState],
       summary: "Rows the composer's recent-screen-frames menu will offer (loader output, metadata only)",
       params: ["limit"],
       category: "chat",
-      surfaces: ["main_chat"],
-      safety: "read_only"
+      surfaces: ["main_chat"]
     ) { params in
       guard AppBuild.isNonProduction else {
         return ["error": "recent_screen_frames_snapshot is disabled on production bundles"]
@@ -135,6 +137,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "open_chat_prefilled_with_screen_frame",
+      effects: [.localState, .localArtifact],
       summary:
         "Drive the first-real-app card's handoff end to end: capture (or load) the screen referent, "
         + "stage it, and open the chat with the prompt prefilled and the frame attached (not sent)",
@@ -192,11 +195,11 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "chat_composer_snapshot",
+      effects: [],
       summary: "Main composer state: draft, staged attachments, placeholder, and query-shell mode",
       params: [],
       category: "chat",
-      surfaces: ["main_chat"],
-      safety: "read_only"
+      surfaces: ["main_chat"]
     ) { _ in
       guard AppBuild.isNonProduction else {
         return ["error": "chat_composer_snapshot is disabled on production bundles"]
@@ -212,6 +215,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "paste_clipboard_into_chat",
+      effects: [.localState, .localArtifact],
       summary:
         "Run the composer's ⌘V path with a screenshot fixture on the clipboard: pasteboard "
         + "classifier, staging, and provider staging (non-prod paste harness; replaces the clipboard)",
@@ -272,6 +276,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "tap_chat_follow_up_chip",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary:
         "Tap the follow-up chip under the last main-chat answer (same send as the chip) and report "
         + "the `question_asked` origin it produced",
@@ -330,6 +335,7 @@ extension DesktopAutomationActionRegistry {
   private func registerMemoryReviewActions() {
     register(
       name: "seed_memory_review_fixture",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Create `count` real memories and a local-only daily summary that learned them, then "
         + "refresh the shared store so the review card mounts (offline dev stack only)",
@@ -393,11 +399,11 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "memory_review_snapshot",
+      effects: [],
       summary: "Rows the mounted 'Things I learned today' section bound, and the first two verdicts",
       params: [],
       category: "chat",
-      surfaces: ["main_chat"],
-      safety: "read_only"
+      surfaces: ["main_chat"]
     ) { _ in
       guard AppBuild.isNonProduction else {
         return ["error": "memory_review_snapshot is disabled on production bundles"]
@@ -419,6 +425,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "memory_review_vote",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Vote on one mounted review row through the store the ✓ / ✗ buttons call, then report the "
         + "row once the mutation settles",

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationAskOmiActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationAskOmiActions.swift
@@ -100,6 +100,7 @@ extension DesktopAutomationActionRegistry {
   func registerOpenAskOmiActions() {
     register(
       name: "open_ask_omi",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Open the chat-first main-window composer (typed Ask Omi) and return open/focus timing. "
         + "Does not call revealForUser, so quiet automation presentation stays quiet: the action "
@@ -126,6 +127,7 @@ extension DesktopAutomationActionRegistry {
   func registerCloseAskOmiActions() {
     register(
       name: "close_ask_omi",
+      effects: [.localState],
       summary:
         "Close the floating Ask Omi input panel if it is open; the chat-first main-window "
         + "composer is the resting Chat surface, so when it is presented the result reports "

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationFirstUsePopupActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationFirstUsePopupActions.swift
@@ -13,6 +13,7 @@ extension DesktopAutomationActionRegistry {
   func registerFirstUsePopupActions() {
     register(
       name: "first_use_popup_show",
+      effects: [.localState],
       summary: "Re-arm and raise the first-use popup onboarding shows (legacy shell only; non-prod)",
       examples: ["./scripts/omi-ctl action first_use_popup_show"]
     ) { _ in
@@ -28,6 +29,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "first_use_popup_select",
+      effects: [.localState],
       summary: "Select a case in the first-use popup (same handler as clicking its chip)",
       params: ["use_case"],
       examples: ["./scripts/omi-ctl action first_use_popup_select use_case=design"]
@@ -43,6 +45,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "first_use_popup_try",
+      effects: [.localState, .networkOrModel],
       summary: "Press \"Try it now\" in the first-use popup (opens the site)",
       examples: ["./scripts/omi-ctl action first_use_popup_try"]
     ) { _ in

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationHomeStageActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationHomeStageActions.swift
@@ -25,6 +25,7 @@ extension DesktopAutomationActionRegistry {
   func registerHomeStageActions() {
     register(
       name: "home_open_chat",
+      effects: [.localState],
       summary: "Open the inline chat on Home (same path as clicking the ask bar)"
     ) { _ in
       NotificationCenter.default.post(name: .homeStageOpenChat, object: nil)
@@ -42,6 +43,7 @@ extension DesktopAutomationActionRegistry {
     // watch the wrong surface and call it a pass — the same lie in new clothes.
     register(
       name: "home_connect_toggle",
+      effects: [.localState],
       summary:
         "Toggle the Connect tray on the Home stage (same path as the ask-bar Connect button). "
         + "Errors on shells whose Home has no stage; connectors live on the Apps page there."
@@ -62,6 +64,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "home_close_panel",
+      effects: [.localState],
       summary: "Collapse Home back to its resting surface (same as Esc / the close buttons)"
     ) { _ in
       NotificationCenter.default.post(name: .homeStageClose, object: nil)
@@ -70,6 +73,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "home_ask",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Send a query through the Home ask bar (opens the inline chat and sends)",
       params: ["query"]
     ) { params in
@@ -82,6 +86,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "home_attach",
+      effects: [.localState],
       summary: "Stage a file in the Home ask bar (same wiring as the paperclip/drag-drop)",
       params: ["path"]
     ) { params in

--- a/desktop/macos/Desktop/Sources/Automation/DesktopAutomationPTTRecoveryActions.swift
+++ b/desktop/macos/Desktop/Sources/Automation/DesktopAutomationPTTRecoveryActions.swift
@@ -4,8 +4,9 @@ extension DesktopAutomationActionRegistry {
   func registerPTTRecoveryActions() {
     register(
       name: "voice_typing_deliver_text",
+      effects: [.localState],
       summary: "Verify dictation insertion with a supplied transcript (bypasses microphone and ASR, no network)",
-      params: ["text"], category: "voice", surfaces: ["floating_bar"], safety: "local_ui_state"
+      params: ["text"], category: "voice", surfaces: ["floating_bar"]
     ) { params in
       guard AppBuild.isNonProduction else { return ["error": "non-production only"] }
       guard let text = params["text"], !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -17,8 +18,9 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "voice_typing_undo",
+      effects: [.localState],
       summary: "Invoke the guarded Undo Last Dictation action on the unchanged focused editor",
-      category: "voice", surfaces: ["floating_bar"], safety: "local_ui_state"
+      category: "voice", surfaces: ["floating_bar"]
     ) { _ in
       guard AppBuild.isNonProduction else { return ["error": "non-production only"] }
       return ["undone": PushToTalkManager.shared.undoLastDictation() ? "true" : "false"]
@@ -26,8 +28,9 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "ptt_recovery_snapshot",
+      effects: [],
       summary: "Report offline-question and guarded dictation-undo availability without text",
-      category: "voice", surfaces: ["floating_bar"], safety: "read_only"
+      category: "voice", surfaces: ["floating_bar"]
     ) { _ in
       guard AppBuild.isNonProduction else { return ["error": "non-production only"] }
       return [
@@ -38,8 +41,9 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "ptt_recovery_fixture",
+      effects: [.localState],
       summary: "Stage a supplied offline question through the real recovery store; does not send or journal it",
-      params: ["text"], category: "voice", surfaces: ["floating_bar"], safety: "local_ui_state"
+      params: ["text"], category: "voice", surfaces: ["floating_bar"]
     ) { params in
       guard AppBuild.isNonProduction else { return ["error": "non-production only"] }
       guard let text = params["text"],
@@ -54,8 +58,9 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "ptt_recovery_review",
+      effects: [.localState],
       summary: "Review the recovered offline question in the main composer without sending it",
-      category: "voice", surfaces: ["main_chat"], safety: "local_ui_state"
+      category: "voice", surfaces: ["main_chat"]
     ) { _ in
       guard AppBuild.isNonProduction else { return ["error": "non-production only"] }
       OfflinePTTQuestionRecovery.shared.reviewInMainChat()

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+GlassTransparency.swift
@@ -8,6 +8,7 @@ extension DesktopAutomationActionRegistry {
   func registerGlassTransparencyActions() {
     register(
       name: "glass_transparency_snapshot",
+      effects: [],
       summary: "Return the glass transparency (0 solid … 1 bare material), its default, and the effective ground alpha"
     ) { _ in
       await MainActor.run { Self.glassTransparencySnapshot() }
@@ -15,6 +16,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "set_glass_transparency",
+      effects: [.localState],
       summary: "Set the glass transparency through the slider's own published value (0…1)",
       params: ["value"]
     ) { params in
@@ -33,6 +35,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "reset_glass_transparency",
+      effects: [.localState],
       summary: "Return the glass transparency to the shipped default, as the card's Reset button does"
     ) { _ in
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
@@ -5,6 +5,7 @@ extension DesktopAutomationActionRegistry {
   func registerNotificationActions() {
     register(
       name: "settings_notifications_snapshot",
+      effects: [.networkOrModel],
       summary: "Return notification settings and local permission state"
     ) { _ in
       async let settingsTask = APIClient.shared.getNotificationSettings()
@@ -24,6 +25,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "set_notification_settings",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Update notification settings via the real API",
       params: ["enabled", "frequency"]
     ) { params in
@@ -53,6 +55,7 @@ extension DesktopAutomationActionRegistry {
     // token the caller holds, through the same production sendNotification path.
     register(
       name: "send_test_notification",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Deliver a proactive test notification through the real sendNotification path (this bundle only)",
       params: ["title", "message", "assistant_id"]
     ) { params in

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -8,6 +8,7 @@ extension DesktopAutomationActionRegistry {
   func registerRatingPromptActions() {
     register(
       name: "rating_prompt_state",
+      effects: [],
       summary: "Return the rating prompt's persisted trigger state and visibility"
     ) { _ in
       await MainActor.run {
@@ -31,6 +32,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_submit",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Submit a 1-5 star rating through the same path as the star buttons",
       params: ["rating"]
     ) { params in
@@ -51,6 +53,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_submit_comment",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Send the pending low-score comment through the same path as the Send button (empty comment = Skip)",
       params: ["comment"]
     ) { params in
@@ -67,6 +70,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_record_question",
+      effects: [.localState],
       summary:
         "Count one asked question through RatingPromptManager.recordQuestionAsked — the exact call the chatMessageSent analytics funnel makes"
     ) { _ in
@@ -82,6 +86,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_refer",
+      effects: [.localState],
       summary: "Trigger the thank-you bar's refer-a-friend proposal (same path as the button)"
     ) { _ in
       await MainActor.run {
@@ -95,6 +100,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_seed",
+      effects: [.localState, .networkOrModel],
       summary: "Run the history seed now (same call as app launch)"
     ) { _ in
       await RatingPromptManager.shared.seedFromHistoryIfNeeded()
@@ -106,6 +112,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_reset",
+      effects: [.localState],
       summary: "Reset persisted rating-prompt state so the trigger can be exercised again"
     ) { _ in
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -86,7 +86,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "rating_prompt_refer",
-      effects: [.localState],
+      effects: [.localState, .networkOrModel],
       summary: "Trigger the thank-you bar's refer-a-friend proposal (same path as the button)"
     ) { _ in
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RatingPrompt.swift
@@ -8,7 +8,7 @@ extension DesktopAutomationActionRegistry {
   func registerRatingPromptActions() {
     register(
       name: "rating_prompt_state",
-      effects: [],
+      effects: [.localState],
       summary: "Return the rating prompt's persisted trigger state and visibility"
     ) { _ in
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RealtimeHub.swift
@@ -9,6 +9,7 @@ extension DesktopAutomationActionRegistry {
     // "Open the doors" button), so agents can exercise the demo without the cursor.
     register(
       name: "onboarding_open_doors",
+      effects: [.localState],
       summary: "Onboarding screen-demo step: open the three-doors page (same path as the Open the doors button)"
     ) { _ in
       await MainActor.run {
@@ -22,6 +23,7 @@ extension DesktopAutomationActionRegistry {
     // can be exercised without waiting for the shared key to actually throttle.
     register(
       name: "realtime_failover",
+      effects: [.localState, .networkOrModel],
       summary: "Fail the realtime hub over to the alternate provider via the production path (non-prod).",
       params: []
     ) { _ in
@@ -44,6 +46,7 @@ extension DesktopAutomationActionRegistry {
     // 10-minute walk-away. Everything downstream is the production path.
     register(
       name: "realtime_presence",
+      effects: [.localState],
       summary: "Override the realtime hub's user-idle sample (non-prod): idle_seconds=<n> or reset.",
       params: ["idle_seconds"]
     ) { params in

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RemotePrompts.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+RemotePrompts.swift
@@ -7,6 +7,7 @@ extension DesktopAutomationActionRegistry {
   func registerRemotePromptActions() {
     register(
       name: "remote_prompts_state",
+      effects: [],
       summary: "Return the remote-prompt engine's fetched specs and active prompt"
     ) { _ in
       await MainActor.run {
@@ -23,6 +24,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "remote_prompts_refresh",
+      effects: [.localState, .networkOrModel],
       summary: "Fetch prompts from the backend now (same call as the 5-minute poll)"
     ) { _ in
       await RemotePromptEngine.shared.refreshFromServer()
@@ -38,6 +40,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "remote_prompt_answer",
+      effects: [.localState],
       summary: "Answer the active remote prompt through the same path as its buttons",
       params: ["value"]
     ) { params in
@@ -55,6 +58,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "remote_prompt_dismiss",
+      effects: [.localState],
       summary: "Dismiss the active remote prompt through the same path as its close button"
     ) { _ in
       await MainActor.run {
@@ -69,6 +73,7 @@ extension DesktopAutomationActionRegistry {
 
     register(
       name: "remote_prompts_reset",
+      effects: [.localState],
       summary: "Forget local prompt resolutions and counters so triggers can be exercised again"
     ) { _ in
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ResponseContext.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+ResponseContext.swift
@@ -12,6 +12,7 @@ extension DesktopAutomationActionRegistry {
     // (hover-reveal + click are cursor gestures automation must not use).
     register(
       name: "main_chat_open_response_context",
+      effects: [.localState],
       summary: "Open the Response Context popover on the latest attributed assistant message (non-prod)",
       params: []
     ) { _ in

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -235,7 +235,9 @@ struct DesktopAutomationActionDescriptor: Codable {
   let category: String
   /// Screens or app surfaces this action is meant to replace AX interaction on.
   let surfaces: [String]
-  /// Agent-facing risk label; the bridge is still non-production only.
+  /// Explicit effect union, sorted for stable discovery JSON. Empty means read-only.
+  let effects: [DesktopAutomationActionEffect]
+  /// Derived coarse risk label for discovery clients.
   let safety: String
   /// Plain-language effects so callers can prefer read-only probes before clicks.
   let sideEffects: [String]
@@ -246,11 +248,11 @@ struct DesktopAutomationActionDescriptor: Codable {
 
   init(
     name: String,
+    effects: Set<DesktopAutomationActionEffect>,
     summary: String,
     params: [String] = [],
     category: String? = nil,
     surfaces: [String]? = nil,
-    safety: String? = nil,
     sideEffects: [String]? = nil,
     examples: [String] = [],
     preferSemantic: Bool = true
@@ -258,10 +260,12 @@ struct DesktopAutomationActionDescriptor: Codable {
     self.name = name
     self.summary = summary
     self.params = params
-    self.category = category ?? Self.inferCategory(name)
+    let inferredCategory = Self.inferCategory(name)
+    self.category = category ?? (effects.isEmpty ? "read" : (inferredCategory == "read" ? "write" : inferredCategory))
     self.surfaces = surfaces ?? Self.inferSurfaces(name)
-    self.safety = safety ?? Self.inferSafety(name)
-    self.sideEffects = sideEffects ?? Self.inferSideEffects(name)
+    self.effects = effects.sorted { $0.rawValue < $1.rawValue }
+    self.safety = DesktopAutomationActionEffect.safety(for: effects)
+    self.sideEffects = self.effects.map(\.description) + (sideEffects ?? [])
     self.examples = examples.isEmpty ? [Self.commandExample(name: name, params: params)] : examples
     self.preferSemantic = preferSemantic
   }
@@ -321,45 +325,6 @@ struct DesktopAutomationActionDescriptor: Codable {
     return ["app"]
   }
 
-  private static func inferSafety(_ name: String) -> String {
-    if name.contains("delete") {
-      return "remote_write"
-    }
-    if name.contains("snapshot") || name.contains("probe") || name.contains("state")
-      || name.contains("tail") || name.contains("evidence") || name.contains("qa_export")
-    {
-      return "read_only"
-    }
-    if name.hasPrefix("capture") {
-      return "local_artifact"
-    }
-    if name.contains("ask") || name.contains("omni") || name.contains("import") {
-      return "network_or_model"
-    }
-    return "local_ui_state"
-  }
-
-  private static func inferSideEffects(_ name: String) -> [String] {
-    if name.contains("delete") {
-      return ["may mutate remote user data"]
-    }
-    if name.hasPrefix("capture") {
-      return ["writes local artifact file"]
-    }
-    if name.contains("ask") || name.contains("omni") {
-      return ["may call model/backend services"]
-    }
-    if name.contains("import") {
-      return ["may read local connector data", "may save imported memory data"]
-    }
-    if name.contains("toggle") || name.contains("debug") || name.contains("open") || name.contains("close")
-      || name.contains("seed") || name.contains("swap") || name.contains("clear")
-    {
-      return ["mutates non-production app state"]
-    }
-    return []
-  }
-
   private static func commandExample(name: String, params: [String]) -> String {
     var pieces = ["./scripts/omi-ctl", "action", name]
     for param in params {
@@ -414,11 +379,13 @@ struct DesktopAutomationRouteTrace: Codable {
 
 enum DesktopAutomationActionError: LocalizedError {
   case unknownAction(String)
+  case requiresEffects(String)
   case invalidParams(String)
 
   var errorDescription: String? {
     switch self {
     case .unknownAction(let name): return "unknown_action: \(name)"
+    case .requiresEffects(let name): return "action_requires_effects: \(name)"
     case .invalidParams(let detail): return "invalid_params: \(detail)"
     }
   }
@@ -655,7 +622,7 @@ actor DesktopAutomationTraceStore {
 /// "command channel" equivalent of the Flutter app's Marionette driver.
 ///
 /// Built-ins are registered at bridge startup. Feature code can register more via
-/// `register(name:summary:params:handler:)` (e.g. from a view model's lifecycle) and
+/// `register(name:effects:summary:params:handler:)` (e.g. from a view model's lifecycle) and
 /// remove them with `unregister(_:)`.
 @MainActor
 private func ensureConversationsTabVisibleForAutomation() async throws {
@@ -728,11 +695,11 @@ final class DesktopAutomationActionRegistry {
 
   func register(
     name: String,
+    effects: Set<DesktopAutomationActionEffect>,
     summary: String,
     params: [String] = [],
     category: String? = nil,
     surfaces: [String]? = nil,
-    safety: String? = nil,
     sideEffects: [String]? = nil,
     examples: [String] = [],
     preferSemantic: Bool = true,
@@ -741,11 +708,11 @@ final class DesktopAutomationActionRegistry {
     entries[name] = Entry(
       descriptor: DesktopAutomationActionDescriptor(
         name: name,
+        effects: effects,
         summary: summary,
         params: params,
         category: category,
         surfaces: surfaces,
-        safety: safety,
         sideEffects: sideEffects,
         examples: examples,
         preferSemantic: preferSemantic
@@ -759,9 +726,15 @@ final class DesktopAutomationActionRegistry {
     entries.values.map(\.descriptor).sorted { $0.name < $1.name }
   }
 
-  func perform(_ name: String, params: [String: String]) async throws -> [String: String]? {
+  func perform(
+    _ name: String, params: [String: String], readOnly: Bool = false
+  ) async throws -> [String: String]? {
     guard let entry = entries[name] else {
       throw DesktopAutomationActionError.unknownAction(name)
+    }
+    // Check before invoking the handler, including handlers that launch Tasks.
+    guard !readOnly || entry.descriptor.effects.isEmpty else {
+      throw DesktopAutomationActionError.requiresEffects(name)
     }
     return try await entry.run(params)
   }
@@ -775,12 +748,12 @@ final class DesktopAutomationActionRegistry {
     registerOpenOmiShortcutActionsForQA()
     register(
       name: "set_automation_ui_presentation",
+      effects: [.localState],
       summary:
         "Park automation windows quietly, reveal them briefly for Accessibility, or restore normal user presentation",
       params: ["mode", "activate"],
       category: "app_control",
       surfaces: ["app"],
-      safety: "local_ui_state",
       sideEffects: ["changes non-production window placement and input handling"],
       examples: [
         "./scripts/omi-ctl ui quiet",
@@ -819,6 +792,7 @@ final class DesktopAutomationActionRegistry {
     registerFirstUsePopupActions()
     register(
       name: "refresh_all_data",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Refresh conversations, chat, tasks, and memories (same as Cmd+R)"
     ) { _ in
       NotificationCenter.default.post(name: .refreshAllData, object: nil)
@@ -831,6 +805,7 @@ final class DesktopAutomationActionRegistry {
     // Accessibility permission or a frontmost window. Non-prod only.
     register(
       name: "post_key",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary:
         "Post a keyDown+keyUp NSEvent through the app event queue (e.g. key_code=124 for right arrow). Non-prod only.",
       params: ["key_code", "modifiers"]
@@ -887,6 +862,7 @@ final class DesktopAutomationActionRegistry {
     // prove the counter is deterministic without spending LLM calls. Read-only.
     register(
       name: "usage_limiter_snapshot",
+      effects: [],
       summary: "Read the free-tier monthly chat usage-limiter state (deterministic counter) — CHAT-05 harness read."
     ) { _ in
       await MainActor.run {
@@ -913,6 +889,7 @@ final class DesktopAutomationActionRegistry {
     // dev-resettable (the criterion's second half) without driving real LLM usage.
     register(
       name: "reset_usage_limiter",
+      effects: [.localState],
       summary: "Reset the free-tier monthly chat usage-limiter counter (dev-resettable proof) — CHAT-05. Non-prod only."
     ) { _ in
       guard AppBuild.isNonProduction else {
@@ -932,6 +909,7 @@ final class DesktopAutomationActionRegistry {
     // walk 90/100 without spending a month of real questions. Non-prod only.
     register(
       name: "apply_usage_quota",
+      effects: [.localState],
       summary: "Seed the chat usage-quota snapshot (threshold-warning harness). Non-prod only.",
       params: ["used", "limit", "plan", "unit", "is_overage_plan", "reset_at"]
     ) { params in
@@ -973,6 +951,7 @@ final class DesktopAutomationActionRegistry {
     }
     register(
       name: "task_capture_fixture",
+      effects: [],
       summary: "Evaluate canonical screen-capture policy facts without screenshot bytes",
       params: ["facts_json"]
     ) { params in
@@ -1005,6 +984,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "configure_contextual_task_interruptions",
+      effects: [.localState],
       summary: "Configure the non-production contextual task interruption gate",
       params: [
         "enabled", "shipped_cohorts_enabled", "daily_limit", "minimum_spacing_seconds",
@@ -1045,6 +1025,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "probe_contextual_task_interruption",
+      effects: [.localState],
       summary: "Evaluate a synthetic bounded recommendation through the real interruption gate",
       params: ["can_wait", "expires_in_seconds"]
     ) { params in
@@ -1077,9 +1058,9 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "probe_suggestion_nudge",
+      effects: [.localState, .networkOrModel],
       summary: "Run the real suggestion grounding/evaluation/delivery path on the latest frame",
       params: ["app", "window_title"],
-      safety: "network_or_model",
       sideEffects: [
         "may call model/backend services",
         "may deliver a user-visible suggestion when notification controls allow",
@@ -1096,6 +1077,7 @@ final class DesktopAutomationActionRegistry {
     registerContextBucketDirectorProbe()
     register(
       name: "set_contextual_task_focus",
+      effects: [.localState],
       summary: "Set deterministic focus suppression for contextual task interruptions",
       params: ["suppressed"]
     ) { params in
@@ -1107,6 +1089,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "observe_task_context",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Submit a normalized task-context event and optionally flush re-evaluation",
       params: [
         "kind", "reference", "subject_kind", "subject_id", "workstream_id", "urgency", "flush",
@@ -1154,6 +1137,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "prepare_task_artifact_fixture",
+      effects: [.localState, .localArtifact],
       summary: "Persist an allowlisted prepared artifact through the workstream kernel",
       params: ["workstream_id", "logical_key", "kind", "content", "execution_ready", "grant_id"]
     ) { params in
@@ -1270,12 +1254,12 @@ final class DesktopAutomationActionRegistry {
     // TextEditor. Writes real memories on success, like the sheet would.
     register(
       name: "memory_log_import_probe",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Import a ChatGPT/Claude memory-log text through the real connector pipeline and return the outcome message",
       params: ["source", "text", "fixture"],
       category: "write",
       surfaces: ["import_connectors"],
-      safety: "remote_write",
       sideEffects: [
         "may call model/backend services",
         "may save imported memory data",
@@ -1320,6 +1304,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "toggle_transcription",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Enable or disable live transcription (mirrors the menu-bar toggle)",
       params: ["enabled"]
     ) { params in
@@ -1330,6 +1315,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "capture_test_transcript",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Hermetic capture seam: start/inject/stop a test recording session without mic/STT",
       params: ["phase", "text", "segments"]
     ) { params in
@@ -1362,12 +1348,12 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "local_summary_benchmark",
+      effects: [.localArtifact, .networkOrModel],
       summary:
         "S12: run the local summarizer over the last K GRDB sessions and write schema-validity + timings JSON",
       params: ["limit", "engine", "output"],
       category: "debug",
       surfaces: ["app"],
-      safety: "local_debug",
       sideEffects: ["writes a JSON report under Application Support; does not persist projections"],
       examples: [
         "./scripts/omi-ctl action local_summary_benchmark limit=5 engine=local-server"
@@ -1430,6 +1416,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "conversation_list_snapshot",
+      effects: [.localState, .networkOrModel],
       summary: "Return conversation list counts and recent titles for harness assertions",
       params: ["limit"]
     ) { params in
@@ -1472,6 +1459,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "conversation_reconciliation_snapshot",
+      effects: [.localState, .networkOrModel],
       summary: "Exercise cache-first list/detail reconciliation and open the canonical detail",
       params: []
     ) { _ in
@@ -1505,6 +1493,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memories_snapshot",
+      effects: [.localState, .networkOrModel],
       summary: "Return memories page load state for harness assertions",
       params: []
     ) { _ in
@@ -1541,6 +1530,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "tasks_snapshot",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Return tasks store counts for harness assertions",
       params: []
     ) { _ in
@@ -1584,6 +1574,7 @@ final class DesktopAutomationActionRegistry {
     // the shortcut handler calls, so no synthetic key events or cursor are involved.
     register(
       name: "ptt_start",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary:
         "Begin a push-to-talk capture after admission (mirrors the PTT shortcut key-down). Returns after capture admission; provider/hub readiness and screen evidence are polled via ptt_turn_snapshot"
     ) { _ in
@@ -1592,12 +1583,14 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "ptt_quick_tap",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Mirror one quick tap of a modifier-only PTT key; two inside the double-tap window lock"
     ) { _ in
       PushToTalkManager.shared.quickTapPushToTalkForAutomation()
     }
     register(
       name: "ptt_stop",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Finalize the in-progress push-to-talk capture (mirrors a long-hold release)"
     ) { _ in
       PushToTalkManager.shared.endPushToTalkForAutomation()
@@ -1613,6 +1606,7 @@ final class DesktopAutomationActionRegistry {
     // release for the closing transcription, polish, and paste to land.
     register(
       name: "ptt_manager_turn",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary:
         "Inject a PCM16/16k mono hold through PushToTalkManager and realtime admission; returns lifecycle diagnostics",
       params: ["pcm", "pace_ms", "settle_ms", "chunk_bytes"]
@@ -1664,6 +1658,7 @@ final class DesktopAutomationActionRegistry {
     // with network=false, no sign-in.
     register(
       name: "voice_typing_dictate",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Run a PCM16/16k recording through the dictation pipeline and paste the result into the frontmost app",
       params: ["pcm", "network"]
     ) { params in
@@ -1677,6 +1672,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "ptt_turn_snapshot",
+      effects: [],
       summary: "Return typed PTT lifecycle state, pending-tool fences, and safe screen-evidence diagnostics"
     ) { _ in
       RealtimeHubController.shared.automationPTTDiagnostics()
@@ -1686,6 +1682,7 @@ final class DesktopAutomationActionRegistry {
     // real realtime omni STT path and return the transcript. No mic, no human.
     register(
       name: "omni_test_turn",
+      effects: [.networkOrModel],
       summary: "Inject a raw PCM16/16kHz mono file through the omni STT path; returns the transcript",
       params: ["pcm", "timeout", "provider"]
     ) { params in
@@ -1716,6 +1713,7 @@ final class DesktopAutomationActionRegistry {
     // without driving the onboarding UI or the cursor.
     register(
       name: "onboarding_local_file_import",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Run the post-scan local-file memory import from the indexed snapshot; returns saved count"
     ) { _ in
       let coordinator = OnboardingPagedIntroCoordinator()
@@ -1732,6 +1730,7 @@ final class DesktopAutomationActionRegistry {
     // only when the save succeeded — mirroring OnboardingLanguageStepView.
     register(
       name: "onboarding_confirm_languages",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Select languages on the live onboarding coordinator and run the real Continue save",
       params: ["languages"]
     ) { params in
@@ -1757,6 +1756,7 @@ final class DesktopAutomationActionRegistry {
     // driving menus or the cursor.
     register(
       name: "reset_onboarding",
+      effects: [.localState],
       summary: "Reset onboarding state and restart the app (same path as the Reset Onboarding menu item)"
     ) { _ in
       await MainActor.run {
@@ -1767,6 +1767,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "sign_out",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Sign out via AuthService (local Auth emulator harness only)",
       params: ["accepted_account_deletion"]
     ) { params in
@@ -1788,6 +1789,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "ask",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Send a query to the floating-bar AI (typed path); exercises the full chat pipeline",
       params: ["query"]
     ) { params in
@@ -1815,6 +1817,7 @@ final class DesktopAutomationActionRegistry {
     // turn sets; non-prod bridge only. state = idle|listening|thinking|answering.
     register(
       name: "debug_bar_state",
+      effects: [.localState],
       summary: "Force floating-bar state: idle|listening|thinking|answering (visual verification)",
       params: ["state"]
     ) { params in
@@ -1833,6 +1836,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "debug_reach_error",
+      effects: [.localState],
       summary: "Show the actionable 'Couldn't reach Omi' card on the bar (Retry/Skip) for visual verification",
       params: []
     ) { _ in
@@ -1850,6 +1854,7 @@ final class DesktopAutomationActionRegistry {
     // share card). Same NotificationCenter signal the finalization service posts.
     register(
       name: "trigger_meeting_completion",
+      effects: [.localState],
       summary:
         "Post the real meeting-completion signal for a conversation id (presents the meeting summary share card). Non-prod only.",
       params: ["conversation_id"]
@@ -1870,6 +1875,7 @@ final class DesktopAutomationActionRegistry {
     // person actually sees rather than trusting that a trigger fired.
     register(
       name: "notification_state",
+      effects: [],
       summary: "Read the notch notification currently on screen (title, message, persistence).",
       params: []
     ) { _ in
@@ -1890,6 +1896,7 @@ final class DesktopAutomationActionRegistry {
     // posts once a detected meeting has rotated into its recording session.
     register(
       name: "trigger_meeting_started_notice",
+      effects: [.localState],
       summary:
         "Present the meeting-started note-taking notice (the card shown when a meeting is detected). Non-prod only.",
       params: []
@@ -1906,6 +1913,7 @@ final class DesktopAutomationActionRegistry {
     // card's buttons call, `close` is the user dismissal path.
     register(
       name: "meeting_summary_share",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Inspect or drive the presented meeting summary share card (action=state|copy|send|close). Non-prod only.",
       params: ["action"]
@@ -1965,6 +1973,7 @@ final class DesktopAutomationActionRegistry {
     // click X and nothing happens" is otherwise undiagnosable without synthesizing real clicks.
     register(
       name: "debug_hit_probe",
+      effects: [],
       summary: "Report topmost window + hit-tested view at screen point (top-left coords)",
       params: ["x", "y"]
     ) { params in
@@ -2028,6 +2037,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "reset_main_chat",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Clear main-window chat messages and start a fresh session (harness flow isolation)",
       params: []
     ) { _ in
@@ -2045,6 +2055,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "present_onboarding_opener",
+      effects: [.localState, .networkOrModel],
       summary: "Compose and show the post-onboarding opener in the empty-chat slot (QA rendering seam)",
       params: []
     ) { _ in
@@ -2066,6 +2077,7 @@ final class DesktopAutomationActionRegistry {
     // or keyboard input, so it never touches the user's actual cursor.
     register(
       name: "ask_main_chat",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Send a query to the main-window chat (typed path); exercises the full chat pipeline",
       params: ["query"]
     ) { params in
@@ -2110,6 +2122,7 @@ final class DesktopAutomationActionRegistry {
     // latency keeping isSending true.
     register(
       name: "ask_main_chat_no_wait",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Fire-and-forget main-chat send; returns immediately without waiting for the turn",
       params: ["query", "hold_busy_ms"]
     ) { params in
@@ -2169,6 +2182,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "main_chat_busy_state",
+      effects: [.localState],
       summary: "Return whether main chat is currently sending or streaming (race/busy probes)",
       params: []
     ) { _ in
@@ -2190,6 +2204,7 @@ final class DesktopAutomationActionRegistry {
     // and run one assembled-context probe turn. Non-production bundles only.
     register(
       name: "swap_test_owner",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Clear owner A kernel state, swap to synthetic owner B, and run one probe turn",
       params: ["owner_b", "query"]
     ) { params in
@@ -2207,6 +2222,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "restore_test_owner",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Restore the real owner after swap_test_owner (harness cleanup; no-op if no swap active)",
       params: []
     ) { _ in
@@ -2221,6 +2237,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "main_chat_snapshot",
+      effects: [],
       summary: "Export main-chat transcript, session ids, and stream state for continuity harnesses",
       params: ["limit"]
     ) { params in
@@ -2233,11 +2250,11 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "set_chat_drafts",
+      effects: [.localState],
       summary: "Set main and floating composer drafts without sending (non-prod persistence harness)",
       params: ["main", "floating"],
       category: "chat",
       surfaces: ["main_chat", "ask_omi"],
-      safety: "local",
       sideEffects: ["local_storage"],
       examples: ["./scripts/omi-ctl action set_chat_drafts main=main-draft floating=notch-draft"]
     ) { params in
@@ -2270,10 +2287,10 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "chat_drafts_snapshot",
+      effects: [],
       summary: "Read current main and floating composer drafts (non-prod persistence harness)",
       category: "chat",
       surfaces: ["main_chat", "ask_omi"],
-      safety: "read_only"
     ) { _ in
       guard AppBuild.isNonProduction else {
         return ["error": "chat_drafts_snapshot is disabled on production bundles"]
@@ -2288,11 +2305,11 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "clear_owner_surface_state",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Clear kernel main_chat turns for the active owner (non-prod continuity harness hygiene)",
       params: ["chatId"],
       category: "write",
       surfaces: ["main_chat"],
-      safety: "remote_write",
       sideEffects: [
         "clears the local non-production main-chat projection",
         "may delete the active owner's main-chat journal turns from the backend",
@@ -2310,6 +2327,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "kernel_turn_tail",
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Return the last N kernel main_chat turns for continuity harness evidence",
       params: ["limit"]
     ) { params in
@@ -2322,6 +2340,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "suspend_agent_stream",
+      effects: [.localState],
       summary:
         "Freeze the agent stdio stream (SIGSTOP) to induce a chat stall; auto-resumes after durationMs. Non-prod only.",
       params: ["durationMs"]
@@ -2337,6 +2356,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "resume_agent_stream",
+      effects: [.localState],
       summary: "Resume a suspended agent stdio stream (SIGCONT) immediately. Non-prod only.",
       params: []
     ) { _ in
@@ -2350,6 +2370,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "floating_bar_chat_snapshot",
+      effects: [],
       summary: "Export floating-bar chat transcript and stream state for harness assertions",
       params: ["limit"]
     ) { params in
@@ -2359,6 +2380,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "wait_floating_bar_chat_idle",
+      effects: [.localState],
       summary: "Block until the latest submitted floating-bar turn is observed and becomes idle",
       params: ["timeoutMs", "pollMs"]
     ) { params in
@@ -2402,6 +2424,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "wait_main_chat_idle",
+      effects: [.localState],
       summary: "Block until main chat is not sending or streaming (continuity harness)",
       params: ["timeoutMs", "pollMs"]
     ) { params in
@@ -2430,6 +2453,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "agent_runtime_evidence",
+      effects: [],
       summary: "Return omi-agentd.sqlite3 path and SHA-256 for continuity harness evidence bundles"
     ) { _ in
       let stateDir = AgentRuntimeProcess.defaultStateDirectory()
@@ -2452,6 +2476,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memories_qa_export",
+      effects: [.networkOrModel],
       summary: "Export memory counts by tier from the live API (local QA automation)",
       params: ["limit"]
     ) { params in
@@ -2480,6 +2505,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "apple_notes_read_probe",
+      effects: [.localState],
       summary: "Probe Apple Notes access without importing or saving memories",
       params: ["folderPath", "maxResults", "remember"]
     ) { params in
@@ -2544,6 +2570,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "delete_conversation",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Delete conversation with cascade (API + conversationDeleted notification)",
       params: ["id"]
     ) { params in
@@ -2567,6 +2594,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "capture_main_window_png",
+      effects: [.localArtifact],
       summary: "Write PNG of the frontmost Omi window (in-process capture)",
       params: ["path", "surface"]
     ) { params in
@@ -2624,6 +2652,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "capture_floating_bar_png",
+      effects: [.localArtifact],
       summary: "Write PNG of the floating control bar window (in-process capture)",
       params: ["path"]
     ) { params in
@@ -2664,6 +2693,7 @@ final class DesktopAutomationActionRegistry {
     // visibility inputs so a stuck reveal or menu can be caught mechanically.
     register(
       name: "notch_hover",
+      effects: [.localState],
       summary: "Simulate notch pointer enter/exit or read island state (non-prod). action=enter|exit|state",
       params: ["action"]
     ) { params in
@@ -2688,6 +2718,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "seed_subagents",
+      effects: [.localState],
       summary: "Seed synthetic floating-bar subagents for deterministic UI benchmarks",
       params: ["count"]
     ) { params in
@@ -2697,6 +2728,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "open_seeded_subagent",
+      effects: [.localState],
       summary: "Open a seeded subagent in the floating-bar chat",
       params: ["index", "wait"]
     ) { params in
@@ -2707,6 +2739,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "back_from_subagent",
+      effects: [.localState],
       summary: "Return from the selected subagent to the main Ask Omi chat",
       params: ["wait"]
     ) { params in
@@ -2716,6 +2749,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "spatial_overlay_present_fixture",
+      effects: [.localState],
       summary: "Present a deterministic spatial-overlay fixture for dogfood harnesses",
       params: ["fixture", "settleMs"]
     ) { params in
@@ -2730,6 +2764,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "spatial_overlay_state",
+      effects: [],
       summary: "Return the current spatial-overlay dogfood state"
     ) { _ in
       CloudConnectorGuidanceOverlay.shared.automationState()
@@ -2737,6 +2772,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "spatial_overlay_dismiss",
+      effects: [.localState],
       summary: "Dismiss the current spatial-overlay dogfood overlay"
     ) { _ in
       CloudConnectorGuidanceOverlay.shared.dismiss()
@@ -2745,11 +2781,11 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "integration_nudge_evaluate",
+      effects: [.localState],
       summary:
         "Read-only: which integration a given frontmost app/window maps to, and whether a nudge would fire",
       params: ["bundle_id", "window_title"],
       category: "read",
-      safety: "read_only"
     ) { params in
       await IntegrationNudgeAutomation.evaluate(
         bundleID: params["bundle_id"],
@@ -2759,17 +2795,18 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "integration_nudge_present",
+      effects: [.localState],
       summary: "Present the integration-connect card for one catalog entry (QA of the real card path)",
       params: ["telemetry_id"],
       category: "write",
       surfaces: ["floating_bar"],
-      safety: "presents_ui"
     ) { params in
       await MainActor.run { IntegrationNudgeAutomation.present(telemetryID: params["telemetry_id"] ?? "") }
     }
 
     register(
       name: "cloud_connector_guidance_probe",
+      effects: [],
       summary: "Read-only diagnostic of the live Claude Add detection (no overlay, no clicks)"
     ) { _ in
       await MainActor.run { CloudConnectorFormAutomation.claudeAddGuidanceDiagnostics() }
@@ -2777,6 +2814,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_awareness_snapshot",
+      effects: [.networkOrModel],
       summary: "Read the Swift coordinator awareness projection for Agents & Attention debugging",
       params: ["limit"]
     ) { params in
@@ -2787,11 +2825,11 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "agent_lifecycle_convergence_snapshot",
+      effects: [.networkOrModel],
       summary: "Read canonical child-run status alongside the rendered pill and journal-completion projection",
       params: ["runIds"],
       category: "read",
       surfaces: ["floating_bar", "main_chat", "realtime"],
-      safety: "read_only"
     ) { params in
       let runIDs = Set(
         (params["runIds"] ?? "")
@@ -2805,6 +2843,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_inspect_run",
+      effects: [.networkOrModel],
       summary: "Inspect one owner-scoped kernel run and its bounded tool-invocation ledger",
       params: ["runId"]
     ) { params in
@@ -2819,6 +2858,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_continue_agent",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Continue one owner-scoped canonical agent session and return its new run handles",
       params: ["sessionId", "prompt", "surfaceKind"]
     ) { params in
@@ -2850,6 +2890,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_action_queue",
+      effects: [.networkOrModel],
       summary: "Read the derived Swift coordinator attention queue",
       params: ["limit"]
     ) { params in
@@ -2860,6 +2901,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_open_loops",
+      effects: [.networkOrModel],
       summary: "Read unresolved agent/coordinator loops from the Swift projection"
     ) { _ in
       let loops = try await DesktopCoordinatorService.shared.openLoopsJSON()
@@ -2868,6 +2910,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_route_intent",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Route a structured proposal through the canonical agent kernel",
       params: [
         "intent", "surfaceKind", "taskId", "proposal", "snapshotVersion",
@@ -2901,6 +2944,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_create_dispatch",
+      effects: [.localState],
       summary: "Create a coordinator dispatch through the runtime control path for Agents & Attention testing",
       params: ["kind", "title", "decisionPrompt", "recommendedDefault", "sourceSessionId", "sourceRunId"]
     ) { params in
@@ -2917,6 +2961,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_resolve_dispatch",
+      effects: [.localState],
       summary: "Resolve a coordinator dispatch through the runtime control path",
       params: ["dispatchId", "resolution"]
     ) { params in
@@ -2932,6 +2977,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "calendar_read_probe",
+      effects: [.localState, .networkOrModel],
       summary: "Read Google Calendar through the real connector path and return classified status",
       params: ["daysBack", "daysForward", "maxResults"]
     ) { params in
@@ -2990,6 +3036,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "gmail_read_probe",
+      effects: [.localState, .networkOrModel],
       summary: "Read Gmail through the real connector path and return classified status",
       params: ["maxResults", "query"]
     ) { params in
@@ -3047,6 +3094,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "spatial_overlay_present_instruction",
+      effects: [.localState],
       summary: "Present the Screen Recording fallback instruction card (dogfood/visual)"
     ) { params in
       let title = params["title"] ?? "Allow Screen Recording for Omi"
@@ -3061,6 +3109,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "preview_screen_recording_drag_helper",
+      effects: [.localState],
       summary: "Open Screen Recording settings and show the drag-to-enable helper"
     ) { _ in
       await MainActor.run { ScreenCaptureService.openScreenRecordingPreferences() }
@@ -3069,6 +3118,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "open_conversation",
+      effects: [.localState, .networkOrModel],
       summary: "Open a conversation detail view (same path as POST /conversation/open)",
       params: ["conversationId", "showTranscript", "timeoutMs"]
     ) { params in
@@ -3096,6 +3146,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "set_conversations_search",
+      effects: [.localState, .networkOrModel],
       summary: "Set the Conversations page search query (drives the real debounced search path)",
       params: ["query"]
     ) { params in
@@ -3110,6 +3161,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "open_latest_conversation",
+      effects: [.localState, .networkOrModel],
       summary: "Open the most recently loaded conversation detail view",
       params: ["showTranscript", "timeoutMs"]
     ) { params in
@@ -3141,6 +3193,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "conversation_detail_snapshot",
+      effects: [.localState, .networkOrModel],
       summary: "Return open conversation detail fields for harness assertions",
       params: ["conversationId"]
     ) { params in
@@ -3198,6 +3251,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "create_test_memory",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Create a hermetic test memory via the real API",
       params: ["content", "source"]
     ) { params in
@@ -3222,6 +3276,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "edit_test_memory",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Edit a hermetic test memory via the real API",
       params: ["id", "marker", "content"]
     ) { params in
@@ -3256,6 +3311,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "delete_test_memory",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Delete a hermetic test memory via the real API",
       params: ["id", "marker"]
     ) { params in
@@ -3288,6 +3344,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "vocabulary_snapshot",
+      effects: [],
       summary: "Return transcription custom vocabulary for harness assertions"
     ) { _ in
       let terms = AssistantSettings.shared.transcriptionVocabulary
@@ -3307,6 +3364,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "vocabulary_set_terms",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Set transcription custom vocabulary (local + backend)",
       params: ["terms"]
     ) { params in
@@ -3327,6 +3385,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "goals_snapshot",
+      effects: [.networkOrModel],
       summary: "Return dashboard goals state for harness assertions"
     ) { _ in
       let goals: [Goal]
@@ -3354,6 +3413,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "create_test_goal",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Create a hermetic dashboard goal via the real API",
       params: ["title", "targetValue", "currentValue"]
     ) { params in
@@ -3381,6 +3441,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "apps_catalog_snapshot",
+      effects: [.networkOrModel],
       summary: "Return apps marketplace catalog counts for harness assertions"
     ) { _ in
       let v2 = try await APIClient.shared.getAppsV2()
@@ -3396,6 +3457,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "subscription_snapshot",
+      effects: [.networkOrModel],
       summary: "Return cached subscription/plan info from the billing API"
     ) { _ in
       let response = try await APIClient.shared.getUserSubscription()
@@ -3411,6 +3473,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "settings_privacy_snapshot",
+      effects: [.networkOrModel],
       summary: "Return privacy toggle defaults (store recordings, cloud sync, tracking)"
     ) { _ in
       async let recordingTask = APIClient.shared.getRecordingPermission()
@@ -3424,12 +3487,15 @@ final class DesktopAutomationActionRegistry {
       ]
     }
 
-    register(name: "permissions_snapshot", summary: "Every permission row the Permissions page shows") {
+    register(
+      name: "permissions_snapshot", effects: [.localState], summary: "Every permission row the Permissions page shows"
+    ) {
       _ in await PermissionsSnapshot.capture()
     }
 
     register(
       name: "create_test_folder",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Create a hermetic conversation folder via the real API",
       params: ["name"]
     ) { params in
@@ -3453,6 +3519,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "set_conversation_starred",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Set conversation starred status via the real API",
       params: ["conversationId", "starred"]
     ) { params in
@@ -3490,6 +3557,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "set_conversation_folder",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Move a conversation into a folder via the real API",
       params: ["conversationId", "folderId"]
     ) { params in
@@ -3526,6 +3594,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "set_transcription_language",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Set transcription language (local + backend)",
       params: ["language", "autoDetect"]
     ) { params in
@@ -3550,6 +3619,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "transcription_language_snapshot",
+      effects: [],
       summary: "Return transcription language settings for harness assertions"
     ) { _ in
       let settings = AssistantSettings.shared
@@ -3562,6 +3632,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_graph_rebuild",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Regenerate the server-side knowledge graph from the signed-in account's memories",
       params: []
@@ -3587,6 +3658,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_graph_snapshot",
+      effects: [.networkOrModel],
       summary: "Return knowledge graph node/edge counts (no SceneKit rendering)",
       params: ["label"]
     ) { params in
@@ -3630,6 +3702,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_atlas_select",
+      effects: [.localState],
       summary: "Select a Brain Map entity or connection so the inspector can be checked cursor-free",
       params: ["target", "node_id", "label", "edge_id", "clear"]
     ) { params in
@@ -3658,6 +3731,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memories_open_detail",
+      effects: [.localState, .networkOrModel],
       summary: "Open a memory's detail panel by backend id (omit the id to close it)",
       params: ["memory_id"]
     ) { params in
@@ -3674,6 +3748,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "open_memory_atlas",
+      effects: [.localState, .networkOrModel],
       summary: "Open the canonical memory atlas page for non-production UI and performance harnesses"
     ) { _ in
       await MainActor.run {
@@ -3687,6 +3762,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_atlas_set_viewport",
+      effects: [.localState],
       summary: "Set memory atlas zoom and pan for deterministic non-production performance sweeps",
       params: ["target", "zoom", "pan_x", "pan_y", "reset"]
     ) { params in
@@ -3714,6 +3790,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_atlas_enter_region",
+      effects: [.localState],
       summary: "Go into a Brain Map neighbourhood by caption, or leave the one you are in",
       params: ["target", "caption", "leave"]
     ) { params in
@@ -3736,6 +3813,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "memory_atlas_set_time",
+      effects: [.localState],
       summary: "Scrub or play the memory atlas time axis for deterministic non-production checks",
       params: ["target", "fraction", "play", "reset_to_start", "reset"]
     ) { params in
@@ -3762,6 +3840,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "open_quick_note",
+      effects: [.localState],
       summary: "Open Quick Note via Rewind notes path (same as dashboard Quick Note button)"
     ) { _ in
       NotificationCenter.default.post(name: .navigateToRewindNotes, object: nil)
@@ -3774,6 +3853,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "about_snapshot",
+      effects: [],
       summary: "Return About settings version/build/bundle metadata"
     ) { _ in
       let updater = UpdaterViewModel.shared
@@ -3792,6 +3872,7 @@ final class DesktopAutomationActionRegistry {
     registerRealtimeHubActions()
     register(
       name: "rewind_settings_snapshot",
+      effects: [],
       summary: "Return Rewind settings retention and excluded-app counts"
     ) { _ in
       let settings = RewindSettings.shared
@@ -3808,6 +3889,7 @@ final class DesktopAutomationActionRegistry {
     registerRewindArtifactRecoveryGauntlet()
     register(
       name: "navigate_via_shortcut",
+      effects: [.localState, .networkOrModel],
       summary: "Post the same sidebar navigation notification as Cmd+1..6 / Cmd+, shortcuts",
       params: ["shortcut"]
     ) { params in
@@ -3852,6 +3934,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "advanced_settings_snapshot",
+      effects: [],
       summary: "Return safe Advanced settings booleans (never raw BYOK keys)",
       params: []
     ) { _ in
@@ -3873,6 +3956,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "settings_aichat_snapshot",
+      effects: [],
       summary: "Return AI Chat settings safe fields (provider mode, working directory presence)",
       params: []
     ) { _ in
@@ -3888,6 +3972,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "assign_speaker_fixture",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Assign a person name to a conversation segment (hermetic speaker naming)",
       params: ["conversationId", "segmentIndex", "personName"]
     ) { params in
@@ -3974,6 +4059,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "screen_frame_quick_look_probe",
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Open screenshots in Quick Look and read the panel back",
       params: ["conversationId", "source", "dismiss"]
     ) { params in
@@ -4052,6 +4138,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "conversation_share_probe",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Hermetic share affordance probe — fetches share link without clipboard",
       params: ["conversationId"]
     ) { params in
@@ -4090,6 +4177,7 @@ final class DesktopAutomationActionRegistry {
     // side effect and cannot drift toward a raw-log upload.
     register(
       name: "dump_feedback_payload_dryrun",
+      effects: [.localArtifact],
       summary:
         "Assemble the feedback report payload (title + redacted desktop_diagnostics.json) without submitting to Sentry; returns the diagnostics JSON for secret-scanning. Non-prod only.",
       params: ["message"]
@@ -4132,6 +4220,7 @@ final class DesktopAutomationActionRegistry {
     // `suspend_agent_stream`'s role for the agent-stall path.
     register(
       name: "debug_block_main_thread",
+      effects: [.localState],
       summary: "Block the main thread for durationMs to exercise the /state wedged-MainActor fallback. Non-prod only.",
       params: ["durationMs"]
     ) { params in
@@ -4158,6 +4247,7 @@ final class DesktopAutomationActionRegistry {
     // Non-prod only (double-gated: here and inside AuthService).
     register(
       name: "expire_auth_token",
+      effects: [.localState],
       summary:
         "Expire the stored idToken via AuthService's real storage path (keychain or UserDefaults) so a relaunch must refresh it without signing out — AUTH-03. Status only, no token material. Non-prod only.",
       params: []
@@ -4174,6 +4264,7 @@ final class DesktopAutomationActionRegistry {
     // no longer use. Presence/expiry booleans only — never token material. Non-prod only.
     register(
       name: "auth_token_status",
+      effects: [],
       summary:
         "Read-only auth token status (signed_in, storage backend, has_id_token, has_refresh_token, is_token_expired) — AUTH-03. No token material. Non-prod only.",
       params: []
@@ -4195,6 +4286,7 @@ final class DesktopAutomationActionRegistry {
     // Read-only with respect to user data; non-prod only.
     register(
       name: "simulate_system_wake",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Post NSWorkspace.didWakeNotification on the workspace center (the top of the real wake chain: RealtimeHub re-warm + AppState .systemDidWake re-broadcast) so post-wake restart paths run without a real sleep — CHAT-07 harness. Non-prod only.",
       params: []
@@ -4218,6 +4310,7 @@ final class DesktopAutomationActionRegistry {
     // response flushes before restartApp() terminates the process. Non-prod only.
     register(
       name: "quit_and_reopen",
+      effects: [.localState],
       summary:
         "Trigger the permission-flow Quit & Reopen restart (AppState.restartApp) — relaunches the same bundle; auth/onboarding session persists. Non-prod only.",
       params: ["delayMs"]
@@ -4434,13 +4527,18 @@ final class DesktopAutomationBridge: @unchecked Sendable {
   /// Parse a `POST /action` body: `{ "name": "...", "params": { "k": "v", ... } }`.
   /// Param values are coerced to strings (bools → "true"/"false", numbers → digits)
   /// so callers can send natural JSON types.
-  private func parseActionRequest(from body: Data) -> (name: String, params: [String: String])? {
+  private func parseActionRequest(from body: Data) -> (name: String, params: [String: String], readOnly: Bool)? {
     guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
       let name = object["name"] as? String, !name.isEmpty
     else {
       return nil
     }
 
+    var readOnly = false
+    if let raw = object["readOnly"] {
+      guard let value = raw as? NSNumber, CFGetTypeID(value) == CFBooleanGetTypeID() else { return nil }
+      readOnly = value.boolValue
+    }
     var params: [String: String] = [:]
     if let raw = object["params"] as? [String: Any] {
       for (key, value) in raw {
@@ -4457,7 +4555,7 @@ final class DesktopAutomationBridge: @unchecked Sendable {
         }
       }
     }
-    return (name, params)
+    return (name, params, readOnly)
   }
 
   private func route(request: DesktopAutomationHTTPRequest) async -> DesktopAutomationHTTPResponse {
@@ -4618,7 +4716,7 @@ final class DesktopAutomationBridge: @unchecked Sendable {
       }
       do {
         let detail = try await DesktopAutomationActionRegistry.shared.perform(
-          parsed.name, params: parsed.params)
+          parsed.name, params: parsed.params, readOnly: parsed.readOnly)
         try await sleepForAutomationSettle(intParam(parsed.params["settleMs"], default: 0))
         let snapshot = await liveAutomationSnapshot()
         let result = DesktopAutomationActionResult(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2814,7 +2814,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_awareness_snapshot",
-      effects: [.networkOrModel],
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Read the Swift coordinator awareness projection for Agents & Attention debugging",
       params: ["limit"]
     ) { params in
@@ -2825,7 +2825,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "agent_lifecycle_convergence_snapshot",
-      effects: [.networkOrModel],
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Read canonical child-run status alongside the rendered pill and journal-completion projection",
       params: ["runIds"],
       category: "read",
@@ -2843,7 +2843,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_inspect_run",
-      effects: [.networkOrModel],
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Inspect one owner-scoped kernel run and its bounded tool-invocation ledger",
       params: ["runId"]
     ) { params in
@@ -2890,7 +2890,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_action_queue",
-      effects: [.networkOrModel],
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Read the derived Swift coordinator attention queue",
       params: ["limit"]
     ) { params in
@@ -2901,7 +2901,7 @@ final class DesktopAutomationActionRegistry {
 
     register(
       name: "coordinator_open_loops",
-      effects: [.networkOrModel],
+      effects: [.localState, .localArtifact, .networkOrModel],
       summary: "Read unresolved agent/coordinator loops from the Swift projection"
     ) { _ in
       let loops = try await DesktopCoordinatorService.shared.openLoopsJSON()

--- a/desktop/macos/Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift
@@ -7,6 +7,7 @@ extension DesktopAutomationActionRegistry {
     #if DEBUG
       register(
         name: "proactive_assistant_proxy_routes",
+        effects: [],
         summary: "Resolve the Gemini and embedding proxy routes through their production clients. DEBUG non-prod only."
       ) { _ in
         guard AppBuild.isNonProduction else {
@@ -21,6 +22,7 @@ extension DesktopAutomationActionRegistry {
 
       register(
         name: "knowledge_ledger_foundation_contracts",
+        effects: [],
         summary: "Exercise the pure knowledge-ledger prompt and trigger projections. DEBUG non-prod only."
       ) { _ in
         guard AppBuild.isNonProduction else {
@@ -159,6 +161,7 @@ extension DesktopAutomationActionRegistry {
 
       register(
         name: "set_open_omi_shortcut",
+        effects: [.localState],
         summary: "Select an Open Omi shortcut preset through the production settings mutation. DEBUG non-prod only.",
         params: ["preset"]
       ) { params in
@@ -197,6 +200,7 @@ extension DesktopAutomationActionRegistry {
 
       register(
         name: "trigger_open_omi_shortcut",
+        effects: [.localState],
         summary: "Trigger the registered Open Omi shortcut action. DEBUG non-prod only."
       ) { _ in
         guard AppBuild.isNonProduction else {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -1004,6 +1004,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   func registerPTTLanguageTestAction() {
     DesktopAutomationActionRegistry.shared.register(
       name: "ptt_test_turn",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Drive a real PTT hub turn from a PCM16/16k mono file through the controller "
         + "with the production pre-overlay screen capture; returns safe lifecycle and screen-protocol diagnostics.",
       params: ["pcm", "timeout", "force_transcript", "text_only"]
@@ -1386,6 +1387,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   func registerRapidPTTBurstTestAction() {
     DesktopAutomationActionRegistry.shared.register(
       name: "ptt_test_burst",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Drive three back-to-back PCM PTT turns and return final diagnostics.",
       params: ["pcm1", "pcm2", "pcm3", "timeout"]
     ) { [weak self] params in

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -186,6 +186,7 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
   static func registerAutomationAction() {
     DesktopAutomationActionRegistry.shared.register(
       name: "hub_test_turn",
+      effects: [.networkOrModel],
       summary: "Drive the realtime hub with a PCM16/16k file; returns the normalized turn. "
         + "auth=byok (default, uses BYOK key) | ephemeral (mints a server token, Phase 2)",
       params: ["pcm", "provider", "timeout", "auth"]

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstAutomationRuntime.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstAutomationRuntime.swift
@@ -52,10 +52,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_runtime_snapshot",
+      effects: [],
       summary: "Read shape-only state from the live Chat-first pages",
       category: "read",
       surfaces: ["main_chat", "goals", "tasks", "conversations"],
-      safety: "read_only",
       sideEffects: []
     ) { [weak self] _ in
       guard let self else { return nil }
@@ -64,11 +64,11 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_request_prompt_materialization",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Run the normal foreground materialization path from mounted main Chat",
       params: ["timeoutMs"],
       category: "coordinator",
       surfaces: ["main_chat"],
-      safety: "chat_turn",
       sideEffects: ["requests server-owned prompt materialization"]
     ) { [weak self] params in
       guard let self, let requestPromptMaterialization = self.requestPromptMaterialization else {
@@ -89,10 +89,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_render_fixture_task_card",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Invoke the real authorized Chat-first block executor from mounted main Chat",
       category: "chat",
       surfaces: ["main_chat"],
-      safety: "chat_turn",
       sideEffects: ["creates one local fixture journal turn", "validates and appends one fixture task card"]
     ) { [weak self] _ in
       guard let self, self.requestPromptMaterialization != nil else {
@@ -103,10 +103,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_set_focus",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Set focus through the currently visible Chat-first Goals page",
       category: "coordinator",
       surfaces: ["goals"],
-      safety: "server_mutation",
       sideEffects: ["updates canonical goal focus"]
     ) { [weak self] _ in
       guard let self, let setFocus = self.setFocus else {
@@ -117,10 +117,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_open_related_tasks",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Open related Tasks through the currently visible focused Goal",
       category: "coordinator",
       surfaces: ["goals", "tasks"],
-      safety: "local_ui_state",
       sideEffects: ["changes Chat-first route"]
     ) { [weak self] _ in
       guard let self, let openRelatedTasks = self.openRelatedTasks else {
@@ -134,10 +134,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_toggle_task",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Toggle one visible Chat-first task through the shared Tasks store",
       category: "coordinator",
       surfaces: ["tasks", "main_chat"],
-      safety: "server_mutation",
       sideEffects: ["updates task completion"]
     ) { [weak self] _ in
       guard let self, let toggleTask = self.toggleTask else {
@@ -148,10 +148,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_open_capture",
+      effects: [.localState, .networkOrModel],
       summary: "Select an Omi-device capture through the visible archive page",
       category: "coordinator",
       surfaces: ["conversations"],
-      safety: "read_only",
       sideEffects: ["selects a local capture detail"]
     ) { [weak self] _ in
       guard let self, let openCapture = self.openCapture else {
@@ -162,10 +162,10 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_discuss_capture",
+      effects: [.localState],
       summary: "Stage the selected capture as a reference in the main-Chat composer",
       category: "chat",
       surfaces: ["conversations", "main_chat"],
-      safety: "local_ui_state",
       sideEffects: ["navigates to main Chat", "stages one removable composer reference"]
     ) { [weak self] _ in
       guard let self, let discussCapture = self.discussCapture else {
@@ -184,11 +184,11 @@ final class ChatFirstAutomationRuntime: ObservableObject {
 
     registry.register(
       name: "chat_first_select_question_option",
+      effects: [.localState, .localArtifact, .networkOrModel, .remoteWrite],
       summary: "Select a bounded actionable question option through the mounted main-Chat journal",
       params: ["selection"],
       category: "chat",
       surfaces: ["main_chat"],
-      safety: "chat_turn",
       sideEffects: ["creates one prepared main-Chat turn"]
     ) { [weak self] params in
       guard let self, let selectQuestionOption = self.selectQuestionOption else {

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
@@ -167,11 +167,20 @@ final class ChatFollowGlide {
   /// several steps before the next follow retargets.
   private static let stepInterval: TimeInterval = 1.0 / 60.0
 
-  private var timer: Timer?
+  private var timer: OwnedRunLoopTimer?
   private var isGliding = false
+  private let now: () -> Date
+  private let schedule: OwnedRunLoopTimer.Scheduler
+
+  init(
+    now: @escaping () -> Date = Date.init, schedule: @escaping OwnedRunLoopTimer.Scheduler = OwnedRunLoopTimer.schedule
+  ) {
+    self.now = now
+    self.schedule = schedule
+  }
 
   #if DEBUG
-    var debugRunLoopTimer: Timer? { timer }
+    var debugRunLoopTimer: Timer? { timer?.timer }
   #endif
 
   /// True while a glide is moving the viewport. Reader input checks this the
@@ -187,49 +196,34 @@ final class ChatFollowGlide {
     let start = clipView.bounds.origin
     guard abs(start.y - target.y) > 0.5 else { return false }
     isGliding = true
-    let began = Date()
-    let step = Timer(timeInterval: Self.stepInterval, repeats: true) {
-      [weak self, weak clipView] _ in
-      MainActor.assumeIsolated {
-        guard let self, let clipView, self.isGliding else {
-          self?.cancel()
-          return
-        }
-        let progress = Date().timeIntervalSince(began) / duration
-        guard progress < 1 else {
-          self.moveTo(target, in: clipView)
-          self.cancel()
-          return
-        }
-        // Ease-out cubic: fast while the reader's eye is on the arriving
-        // text, settling as it reaches the live edge.
-        let eased = 1 - pow(1 - progress, 3)
-        var origin = start
-        origin.y = start.y + (target.y - start.y) * eased
-        self.moveTo(origin, in: clipView)
+    let began = now()
+    timer = schedule(Self.stepInterval) { [weak self, weak clipView] in
+      guard let self, let clipView, self.isGliding else {
+        self?.cancel()
+        return
       }
+      let progress = self.now().timeIntervalSince(began) / duration
+      guard progress < 1 else {
+        self.moveTo(target, in: clipView)
+        self.cancel()
+        return
+      }
+      // Ease-out cubic: fast while the reader's eye is on the arriving
+      // text, settling as it reaches the live edge.
+      let eased = 1 - pow(1 - progress, 3)
+      var origin = start
+      origin.y = start.y + (target.y - start.y) * eased
+      self.moveTo(origin, in: clipView)
     }
-    timer = step
-    RunLoop.main.add(step, forMode: .common)
     return true
   }
 
   /// Reader input and teardown call this; an in-flight glide must never fight
   /// the viewport's owner.
   func cancel() {
-    timer?.invalidate()
+    timer?.cancel()
     timer = nil
     isGliding = false
-  }
-
-  deinit {
-    // The run loop retains the timer independently of this object. Without an
-    // invalidate here, SwiftUI dropping a transcript (or a test releasing the
-    // glide) leaves a 60 Hz `.common` source on `RunLoop.main` that ends later
-    // `run(mode:before:)` drains before queued main-async work can run.
-    if Thread.isMainThread {
-      MainActor.assumeIsolated { cancel() }
-    }
   }
 
   private func moveTo(_ origin: NSPoint, in clipView: NSClipView) {
@@ -264,12 +258,17 @@ final class ChatLiveEdgePinner {
   /// 60 Hz, matching the display cadence the glide's clock was built for.
   private static let tickInterval: TimeInterval = 1.0 / 60.0
 
-  private var timer: Timer?
+  private var timer: OwnedRunLoopTimer?
   private(set) var isPinning = false
   private var track: (() -> Void)?
+  private let schedule: OwnedRunLoopTimer.Scheduler
+
+  init(schedule: @escaping OwnedRunLoopTimer.Scheduler = OwnedRunLoopTimer.schedule) {
+    self.schedule = schedule
+  }
 
   #if DEBUG
-    var debugRunLoopTimer: Timer? { timer }
+    var debugRunLoopTimer: Timer? { timer?.timer }
   #endif
 
   var isActive: Bool { isPinning }
@@ -281,31 +280,19 @@ final class ChatLiveEdgePinner {
     self.track = track
     guard !isPinning else { return }
     isPinning = true
-    let tick = Timer(timeInterval: Self.tickInterval, repeats: true) { [weak self] _ in
-      MainActor.assumeIsolated {
-        guard let self, self.isPinning else { return }
-        self.track?()
-      }
+    timer = schedule(Self.tickInterval) { [weak self] in
+      guard let self, self.isPinning else { return }
+      self.track?()
     }
-    timer = tick
-    RunLoop.main.add(tick, forMode: .common)
   }
 
   /// Reader input, stream end, and teardown call this; a pinner must never
   /// fight the viewport's owner.
   func cancel() {
-    timer?.invalidate()
+    timer?.cancel()
     timer = nil
     isPinning = false
     track = nil
-  }
-
-  deinit {
-    // Same run-loop ownership as `ChatFollowGlide`: `RunLoop.main.add(_:forMode: .common)`
-    // keeps the tick alive after this object is gone unless we invalidate it.
-    if Thread.isMainThread {
-      MainActor.assumeIsolated { cancel() }
-    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OwnedRunLoopTimer.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OwnedRunLoopTimer.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The run loop retains a scheduled timer, so releasing its feature owner is
+/// insufficient. This token owns invalidation even when explicit stop is missed.
+/// Keep callbacks weakly bound to the feature owner to avoid a retain cycle.
+final class OwnedRunLoopTimer {
+  let timer: Timer
+
+  init(_ timer: Timer) {
+    self.timer = timer
+  }
+
+  func cancel() {
+    timer.invalidate()
+  }
+
+  deinit {
+    timer.invalidate()
+  }
+
+  typealias Scheduler = @MainActor (TimeInterval, @escaping @MainActor () -> Void) -> OwnedRunLoopTimer
+
+  @MainActor
+  static func schedule(interval: TimeInterval, tick: @escaping @MainActor () -> Void) -> OwnedRunLoopTimer {
+    let timer = Timer(timeInterval: interval, repeats: true) { _ in
+      MainActor.assumeIsolated { tick() }
+    }
+    RunLoop.main.add(timer, forMode: .common)
+    return OwnedRunLoopTimer(timer)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1798,6 +1798,7 @@ class MemoriesViewModel: ObservableObject {
     // production. This presents the real sheet with the real draft text.
     registry.register(
       name: "memories_open_add_sheet",
+      effects: [.localState],
       summary: "Present the Add Memory sheet, optionally pre-filled with draft text",
       params: ["text"]
     ) { [weak self] params in
@@ -1811,6 +1812,7 @@ class MemoriesViewModel: ObservableObject {
     }
     registry.register(
       name: "memories_search",
+      effects: [.localState, .networkOrModel],
       summary: "Set memories search query and return filtered result count",
       params: ["query"]
     ) { [weak self] params in
@@ -1839,6 +1841,7 @@ class MemoriesViewModel: ObservableObject {
 
     registry.register(
       name: "memories_set_tag_filter",
+      effects: [.localState],
       summary: "Set memory tag/category filters and return filtered count",
       params: ["tags"]
     ) { [weak self] params in
@@ -1874,6 +1877,7 @@ class MemoriesViewModel: ObservableObject {
 
     registry.register(
       name: "toggle_memory_visibility",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Toggle a memory's public/private visibility via the real API path",
       params: ["id", "marker"]
     ) { [weak self] params in

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -2827,6 +2827,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "create_task",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Create a task through the genuine store path; waits for the backend id (see 'synced') and returns it",
       params: ["description", "priority"]
     ) { [weak self] params in
@@ -2851,6 +2852,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "open_task_details",
+      effects: [.localState],
       summary: "Open a task's detail panel by id — the same panel a row click opens. Omit the id to close it.",
       params: ["id"]
     ) { [weak self] params in
@@ -2866,6 +2868,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "seed_tasks",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Create N tasks for reorder/stress testing; waits for backend ids so they are reorder-persistable; returns synced count + ids",
       params: ["count", "prefix"]
@@ -2896,6 +2899,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "toggle_task",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Toggle a task's completed state by id (mirrors the checkbox); returns the actual post-toggle state",
       params: ["id", "description"]
     ) { [weak self] params in
@@ -2927,6 +2931,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "delete_task",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Delete a task by id (mirrors swipe / menu delete)",
       params: ["id", "description"]
     ) { [weak self] params in
@@ -2955,6 +2960,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "reorder_task",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "Move a task to a new index within a category (today|tomorrow|later|nodeadline) via the real drag path and return the resulting order. Resolve by id or description. Flushes the sortOrder sync to SQLite + backend by default; pass flush=false to leave the production 500ms debounce running so a harness can prove coalescing (TASK-05).",
       params: ["id", "description", "index", "category", "flush"]
@@ -3008,6 +3014,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "dump_tasks",
+      effects: [.localState],
       summary:
         "Snapshot tasks from SQLite (id, description, completed, sortOrder, category) sorted by sortOrder — proves reorder/CRUD persistence. Returns every task; filter client-side on the per-row category field. Pass `marker` to get a boolean `marker_absent` field for post-delete verification.",
       params: ["includeCompleted", "limit", "marker"]
@@ -3050,6 +3057,7 @@ class TasksViewModel: ObservableObject {
 
     registry.register(
       name: "inject_requery_during_drag",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary:
         "TASK-06: inject a server-push recompute while a drag is active and report whether the SQLite requery was suppressed (order not clobbered). Non-prod only.",
       params: []

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
@@ -1094,6 +1094,7 @@ final class SuggestedTasksStore: ObservableObject {
     didRegisterAutomationActions = true
     DesktopAutomationActionRegistry.shared.register(
       name: "refresh_suggested_tasks",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Refresh the canonical Suggested lane",
       params: []
     ) { [weak self] _ in
@@ -1103,6 +1104,7 @@ final class SuggestedTasksStore: ObservableObject {
     }
     DesktopAutomationActionRegistry.shared.register(
       name: "dump_suggested_tasks",
+      effects: [],
       summary: "Return privacy-safe Suggested candidate opaque ids",
       params: []
     ) { [weak self] _ in
@@ -1111,6 +1113,7 @@ final class SuggestedTasksStore: ObservableObject {
     }
     DesktopAutomationActionRegistry.shared.register(
       name: "suggested_task_action",
+      effects: [.localState, .networkOrModel, .remoteWrite],
       summary: "Perform a Suggested card action through the real store",
       params: ["candidate_id", "action", "title", "reason"]
     ) { [weak self] params in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskAgent/TaskChatCoordinator.swift
@@ -625,6 +625,7 @@ final class TaskChatCoordinator: ObservableObject {
     func registerAutomationActions() {
       DesktopAutomationActionRegistry.shared.register(
         name: "task_thread_scenario_13",
+        effects: [.localState, .networkOrModel, .remoteWrite],
         summary: "Exercise live task-backed thread continuity through the app kernel",
         params: ["task", "resume"]
       ) { [weak self] params in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbeRegistration.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbeRegistration.swift
@@ -5,17 +5,18 @@
     func registerContextBucketDirectorProbe() {
       register(
         name: "probe_context_bucket_director",
+        effects: [.localState, .networkOrModel, .remoteWrite],
         summary:
           "Replay a synthetic context bucket through the director model boundary; present=1 continues a grounding-permitted decision into the real presentation gate stack",
         params: [
           "bucket_id", "version", "header", "frozen", "tail", "validated_facts", "tasks", "app", "window",
           "captured_at", "notify_worthiness", "visit_count", "retrieved", "lookup_query", "present",
         ],
-        safety: "network_or_model",
         sideEffects: [
           "may call model/backend services",
           "eligible replays consume the signed-in account's proactivity reasoning quota",
-          "does not write the database, change gates/settings, or graduate tasks",
+          "does not change gates/settings or graduate tasks",
+          "may persist notification/journal delivery state when present=1",
           "present=1 shows a real notification, subject to the same owner/toggle/throttle gates as an organic delivery; without it nothing is delivered",
         ]
       ) { params in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveCaptureStatusSnapshotRegistration.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveCaptureStatusSnapshotRegistration.swift
@@ -5,8 +5,8 @@
     func registerProactiveCaptureStatusSnapshot() {
       register(
         name: "proactive_capture_status_snapshot",
+        effects: [],
         summary: "Read coarse screen-capture and context-bucket monitoring state without content",
-        safety: "read_only",
         sideEffects: [
           "read-only local state",
           "does not capture a screenshot, call a model/backend, or deliver notifications",

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift
@@ -233,11 +233,11 @@ extension DesktopAutomationActionRegistry {
   func registerRewindArtifactRecoveryGauntlet() {
     register(
       name: "rewind_artifact_recovery_gauntlet",
+      effects: [.localState, .localArtifact],
       summary:
         "Write safe synthetic Rewind frames through encoder, SQLite, and video readback; prove privacy exclusion and database reopen. Non-prod only.",
       category: "test",
       surfaces: ["rewind"],
-      safety: "local_artifact",
       sideEffects: [
         "writes and removes a synthetic local video artifact", "closes and reopens the local Rewind database",
       ],

--- a/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentContinuityGauntletTests.swift
@@ -167,11 +167,11 @@ final class AgentContinuityGauntletTests: XCTestCase {
     let registry = DesktopAutomationActionRegistry.shared
     registry.register(
       name: "__metadata_contract_test__",
+      effects: [],
       summary: "Read test-only metadata",
       params: ["limit"],
       category: "read",
       surfaces: ["test_surface"],
-      safety: "read_only",
       sideEffects: [],
       examples: ["./scripts/omi-ctl action __metadata_contract_test__ limit=1"]
     ) { _ in
@@ -191,9 +191,10 @@ final class AgentContinuityGauntletTests: XCTestCase {
     XCTAssertTrue(descriptor.preferSemantic)
   }
 
-  func testAutomationActionDescriptorInfersUsefulMetadataForBuiltins() throws {
+  func testAutomationActionDescriptorUsesDeclaredEffectsAndInfersSurfaceHints() throws {
     let snapshot = DesktopAutomationActionDescriptor(
       name: "main_chat_snapshot",
+      effects: [],
       summary: "Export main-chat state",
       params: ["limit"]
     )
@@ -204,6 +205,7 @@ final class AgentContinuityGauntletTests: XCTestCase {
 
     let capture = DesktopAutomationActionDescriptor(
       name: "capture_floating_bar_png",
+      effects: [.localArtifact],
       summary: "Capture the floating bar",
       params: ["path"]
     )

--- a/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatScrollLiveEdgeTests.swift
@@ -417,6 +417,75 @@ final class UserScrollDetectorTests: XCTestCase {
     return event
   }
 
+  func testFollowGlideUsesInjectedTimeAndCancelsItsTimerAtTheTarget() {
+    let (scrollView, _) = makeScrollViewAtBottom()
+    let scheduler = ManualRunLoopTimerScheduler()
+    let glide = ChatFollowGlide(now: { scheduler.now }, schedule: scheduler.schedule)
+    XCTAssertTrue(glide.glide(clipView: scrollView.contentView, to: NSPoint(x: 0, y: 200), duration: 1))
+    XCTAssertEqual(scheduler.activeTimerCount, 1)
+
+    scheduler.fire()
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 700, accuracy: 0.01)
+    scheduler.advance(by: 0.5)
+    scheduler.fire()
+    // The existing ease-out cubic moves 7/8 of the 500-point distance halfway through.
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 262.5, accuracy: 0.01)
+    scheduler.advance(by: 0.5)
+    scheduler.fire()
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 200, accuracy: 0.01)
+    XCTAssertFalse(glide.isActive)
+    XCTAssertEqual(scheduler.activeTimerCount, 0)
+  }
+
+  func testFollowGlideRetargetAndReleaseCancelEveryOwnedTimer() {
+    let (scrollView, _) = makeScrollViewAtBottom()
+    let scheduler = ManualRunLoopTimerScheduler()
+    var glide: ChatFollowGlide? = ChatFollowGlide(now: { scheduler.now }, schedule: scheduler.schedule)
+    weak var weakGlide: ChatFollowGlide?
+    weakGlide = glide
+    glide?.glide(clipView: scrollView.contentView, to: NSPoint(x: 0, y: 200), duration: 1)
+    glide?.glide(clipView: scrollView.contentView, to: NSPoint(x: 0, y: 100), duration: 1)
+    XCTAssertEqual(scheduler.timers.count, 2)
+    XCTAssertFalse(scheduler.timers[0].isValid)
+    XCTAssertEqual(scheduler.activeTimerCount, 1)
+
+    glide = nil
+    XCTAssertNil(weakGlide)
+    XCTAssertEqual(scheduler.activeTimerCount, 0)
+    scheduler.advance(by: 1)
+    scheduler.fire()
+    XCTAssertEqual(scrollView.contentView.bounds.origin.y, 700, accuracy: 0.01)
+  }
+
+  func testPinnersOwnIndependentTimersAndReleaseStopsFurtherTicks() {
+    let scheduler = ManualRunLoopTimerScheduler()
+    let first = ChatLiveEdgePinner(schedule: scheduler.schedule)
+    var second: ChatLiveEdgePinner? = ChatLiveEdgePinner(schedule: scheduler.schedule)
+    weak var weakSecond: ChatLiveEdgePinner?
+    weakSecond = second
+    var firstTicks = 0
+    var secondTicks = 0
+    first.start { firstTicks += 1 }
+    second?.start { secondTicks += 1 }
+    second?.start { secondTicks += 10 }
+    XCTAssertEqual(scheduler.activeTimerCount, 2, "updating the callback must reuse the armed timer")
+    scheduler.fire()
+    XCTAssertEqual(firstTicks, 1)
+    XCTAssertEqual(secondTicks, 10)
+
+    first.cancel()
+    first.cancel()
+    scheduler.fire()
+    XCTAssertEqual(firstTicks, 1)
+    XCTAssertEqual(secondTicks, 20)
+    XCTAssertEqual(scheduler.activeTimerCount, 1)
+    second = nil
+    XCTAssertNil(weakSecond)
+    XCTAssertEqual(scheduler.activeTimerCount, 0)
+    scheduler.fire()
+    XCTAssertEqual(secondTicks, 20)
+  }
+
   #if DEBUG
     func testFollowGlideInvalidatesItsCommonModeTimerOnDeinit() {
       let (scrollView, _) = makeScrollViewAtBottom()

--- a/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
@@ -22,6 +22,22 @@ final class DesktopAutomationActionEffectTests: XCTestCase {
       descriptor.effects.map(\.description) + ["Custom detail supplements the mandatory descriptions"])
   }
 
+  func testReferralActionDeclaresTheRequestStartedByItsSheet() throws {
+    let registry = DesktopAutomationActionRegistry()
+    registry.registerBuiltins()
+    let descriptor = try XCTUnwrap(registry.descriptors().first { $0.name == "rating_prompt_refer" })
+    XCTAssertTrue(descriptor.effects.contains(.networkOrModel))
+  }
+
+  func testTimerLifetimeFlowProbeObservesRealTimerInvalidation() async throws {
+    let registry = DesktopAutomationActionRegistry()
+    registry.registerBuiltins()
+    let result = try await registry.perform("chat_timer_lifetime_probe", params: [:])
+    XCTAssertEqual(result?["scheduled"], "true")
+    XCTAssertEqual(result?["cancelledValid"], "false")
+    XCTAssertEqual(result?["releasedValid"], "false")
+  }
+
   func testReadOnlyDispatchRejectsEveryDeclaredEffectBeforeCallingHandler() async throws {
     let registry = DesktopAutomationActionRegistry()
     var mutations = 0
@@ -69,6 +85,7 @@ final class DesktopAutomationActionEffectTests: XCTestCase {
       "permissions_snapshot", "coordinator_awareness_snapshot", "coordinator_inspect_run",
       "coordinator_action_queue", "coordinator_open_loops", "agent_lifecycle_convergence_snapshot",
       "recent_screen_frames_snapshot", "kernel_turn_tail", "integration_nudge_evaluate", "rating_prompt_state",
+      "chat_timer_lifetime_probe",
     ] {
       do {
         // No params: a wrongly admitted handler would run or fail parameter validation.

--- a/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DesktopAutomationActionEffectTests: XCTestCase {
+  func testDiscoveryUsesEffectsEvenWhenTheNameLooksReadOnly() throws {
+    let descriptor = DesktopAutomationActionDescriptor(
+      name: "memory_import_state_probe",
+      effects: [.remoteWrite, .networkOrModel, .localState],
+      summary: "Exercise a writer",
+      sideEffects: ["Custom detail supplements the mandatory descriptions"]
+    )
+    let json = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: JSONEncoder().encode(descriptor)) as? [String: Any])
+    XCTAssertEqual(json["safety"] as? String, "remote_write")
+    XCTAssertEqual(json["category"] as? String, "write")
+    XCTAssertEqual(
+      json["effects"] as? [String], ["local_ui_state", "network_or_model", "remote_write"])
+    XCTAssertEqual(
+      descriptor.sideEffects,
+      descriptor.effects.map(\.description) + ["Custom detail supplements the mandatory descriptions"])
+  }
+
+  func testReadOnlyDispatchRejectsEveryDeclaredEffectBeforeCallingHandler() async throws {
+    let registry = DesktopAutomationActionRegistry()
+    var mutations = 0
+    for effect in DesktopAutomationActionEffect.allCases {
+      registry.register(
+        name: "harmless_state_probe", effects: [effect], summary: "A deliberately misleading name"
+      ) { _ in
+        mutations += 1
+        return nil
+      }
+      do {
+        _ = try await registry.perform("harmless_state_probe", params: [:], readOnly: true)
+        XCTFail("Read-only dispatch must reject \(effect)")
+      } catch DesktopAutomationActionError.requiresEffects(let name) {
+        XCTAssertEqual(name, "harmless_state_probe")
+      }
+      XCTAssertEqual(mutations, 0)
+    }
+    // Ordinary action execution still reaches the handler.
+    _ = try await registry.perform("harmless_state_probe", params: [:])
+    XCTAssertEqual(mutations, 1)
+  }
+
+  func testReadOnlyDispatchPreservesReadResultAndUnknownActionError() async throws {
+    let registry = DesktopAutomationActionRegistry()
+    registry.register(name: "snapshot", effects: [], summary: "Read injected state") { params in
+      ["value": params["value"] ?? ""]
+    }
+    let result = try await registry.perform("snapshot", params: ["value": "stable"], readOnly: true)
+    XCTAssertEqual(result, ["value": "stable"])
+    do {
+      _ = try await registry.perform("missing", params: [:], readOnly: true)
+      XCTFail("Unknown actions must fail")
+    } catch DesktopAutomationActionError.unknownAction(let name) {
+      XCTAssertEqual(name, "missing")
+    }
+  }
+
+  func testHistoricalWritersAndLoadingSnapshotsCannotRunAsReadOnly() async throws {
+    let registry = DesktopAutomationActionRegistry()
+    registry.registerBuiltins()
+    for action in [
+      "memory_log_import_probe", "clear_owner_surface_state", "memories_snapshot",
+      "conversation_list_snapshot", "screen_frame_quick_look_probe",
+      "permissions_snapshot", "coordinator_awareness_snapshot", "coordinator_inspect_run",
+      "coordinator_action_queue", "coordinator_open_loops", "agent_lifecycle_convergence_snapshot",
+      "recent_screen_frames_snapshot", "kernel_turn_tail", "integration_nudge_evaluate",
+    ] {
+      do {
+        // No params: a wrongly admitted handler would run or fail parameter validation.
+        _ = try await registry.perform(action, params: [:], readOnly: true)
+        XCTFail("\(action) must require its declared effects")
+      } catch DesktopAutomationActionError.requiresEffects(let name) {
+        XCTAssertEqual(name, action)
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationActionEffectTests.swift
@@ -68,7 +68,7 @@ final class DesktopAutomationActionEffectTests: XCTestCase {
       "conversation_list_snapshot", "screen_frame_quick_look_probe",
       "permissions_snapshot", "coordinator_awareness_snapshot", "coordinator_inspect_run",
       "coordinator_action_queue", "coordinator_open_loops", "agent_lifecycle_convergence_snapshot",
-      "recent_screen_frames_snapshot", "kernel_turn_tail", "integration_nudge_evaluate",
+      "recent_screen_frames_snapshot", "kernel_turn_tail", "integration_nudge_evaluate", "rating_prompt_state",
     ] {
       do {
         // No params: a wrongly admitted handler would run or fail parameter validation.

--- a/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationBridgeRouteTests.swift
@@ -48,6 +48,45 @@ private final class StubPresentationCoordinator: DesktopAutomationPresentationCo
 
 @MainActor
 final class DesktopAutomationBridgeRouteTests: XCTestCase {
+  func testReadOnlyActionRequestRejectsWriterBeforeItsHandler() async throws {
+    let registry = DesktopAutomationActionRegistry.shared
+    let name = "__read_only_route_probe__"
+    var writes = 0
+    registry.register(name: name, effects: [.remoteWrite], summary: "Injected remote writer") { _ in
+      writes += 1
+      return nil
+    }
+    defer { registry.unregister(name) }
+    let body = try JSONSerialization.data(withJSONObject: ["name": name, "readOnly": true])
+    let response = await DesktopAutomationBridge.shared.response(
+      for: authorizedRequest(method: "POST", path: "/action", body: body))
+    let envelope = try JSONDecoder().decode(AutomationErrorEnvelope.self, from: response.body)
+    XCTAssertEqual(response.statusCode, 400)
+    XCTAssertFalse(envelope.ok)
+    XCTAssertEqual(envelope.error, "action_requires_effects: \(name)")
+    XCTAssertEqual(writes, 0)
+  }
+
+  func testMalformedReadOnlyPolicyCannotFallBackToOrdinaryExecution() async throws {
+    let registry = DesktopAutomationActionRegistry.shared
+    let name = "__malformed_policy_probe__"
+    var writes = 0
+    registry.register(name: name, effects: [.remoteWrite], summary: "Injected remote writer") { _ in
+      writes += 1
+      return nil
+    }
+    defer { registry.unregister(name) }
+    for policy in ["true", 1, NSNull()] as [Any] {
+      let body = try JSONSerialization.data(withJSONObject: ["name": name, "readOnly": policy])
+      let response = await DesktopAutomationBridge.shared.response(
+        for: authorizedRequest(method: "POST", path: "/action", body: body))
+      let envelope = try JSONDecoder().decode(AutomationErrorEnvelope.self, from: response.body)
+      XCTAssertEqual(response.statusCode, 400)
+      XCTAssertEqual(envelope.error, "invalid_action_request")
+    }
+    XCTAssertEqual(writes, 0)
+  }
+
   func testOpenAskOmiIsRegisteredOnTheMainChatSurface() throws {
     DesktopAutomationActionRegistry.shared.registerBuiltins()
     let descriptor = try XCTUnwrap(

--- a/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
@@ -145,7 +145,12 @@ final class DesktopAutomationSecondaryActionTests: XCTestCase {
     XCTAssertEqual(importProbe.safety, "remote_write")
     XCTAssertEqual(
       importProbe.sideEffects,
-      ["may call model/backend services", "may save imported memory data"])
+      [
+        "mutates local app, UI, or stored state",
+        "may call agent runtime, model, or backend services",
+        "may mutate remote user data",
+        "may call model/backend services", "may save imported memory data",
+      ])
 
     let clearState = try XCTUnwrap(
       descriptors.first { $0.name == "clear_owner_surface_state" })
@@ -155,6 +160,9 @@ final class DesktopAutomationSecondaryActionTests: XCTestCase {
     XCTAssertEqual(
       clearState.sideEffects,
       [
+        "mutates local app, UI, or stored state",
+        "may call agent runtime, model, or backend services",
+        "may mutate remote user data",
         "clears the local non-production main-chat projection",
         "may delete the active owner's main-chat journal turns from the backend",
       ])

--- a/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
+++ b/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+final class IsolatedTestDefaultsTests: XCTestCase {
+  @MainActor
+  func testXCTestHelperCleansDomainBeforeEarlierTeardownBlocks() throws {
+    var retainedDefaults: UserDefaults?
+    // XCTest runs teardown blocks in reverse registration order. Keep a defaults
+    // reference alive until after the helper's teardown has removed its domain.
+    addTeardownBlock {
+      XCTAssertNil(retainedDefaults?.string(forKey: "auth_userId"))
+    }
+    retainedDefaults = try makeIsolatedDefaults()
+    retainedDefaults?.set("owner", forKey: "auth_userId")
+  }
+
+  func testFixturesKeepTheSameAuthKeyIndependentAndCleanOnlyTheirOwnedDomain() throws {
+    let first = try IsolatedTestDefaults()
+    let second = try IsolatedTestDefaults()
+    let key = "auth_userId"
+    first.defaults.set("owner-a", forKey: key)
+    XCTAssertNil(second.defaults.string(forKey: key))
+    second.defaults.set("owner-b", forKey: key)
+
+    XCTAssertNotEqual(first.suiteName, second.suiteName)
+    XCTAssertEqual(first.defaults.string(forKey: key), "owner-a")
+    first.cleanUp()
+    first.cleanUp()
+    XCTAssertNil(first.defaults.string(forKey: key))
+    XCTAssertEqual(second.defaults.string(forKey: key), "owner-b")
+  }
+
+  func testReleasingFixtureCleansDomainEvenWhenDefaultsAreRetained() throws {
+    var fixture: IsolatedTestDefaults? = try IsolatedTestDefaults()
+    let defaults = try XCTUnwrap(fixture?.defaults)
+    defaults.set("owner", forKey: "auth_userId")
+    fixture = nil
+    XCTAssertNil(defaults.string(forKey: "auth_userId"))
+  }
+}

--- a/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
+++ b/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
@@ -1,17 +1,19 @@
 import XCTest
 
+private let isolatedDefaultsOwnerKey = "auth_userId"
+
 final class IsolatedTestDefaultsTests: XCTestCase {
   @MainActor
   func testDefaultsHandleCanCrossIntoANonisolatedAsyncAPI() async throws {
     let defaults = try makeIsolatedDefaults()
-    defaults.set("owner", forKey: "auth_userId")
+    defaults.set("owner", forKey: isolatedDefaultsOwnerKey)
     let owner = await Self.readOwner(defaults: defaults)
     XCTAssertEqual(owner, "owner")
-    XCTAssertEqual(defaults.string(forKey: "auth_userId"), "owner")
+    XCTAssertEqual(defaults.string(forKey: isolatedDefaultsOwnerKey), "owner")
   }
 
   private nonisolated static func readOwner(defaults: UserDefaults) async -> String? {
-    defaults.string(forKey: "auth_userId")
+    defaults.string(forKey: isolatedDefaultsOwnerKey)
   }
 
   @MainActor
@@ -20,10 +22,10 @@ final class IsolatedTestDefaultsTests: XCTestCase {
     // XCTest runs teardown blocks in reverse registration order. Keep a defaults
     // reference alive until after the helper's teardown has removed its domain.
     addTeardownBlock {
-      XCTAssertNil(retainedDefaults?.string(forKey: "auth_userId"))
+      XCTAssertNil(retainedDefaults?.string(forKey: isolatedDefaultsOwnerKey))
     }
     retainedDefaults = try makeIsolatedDefaults()
-    retainedDefaults?.set("owner", forKey: "auth_userId")
+    retainedDefaults?.set("owner", forKey: isolatedDefaultsOwnerKey)
   }
 
   func testFixturesKeepTheSameAuthKeyIndependentAndCleanOnlyTheirOwnedDomain() throws {
@@ -31,7 +33,7 @@ final class IsolatedTestDefaultsTests: XCTestCase {
     let firstDefaults = try first.makeDefaults()
     let second = IsolatedTestDefaults()
     let secondDefaults = try second.makeDefaults()
-    let key = "auth_userId"
+    let key = isolatedDefaultsOwnerKey
     firstDefaults.set("owner-a", forKey: key)
     XCTAssertNil(secondDefaults.string(forKey: key))
     secondDefaults.set("owner-b", forKey: key)
@@ -47,8 +49,8 @@ final class IsolatedTestDefaultsTests: XCTestCase {
   func testReleasingFixtureCleansDomainEvenWhenDefaultsAreRetained() throws {
     var fixture: IsolatedTestDefaults? = IsolatedTestDefaults()
     let defaults = try XCTUnwrap(fixture).makeDefaults()
-    defaults.set("owner", forKey: "auth_userId")
+    defaults.set("owner", forKey: isolatedDefaultsOwnerKey)
     fixture = nil
-    XCTAssertNil(defaults.string(forKey: "auth_userId"))
+    XCTAssertNil(defaults.string(forKey: isolatedDefaultsOwnerKey))
   }
 }

--- a/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
+++ b/desktop/macos/Desktop/Tests/IsolatedTestDefaultsTests.swift
@@ -2,6 +2,19 @@ import XCTest
 
 final class IsolatedTestDefaultsTests: XCTestCase {
   @MainActor
+  func testDefaultsHandleCanCrossIntoANonisolatedAsyncAPI() async throws {
+    let defaults = try makeIsolatedDefaults()
+    defaults.set("owner", forKey: "auth_userId")
+    let owner = await Self.readOwner(defaults: defaults)
+    XCTAssertEqual(owner, "owner")
+    XCTAssertEqual(defaults.string(forKey: "auth_userId"), "owner")
+  }
+
+  private nonisolated static func readOwner(defaults: UserDefaults) async -> String? {
+    defaults.string(forKey: "auth_userId")
+  }
+
+  @MainActor
   func testXCTestHelperCleansDomainBeforeEarlierTeardownBlocks() throws {
     var retainedDefaults: UserDefaults?
     // XCTest runs teardown blocks in reverse registration order. Keep a defaults
@@ -14,24 +27,26 @@ final class IsolatedTestDefaultsTests: XCTestCase {
   }
 
   func testFixturesKeepTheSameAuthKeyIndependentAndCleanOnlyTheirOwnedDomain() throws {
-    let first = try IsolatedTestDefaults()
-    let second = try IsolatedTestDefaults()
+    let first = IsolatedTestDefaults()
+    let firstDefaults = try first.makeDefaults()
+    let second = IsolatedTestDefaults()
+    let secondDefaults = try second.makeDefaults()
     let key = "auth_userId"
-    first.defaults.set("owner-a", forKey: key)
-    XCTAssertNil(second.defaults.string(forKey: key))
-    second.defaults.set("owner-b", forKey: key)
+    firstDefaults.set("owner-a", forKey: key)
+    XCTAssertNil(secondDefaults.string(forKey: key))
+    secondDefaults.set("owner-b", forKey: key)
 
     XCTAssertNotEqual(first.suiteName, second.suiteName)
-    XCTAssertEqual(first.defaults.string(forKey: key), "owner-a")
+    XCTAssertEqual(firstDefaults.string(forKey: key), "owner-a")
     first.cleanUp()
     first.cleanUp()
-    XCTAssertNil(first.defaults.string(forKey: key))
-    XCTAssertEqual(second.defaults.string(forKey: key), "owner-b")
+    XCTAssertNil(firstDefaults.string(forKey: key))
+    XCTAssertEqual(secondDefaults.string(forKey: key), "owner-b")
   }
 
   func testReleasingFixtureCleansDomainEvenWhenDefaultsAreRetained() throws {
-    var fixture: IsolatedTestDefaults? = try IsolatedTestDefaults()
-    let defaults = try XCTUnwrap(fixture?.defaults)
+    var fixture: IsolatedTestDefaults? = IsolatedTestDefaults()
+    let defaults = try XCTUnwrap(fixture).makeDefaults()
     defaults.set("owner", forKey: "auth_userId")
     fixture = nil
     XCTAssertNil(defaults.string(forKey: "auth_userId"))

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -608,12 +608,8 @@ import XCTest
       XCTAssertEqual(deleteBackendCalls, [false])
     }
 
-    func testTemporaryAutomationOwnerKeepsFaultResetOnKernelBoundary() async {
-      let suiteName = "KernelTurnRecordedProjectionTests.\(UUID().uuidString)"
-      guard let defaults = UserDefaults(suiteName: suiteName) else {
-        return XCTFail("failed to create isolated defaults")
-      }
-      defer { defaults.removePersistentDomain(forName: suiteName) }
+    func testTemporaryAutomationOwnerKeepsFaultResetOnKernelBoundary() async throws {
+      let defaults = try makeIsolatedDefaults()
 
       let provider = ChatProvider()
       let surface = provider.mainChatSurfaceReference()
@@ -876,19 +872,14 @@ import XCTest
     /// standard domain is shared with every other suite process on the runner (cfprefsd
     /// routes it past `CFFIXED_USER_HOME`), and a concurrent suite that has `auth_userId`
     /// set there turns this into a no-op transition that leaves the revocation in place.
-    func testAnOwnerTransitionDissolvesAnOutstandingRevocation() async {
+    func testAnOwnerTransitionDissolvesAnOutstandingRevocation() async throws {
+      let defaults = try makeIsolatedDefaults()
       var observedInsideBody: Bool?
 
       await RuntimeOwnerIdentity.withEffectiveOwnerTransitionForTests {
         XCTAssertTrue(
           RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress,
           "precondition: the revocation is outstanding on entry")
-
-        let suiteName = "KernelTurnRecordedProjectionTests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-          return XCTFail("failed to create isolated defaults")
-        }
-        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         await RuntimeOwnerIdentity.withAutomationOwnerIfMissing(
           "revocation-dissolve-owner",

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -873,10 +873,10 @@ import XCTest
     /// routes it past `CFFIXED_USER_HOME`), and a concurrent suite that has `auth_userId`
     /// set there turns this into a no-op transition that leaves the revocation in place.
     func testAnOwnerTransitionDissolvesAnOutstandingRevocation() async throws {
-      let defaults = try makeIsolatedDefaults()
       var observedInsideBody: Bool?
 
-      await RuntimeOwnerIdentity.withEffectiveOwnerTransitionForTests {
+      try await RuntimeOwnerIdentity.withEffectiveOwnerTransitionForTests {
+        let defaults = try makeIsolatedDefaults()
         XCTAssertTrue(
           RuntimeOwnerIdentity.effectiveOwnerTransitionInProgress,
           "precondition: the revocation is outstanding on entry")

--- a/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
+++ b/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
@@ -1,0 +1,30 @@
+import Foundation
+import XCTest
+
+/// Owns only its unique domain; cleanup cannot remove another fixture's keys.
+final class IsolatedTestDefaults {
+  let suiteName = "omi.tests.\(UUID().uuidString)"
+  let defaults: UserDefaults
+
+  init() throws {
+    defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+  }
+
+  func cleanUp() {
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  deinit {
+    cleanUp()
+  }
+}
+
+extension XCTestCase {
+  /// Teardown retains the domain owner even if the subject retains the defaults.
+  @MainActor
+  func makeIsolatedDefaults() throws -> UserDefaults {
+    let fixture = try IsolatedTestDefaults()
+    addTeardownBlock { fixture.cleanUp() }
+    return fixture.defaults
+  }
+}

--- a/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
+++ b/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
@@ -22,7 +22,6 @@ final class IsolatedTestDefaults: Sendable {
 
 extension XCTestCase {
   /// Teardown retains the domain identity, never the subject's defaults handle.
-  @MainActor
   func makeIsolatedDefaults() throws -> sending UserDefaults {
     let fixture = IsolatedTestDefaults()
     addTeardownBlock { fixture.cleanUp() }

--- a/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
+++ b/desktop/macos/Desktop/Tests/Support/IsolatedTestDefaults.swift
@@ -2,16 +2,17 @@ import Foundation
 import XCTest
 
 /// Owns only its unique domain; cleanup cannot remove another fixture's keys.
-final class IsolatedTestDefaults {
+final class IsolatedTestDefaults: Sendable {
   let suiteName = "omi.tests.\(UUID().uuidString)"
-  let defaults: UserDefaults
 
-  init() throws {
-    defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+  /// Return an independently owned handle. Retaining that handle in a teardown
+  /// closure would bind it to XCTest's actor and prevent async API injection.
+  func makeDefaults() throws -> sending UserDefaults {
+    try XCTUnwrap(UserDefaults(suiteName: suiteName))
   }
 
   func cleanUp() {
-    defaults.removePersistentDomain(forName: suiteName)
+    UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
   }
 
   deinit {
@@ -20,11 +21,11 @@ final class IsolatedTestDefaults {
 }
 
 extension XCTestCase {
-  /// Teardown retains the domain owner even if the subject retains the defaults.
+  /// Teardown retains the domain identity, never the subject's defaults handle.
   @MainActor
-  func makeIsolatedDefaults() throws -> UserDefaults {
-    let fixture = try IsolatedTestDefaults()
+  func makeIsolatedDefaults() throws -> sending UserDefaults {
+    let fixture = IsolatedTestDefaults()
     addTeardownBlock { fixture.cleanUp() }
-    return fixture.defaults
+    return try fixture.makeDefaults()
   }
 }

--- a/desktop/macos/Desktop/Tests/Support/ManualRunLoopTimerScheduler.swift
+++ b/desktop/macos/Desktop/Tests/Support/ManualRunLoopTimerScheduler.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@testable import Omi_Computer
+
+/// Uses real, unscheduled timers so invalidation is measured without introducing
+/// run-loop sources. Advancing time and delivering a tick are separate operations.
+@MainActor
+final class ManualRunLoopTimerScheduler {
+  private(set) var now = Date(timeIntervalSince1970: 1_700_000_000)
+  private(set) var timers: [Timer] = []
+
+  var activeTimerCount: Int { timers.filter(\.isValid).count }
+
+  func schedule(interval: TimeInterval, tick: @escaping @MainActor () -> Void) -> OwnedRunLoopTimer {
+    let timer = Timer(timeInterval: interval, repeats: true) { _ in
+      MainActor.assumeIsolated { tick() }
+    }
+    timers.append(timer)
+    return OwnedRunLoopTimer(timer)
+  }
+
+  func advance(by interval: TimeInterval) {
+    now.addTimeInterval(interval)
+  }
+
+  func fire() {
+    for timer in timers where timer.isValid {
+      timer.fire()
+    }
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260912-desktop-agent-guardrails.json
+++ b/desktop/macos/changelog/unreleased/20260912-desktop-agent-guardrails.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved chat scrolling cleanup and made desktop automation clearly identify actions that change data."
+}

--- a/desktop/macos/changelog/unreleased/20260912-desktop-agent-guardrails.json
+++ b/desktop/macos/changelog/unreleased/20260912-desktop-agent-guardrails.json
@@ -1,3 +1,3 @@
 {
-  "change": "Improved chat scrolling cleanup and made desktop automation clearly identify actions that change data."
+  "change": "Improved chat scrolling reliability and added read-only automation that blocks actions which can change app or account data."
 }

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -4,6 +4,8 @@ tier: 2
 description: Hermetic chat in Home tab — send/receive with Rust OMI_LLM_STUB=1 (v0.12.119+ redesign — chat is embedded in Home, not a separate tab)
 app: non-prod
 covers:
+  # The harness records /capabilities before dispatching these chat actions.
+  - desktop/macos/Desktop/Sources/Automation/DesktopAutomationActionEffect.swift
   - desktop/macos/Desktop/Sources/Chat/ChatTurnFailureNotice.swift
   - desktop/macos/Desktop/Sources/Chat/ChatAttachmentOnlySend.swift
   - desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift
@@ -32,6 +34,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ToolActivityTimelineLayout.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/OwnedRunLoopTimer.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
   # The grounded follow-up chip, S6-S10. The stub gained one delimiter-carrying
   # reply so a tail is reachable hermetically at all; S8 asserts the split by

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -34,6 +34,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Components/ToolActivityTimelineLayout.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatInputView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatScrollBehavior.swift
+  # S0 observes actual common-runloop sources after explicit cancel and owner release.
   - desktop/macos/Desktop/Sources/MainWindow/Components/OwnedRunLoopTimer.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
   # The grounded follow-up chip, S6-S10. The stub gained one delimiter-carrying
@@ -101,6 +102,16 @@ preconditions:
   - automation_bridge_ready
 
 steps:
+  - id: S0
+    name: Verify chat timer sources are invalidated on cancel and owner release
+    bridge.action:
+      name: chat_timer_lifetime_probe
+    expect:
+      result.detail.scheduled: "true"
+      result.detail.cancelledValid: "false"
+      result.detail.releasedValid: "false"
+    halt_on_failure: true
+
   - id: S1
     name: Reset main chat for flow isolation
     bridge.action:

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Guard Swift collection construction and keep brittle desktop tests from growing.
 
-The checker enforces three lessons from recurring macOS bug fixes:
+The checker enforces four lessons from recurring macOS bug fixes:
 
 1. `Dictionary(uniqueKeysWithValues:)` is a process-terminating assertion when
    external or persisted data contains a duplicate key. Production code must use
@@ -14,6 +14,10 @@ The checker enforces three lessons from recurring macOS bug fixes:
 3. Wall-clock sleeps make tests timing-dependent. Existing debt is ratcheted;
    new tests should inject a clock, await a signal, or annotate an unavoidable
    integration wait with a reason.
+4. Direct shared UserDefaults mutations let parallel suites change each other's
+   auth owner (#13260). Existing debt is ratcheted; use makeIsolatedDefaults()
+   and inject the returned instance. This is a static tripwire, not alias or
+   interprocedural analysis of all shared state.
 
 Escapes are deliberately local (same line or immediately preceding line):
 
@@ -25,6 +29,9 @@ Escapes are deliberately local (same line or immediately preceding line):
 
   // omi-test-quality: wall-clock-wait -- exercises the real scheduler integration
   try await Task.sleep(for: .milliseconds(10))
+
+  // omi-test-quality: shared-defaults -- integration: exercises a singleton with no defaults seam
+  UserDefaults.standard.set(testOwner, forKey: .authUserId)
 
 The collection escape is only for uniqueness proven by a static type contract.
 The source-inspection escape is only for forbidden-pattern/static wiring
@@ -47,6 +54,7 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 SOURCE_INSPECTION_FILE_BASELINE = 53
 SOURCE_INSPECTION_SITE_BASELINE = 143
 WALL_CLOCK_WAIT_BASELINE = 16
+SHARED_DEFAULTS_MUTATION_BASELINE = 292
 
 MIN_REASON_LENGTH = 12
 
@@ -59,6 +67,14 @@ COLLECTION_SAFETY_GUIDANCE = (
 COLLECTION_ANNOTATION_RE = re.compile(r"//\s*omi-collection-safety:\s*static-unique-keys(?:\s*--\s*(.*?))?\s*$")
 SOURCE_ANNOTATION_RE = re.compile(r"//\s*omi-test-quality:\s*source-inspection(?:\s*--\s*(.*?))?\s*$")
 WAIT_ANNOTATION_RE = re.compile(r"//\s*omi-test-quality:\s*wall-clock-wait(?:\s*--\s*(.*?))?\s*$")
+
+DEFAULTS_ANNOTATION_RE = re.compile(r"//\s*omi-test-quality:\s*shared-defaults(?:\s*--\s*(.*?))?\s*$")
+SHARED_DEFAULTS_MUTATION_RE = re.compile(
+    r"\bUserDefaults\s*\.\s*standard\s*\.\s*"
+    r"(?:set|removeObject|register|setPersistentDomain|removePersistentDomain|"
+    r"setVolatileDomain|removeVolatileDomain|addSuite|removeSuite)\s*\(",
+    re.MULTILINE,
+)
 
 STRING_READ_RE = re.compile(r"\bString\s*\(\s*contentsOf(?:File)?\s*:", re.MULTILINE)
 WALL_CLOCK_WAIT_RE = re.compile(
@@ -90,6 +106,7 @@ class ScanReport:
     collection_findings: tuple[Finding, ...]
     source_findings: tuple[Finding, ...]
     wait_findings: tuple[Finding, ...]
+    defaults_findings: tuple[Finding, ...]
     annotation_findings: tuple[Finding, ...]
 
 
@@ -257,14 +274,16 @@ def _annotation_allows(
     *,
     require_static_contract: bool,
     path: str,
+    required_prefix: str | None = None,
 ) -> tuple[bool, Finding | None]:
     annotated = _annotation_line(lines, line, annotation_re)
     if annotated is None:
         return False, None
     annotation_line, match = annotated
     reason = (match.group(1) or "").strip()
-    if require_static_contract:
-        prefix = "static contract:"
+    if require_static_contract or required_prefix:
+        prefix = "static contract:" if require_static_contract else required_prefix
+        assert prefix is not None
         valid = reason.lower().startswith(prefix) and len(reason[len(prefix) :].strip()) >= MIN_REASON_LENGTH
         expectation = f"a '{prefix}' reason of at least {MIN_REASON_LENGTH} characters"
     else:
@@ -344,6 +363,7 @@ def scan_swift_file(path: Path, *, relative_path: str, role: str) -> ScanReport:
     collection_findings: list[Finding] = []
     source_findings: list[Finding] = []
     wait_findings: list[Finding] = []
+    defaults_findings: list[Finding] = []
     annotation_findings: list[Finding] = []
 
     if role == "production":
@@ -417,10 +437,34 @@ def scan_swift_file(path: Path, *, relative_path: str, role: str) -> ScanReport:
                     )
                 )
 
+        for match in SHARED_DEFAULTS_MUTATION_RE.finditer(masked):
+            line = _line_number(text, match.start())
+            allowed, invalid = _annotation_allows(
+                lines,
+                line,
+                DEFAULTS_ANNOTATION_RE,
+                require_static_contract=False,
+                required_prefix="integration:",
+                path=relative_path,
+            )
+            if invalid is not None:
+                annotation_findings.append(invalid)
+            if not allowed:
+                defaults_findings.append(
+                    Finding(
+                        category="shared-defaults",
+                        path=relative_path,
+                        line=line,
+                        excerpt=_line_excerpt(lines, line),
+                        message="test mutates shared defaults instead of an owned unique domain",
+                    )
+                )
+
     return ScanReport(
         collection_findings=tuple(collection_findings),
         source_findings=tuple(source_findings),
         wait_findings=tuple(wait_findings),
+        defaults_findings=tuple(defaults_findings),
         annotation_findings=tuple(annotation_findings),
     )
 
@@ -442,6 +486,7 @@ def scan_repository(root: Path) -> ScanReport:
         collection_findings=tuple(finding for report in reports for finding in report.collection_findings),
         source_findings=tuple(finding for report in reports for finding in report.source_findings),
         wait_findings=tuple(finding for report in reports for finding in report.wait_findings),
+        defaults_findings=tuple(finding for report in reports for finding in report.defaults_findings),
         annotation_findings=tuple(finding for report in reports for finding in report.annotation_findings),
     )
 
@@ -463,11 +508,13 @@ def main() -> int:
     source_files = len({finding.path for finding in report.source_findings})
     source_sites = len(report.source_findings)
     wait_sites = len(report.wait_findings)
+    defaults_sites = len(report.defaults_findings)
 
     if args.print_findings:
         _print_findings(report.collection_findings)
         _print_findings(report.source_findings)
         _print_findings(report.wait_findings)
+        _print_findings(report.defaults_findings)
         _print_findings(report.annotation_findings)
         print(
             "\n"
@@ -475,6 +522,7 @@ def main() -> int:
             f"production-source inspection: {source_files} files / {source_sites} sites "
             f"(baselines {SOURCE_INSPECTION_FILE_BASELINE} / {SOURCE_INSPECTION_SITE_BASELINE})\n"
             f"wall-clock waits: {wait_sites} (baseline {WALL_CLOCK_WAIT_BASELINE})\n"
+            f"shared defaults mutations: {defaults_sites} (baseline {SHARED_DEFAULTS_MUTATION_BASELINE})\n"
             f"invalid annotations: {len(report.annotation_findings)}"
         )
         return 0
@@ -517,6 +565,15 @@ def main() -> int:
             "unavoidable integration wait and include the reason.",
             file=sys.stderr,
         )
+    if defaults_sites > SHARED_DEFAULTS_MUTATION_BASELINE:
+        failed = True
+        print(
+            f"FAIL: direct shared defaults mutations rose to {defaults_sites} "
+            f"(baseline {SHARED_DEFAULTS_MUTATION_BASELINE}). Use makeIsolatedDefaults() and inject it; "
+            "#13260 showed shared auth domains racing between suites. Only a real singleton "
+            "integration boundary may use a local shared-defaults annotation with an integration: reason.",
+            file=sys.stderr,
+        )
     if failed:
         print(
             "See counted sites with: python3 desktop/macos/scripts/check_desktop_test_quality.py --print",
@@ -531,11 +588,14 @@ def main() -> int:
         )
     if wait_sites < WALL_CLOCK_WAIT_BASELINE:
         notes.append("wall-clock-wait debt fell; lower WALL_CLOCK_WAIT_BASELINE")
+    if defaults_sites < SHARED_DEFAULTS_MUTATION_BASELINE:
+        notes.append("shared-defaults debt fell; lower SHARED_DEFAULTS_MUTATION_BASELINE")
     if notes:
         print("NOTE: " + "; ".join(notes) + ".")
     print(
         "OK: no trapping dictionary initializers; desktop test-quality debt at or below "
-        f"baseline ({source_files} source-reading files / {source_sites} sites, {wait_sites} waits)."
+        f"baseline ({source_files} source-reading files / {source_sites} sites, {wait_sites} waits, "
+        f"{defaults_sites} shared defaults mutations)."
     )
     return 0
 

--- a/desktop/macos/scripts/omi-ctl
+++ b/desktop/macos/scripts/omi-ctl
@@ -178,7 +178,8 @@ Usage:
   omi-ctl wait-ready [tries]             Block until a live signed-in owner-ready main state (0.5s/try)
   omi-ctl screens                        List valid screen targets
   omi-ctl actions                        List semantic actions the app exposes
-  omi-ctl action <name> [key=value ...]  Run a semantic action (cursor-free, in-process)
+  omi-ctl action <name> [--read-only] [key=value ...]
+                                         Run a semantic action; --read-only rejects actions with declared effects
 
 Examples:
   omi-ctl navigate rewind
@@ -187,6 +188,7 @@ Examples:
   omi-ctl navigate settings rewind       # Settings page, Rewind sub-section
   omi-ctl wait-ready && omi-ctl navigate memories
   omi-ctl actions                        # discover available actions
+  omi-ctl action permissions_snapshot --read-only
   omi-ctl action refresh_all_data
   omi-ctl action toggle_transcription enabled=false
 

--- a/desktop/macos/scripts/omi-ctl
+++ b/desktop/macos/scripts/omi-ctl
@@ -97,7 +97,7 @@ print(path)
   actions)
     curl_bridge "$BASE/actions"; echo ;;
   action)
-    name="${1:?usage: omi-ctl action <name> [key=value ...]}"; shift || true
+    name="${1:?usage: omi-ctl action <name> [--read-only] [key=value ...]}"; shift || true
     body="$(python3 - "$name" "$@" <<'PY'
 import json
 import sys
@@ -105,6 +105,9 @@ import sys
 body = {"name": sys.argv[1]}
 params = {}
 for argument in sys.argv[2:]:
+    if argument == "--read-only":
+        body["readOnly"] = True
+        continue
     key, separator, value = argument.partition("=")
     if not separator or not key:
         raise SystemExit("omi-ctl: action parameters must be nonempty key=value pairs")

--- a/desktop/macos/scripts/tests/test_check_desktop_test_quality.py
+++ b/desktop/macos/scripts/tests/test_check_desktop_test_quality.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -113,6 +115,65 @@ class TestQualityRatchetTests(unittest.TestCase):
         self.assertIsNone(CHECKER.WALL_CLOCK_WAIT_RE.search(masked))
 
 
+class SharedDefaultsRatchetTests(unittest.TestCase):
+    def scan_text(self, text: str):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "Fixture.swift"
+            path.write_text(text)
+            return CHECKER.scan_swift_file(path, relative_path=path.name, role="test")
+
+    def test_counts_direct_multiline_mutations_but_not_reads_or_owned_defaults(self) -> None:
+        report = self.scan_text("""UserDefaults.standard.set("owner", forKey: "auth_userId")
+UserDefaults
+  .standard
+  .removeObject(forKey: "auth_userId")
+UserDefaults.standard.setPersistentDomain([:], forName: "domain")
+UserDefaults.standard.register(defaults: [:])
+UserDefaults.standard.string(forKey: "auth_userId")
+let defaults = try makeIsolatedDefaults()
+defaults.set("owner", forKey: "auth_userId")
+// UserDefaults.standard.removeObject(forKey: "comment")
+let prose = "UserDefaults.standard.set(true, forKey: key)"
+""")
+        self.assertEqual([finding.line for finding in report.defaults_findings], [1, 2, 5, 6])
+        self.assertEqual(report.annotation_findings, ())
+
+    def test_integration_escape_is_local_and_requires_a_reason(self) -> None:
+        report = self.scan_text("""// omi-test-quality: shared-defaults -- integration: singleton has no defaults injection seam
+UserDefaults.standard.set("owner", forKey: "auth_userId")
+UserDefaults.standard.removeObject(forKey: "unannotated")
+// omi-test-quality: shared-defaults -- convenient setup is not an integration boundary
+UserDefaults.standard.removeObject(forKey: "invalid")
+// omi-test-quality: shared-defaults -- integration: short
+UserDefaults.standard.removeObject(forKey: "short")
+""")
+        self.assertEqual([finding.line for finding in report.defaults_findings], [3, 5, 7])
+        self.assertEqual([finding.line for finding in report.annotation_findings], [4, 6])
+
+    def test_no_increase_boundary_is_enforced_by_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / CHECKER.COLLECTION_ROOT).mkdir(parents=True)
+            tests = root / CHECKER.TEST_ROOT
+            tests.mkdir(parents=True)
+            fixture = tests / "Legacy.swift"
+            mutation = 'UserDefaults.standard.removeObject(forKey: "auth_userId")\n'
+            for count, expected_status in [
+                (CHECKER.SHARED_DEFAULTS_MUTATION_BASELINE, 0),
+                (CHECKER.SHARED_DEFAULTS_MUTATION_BASELINE + 1, 1),
+            ]:
+                with self.subTest(count=count):
+                    fixture.write_text(mutation * count)
+                    result = subprocess.run(
+                        [sys.executable, str(SCRIPT_PATH), "--root", str(root)],
+                        capture_output=True, text=True, check=False,
+                    )
+                    self.assertEqual(result.returncode, expected_status, result.stdout + result.stderr)
+                    if expected_status:
+                        self.assertIn("makeIsolatedDefaults()", result.stderr)
+                        self.assertIn("#13260", result.stderr)
+
+
 class GuardrailWiringTests(unittest.TestCase):
     def test_component_suite_and_manifest_run_the_guard(self) -> None:
         suite = (REPO_ROOT / "desktop/macos/scripts/swift-test-suites.sh").read_text()
@@ -122,6 +183,8 @@ class GuardrailWiringTests(unittest.TestCase):
         self.assertIn('python3 "$SCRIPT_DIR/check_desktop_test_quality.py"', suite)
         self.assertIn("desktop-test-quality", manifest)
         self.assertIn("check_desktop_test_quality.py", manifest)
+        self.assertIn("desktop-test-quality-fixtures", manifest)
+        self.assertIn("test_check_desktop_test_quality.py", manifest)
 
 
 if __name__ == "__main__":

--- a/desktop/macos/tests/test-omi-ctl-action.sh
+++ b/desktop/macos/tests/test-omi-ctl-action.sh
@@ -45,6 +45,11 @@ assert json.loads(request.read_text()) == {
 result = run("permissions_snapshot")
 assert result.returncode == 0, result.stderr
 assert json.loads(request.read_text()) == {"name": "permissions_snapshot"}
+result = run("about_snapshot", "--read-only", "label=--read-only")
+assert result.returncode == 0, result.stderr
+assert json.loads(request.read_text()) == {
+    "name": "about_snapshot", "readOnly": True, "params": {"label": "--read-only"}
+}
 for argument in ("missing-separator", "=missing-key"):
     request.unlink(missing_ok=True)
     result = run("set_conversations_search", argument)


### PR DESCRIPTION
Desktop automation inferred safety from action names, allowing mutating probes and loading snapshots to appear read-only. Require typed effects at every registration, derive discovery descriptions from them, and add opt-in `omi-ctl action <name> --read-only` dispatch that rejects effects before calling handlers. Migrate the entire registry, including asynchronous and parameter-dependent effects, and pin historical misleading probes in registry/HTTP regression tests.

Add a shared defaults-domain fixture with teardown ownership, a cancellable run-loop timer token with automatic invalidation, and an injected clock/scheduler for deterministic chat-scroll tests. Migrate the two owner-projection defaults fixtures and chat glide/pinner timers. Extend the existing test-quality ratchet to reject growth beyond the current 292 direct shared-defaults mutations; narrowly documented integration exceptions remain possible. Existing debt is preserved for gradual migration.

These are declared product effects, not a sandbox: Swift still needs correct effect annotations. The defaults matcher covers direct mutations, not aliases. Timer lifetime tests retain real run-loop coverage alongside deterministic clock tests. No app launch or backend access was used for validation.

Validation in `/Volumes/scratch/worktrees/omi/desktop-agent-guardrails`, based on `d5cbd548f6`, using host Xcode 26.6 / 17F113:

- Normal committed-diff `git push` gate passes, including debug compilation (82.95s), desktop tool/launcher fixtures, and metadata validation.
- `make setup` and `OMI_PR_BODY_FILE=/tmp/omi-agent-guardrails-pr-body.md make preflight`: 29 checks pass (93.69s); metadata checks pass, including exact growth allowances below.
- Full desktop test-target compilation with `xcrun swift build --package-path desktop/macos/Desktop --build-tests` passes. This caught and corrected actor-region ownership in the actual migrated projection tests.
- `CFFIXED_USER_HOME=<task-owned directory> xcrun swift test --package-path desktop/macos/Desktop -j 4 --filter 'DesktopAutomationActionEffectTests|DesktopAutomationBridgeRouteTests|DesktopAutomationSecondaryActionTests|AgentContinuityGauntletTests|IsolatedTestDefaultsTests|UserScrollDetectorTests|ChatScrollLiveEdgeTests|ChatPressPromotionPolicyTests|KernelTurnRecordedProjectionTests'`: 145 tests pass, including actual run-loop lifetime and injected clock coverage.
- Static quality checker plus its 15 fixtures, CLI wire tests, strict flow coverage mapping, pinned Swift formatting/SwiftLint, and independent source review pass. The timer negative-control experiment fails both owner-release cases when token invalidation is removed.

Hosted pinned Xcode 16.4 validation remains CI evidence. Flow coverage was checked statically; chat-hermetic now asserts actual common-runloop timer validity after cancel and owner release via chat_timer_lifetime_probe. The probe is executed by the focused Swift suite; no full live UI flow was run.

Product invariants preserved: INV-CHAT-1, INV-CHAT-2, INV-NAV-1, INV-VOICE-1, INV-TASK-1, INV-TASK-2.
Failure-Class: FC-run-loop-timer-outlives-owner

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 5019 -> 5117 | Compiler-required effect declarations at existing registration owners; the enum policy is extracted into its own file.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift | 1591 -> 1593 | Compiler-required effect declarations at existing registration owners; the enum policy is extracted into its own file.

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift | 3701 -> 3705 | Compiler-required effect declarations at existing registration owners; the enum policy is extracted into its own file.

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift | 6689 -> 6698 | Compiler-required effect declarations at existing registration owners; the enum policy is extracted into its own file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


