### PR TITLE
fix(python-sdk): preserve query params and build valid Parakeet WS URLs

### DIFF
--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -5,12 +5,28 @@ import json
 import os
 from asyncio import Queue
 from typing import Callable, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 
 def parakeet_ws_url(api_url: str, sample_rate: int = 16000) -> str:
-    base = api_url.strip().rstrip("/")
-    base = base.replace("https://", "wss://").replace("http://", "ws://")
-    return f"{base}/v3/stream?sample_rate={sample_rate}"
+    """Append the stream path, preserving query values and overriding sample_rate."""
+    base = urlsplit(api_url.strip())
+    scheme = {"https": "wss", "http": "ws"}.get(base.scheme, base.scheme)
+    query = [
+        (key, value)
+        for key, value in parse_qsl(base.query, keep_blank_values=True)
+        if key != "sample_rate"
+    ]
+    query.append(("sample_rate", str(sample_rate)))
+    return urlunsplit(
+        (
+            scheme,
+            base.netloc,
+            base.path.rstrip("/") + "/v3/stream",
+            urlencode(query),
+            "",
+        )
+    )
 
 
 class ParakeetTranscriber:

--- a/sdks/python/tests/test_parakeet_url.py
+++ b/sdks/python/tests/test_parakeet_url.py
@@ -1,0 +1,71 @@
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from omi.stt.parakeet import parakeet_ws_url
+
+
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        (
+            "https://parakeet.example/",
+            "wss://parakeet.example/v3/stream?sample_rate=16000",
+        ),
+        (
+            "http://localhost:8080/proxy/",
+            "ws://localhost:8080/proxy/v3/stream?sample_rate=16000",
+        ),
+        (
+            "wss://parakeet.example",
+            "wss://parakeet.example/v3/stream?sample_rate=16000",
+        ),
+    ],
+)
+def test_plain_base_urls_remain_supported(base, expected):
+    assert parakeet_ws_url(base) == expected
+
+
+def test_query_belongs_after_stream_path():
+    result = urlsplit(
+        parakeet_ws_url("https://parakeet.example/proxy?tenant=demo", 8000)
+    )
+    assert result.path == "/proxy/v3/stream"
+    assert parse_qs(result.query) == {"tenant": ["demo"], "sample_rate": ["8000"]}
+
+
+def test_url_inside_query_is_not_rewritten():
+    result = urlsplit(
+        parakeet_ws_url("https://parakeet.example?origin=https://demo.example/")
+    )
+    assert parse_qs(result.query)["origin"] == ["https://demo.example/"]
+
+
+def test_query_preserves_repeated_and_blank_values():
+    result = urlsplit(
+        parakeet_ws_url("https://parakeet.example?tag=a&tag=b&empty=&token=a%2Bb%2F")
+    )
+    assert parse_qs(result.query, keep_blank_values=True) == {
+        "tag": ["a", "b"],
+        "empty": [""],
+        "token": ["a+b/"],
+        "sample_rate": ["16000"],
+    }
+
+
+def test_explicit_sample_rate_replaces_existing_query_value():
+    result = urlsplit(
+        parakeet_ws_url(
+            "https://parakeet.example?sample_rate=8000&sample_rate=44100", 16000
+        )
+    )
+    assert parse_qs(result.query) == {"sample_rate": ["16000"]}
+
+
+def test_fragment_is_not_sent_to_websocket():
+    result = urlsplit(
+        parakeet_ws_url("https://parakeet.example/proxy?tenant=demo#section")
+    )
+    assert result.fragment == ""
+    assert result.path == "/proxy/v3/stream"
+    assert parse_qs(result.query) == {"tenant": ["demo"], "sample_rate": ["16000"]}


### PR DESCRIPTION
## What

`sdks/python`: building the Parakeet streaming endpoint by string concatenation drops an
existing query string and can produce an invalid WebSocket handshake target. This composes
the endpoint from its parsed parts so query parameters survive, and adds regression tests for
query-bearing and plain base URLs.

## Why

`parakeet.py` derived the socket path with naive concatenation. With a base URL that carries a
query string, the resulting target was wrong: the handshake requested the wrong path. The
upstream service answered the wrong resource instead of the requested one.

Observed locally before the fix (local WebSocket harness, no hosted service involved):

- wrong request target on the wire for a query-bearing base URL
- after the fix: correct target, and synthetic audio/transcript round-trip delivered

## Changes

- `sdks/python/omi/stt/parakeet.py` — parse the base URL and compose the WebSocket target from
  its parts, so existing query parameters are preserved and the handshake path is valid.
- `sdks/python/tests/test_parakeet_url.py` — new regression tests.

## Tests

Five new regression cases fail on the unpatched baseline and pass with the fix; three control
cases pass on both. Full Python SDK suite: **32 passed** on Python 3.12.10.

```
python -m pytest sdks/python/tests -q
```

Also exercised a real local WebSocket exchange against the harness: before the fix the wrong
request target was sent; after the fix the target is correct and synthetic audio/transcript is
delivered.

## Not exercised

No hosted Parakeet service run and no hardware test this session — verification is the local
suite plus a local WebSocket harness. Saying so explicitly rather than implying a live service
was exercised.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

