### PR TITLE
feat(python-cli): export conversation transcripts as SRT

### DIFF
--- a/_commit_msg.txt
+++ b/_commit_msg.txt
@@ -1,0 +1,22 @@
+fix(python-cli): address SRT export review feedback
+
+Automated review flagged real gaps in the initial SRT export. Changes:
+
+- Honor the global --json contract: with --json the subtitles are emitted as a
+  {"format": "srt", "srt": ...} JSON object instead of raw text, so stdout stays
+  machine-readable for callers.
+- Skip non-finite segment starts. JSON decoding can yield NaN/Infinity, which
+  previously reached int(round(seconds * 1000)) and raised instead of being
+  treated as an unusable timestamp.
+- Order cues by start time. The endpoint does not promise a sorted list and SRT
+  readers expect a monotonic timeline.
+- Fold blank lines inside cue text. A blank line terminates a cue, so an
+  embedded one produced a malformed extra cue.
+- Write CRLF throughout. newline="" on write only disables translation; the
+  line breaks themselves have to be CRLF, including inside cue text.
+- Refuse to overwrite an existing --output target unless --force is passed.
+- Document --format/--output/--force in the CLI reference and README.
+
+Tests: sdks/python-cli suite 408 passed. New cases cover JSON mode, cue order,
+blank-line folding, non-finite starts, overwrite refusal, the --force path, and
+the JSON --output path.

--- a/docs/doc/developer/cli/commands.mdx
+++ b/docs/doc/developer/cli/commands.mdx
@@ -84,7 +84,7 @@ Visibility: `public` or `private`.
 | Command                                       | Endpoint                                                       |
 | --------------------------------------------- | -------------------------------------------------------------- |
 | `omi conversation list [...filters]`          | `GET /v1/dev/user/conversations`                               |
-| `omi conversation get ID [--include-transcript]` | `GET /v1/dev/user/conversations/{id}`                       |
+| `omi conversation get ID [--include-transcript] [--format json\|srt] [--output FILE] [--force]` | `GET /v1/dev/user/conversations/{id}`                       |
 | `omi conversation create --text ... [...]`    | `POST /v1/dev/user/conversations`                              |
 | `omi conversation from-segments FILE.json [--source ...]` | `POST /v1/dev/user/conversations/from-segments`    |
 | `omi conversation update ID [--title ... --discarded/--no-discarded]` | `PATCH /v1/dev/user/conversations/{id}` |
@@ -95,6 +95,23 @@ The `--text` flag accepts `-` to read from stdin:
 ```bash
 cat meeting_notes.md | omi conversation create --text - --text-source message
 ```
+
+`omi conversation get` can export the timed transcript as SRT. This needs
+`--include-transcript`, because the API only returns `transcript_segments` when it is set:
+
+```bash
+# to stdout
+omi conversation get CONVERSATION_ID --include-transcript --format srt
+
+# to a file; refuses to overwrite an existing one unless --force is passed
+omi conversation get CONVERSATION_ID --include-transcript --format srt \
+  --output transcript.srt
+```
+
+Cues are ordered by start time, segments without a usable start time are skipped rather
+than given a fabricated timestamp, and output uses CRLF line endings. With the global
+`--json` flag the subtitles are returned as a `{"format": "srt", "srt": "..."}` object so
+stdout stays machine-readable.
 
 ## `omi action-item`
 

--- a/sdks/python-cli/README.md
+++ b/sdks/python-cli/README.md
@@ -213,7 +213,7 @@ omi
 │   └── delete <id> [-y]
 ├── conversation
 │   ├── list [--limit N] [--start-date ...] [--end-date ...] [--include-transcript]
-│   ├── get <id> [--include-transcript]
+│   ├── get <id> [--include-transcript] [--format json|srt] [--output FILE] [--force]
 │   ├── create [--text ...] [--text-source ...] [...]
 │   ├── from-segments <file.json> [--source ...]
 │   ├── update <id> [--title ...] [--discarded/--no-discarded]

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -32,6 +32,80 @@ def _ctx(typer_ctx: typer.Context) -> "AppContext":
 
 _LIST_COLUMNS = ["id", "title", "category", "started_at", "source"]
 
+#: SRT timestamps are ``HH:MM:SS,mmm`` and address a zero-based timeline, so a
+#: negative offset has no representation. Clamping keeps a segment that starts a
+#: few milliseconds before the conversation timeline from producing ``-1:-1:-1``.
+_SRT_MAX_MILLISECONDS = 99 * 3600 * 1000 + 59 * 60 * 1000 + 59 * 1000 + 999
+
+
+def _segment_start_seconds(segment: dict) -> Optional[float]:
+    """Return the segment start in seconds, or ``None`` when it has no usable one."""
+    for key in ("start", "start_seconds", "start_time"):
+        value = segment.get(key)
+        if isinstance(value, bool):  # bool is an int subclass; not a timestamp
+            continue
+        if isinstance(value, (int, float)):
+            return float(value)
+    for key in ("start_timestamp", "started_at", "start_time"):
+        value = segment.get(key)
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                continue
+    return None
+
+
+def _format_srt_timestamp(seconds: float) -> str:
+    """Format seconds as an SRT timestamp (``HH:MM:SS,mmm``).
+
+    SRT has no negative or sub-hour fields beyond two digits, so values are
+    clamped into the representable range instead of printing something a player
+    would reject.
+    """
+    milliseconds = int(round(seconds * 1000))
+    if milliseconds < 0:
+        milliseconds = 0
+    elif milliseconds > _SRT_MAX_MILLISECONDS:
+        milliseconds = _SRT_MAX_MILLISECONDS
+    hours, remainder = divmod(milliseconds, 3600 * 1000)
+    minutes, remainder = divmod(remainder, 60 * 1000)
+    secs, millis = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def _segments_to_srt(segments: list) -> str:
+    """Convert ``transcript_segments`` into SRT.
+
+    Segments without a usable start time are skipped rather than emitted with a
+    fabricated timestamp: a wrong cue time is worse than a missing cue because
+    it silently desynchronises the whole caption track. A segment with no end
+    falls back to its own start so the cue stays valid for the one frame.
+    """
+    blocks: list[str] = []
+    index = 0
+    for segment in segments or []:
+        if not isinstance(segment, dict):
+            continue
+        start = _segment_start_seconds(segment)
+        if start is None:
+            continue
+        end = _segment_start_seconds({"start": segment.get("end")})
+        if end is None or end < start:
+            end = start
+        text = segment.get("text")
+        if text is None:
+            continue
+        text = str(text).strip()
+        if not text:
+            continue
+        index += 1
+        blocks.append(
+            f"{index}\n{_format_srt_timestamp(start)} --> {_format_srt_timestamp(end)}\n{text}\n"
+        )
+    return "\n".join(blocks)
+
+
 
 @app.command("list", help="List conversations.")
 def list_conversations(
@@ -83,13 +157,47 @@ def get_conversation(
     typer_ctx: typer.Context,
     conversation_id: str = typer.Argument(..., help="Conversation ID."),
     include_transcript: bool = typer.Option(False, "--include-transcript"),
+    format: str = typer.Option("json", "--format", help="Output format: json or srt."),
+    output: Optional[Path] = typer.Option(None, "--output", help="Write the result to this file."),
 ) -> None:
     ctx = _ctx(typer_ctx)
+
+    srt_format = format.lower()
+    if srt_format not in ("json", "srt"):
+        raise UsageError(
+            message=f"Unsupported --format: {format}",
+            detail="Supported formats are 'json' (default) and 'srt'.",
+        )
+    if srt_format == "srt" and not include_transcript:
+        raise UsageError(
+            message="--format srt requires --include-transcript",
+            detail="SRT is built from transcript segments, which the API only returns when "
+            "--include-transcript is set.",
+        )
+
     with ctx.make_client() as client:
         result = client.get(
             f"/v1/dev/user/conversations/{conversation_id}",
             params={"include_transcript": include_transcript},
         )
+
+    if srt_format == "srt":
+        subtitles = _segments_to_srt((result or {}).get("transcript_segments") or [])
+        if output is not None:
+            # newline="" keeps the CRLF line endings SRT consumers expect instead
+            # of letting Python translate them per platform.
+            output.write_text(subtitles, encoding="utf-8", newline="")
+            ctx.renderer.success(f"Wrote [bold]{output}[/bold]")
+            return
+        # Subtitles go to stdout unchanged: routing them through the renderer would
+        # reflow the very cue text a player reads.
+        typer.echo(subtitles, nl=False)
+        return
+
+    if output is not None:
+        output.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        ctx.renderer.success(f"Wrote [bold]{output}[/bold]")
+        return
     ctx.renderer.emit(result, title="conversation")
 
 

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import math
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -37,6 +39,12 @@ _LIST_COLUMNS = ["id", "title", "category", "started_at", "source"]
 #: few milliseconds before the conversation timeline from producing ``-1:-1:-1``.
 _SRT_MAX_MILLISECONDS = 99 * 3600 * 1000 + 59 * 60 * 1000 + 59 * 1000 + 999
 
+#: A cue ends at the first blank line, so embedded blank lines inside one
+#: segment's text would split it into a malformed extra cue. Line endings are
+#: matched explicitly because a lone LF is itself a line break in SRT, and CRLF is
+#: the form written below.
+_SRT_BLANK_LINE = re.compile(r"(?:\r?\n)[ \t]*(?:\r?\n)+")
+
 
 def _segment_start_seconds(segment: dict) -> Optional[float]:
     """Return the segment start in seconds, or ``None`` when it has no usable one."""
@@ -45,14 +53,18 @@ def _segment_start_seconds(segment: dict) -> Optional[float]:
         if isinstance(value, bool):  # bool is an int subclass; not a timestamp
             continue
         if isinstance(value, (int, float)):
-            return float(value)
+            # JSON decoding can yield NaN/Infinity, which has no SRT timestamp and
+            # would raise on the later int() conversion instead of being skipped.
+            return float(value) if math.isfinite(value) else None
     for key in ("start_timestamp", "started_at", "start_time"):
         value = segment.get(key)
         if isinstance(value, str):
             try:
-                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+                seconds = datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
             except ValueError:
                 continue
+            if math.isfinite(seconds):
+                return seconds
     return None
 
 
@@ -63,6 +75,8 @@ def _format_srt_timestamp(seconds: float) -> str:
     clamped into the representable range instead of printing something a player
     would reject.
     """
+    if not math.isfinite(seconds):
+        seconds = 0.0
     milliseconds = int(round(seconds * 1000))
     if milliseconds < 0:
         milliseconds = 0
@@ -74,6 +88,18 @@ def _format_srt_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
 
 
+def _cue_text(segment: dict) -> Optional[str]:
+    """Return the cue text, with blank lines folded and line endings normalised."""
+    text = segment.get("text")
+    if text is None:
+        return None
+    # Fold blank lines first (they terminate a cue), then make every remaining
+    # break CRLF so the cue's internal breaks match the separator written below.
+    folded = _SRT_BLANK_LINE.sub("\n", str(text))
+    normalised = re.sub(r"\r\n|\r|\n", "\r\n", folded).strip()
+    return normalised or None
+
+
 def _segments_to_srt(segments: list) -> str:
     """Convert ``transcript_segments`` into SRT.
 
@@ -81,9 +107,12 @@ def _segments_to_srt(segments: list) -> str:
     fabricated timestamp: a wrong cue time is worse than a missing cue because
     it silently desynchronises the whole caption track. A segment with no end
     falls back to its own start so the cue stays valid for the one frame.
+
+    Cues are ordered by start time. The endpoint does not promise a sorted
+    stored-list order, and SRT readers expect a monotonic timeline, so relying on
+    the response order would emit cues out of sequence.
     """
-    blocks: list[str] = []
-    index = 0
+    prepared: list[tuple[float, float, str]] = []
     for segment in segments or []:
         if not isinstance(segment, dict):
             continue
@@ -93,17 +122,21 @@ def _segments_to_srt(segments: list) -> str:
         end = _segment_start_seconds({"start": segment.get("end")})
         if end is None or end < start:
             end = start
-        text = segment.get("text")
+        text = _cue_text(segment)
         if text is None:
             continue
-        text = str(text).strip()
-        if not text:
-            continue
-        index += 1
-        blocks.append(
-            f"{index}\n{_format_srt_timestamp(start)} --> {_format_srt_timestamp(end)}\n{text}\n"
-        )
-    return "\n".join(blocks)
+        prepared.append((start, end, text))
+
+    # sort() is stable, so segments sharing a start time keep their input order.
+    prepared.sort(key=lambda cue: cue[0])
+
+    # SRT consumers expect CRLF, so both the in-cue line breaks and the blank
+    # separator line are explicit; without this, LF reaches the file unchanged.
+    blocks = [
+        f"{index}\r\n{_format_srt_timestamp(start)} --> {_format_srt_timestamp(end)}\r\n{text}\r\n"
+        for index, (start, end, text) in enumerate(prepared, start=1)
+    ]
+    return "\r\n".join(blocks)
 
 
 
@@ -159,6 +192,7 @@ def get_conversation(
     include_transcript: bool = typer.Option(False, "--include-transcript"),
     format: str = typer.Option("json", "--format", help="Output format: json or srt."),
     output: Optional[Path] = typer.Option(None, "--output", help="Write the result to this file."),
+    force: bool = typer.Option(False, "--force", help="Overwrite --output if it already exists."),
 ) -> None:
     ctx = _ctx(typer_ctx)
 
@@ -174,6 +208,12 @@ def get_conversation(
             detail="SRT is built from transcript segments, which the API only returns when "
             "--include-transcript is set.",
         )
+    if output is not None and output.exists() and not force:
+        # Re-running an export should not silently destroy an earlier transcript.
+        raise UsageError(
+            message=f"Refusing to overwrite existing file: {output}",
+            detail="Pass --force to overwrite it.",
+        )
 
     with ctx.make_client() as client:
         result = client.get(
@@ -184,10 +224,13 @@ def get_conversation(
     if srt_format == "srt":
         subtitles = _segments_to_srt((result or {}).get("transcript_segments") or [])
         if output is not None:
-            # newline="" keeps the CRLF line endings SRT consumers expect instead
-            # of letting Python translate them per platform.
             output.write_text(subtitles, encoding="utf-8", newline="")
             ctx.renderer.success(f"Wrote [bold]{output}[/bold]")
+            return
+        if ctx.renderer.json_mode:
+            # --json promises machine-readable output on stdout. Raw subtitle text
+            # is not JSON, so it is returned as a field of the JSON envelope.
+            ctx.renderer.emit({"format": "srt", "srt": subtitles})
             return
         # Subtitles go to stdout unchanged: routing them through the renderer would
         # reflow the very cue text a player reads.

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -122,9 +122,9 @@ def test_conversation_get_srt_writes_stdout(authed_profile, respx_mock, cli_runn
     result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
 
     assert result.exit_code == 0, result.output
-    # Cue numbering starts at 1, timestamps are comma-separated, and cues are blank-line separated.
-    assert result.stdout.startswith("1\n00:00:00,000 --> 00:00:01,000\nhi\n")
-    assert "2\n00:00:01,500 --> 00:00:02,500\nhello\n" in result.stdout
+    # SRT consumers expect CRLF; cue numbering starts at 1 and timestamps use a comma.
+    assert result.stdout.startswith("1\r\n00:00:00,000 --> 00:00:01,000\r\nhi\r\n")
+    assert "2\r\n00:00:01,500 --> 00:00:02,500\r\nhello\r\n" in result.stdout
 
 
 def test_conversation_get_srt_writes_file(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
@@ -139,8 +139,9 @@ def test_conversation_get_srt_writes_file(authed_profile, respx_mock, cli_runner
     )
 
     assert result.exit_code == 0, result.output
-    written = target.read_text(encoding="utf-8")
-    assert written.startswith("1\n00:00:00,000 --> 00:00:01,000\nhi\n")
+    # Read as bytes: text mode would translate CRLF and hide the line endings.
+    written = target.read_bytes().decode("utf-8")
+    assert written.startswith("1\r\n00:00:00,000 --> 00:00:01,000\r\nhi\r\n")
     assert "hello" in written
 
 
@@ -161,7 +162,7 @@ def test_conversation_get_srt_skips_segments_without_start(authed_profile, respx
     # The untimed segment is dropped rather than given a fabricated cue time; the
     # surviving cue keeps index 1 so the track stays contiguous.
     assert "no timestamp" not in result.stdout
-    assert result.stdout.startswith("1\n00:00:03,000 --> 00:00:04,000\nkept\n")
+    assert result.stdout.startswith("1\r\n00:00:03,000 --> 00:00:04,000\r\nkept\r\n")
 
 
 def test_conversation_get_srt_clamps_negative_start(authed_profile, respx_mock, cli_runner) -> None:
@@ -172,7 +173,135 @@ def test_conversation_get_srt_clamps_negative_start(authed_profile, respx_mock, 
     result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
 
     assert result.exit_code == 0, result.output
-    assert result.stdout.startswith("1\n00:00:00,000 --> 00:00:00,500\nearly\n")
+    assert result.stdout.startswith("1\r\n00:00:00,000 --> 00:00:00,500\r\nearly\r\n")
+
+
+def test_conversation_get_srt_orders_cues_by_start(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "transcript_segments": [
+                {"text": "second", "start": 5.0, "end": 6.0},
+                {"text": "first", "start": 1.0, "end": 2.0},
+            ],
+        }
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    assert result.exit_code == 0, result.output
+    # The response order is not guaranteed to be a timeline, and SRT readers need one.
+    assert result.stdout.index("first") < result.stdout.index("second")
+    assert result.stdout.startswith("1\r\n00:00:01,000 --> 00:00:02,000\r\nfirst\r\n")
+
+
+def test_conversation_get_srt_folds_blank_lines_in_text(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "transcript_segments": [{"text": "para one\n\npara two", "start": 0.0, "end": 1.0}],
+        }
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    assert result.exit_code == 0, result.output
+    # A blank line ends a cue, so an embedded one would emit a malformed extra cue.
+    assert "\r\n\r\n" not in result.stdout.strip()
+    assert "para one\r\npara two" in result.stdout
+
+def test_conversation_get_srt_skips_non_finite_start(authed_profile, respx_mock, cli_runner) -> None:
+    # Sent as raw JSON text: Python's strict JSON encoder refuses NaN, but a real
+    # server can emit it and the CLI's own decoder accepts it.
+    payload = (
+        '{"id": "c1", "transcript_segments": ['
+        '{"text": "nan start", "start": NaN, "end": 1.0},'
+        '{"text": "inf start", "start": Infinity, "end": 1.0},'
+        '{"text": "kept", "start": 1.0, "end": 2.0}]}'
+    )
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        content=payload, headers={"content-type": "application/json"}
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    # Non-finite starts must be skipped, not crash the export on int() conversion.
+    assert result.exit_code == 0, result.output
+    assert "nan start" not in result.stdout
+    assert "inf start" not in result.stdout
+    assert result.stdout.startswith("1\r\n00:00:01,000 --> 00:00:02,000\r\nkept\r\n")
+
+
+def test_conversation_get_srt_output_refuses_overwrite(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+    target = tmp_path / "transcript.srt"
+    target.write_text("previous export", encoding="utf-8")
+
+    result = cli_runner.invoke(
+        app,
+        ["conversation", "get", "c1", "--include-transcript", "--format", "srt", "--output", str(target)],
+    )
+
+    assert result.exit_code == 1
+    assert "Refusing to overwrite" in result.stderr
+    assert target.read_text(encoding="utf-8") == "previous export"
+
+
+def test_conversation_get_srt_output_overwrites_with_force(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+    target = tmp_path / "transcript.srt"
+    target.write_text("previous export", encoding="utf-8")
+
+    result = cli_runner.invoke(
+        app,
+        [
+            "conversation",
+            "get",
+            "c1",
+            "--include-transcript",
+            "--format",
+            "srt",
+            "--output",
+            str(target),
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert target.read_bytes().decode("utf-8").startswith("1\r\n00:00:00,000")
+
+
+def test_conversation_get_srt_json_mode_stays_json(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+
+    result = cli_runner.invoke(
+        app, ["--json", "conversation", "get", "c1", "--include-transcript", "--format", "srt"]
+    )
+
+    assert result.exit_code == 0, result.output
+    # --json reserves stdout for a JSON payload; raw subtitle text would break callers.
+    payload = json.loads(result.stdout)
+    assert payload["format"] == "srt"
+    assert payload["srt"].startswith("1\r\n00:00:00,000 --> 00:00:01,000\r\nhi\r\n")
+
+
+def test_conversation_get_json_output_writes_file(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+    target = tmp_path / "conversation.json"
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--output", str(target)])
+
+    assert result.exit_code == 0, result.output
+    # The JSON path serializes separately from the renderer, so assert the payload.
+    assert json.loads(target.read_text(encoding="utf-8"))["id"] == "c1"
 
 
 def test_conversation_get_srt_requires_transcript_flag(authed_profile, cli_runner) -> None:

--- a/sdks/python-cli/tests/test_conversation.py
+++ b/sdks/python-cli/tests/test_conversation.py
@@ -106,3 +106,84 @@ def test_conversation_from_segments_rejects_invalid_unicode(config_path, respx_m
     assert result.exit_code == 1
     assert "Invalid JSON" in result.stderr
     assert not respx_mock.calls
+
+
+_TRANSCRIPT_SEGMENTS = [
+    {"text": "hi", "start": 0.0, "end": 1.0, "speaker": "SPEAKER_00"},
+    {"text": "hello", "start": 1.5, "end": 2.5, "speaker": "SPEAKER_01"},
+]
+
+
+def test_conversation_get_srt_writes_stdout(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    assert result.exit_code == 0, result.output
+    # Cue numbering starts at 1, timestamps are comma-separated, and cues are blank-line separated.
+    assert result.stdout.startswith("1\n00:00:00,000 --> 00:00:01,000\nhi\n")
+    assert "2\n00:00:01,500 --> 00:00:02,500\nhello\n" in result.stdout
+
+
+def test_conversation_get_srt_writes_file(authed_profile, respx_mock, cli_runner, tmp_path) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": _TRANSCRIPT_SEGMENTS}
+    )
+    target = tmp_path / "transcript.srt"
+
+    result = cli_runner.invoke(
+        app,
+        ["conversation", "get", "c1", "--include-transcript", "--format", "srt", "--output", str(target)],
+    )
+
+    assert result.exit_code == 0, result.output
+    written = target.read_text(encoding="utf-8")
+    assert written.startswith("1\n00:00:00,000 --> 00:00:01,000\nhi\n")
+    assert "hello" in written
+
+
+def test_conversation_get_srt_skips_segments_without_start(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={
+            "id": "c1",
+            "transcript_segments": [
+                {"text": "no timestamp"},
+                {"text": "kept", "start": 3.0, "end": 4.0},
+            ],
+        }
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    assert result.exit_code == 0, result.output
+    # The untimed segment is dropped rather than given a fabricated cue time; the
+    # surviving cue keeps index 1 so the track stays contiguous.
+    assert "no timestamp" not in result.stdout
+    assert result.stdout.startswith("1\n00:00:03,000 --> 00:00:04,000\nkept\n")
+
+
+def test_conversation_get_srt_clamps_negative_start(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations/c1").respond(
+        json={"id": "c1", "transcript_segments": [{"text": "early", "start": -0.25, "end": 0.5}]}
+    )
+
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--include-transcript", "--format", "srt"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.startswith("1\n00:00:00,000 --> 00:00:00,500\nearly\n")
+
+
+def test_conversation_get_srt_requires_transcript_flag(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--format", "srt"])
+
+    assert result.exit_code == 1
+    assert "--include-transcript" in result.stderr
+
+
+def test_conversation_get_rejects_unknown_format(authed_profile, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["conversation", "get", "c1", "--format", "vtt"])
+
+    assert result.exit_code == 1
+    assert "Unsupported --format" in result.stderr


### PR DESCRIPTION
## What

Adds SRT export to `omi conversation get`, so a conversation's timed transcript can move
straight into an editing or captioning workflow instead of needing a hand-written converter.

```
omi conversation get <ID> --include-transcript --format srt
omi conversation get <ID> --include-transcript --format srt --output transcript.srt
```

## Why

The CLI can already retrieve `transcript_segments` via `--include-transcript`, but had no way to
emit them as a subtitle file. Users writing their own converter is the only option today.

This follows the paid-bounty proposal in #13482 and the suggestion in that thread to add a
`--format srt` flag to the existing `get` command rather than introduce a separate verb.

## Changes

`sdks/python-cli/omi_cli/commands/conversation.py`

- `--format {json,srt}` (default `json`) and `--output PATH` on `omi conversation get`.
- `_segments_to_srt()` builds cue blocks from `transcript_segments`; `_format_srt_timestamp()`
  renders `HH:MM:SS,mmm`.
- `--format srt` requires `--include-transcript` — SRT is built from segments, which the API
  only returns when that flag is set. Asking for SRT without it is a usage error rather than a
  silently empty file.

## Edge cases handled

- **Segment with no usable start time is skipped, not faked.** A wrong cue time silently
  desynchronises the whole track, which is worse than a missing cue. Cue numbering stays
  contiguous across the gap.
- **Negative start is clamped to `00:00:00,000`.** SRT timestamps are zero-based with no sign,
  so a segment starting slightly before the conversation timeline would otherwise render as
  `-1:-1:-1`.
- **Missing or earlier-than-start `end`** falls back to the segment's own start.
- **Empty/whitespace text** is dropped.
- **File output uses `newline=""`** so Python does not translate the CRLF endings SRT
  consumers expect.
- **stdout output bypasses the renderer**, because rich reflowing would alter the cue text a
  player reads.

`--output` also applies to the JSON path, so `get` can be redirected to a file in either format.

## Tests

`sdks/python-cli/tests/test_conversation.py` — 17 passed:

```
python -m pytest tests/test_conversation.py -q
17 passed in 3.49s
```

New coverage: SRT to stdout, SRT to file, untimed segment skipped, negative start clamped,
`--format srt` without `--include-transcript` fails, unknown format fails.

## Not exercised

No live Developer API call was made — tests run against the mocked transport the existing
`conversation` tests already use. Saying so explicitly rather than implying a live run.

## Pre-existing failure, not from this change

`tests/test_auth_api_key.py::test_transport_failure_during_login_leaves_saved_config_unchanged`
fails on this checkout. I confirmed it fails identically with my changes stashed, so it is
unrelated to this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

