### PR TITLE
fix(ci): make development Pusher Firebase probe identity explicit

### DIFF
--- a/.github/workflows/gcp_backend_pusher_auto_deploy.yml
+++ b/.github/workflows/gcp_backend_pusher_auto_deploy.yml
@@ -80,6 +80,23 @@ jobs:
           python3 -m pip install -q pyyaml
           python3 backend/scripts/validate-backend-runtime-env.py --env "${{ vars.ENV }}"
 
+      - name: Validate Firebase probe signer configuration before publishing
+        env:
+          FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" ]]; then
+            echo "Development Pusher semantic probe requires FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT." >&2
+            exit 1
+          fi
+          case "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" in
+            *@based-hardware.iam.gserviceaccount.com) ;;
+            *)
+              echo "FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT must belong to the based-hardware Firebase project." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Verify live finalization alert route before publishing
         env:
           # Dest ops Grafana (monitor.omiapi.com). Do not use GRAFANA_TOKEN; that
@@ -185,29 +202,28 @@ jobs:
 
       - name: Probe deployed development Pusher finalization semantics
         env:
-          FIREBASE_SIGNER_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          # Development Pusher runs in based-hardware-dev but the backend it
+          # exercises authenticates against the production Firebase project.
+          # Sign through IAM as an explicitly named based-hardware principal;
+          # do not pass the dev deploy credential or materialize a key here.
+          FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}
         run: |
           set -euo pipefail
           umask 077
           python3 -m pip install -q websockets==12.0
           token_file="$(mktemp "$RUNNER_TEMP/omi-pusher-probe-token.XXXXXX")"
-          signer_file="$(mktemp "$RUNNER_TEMP/omi-pusher-probe-signer.XXXXXX")"
-          cleanup() {
-            rm -f "$token_file" "$signer_file"
-            unset FIREBASE_SIGNER_CREDENTIALS
-          }
+          cleanup() { rm -f "$token_file"; }
           trap cleanup EXIT
-          if [[ -z "$FIREBASE_SIGNER_CREDENTIALS" ]]; then
-            echo "Development Pusher semantic probe requires the existing GCP_CREDENTIALS Firebase signer." >&2
+          if [[ -z "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" ]]; then
+            echo "Development Pusher semantic probe requires FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT:" >&2
+            echo "a based-hardware signer this lane's deploy identity may impersonate." >&2
             exit 1
           fi
-          printf '%s' "$FIREBASE_SIGNER_CREDENTIALS" > "$signer_file"
           python3 backend/scripts/firebase_release_probe_token.py \
             --secret-project "${{ vars.GCP_PROJECT_ID }}" \
             --firebase-project based-hardware \
-            --signer-credentials-file "$signer_file" \
+            --signer-service-account "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT" \
             --token-output "$token_file"
-          rm -f "$signer_file"
           python3 backend/scripts/pusher_semantic_probe.py \
             --api-url https://api.omiapi.com \
             --bearer-token-file "$token_file" \
@@ -216,6 +232,17 @@ jobs:
             --namespace "${{ vars.ENV }}-omi-backend" \
             --run-id "$GITHUB_RUN_ID" \
             --output pusher-dev-semantic-probe.json
+
+      - name: Upload development Pusher probe diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pusher-dev-probe-diagnostics
+          path: |
+            pusher-dev-deployment-receipt.json
+            pusher-dev-semantic-probe.json
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Record development Pusher qualification evidence
         run: |

--- a/backend/scripts/firebase_release_probe_token.py
+++ b/backend/scripts/firebase_release_probe_token.py
@@ -86,9 +86,11 @@ def _access_secret(project: str) -> str:
     return value
 
 
-def _validated_service_account(account: str, stage: str) -> str:
+def _validated_service_account(account: str, stage: str, *, firebase_project: str | None = None) -> str:
     if '\n' in account or '@' not in account or not account.endswith('.gserviceaccount.com') or len(account) > 320:
         raise ProbeTokenError(stage)
+    if firebase_project is not None and not account.endswith(f'@{firebase_project}.iam.gserviceaccount.com'):
+        raise ProbeTokenError(stage, 'project_mismatch')
     return account
 
 
@@ -368,9 +370,17 @@ def mint_probe_token(
             # roles/iam.serviceAccountTokenCreator on that account) resolves
             # the mismatch without moving the runtime off production auth.
             service_account = (
-                _validated_service_account(signer_service_account, 'signer_service_account')
+                _validated_service_account(
+                    signer_service_account,
+                    'signer_service_account',
+                    firebase_project=firebase_project,
+                )
                 if signer_service_account
-                else _active_service_account()
+                else _validated_service_account(
+                    _active_service_account(),
+                    'service_account',
+                    firebase_project=firebase_project,
+                )
             )
             access_token = _access_token()
             custom_token = _signed_custom_token(service_account, access_token)

--- a/backend/tests/unit/test_firebase_release_probe_token.py
+++ b/backend/tests/unit/test_firebase_release_probe_token.py
@@ -43,7 +43,7 @@ def test_mint_probe_token_uses_fixed_uid_short_lived_custom_claims_and_discards_
         if stage == 'secret_access':
             return 'firebase-api-key-that-must-not-leak'
         if stage == 'service_account':
-            return 'deployer@omi-prod.iam.gserviceaccount.com'
+            return 'deployer@based-hardware.iam.gserviceaccount.com'
         return 'gcp-access-token-that-must-not-leak'
 
     def fake_request(url, *, body, access_token, stage):
@@ -167,7 +167,7 @@ def test_write_token_uses_owner_only_permissions(tmp_path):
 def test_mint_probe_token_rejects_a_token_for_a_different_firebase_auth_project(monkeypatch):
     module = _load_module()
     monkeypatch.setattr(module, '_access_secret', lambda _project: 'api-key-that-must-not-leak')
-    monkeypatch.setattr(module, '_active_service_account', lambda: 'deployer@omi-prod.iam.gserviceaccount.com')
+    monkeypatch.setattr(module, '_active_service_account', lambda: 'deployer@based-hardware.iam.gserviceaccount.com')
     monkeypatch.setattr(module, '_access_token', lambda: 'access-token-that-must-not-leak')
     monkeypatch.setattr(module, '_signed_custom_token', lambda _account, _token: 'custom-token-that-must-not-leak')
     monkeypatch.setattr(module, '_exchange_custom_token', lambda _custom, _key: _id_token(aud='wrong-project'))
@@ -178,6 +178,26 @@ def test_mint_probe_token_rejects_a_token_for_a_different_firebase_auth_project(
         assert error.stage == 'firebase_token_claims'
     else:
         raise AssertionError('expected Firebase auth-project mismatch')
+
+
+def test_remote_signer_rejects_a_cross_project_service_account_before_iam_signing(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, '_access_secret', lambda _project: 'api-key-that-must-not-leak')
+    monkeypatch.setattr(
+        module,
+        '_request_json',
+        lambda *_args, **_kwargs: pytest.fail('cross-project signer must be rejected before IAM signing'),
+    )
+
+    with pytest.raises(module.ProbeTokenError) as caught:
+        module.mint_probe_token(
+            'based-hardware-dev',
+            'based-hardware',
+            signer_service_account='firebase-adminsdk@based-hardware-dev.iam.gserviceaccount.com',
+        )
+
+    assert caught.value.stage == 'signer_service_account'
+    assert caught.value.error_class == 'project_mismatch'
 
 
 @pytest.mark.skipif(
@@ -354,7 +374,7 @@ def test_explicit_signer_service_account_signs_as_the_firebase_projects_account(
         return 'gcp-access-token-that-must-not-leak'
 
     def fake_request(url, *, body, access_token, stage):
-        requests.append((url, stage))
+        requests.append((url, body, stage))
         if stage == 'custom_token_signing':
             return {'signedJwt': 'custom-token-that-must-not-leak'}
         return {'idToken': _id_token(), 'refreshToken': 'refresh-token-that-must-not-leak'}
@@ -365,8 +385,14 @@ def test_explicit_signer_service_account_signs_as_the_firebase_projects_account(
 
     signer = 'firebase-adminsdk-4z2mm@based-hardware.iam.gserviceaccount.com'
     assert module.mint_probe_token('based-hardware-dev', 'based-hardware', signer_service_account=signer) == _id_token()
-    signing_url = requests[0][0]
+    signing_url, signing_body, signing_stage = requests[0]
+    assert signing_stage == 'custom_token_signing'
     assert 'firebase-adminsdk-4z2mm%40based-hardware.iam.gserviceaccount.com' in signing_url
+    claims = json.loads(signing_body['payload'])
+    assert claims['iss'] == signer
+    assert claims['sub'] == signer
+    assert claims['aud'] == module.CUSTOM_TOKEN_AUDIENCE
+    assert claims['uid'] == module.PROBE_UID
 
 
 def test_signer_service_account_must_look_like_a_service_account(monkeypatch):

--- a/backend/tests/unit/test_pusher_deployment_control_workflow.py
+++ b/backend/tests/unit/test_pusher_deployment_control_workflow.py
@@ -69,16 +69,34 @@ def test_prod_evidence_failure_halts_before_any_registry_or_helm_mutation() -> N
 
 
 def test_dev_qualification_runs_real_deployed_semantic_probe_before_recording_pass() -> None:
+    signer_preflight = AUTO.index("Validate Firebase probe signer configuration before publishing")
     probe = AUTO.index("Probe deployed development Pusher finalization semantics")
+    build = AUTO.index("- name: Build and Push Docker image")
+    diagnostics = AUTO.index("Upload development Pusher probe diagnostics")
     qualification = AUTO.index("Record development Pusher qualification evidence")
     upload = AUTO.index("Upload development Pusher qualification")
     probe_block = AUTO[probe:qualification]
     qualification_block = AUTO[qualification:upload]
 
+    assert signer_preflight < build < probe < diagnostics < qualification < upload
+    assert (
+        "FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}"
+        in AUTO[signer_preflight:build]
+    )
+    assert "@based-hardware.iam.gserviceaccount.com" in AUTO[signer_preflight:build]
     assert "firebase_release_probe_token.py" in probe_block
     assert "pusher_semantic_probe.py" in probe_block
     assert "https://api.omiapi.com" in probe_block
-    assert "secrets.GCP_CREDENTIALS" in probe_block
+    assert "FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT: ${{ vars.FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT }}" in probe_block
+    assert '--signer-service-account "$FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT"' in probe_block
+    assert "--firebase-project based-hardware" in probe_block
+    assert "secrets.GCP_CREDENTIALS" not in probe_block
+    assert "secrets.GCP_SERVICE_ACCOUNT" not in probe_block
+    assert "--signer-credentials-file" not in probe_block
+    diagnostics_block = AUTO[diagnostics:qualification]
+    assert "if: always()" in diagnostics_block
+    assert "pusher-dev-deployment-receipt.json" in diagnostics_block
+    assert "pusher-dev-semantic-probe.json" in diagnostics_block
     assert "--semantic-probe-evidence pusher-dev-semantic-probe.json" in qualification_block
     assert "NOT_RUN" not in qualification_block
 


### PR DESCRIPTION
## Product invariants affected

- INV-DATA-1

Failure-Class: FC-release-probe-signer-identity

## Summary

Use an explicitly named Firebase-project service account for the development Pusher semantic probe, reject cross-project remote signers, fail before publishing when signer configuration is missing or from the wrong project, and retain non-secret probe diagnostics on failure.

## Verification

- Focused Pusher/Firebase tests: 36 passed
- Backend changed-surface CI-shaped runner: passed, exit 0
- actionlint, Black, and git diff checks: passed
- Workspace preflight: 37 checks passed

## Operational prerequisite

Set the Development environment variable `FIREBASE_PROBE_SIGNER_SERVICE_ACCOUNT` to an approved `@based-hardware.iam.gserviceaccount.com` account and grant the deployment principal `roles/iam.serviceAccountTokenCreator` on that account. No IAM or deployment changes are included in this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

