### PR TITLE
fix(shopify): paginate create_order product and discount lookups

### DIFF
--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -26,6 +26,7 @@ from db import (
     get_default_store,
     get_user_settings,
 )
+from shopify_paging import fetch_all_pages
 from models import (
     ChatToolResponse,
     ShopifyOrder,
@@ -1044,12 +1045,18 @@ async def tool_create_order(request: Request):
         else:
             return ChatToolResponse(error="Please provide a customer name or email.")
         
-        # Fetch all products once for matching
+        # Fetch all products once for matching (Shopify caps each page at 250)
         print(f"📦 Fetching all products from store...")
-        all_products_result = shopify_api_request(uid, "GET", "/products.json", params={"limit": 250, "status": "active"})
-        print(f"📦 Products API response: {all_products_result}")
+        all_products_result = fetch_all_pages(
+            shopify_api_request,
+            uid,
+            "/products.json",
+            "products",
+            params={"status": "active"},
+        )
+        print(f"📦 Products API response pages={all_products_result.get('page_count')} capped={all_products_result.get('capped')} error={all_products_result.get('error')}")
         all_products = []
-        if "error" in all_products_result:
+        if "error" in all_products_result and not all_products_result.get("products"):
             print(f"❌ Products API error: {all_products_result['error']}")
         else:
             all_products = all_products_result.get("products", [])
@@ -1346,14 +1353,18 @@ async def tool_create_order(request: Request):
             # Apply discount code to draft order if provided
             if discount_code:
                 print(f"🏷️ Looking up discount code: {discount_code}")
-                discount_result = shopify_api_request(
-                    uid, "GET", "/price_rules.json", 
-                    params={"limit": 250}
+                discount_result = fetch_all_pages(
+                    shopify_api_request,
+                    uid,
+                    "/price_rules.json",
+                    "price_rules",
                 )
                 
                 applied_discount = None
-                if "error" not in discount_result:
-                    price_rules = discount_result.get("price_rules", [])
+                price_rules = discount_result.get("price_rules") or []
+                if "error" in discount_result and not price_rules:
+                    print(f"⚠️ Could not fetch price rules: {discount_result['error']}")
+                if price_rules:
                     for rule in price_rules:
                         # Get discount codes for this rule
                         codes_result = shopify_api_request(

--- a/plugins/omi-shopify-app/shopify_paging.py
+++ b/plugins/omi-shopify-app/shopify_paging.py
@@ -1,0 +1,78 @@
+"""Bounded since_id pagination for Shopify REST list endpoints.
+
+Shopify's REST Admin API returns at most 250 records per page. Callers that
+treat a single page as the full collection silently drop the rest of the catalog.
+This helper follows the same since_id loop already used for analytics orders.
+"""
+from typing import Any, Callable, Dict, List, Optional
+
+SHOPIFY_PAGE_SIZE = 250
+SHOPIFY_MAX_PAGES = 10
+
+RequestFn = Callable[..., Dict[str, Any]]
+
+
+def fetch_all_pages(
+    request_fn: RequestFn,
+    uid: str,
+    endpoint: str,
+    resource_key: str,
+    params: Optional[Dict[str, Any]] = None,
+    *,
+    max_pages: int = SHOPIFY_MAX_PAGES,
+    page_size: int = SHOPIFY_PAGE_SIZE,
+) -> Dict[str, Any]:
+    """GET a list endpoint until a short page, an error, or max_pages.
+
+    Returns a dict with `resource_key` (the concatenated records). On the first
+    page, a request error is returned as-is so callers keep their existing
+    fallback. Later-page errors keep records already collected and set `error` plus
+    `partial`. When the page cap is hit on a full last page, `capped` is True.
+    """
+    page_params: Dict[str, Any] = dict(params or {})
+    page_params["limit"] = page_size
+    items: List[Any] = []
+    page_count = 0
+    last_id = None
+    capped = False
+
+    while page_count < max_pages:
+        this_params = dict(page_params)
+        if last_id is not None:
+            this_params["since_id"] = last_id
+        result = request_fn(uid, "GET", endpoint, params=this_params)
+        if "error" in result:
+            if page_count == 0:
+                return result
+            print(
+                f"⚠️ {endpoint} page {page_count + 1} error after {len(items)} "
+                f"{resource_key}: {result['error']}"
+            )
+            return {
+                resource_key: items,
+                "page_count": page_count,
+                "partial": True,
+                "capped": False,
+                "error": result["error"],
+            }
+        page_items = result.get(resource_key) or []
+        items.extend(page_items)
+        page_count += 1
+        if len(page_items) < page_size:
+            break
+        last_id = page_items[-1].get("id") if page_items else None
+        if last_id is None:
+            break
+    else:
+        capped = True
+        print(
+            f"⚠️ {endpoint} pagination cap reached "
+            f"({max_pages} pages, {len(items)} {resource_key})"
+        )
+
+    return {
+        resource_key: items,
+        "page_count": page_count,
+        "partial": False,
+        "capped": capped,
+    }

--- a/plugins/omi-shopify-app/test_shopify_paging.py
+++ b/plugins/omi-shopify-app/test_shopify_paging.py
@@ -1,0 +1,98 @@
+"""Regression tests for Shopify REST since_id pagination.
+
+These tests drive the production helper through a fake request seam. A store
+with more than 250 products or price rules used to be truncated at the first
+page; that is the bug that would have been caught here.
+"""
+import unittest
+
+from shopify_paging import SHOPIFY_MAX_PAGES, SHOPIFY_PAGE_SIZE, fetch_all_pages
+
+
+def _page(resource_key, start, count):
+    return {resource_key: [{"id": i, "title": f"item-{i}"} for i in range(start, start + count)]}
+
+
+class FetchAllPagesTest(unittest.TestCase):
+    def test_single_short_page(self):
+        calls = []
+
+        def request_fn(uid, method, endpoint, params=None):
+            calls.append(params)
+            return _page("products", 1, 3)
+
+        result = fetch_all_pages(request_fn, "u1", "/products.json", "products")
+        self.assertEqual(len(result["products"]), 3)
+        self.assertEqual(result["page_count"], 1)
+        self.assertFalse(result["capped"])
+        self.assertEqual(len(calls), 1)
+        self.assertNotIn("since_id", calls[0])
+
+    def test_walks_since_id_until_short_page(self):
+        calls = []
+
+        def request_fn(uid, method, endpoint, params=None):
+            calls.append(dict(params or {}))
+            since = (params or {}).get("since_id")
+            if since is None:
+                return _page("products", 1, SHOPIFY_PAGE_SIZE)
+            if since == SHOPIFY_PAGE_SIZE:
+                return _page("products", 251, SHOPIFY_PAGE_SIZE)
+            if since == 500:
+                return _page("products", 501, 10)
+            self.fail(f"unexpected since_id {since}")
+
+        result = fetch_all_pages(
+            request_fn, "u1", "/products.json", "products", params={"status": "active"}
+        )
+        self.assertEqual(len(result["products"]), 510)
+        self.assertEqual(result["page_count"], 3)
+        self.assertFalse(result["capped"])
+        self.assertEqual(calls[0]["status"], "active")
+        self.assertEqual(calls[1]["since_id"], SHOPIFY_PAGE_SIZE)
+        self.assertEqual(calls[2]["since_id"], 500)
+
+    def test_first_page_error_is_returned_unchanged(self):
+        def request_fn(uid, method, endpoint, params=None):
+            return {"error": "User not authenticated with Shopify"}
+
+        result = fetch_all_pages(request_fn, "u1", "/products.json", "products")
+        self.assertEqual(result, {"error": "User not authenticated with Shopify"})
+
+    def test_later_page_error_keeps_collected_records(self):
+        def request_fn(uid, method, endpoint, params=None):
+            if (params or {}).get("since_id"):
+                return {"error": "timeout"}
+            return _page("price_rules", 1, SHOPIFY_PAGE_SIZE)
+
+        result = fetch_all_pages(request_fn, "u1", "/price_rules.json", "price_rules")
+        self.assertEqual(len(result["price_rules"]), SHOPIFY_PAGE_SIZE)
+        self.assertTrue(result["partial"])
+        self.assertEqual(result["error"], "timeout")
+
+    def test_cap_on_full_pages(self):
+        def request_fn(uid, method, endpoint, params=None):
+            since = (params or {}).get("since_id") or 0
+            start = since + 1
+            return _page("products", start, SHOPIFY_PAGE_SIZE)
+
+        result = fetch_all_pages(
+            request_fn, "u1", "/products.json", "products", max_pages=3
+        )
+        self.assertEqual(len(result["products"]), 3 * SHOPIFY_PAGE_SIZE)
+        self.assertEqual(result["page_count"], 3)
+        self.assertTrue(result["capped"])
+
+    def test_default_cap_is_ten_pages(self):
+        def request_fn(uid, method, endpoint, params=None):
+            since = (params or {}).get("since_id") or 0
+            return _page("products", since + 1, SHOPIFY_PAGE_SIZE)
+
+        result = fetch_all_pages(request_fn, "u1", "/products.json", "products")
+        self.assertEqual(result["page_count"], SHOPIFY_MAX_PAGES)
+        self.assertTrue(result["capped"])
+        self.assertEqual(len(result["products"]), SHOPIFY_MAX_PAGES * SHOPIFY_PAGE_SIZE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #13560.

`create_order` treated a single Shopify REST page (max 250 records) as the full catalog. Product matching and discount-code lookup therefore silently missed anything past the first page. Analytics already paginated `/orders.json` with `since_id`; this PR reuses that pattern for `/products.json` (`status=active`) and `/price_rules.json`.

- Shared helper `fetch_all_pages` follows `since_id` until a short page.
- Cap of 10 pages (2,500 records) with a log line when the cap is hit.
- First-page errors keep the existing fallback (recent orders / skip discount).
- Later-page errors keep records already collected instead of discarding them.

## Failure-Class
none

This is a plugin-local REST pagination miss, not a registered product invariant. The guard is the reusable `since_id` helper plus behavioral tests through that seam.

## Verification
```
cd plugins/omi-shopify-app
python3 -m unittest test_shopify_paging.py -v
python3 -m py_compile shopify_paging.py main.py
```

6 tests, OK. I did not call a live Shopify store (no store credentials in this environment). The tests drive the production helper with a fake request function: one page, three pages totaling 510 products, first-page error, later-page error keeping 250 rules, and the 10-page cap.

Provenance: automated contributor (see profile bio).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

