### PR TITLE
fix(e2e): wait on chatFirstRoute instead of nil selectedTabIndex

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -279,6 +279,11 @@ checks:
     triggers: ["desktop/macos/scripts/desktop_flow_contract.py", "desktop/macos/tests/test_desktop_flow_contract.py", "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "bridge actions moved into DesktopAutomationBridge+Notifications.swift while the action-source list still named only the base file, so desktop-flow-lint called their flows unknown and failed the push gate on every branch"
+  - id: desktop-flow-lint-tests
+    command: ["python3", "desktop/macos/tests/test_desktop_flow_lint.py"]
+    triggers: ["desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/tests/test_desktop_flow_lint.py", "desktop/macos/e2e/flows/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#13550: chat-first snapshots pin selectedTabIndex to nil, so waits on that field hang forever; the lint must keep rejecting it and the committed flows must not name it"
   - id: desktop-grdb-insert-idiom-tests
     command: ["python3", "desktop/macos/tests/test_check_grdb_insert_idiom.py"]
     triggers: ["desktop/macos/scripts/check-grdb-insert-idiom.py", "desktop/macos/tests/test_check_grdb_insert_idiom.py", ".github/checks-manifest.yaml"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -279,11 +279,6 @@ checks:
     triggers: ["desktop/macos/scripts/desktop_flow_contract.py", "desktop/macos/tests/test_desktop_flow_contract.py", "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "bridge actions moved into DesktopAutomationBridge+Notifications.swift while the action-source list still named only the base file, so desktop-flow-lint called their flows unknown and failed the push gate on every branch"
-  - id: desktop-flow-lint-tests
-    command: ["python3", "desktop/macos/tests/test_desktop_flow_lint.py"]
-    triggers: ["desktop/macos/scripts/desktop-flow-lint.py", "desktop/macos/tests/test_desktop_flow_lint.py", "desktop/macos/e2e/flows/**", ".github/checks-manifest.yaml"]
-    lanes: ["local", "ci"]
-    reason: "#13550: chat-first snapshots pin selectedTabIndex to nil, so waits on that field hang forever; the lint must keep rejecting it and the committed flows must not name it"
   - id: desktop-grdb-insert-idiom-tests
     command: ["python3", "desktop/macos/tests/test_check_grdb_insert_idiom.py"]
     triggers: ["desktop/macos/scripts/check-grdb-insert-idiom.py", "desktop/macos/tests/test_check_grdb_insert_idiom.py", ".github/checks-manifest.yaml"]

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -159,7 +159,7 @@ steps:
       target: conversations
       activateApp: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: memories
 
   - id: S9
     name: Reconcile cached list and canonical detail

--- a/desktop/macos/e2e/flows/chat-fault-5xx.yaml
+++ b/desktop/macos/e2e/flows/chat-fault-5xx.yaml
@@ -29,7 +29,7 @@ steps:
       target: chat
       activateApp: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S3
     name: Send chat query against fault backend

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -111,7 +111,7 @@ steps:
       target: dashboard
       activateApp: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S3
     name: Send marker chat query

--- a/desktop/macos/e2e/flows/conversation-detail.yaml
+++ b/desktop/macos/e2e/flows/conversation-detail.yaml
@@ -36,7 +36,7 @@ steps:
       target: conversations
       activateApp: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Create hermetic capture conversation

--- a/desktop/macos/e2e/flows/conversation-folders.yaml
+++ b/desktop/macos/e2e/flows/conversation-folders.yaml
@@ -17,7 +17,7 @@ steps:
       target: conversations
       activateApp: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Baseline conversation list snapshot

--- a/desktop/macos/e2e/flows/conversation-sharing.yaml
+++ b/desktop/macos/e2e/flows/conversation-sharing.yaml
@@ -20,7 +20,7 @@ steps:
       target: conversations
       activateApp: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Create hermetic capture conversation

--- a/desktop/macos/e2e/flows/goals-dashboard.yaml
+++ b/desktop/macos/e2e/flows/goals-dashboard.yaml
@@ -22,7 +22,7 @@ steps:
       target: dashboard
       activateApp: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S2
     name: Baseline goals snapshot

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -60,7 +60,7 @@ steps:
       target: dashboard
       activateApp: false
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S2
     name: Capture Dashboard Visual
@@ -70,7 +70,7 @@ steps:
   - id: S3
     name: Assert Dashboard State
     state.expect:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S4
     name: Navigate to Memories
@@ -78,7 +78,7 @@ steps:
       target: memories
       activateApp: false
     wait:
-      state.selectedTabIndex: 3
+      state.chatFirstRoute: memories
 
   - id: S5
     name: Refresh Data

--- a/desktop/macos/e2e/flows/keyboard-shortcuts.yaml
+++ b/desktop/macos/e2e/flows/keyboard-shortcuts.yaml
@@ -18,7 +18,7 @@ steps:
       params:
         shortcut: "1"
     wait:
-      state.selectedTabIndex: 0
+      state.chatFirstRoute: chat
 
   - id: S2
     name: Navigate Memories via Cmd+3 equivalent
@@ -27,7 +27,7 @@ steps:
       params:
         shortcut: "3"
     wait:
-      state.selectedTabIndex: 3
+      state.chatFirstRoute: memories
 
   - id: S3
     name: Navigate Settings via Cmd+, equivalent
@@ -36,7 +36,7 @@ steps:
       params:
         shortcut: ","
     wait:
-      state.selectedTabIndex: 9
+      state.chatFirstRoute: more.settings
 
   - id: S4
     name: Logs clean

--- a/desktop/macos/e2e/flows/memory-crud.yaml
+++ b/desktop/macos/e2e/flows/memory-crud.yaml
@@ -18,7 +18,7 @@ steps:
       target: memories
       activateApp: false
     wait:
-      state.selectedTabIndex: 3
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Baseline memories snapshot

--- a/desktop/macos/e2e/flows/memory-depth.yaml
+++ b/desktop/macos/e2e/flows/memory-depth.yaml
@@ -16,7 +16,7 @@ steps:
       target: memories
       activateApp: false
     wait:
-      state.selectedTabIndex: 3
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Create hermetic test memory while the initial projection may still be loading

--- a/desktop/macos/e2e/flows/quick-note.yaml
+++ b/desktop/macos/e2e/flows/quick-note.yaml
@@ -15,7 +15,7 @@ steps:
     bridge.action:
       name: open_quick_note
     wait:
-      state.selectedTabIndex: 7
+      state.chatFirstRoute: more.rewind
 
   - id: S2
     name: Logs clean

--- a/desktop/macos/e2e/flows/speaker-naming.yaml
+++ b/desktop/macos/e2e/flows/speaker-naming.yaml
@@ -19,7 +19,7 @@ steps:
       target: conversations
       activateApp: false
     wait:
-      state.selectedTabIndex: 1
+      state.chatFirstRoute: memories
 
   - id: S2
     name: Start capture session

--- a/desktop/macos/e2e/flows/tasks-crud.yaml
+++ b/desktop/macos/e2e/flows/tasks-crud.yaml
@@ -21,7 +21,7 @@ steps:
       target: tasks
       activateApp: false
     wait:
-      state.selectedTabIndex: 4
+      state.chatFirstRoute: tasks
 
   - id: S2
     name: Create hermetic anchor task

--- a/desktop/macos/e2e/harness.md
+++ b/desktop/macos/e2e/harness.md
@@ -112,6 +112,9 @@ user-facing controls; expected labels must never contain user content.
     state.chatFirstRoute: goals
 ```
 
+Do not wait on `state.selectedTabIndex`. The chat-first snapshot always reports
+that field as nil, so the wait never becomes true.
+
 Use `wait:` after bridge steps when a state or trace must settle before the next
 step. Keep automated checks to facts the harness can measure directly: state,
 traces, logs, timing, and AX text. The harness does not score screenshot quality;

--- a/desktop/macos/scripts/desktop-flow-lint.py
+++ b/desktop/macos/scripts/desktop-flow-lint.py
@@ -137,11 +137,20 @@ def retired_state_field_errors(path: Path, step: dict) -> list[str]:
         payload = step.get(field)
         if not isinstance(payload, dict):
             continue
-        for key in payload:
-            leaf = str(key).rsplit(".", 1)[-1]
-            reason = RETIRED_STATE_FIELDS.get(leaf)
-            if reason:
-                errors.append(f"{path.name}: step {step_id} {field} uses retired {key}; {reason}")
+        mappings = [payload]
+        nested = payload.get("equals")
+        if field == "state.expect" and isinstance(nested, dict):
+            mappings.append(nested)
+        for mapping in mappings:
+            for key in mapping:
+                if key == "equals":
+                    continue
+                leaf = str(key).rsplit(".", 1)[-1]
+                reason = RETIRED_STATE_FIELDS.get(leaf)
+                if reason:
+                    errors.append(
+                        f"{path.name}: step {step_id} {field} uses retired {key}; {reason}"
+                    )
     return errors
 
 

--- a/desktop/macos/scripts/desktop-flow-lint.py
+++ b/desktop/macos/scripts/desktop-flow-lint.py
@@ -46,6 +46,13 @@ MANUAL_TIER = "manual"
 FAULT_TIER = "fault"
 ALLOWED_TIERS = {0, 1, 2, 3, MANUAL_TIER, FAULT_TIER}
 
+# Chat-first shell snapshots pin selectedTabIndex to nil
+# (DesktopHomeView.reportAutomationState). Waiting on it hangs forever.
+# Use state.chatFirstRoute (stableName) instead. This is a static tripwire.
+RETIRED_STATE_FIELDS = {
+    "selectedTabIndex": "always nil on the chat-first shell; wait on state.chatFirstRoute",
+}
+
 
 def fail(message: str) -> None:
     print(f"FAIL: {message}", file=sys.stderr)
@@ -123,6 +130,21 @@ def is_typed_flow(flow: dict, steps: list) -> bool:
     return any(any(key in step for key in TYPED_STEP_KEYS) for step in steps if isinstance(step, dict))
 
 
+def retired_state_field_errors(path: Path, step: dict) -> list[str]:
+    errors: list[str] = []
+    step_id = step.get("id", "?")
+    for field in ("wait", "state.expect"):
+        payload = step.get(field)
+        if not isinstance(payload, dict):
+            continue
+        for key in payload:
+            leaf = str(key).rsplit(".", 1)[-1]
+            reason = RETIRED_STATE_FIELDS.get(leaf)
+            if reason:
+                errors.append(f"{path.name}: step {step_id} {field} uses retired {key}; {reason}")
+    return errors
+
+
 def lint_flow(path: Path, actions: set[str]) -> list[str]:
     errors: list[str] = []
     flow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -151,6 +173,11 @@ def lint_flow(path: Path, actions: set[str]) -> list[str]:
     if not isinstance(steps, list):
         errors.append(f"{path.name}: steps must be a list")
         return errors
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        errors.extend(retired_state_field_errors(path, step))
 
     if not is_typed_flow(flow, steps):
         return errors

--- a/desktop/macos/tests/test_desktop_flow_lint.py
+++ b/desktop/macos/tests/test_desktop_flow_lint.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Prove flow lint rejects waits on always-nil selectedTabIndex.
+
+#13550: harness-smoke and other flows waited on state.selectedTabIndex after the
+chat-first shell started reporting that field as nil, so Tier 1 always timed
+out. This is a static tripwire, not a live harness run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+FLOWS = pathlib.Path(__file__).resolve().parents[1] / "e2e" / "flows"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def load_lint():
+    path = SCRIPTS / "desktop-flow-lint.py"
+    spec = importlib.util.spec_from_file_location("desktop_flow_lint", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LINT = load_lint()
+
+
+class DesktopFlowLintRetiredStateTests(unittest.TestCase):
+    def test_wait_on_selected_tab_index_is_rejected(self):
+        errors = LINT.retired_state_field_errors(
+            pathlib.Path("harness-smoke.yaml"),
+            {"id": "S1", "wait": {"state.selectedTabIndex": 0}},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("selectedTabIndex", errors[0])
+        self.assertIn("chatFirstRoute", errors[0])
+
+    def test_state_expect_selected_tab_index_is_rejected(self):
+        errors = LINT.retired_state_field_errors(
+            pathlib.Path("harness-smoke.yaml"),
+            {"id": "S3", "state.expect": {"state.selectedTabIndex": 0}},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("state.expect", errors[0])
+
+    def test_wait_on_chat_first_route_is_clean(self):
+        errors = LINT.retired_state_field_errors(
+            pathlib.Path("harness-smoke.yaml"),
+            {"id": "S1", "wait": {"state.chatFirstRoute": "chat"}},
+        )
+        self.assertEqual(errors, [])
+
+    def test_committed_flows_do_not_name_selected_tab_index(self):
+        """The live symptom: committed YAML still asked for the retired field."""
+        self.assertTrue(FLOWS.is_dir(), f"missing flows dir: {FLOWS}")
+        offenders = [
+            path.name
+            for path in sorted(FLOWS.glob("*.yaml"))
+            if "selectedTabIndex" in path.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(offenders, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/desktop/macos/tests/test_desktop_flow_lint.py
+++ b/desktop/macos/tests/test_desktop_flow_lint.py
@@ -50,6 +50,15 @@ class DesktopFlowLintRetiredStateTests(unittest.TestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("state.expect", errors[0])
 
+    def test_state_expect_equals_wrapper_selected_tab_index_is_rejected(self):
+        errors = LINT.retired_state_field_errors(
+            pathlib.Path("harness-smoke.yaml"),
+            {"id": "S3", "state.expect": {"equals": {"state.selectedTabIndex": 0}}},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("selectedTabIndex", errors[0])
+        self.assertIn("state.expect", errors[0])
+
     def test_wait_on_chat_first_route_is_clean(self):
         errors = LINT.retired_state_field_errors(
             pathlib.Path("harness-smoke.yaml"),


### PR DESCRIPTION
Fixes #13550.

`DesktopHomeView.reportAutomationState` always sets `selectedTabIndex: nil` after the chat-first redesign. Tier 1 `harness-smoke` (S1/S3/S4) and the same wait in 13 other flows therefore never became true.

`dashboard` / `home` automation names resolve to `chat`. `conversations` lands on the memories hub. `open_quick_note` still posts `navigateToRewindNotes` (`more.rewind`). Keyboard `,` is Settings (`more.settings`).

This PR:

- Replaces every `state.selectedTabIndex` wait/expect with `state.chatFirstRoute`
- Documents the retired field in `e2e/harness.md`
- Adds a static tripwire in `desktop-flow-lint` plus hermetic tests (the hung wait is rejected; `chatFirstRoute` is clean; committed YAML must not name the retired field)

It does **not** add a `checks-manifest` push-gate entry. The lint tests stay hermetic in-tree; a maintainer can wire the lane after the first CI run if wanted.

## Failure-Class

none

This is a harness contract against a snapshot field the app already pins to nil, not a product invariant. The guard is the lint tripwire, labeled as a static checker.

## Verification

```
python3 desktop/macos/tests/test_desktop_flow_lint.py -v
# 5 tests, OK

python3 desktop/macos/scripts/desktop-flow-lint.py
# desktop-flow-lint OK (81 flows, 208 registered actions)
```

I did **not** run `./scripts/desktop-core-harness.sh --tier 1` against a named desktop bundle in this environment (no authorized test bundle). Route mapping is from `ChatFirstRoute.automationVisibilityDestination` / `selectLegacyDestination` on current `main`.

Bounty eligibility remains a maintainer decision after merge.

Provenance: automated contributor (see profile bio).