### PR TITLE
fix(cli): render scalar and mixed JSON arrays in pretty mode

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -72,7 +72,7 @@ class Renderer:
             return
 
         if isinstance(data, list):
-            self._emit_table(data, columns=columns, title=title)
+            self._emit_table(coalesce_rows(data), columns=columns, title=title)
         elif isinstance(data, Mapping):
             self._emit_mapping(data, title=title)
         else:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -68,7 +68,6 @@ def test_json_mode_serializes_datetime() -> None:
         (["alpha", "beta"], ["alpha", "beta"]),
         ([17, 3.5], ["17", "3.5"]),
         ([True, False, None], ["✓", "✗"]),
-        (["alpha", 17, {"k": 1}], ["alpha", "17"]),
     ],
 )
 def test_pretty_mode_renders_scalar_and_mixed_arrays(capsys, rows, expected) -> None:
@@ -76,6 +75,20 @@ def test_pretty_mode_renders_scalar_and_mixed_arrays(capsys, rows, expected) -> 
     output = capsys.readouterr().out
     for token in expected:
         assert token in output
+    first = expected[0]
+    second = expected[1]
+    assert output.index(first) < output.index(second)
+
+
+def test_pretty_mode_renders_mapping_row_inside_mixed_array(capsys) -> None:
+    Renderer(no_color=True).emit(["alpha", 17, {"k": 1}])
+    output = capsys.readouterr().out
+    assert "value" in output
+    assert "k" in output
+    assert "alpha" in output
+    assert "17" in output
+    assert "1" in output
+    assert output.index("alpha") < output.index("17")
 
 
 def test_json_mode_preserves_scalar_array_shape(capsys) -> None:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -62,6 +62,27 @@ def test_json_mode_serializes_datetime() -> None:
     assert parsed["created_at"].startswith("2026-04-26T12:00:00")
 
 
+@pytest.mark.parametrize(
+    "rows, expected",
+    [
+        (["alpha", "beta"], ["alpha", "beta"]),
+        ([17, 3.5], ["17", "3.5"]),
+        ([True, False, None], ["✓", "✗"]),
+        (["alpha", 17, {"k": 1}], ["alpha", "17"]),
+    ],
+)
+def test_pretty_mode_renders_scalar_and_mixed_arrays(capsys, rows, expected) -> None:
+    Renderer(no_color=True).emit(rows)
+    output = capsys.readouterr().out
+    for token in expected:
+        assert token in output
+
+
+def test_json_mode_preserves_scalar_array_shape(capsys) -> None:
+    Renderer(json_mode=True).emit(["alpha", 17])
+    assert json.loads(capsys.readouterr().out) == ["alpha", 17]
+
+
 def test_pretty_mode_renders_table_for_list(capsys) -> None:
     renderer = Renderer(json_mode=False, no_color=True)
     renderer.emit([{"id": "m1", "content": "hello"}], columns=["id", "content"], title="memories")
@@ -107,8 +128,8 @@ def test_coalesce_rows_handles_dicts_and_models() -> None:
         def model_dump(self) -> dict:
             return {"x": 1}
 
-    rows = coalesce_rows([{"a": 1}, Fake()])
-    assert rows == [{"a": 1}, {"x": 1}]
+    rows = coalesce_rows([{"a": 1}, Fake(), "scalar", 9])
+    assert rows == [{"a": 1}, {"x": 1}, {"value": "scalar"}, {"value": 9}]
 
 
 def test_no_color_env_disables_color(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary

- Pretty `Renderer.emit()` sent every list to `_emit_table`, which requires mapping rows.
- Valid scalar and mixed JSON arrays therefore crashed (`AttributeError` on strings, `TypeError` on ints) when `_emit_tool` printed unwrapped local-tool results.
- The shared `coalesce_rows()` helper already wraps scalars under `value` and unwraps mappings/Pydantic models. Pretty list rendering now uses it.
- JSON mode still dumps the original list shape.

Fixes #13554

## Verification

- Reproduced on current `output.py`: `Renderer(no_color=True).emit(["alpha", "beta"])` raised `AttributeError`; `emit([17, 3.5])` raised `TypeError`.
- After the change, `cd sdks/python-cli && pytest tests/test_output.py --noconftest`: 23 passed.
- New coverage: string arrays, numeric arrays, booleans/null, mixed arrays, JSON-mode array shape preserved, `coalesce_rows` scalar wrapping.
- Existing mapping-row table tests still pass.
- `make preflight` / `scripts/pr-preflight` not run: this contributor clone is sparse and does not contain those scripts.
- Backend Hermetic Merge Gate: out of scope (CLI-only).

## Product invariants affected

none

Failure-Class: none

Why isn't this a shared primitive instead? It *is* the existing `coalesce_rows` primitive; pretty emit was the one list boundary that skipped it.

Bounty eligibility remains a maintainer decision after merge.