### PR TITLE
fix(cli): render scalar and mixed JSON arrays in pretty mode

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -72,7 +72,7 @@ class Renderer:
             return
 
         if isinstance(data, list):
-            self._emit_table(data, columns=columns, title=title)
+            self._emit_table(coalesce_rows(data), columns=columns, title=title)
         elif isinstance(data, Mapping):
             self._emit_mapping(data, title=title)
         else:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -77,6 +77,59 @@ def test_pretty_mode_renders_no_results_for_empty_list(capsys) -> None:
     assert "no results" in captured.out
 
 
+@pytest.mark.parametrize(
+    ("rows", "expected"),
+    [
+        (["alpha", "beta"], ["alpha", "beta"]),
+        ([17, 3.5], ["17", "3.5"]),
+        ([True, False], []),  # booleans stringify to checkmarks
+        ([None], []),
+        (["alpha", 17, {"id": "m1"}], ["alpha", "17", "m1"]),
+        (["[draft] literal [/bold] :warning:"], ["[draft] literal [/bold] :warning:"]),
+    ],
+)
+def test_pretty_mode_renders_scalar_and_mixed_lists(capsys, rows, expected) -> None:
+    Renderer(json_mode=False, no_color=True).emit(rows)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    for fragment in expected:
+        assert fragment in captured.out
+
+
+def test_pretty_mode_renders_boolean_and_null_list_without_crashing(capsys) -> None:
+    Renderer(no_color=True).emit([True, False, None])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "✓" in captured.out
+    assert "✗" in captured.out
+
+
+def test_pretty_mode_renders_pydantic_rows_via_coalesce(capsys) -> None:
+    class Fake:
+        def model_dump(self) -> dict:
+            return {"id": "m9", "content": "from-model"}
+
+    Renderer(no_color=True).emit([Fake()])
+    output = capsys.readouterr().out
+    assert "m9" in output
+    assert "from-model" in output
+
+
+def test_json_mode_preserves_scalar_array_shape(capsys) -> None:
+    Renderer(json_mode=True).emit(["alpha", 17, None])
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == ["alpha", 17, None]
+    assert captured.err == ""
+
+
+def test_coalesce_rows_wraps_scalars_under_value() -> None:
+    assert coalesce_rows(["alpha", 17, None]) == [
+        {"value": "alpha"},
+        {"value": 17},
+        {"value": None},
+    ]
+
+
 @pytest.mark.parametrize("first_row", [{}, {"id": "first"}])
 def test_pretty_table_includes_fields_from_later_rows(capsys, first_row) -> None:
     Renderer(no_color=True).emit([first_row, {"id": "second", "detail": "later-value"}])


### PR DESCRIPTION
Fixes #13554

## What changed and why

Pretty `Renderer.emit()` sent every list to `_emit_table()`, which indexes mapping rows with `.get()`. Valid JSON arrays of strings, numbers, mixed values, and Pydantic models therefore crashed (`AttributeError` / `TypeError`) while `--json` already preserved those shapes. The shared list path now runs `coalesce_rows()` first, which already wraps scalars under `value`.

## Product invariants affected

none

## How it was verified

Local venv with `rich` + `pytest`, importing the patched module (no API, no account):

```
PYTHONPATH=/tmp/omi-cli-ut python -m pytest test_output.py -q
# 28 passed

Renderer(no_color=True).emit(["alpha", "beta"])
Renderer(no_color=True).emit([17, 3.5])
# both print a value column instead of raising
```

The installed `omi` command path, repository preflight, and GitHub Actions were not run from this environment.

## Tests

`sdks/python-cli/tests/test_output.py` — scalar strings, numbers, booleans, null, mixed arrays, literal Rich markup in a list, Pydantic rows, and JSON-mode array shape.

## Failure class (fixes)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

