### PR TITLE
fix(cli): pretty-render scalar and mixed JSON arrays

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -72,7 +72,7 @@ class Renderer:
             return
 
         if isinstance(data, list):
-            self._emit_table(data, columns=columns, title=title)
+            self._emit_table(coalesce_rows(data), columns=columns, title=title)
         elif isinstance(data, Mapping):
             self._emit_mapping(data, title=title)
         else:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -77,6 +77,47 @@ def test_pretty_mode_renders_no_results_for_empty_list(capsys) -> None:
     assert "no results" in captured.out
 
 
+@pytest.mark.parametrize(
+    "rows",
+    [
+        ["alpha", "beta"],
+        [17, 3.5],
+        [True, False],
+        [None],
+        ["alpha", 17, None],
+    ],
+)
+def test_pretty_mode_renders_scalar_and_mixed_arrays(capsys, rows) -> None:
+    """Pretty emit used to crash: str rows lacked .get, ints were not iterable."""
+    Renderer(no_color=True).emit(rows)
+    output = capsys.readouterr().out
+    for item in rows:
+        if item is None:
+            continue
+        if isinstance(item, bool):
+            assert ("✓" if item else "✗") in output
+        else:
+            assert str(item) in output
+
+
+def test_pretty_mode_renders_pydantic_rows(capsys) -> None:
+    class Fake:
+        def model_dump(self) -> dict:
+            return {"id": "row-1", "label": "ok"}
+
+    Renderer(no_color=True).emit([Fake()])
+    output = capsys.readouterr().out
+    assert "row-1" in output
+    assert "ok" in output
+
+
+def test_json_mode_preserves_scalar_array_shape(capsys) -> None:
+    Renderer(json_mode=True).emit(["alpha", 17])
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == ["alpha", 17]
+    assert captured.err == ""
+
+
 @pytest.mark.parametrize("first_row", [{}, {"id": "first"}])
 def test_pretty_table_includes_fields_from_later_rows(capsys, first_row) -> None:
     Renderer(no_color=True).emit([first_row, {"id": "second", "detail": "later-value"}])


### PR DESCRIPTION
Fixes #13554.

`Renderer.emit()` sent every list to `_emit_table()`, which requires mapping rows. Pretty mode therefore crashed on valid tool results such as `[\"alpha\", \"beta\"]` (`AttributeError`) and `[17, 3.5]` (`TypeError`). JSON mode already preserved these shapes.

The existing `coalesce_rows()` helper already wraps scalars under `value` and keeps mappings/Pydantic models. This PR uses it at the shared list boundary instead of adding per-command guards.

## Failure-Class

none

This is a CLI renderer contract miss, not a registered product invariant. The guard is `coalesce_rows` at `emit()` plus renderer regression tests.

## Verification

```
cd sdks/python-cli
pytest tests/test_output.py -v
# 25 passed

pytest --ignore=tests/test_openapi_contract.py -q
# remaining CLI suite passed (1 skip); OpenAPI contract tests were not run here because this sparse checkout does not contain docs/api-reference/openapi.json
```

No live Omi API. Inputs are local renderer unit tests, not production records.

@josancamon19 following the contribution guide, would you approve **US$25 after acceptance and merge** for this scoped renderer fix, regression tests, and one review revision? PayPal is the documented claim path. Payment details stay private. No award is assumed.

Provenance: automated contributor (see profile bio).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

