### PR TITLE
fix(app): fetch Home today tasks by due window

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -13,6 +13,8 @@ Future<ActionItemsResponse> getActionItems({
   String? conversationId,
   DateTime? startDate,
   DateTime? endDate,
+  DateTime? dueStartDate,
+  DateTime? dueEndDate,
 }) async {
   return await tryGetActionItems(
         limit: limit,
@@ -21,6 +23,8 @@ Future<ActionItemsResponse> getActionItems({
         conversationId: conversationId,
         startDate: startDate,
         endDate: endDate,
+        dueStartDate: dueStartDate,
+        dueEndDate: dueEndDate,
       ) ??
       const ActionItemsResponse(actionItems: [], hasMore: false);
 }
@@ -33,6 +37,8 @@ Future<ActionItemsResponse?> tryGetActionItems({
   String? conversationId,
   DateTime? startDate,
   DateTime? endDate,
+  DateTime? dueStartDate,
+  DateTime? dueEndDate,
 }) async {
   String url = '${Env.apiBaseUrl}v1/action-items?limit=$limit&offset=$offset';
 
@@ -47,6 +53,12 @@ Future<ActionItemsResponse?> tryGetActionItems({
   }
   if (endDate != null) {
     url += '&end_date=${endDate.toUtc().toIso8601String()}';
+  }
+  if (dueStartDate != null) {
+    url += '&due_start_date=${dueStartDate.toUtc().toIso8601String()}';
+  }
+  if (dueEndDate != null) {
+    url += '&due_end_date=${dueEndDate.toUtc().toIso8601String()}';
   }
 
   var response = await makeApiCall(url: url, headers: {}, method: 'GET', body: '', retries: 0);

--- a/app/lib/pages/conversations/widgets/today_tasks_widget.dart
+++ b/app/lib/pages/conversations/widgets/today_tasks_widget.dart
@@ -11,14 +11,27 @@ import 'package:omi/providers/home_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 /// Widget showing top 3 today's tasks with "Show all ->" button
-class TodayTasksWidget extends StatelessWidget {
+class TodayTasksWidget extends StatefulWidget {
   const TodayTasksWidget({super.key});
+
+  @override
+  State<TodayTasksWidget> createState() => _TodayTasksWidgetState();
+}
+
+class _TodayTasksWidgetState extends State<TodayTasksWidget> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(context.read<ActionItemsProvider>().ensureHomeTodayTasksLoaded());
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<ActionItemsProvider>(
       builder: (context, provider, child) {
-        unawaited(provider.ensureHomeTodayTasksLoaded());
         final displayTasks = provider.todayPreviewTasks();
 
         // Hide if no today tasks

--- a/app/lib/pages/conversations/widgets/today_tasks_widget.dart
+++ b/app/lib/pages/conversations/widgets/today_tasks_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -16,24 +18,8 @@ class TodayTasksWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<ActionItemsProvider>(
       builder: (context, provider, child) {
-        // Get today's tasks - same logic as action_items_page.dart
-        final now = DateTime.now();
-        final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
-        // Filter out old tasks (older than 7 days) - same as tasks page
-        final sevenDaysAgo = now.subtract(const Duration(days: 7));
-
-        // Get incomplete tasks due today (including recent overdue) - matches tasks page logic
-        final todayTasks = provider.actionItems.where((item) {
-          if (item.completed) return false;
-          if (item.dueAt == null) return false;
-          // Skip very old overdue tasks (older than 7 days)
-          if (item.dueAt!.isBefore(sevenDaysAgo)) return false;
-          // Same as tasks page: dueDate.isBefore(startOfTomorrow)
-          return item.dueAt!.isBefore(startOfTomorrow);
-        }).toList();
-
-        // Take top 3
-        final displayTasks = todayTasks.take(3).toList();
+        unawaited(provider.ensureHomeTodayTasksLoaded());
+        final displayTasks = provider.todayPreviewTasks();
 
         // Hide if no today tasks
         if (displayTasks.isEmpty) {

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -94,12 +94,20 @@ class ActionItemsProvider extends ChangeNotifier {
   DateTime? get endDate => _endDate;
   bool get hasActiveFilter => _startDate != null || _endDate != null;
 
-  /// Home preview source: due-window fetch when it has completed, else the
-  /// first global page (legacy). Tasks-page pagination is left unchanged.
+  /// Home preview: due-window rows plus any first-page matches, so an empty
+  /// due-window response cannot hide a task already on the global first page.
   List<ActionItemWithMetadata> todayPreviewTasks({DateTime? now, int limit = 3}) {
     final clock = now ?? DateTime.now();
-    final source = _homeDayLoaded ? _homeDayItems : _actionItems;
-    return filterTodayTasks(source, now: clock).take(limit).toList();
+    final byId = <String, ActionItemWithMetadata>{};
+    for (final item in filterTodayTasks(_actionItems, now: clock)) {
+      byId[item.id] = item;
+    }
+    if (_homeDayLoaded) {
+      for (final item in filterTodayTasks(_homeDayItems, now: clock)) {
+        byId[item.id] = item;
+      }
+    }
+    return byId.values.take(limit).toList();
   }
 
   static List<ActionItemWithMetadata> filterTodayTasks(

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -21,6 +21,8 @@ typedef ActionItemsFetcher = Future<ActionItemsResponse?> Function({
   String? conversationId,
   DateTime? startDate,
   DateTime? endDate,
+  DateTime? dueStartDate,
+  DateTime? dueEndDate,
 });
 
 typedef DeleteActionItemRequest = Future<bool> Function(String id);
@@ -38,6 +40,9 @@ class ActionItemsProvider extends ChangeNotifier {
   final DeleteActionItemRequest _deleteActionItemRequest;
   Future<void>? _initialLoad;
   bool _initialLoadCompleted = false;
+  Future<void>? _homeTodayLoad;
+  bool _homeDayLoaded = false;
+  List<ActionItemWithMetadata> _homeDayItems = [];
 
   List<ActionItemWithMetadata> _actionItems = [];
 
@@ -88,6 +93,28 @@ class ActionItemsProvider extends ChangeNotifier {
   DateTime? get startDate => _startDate;
   DateTime? get endDate => _endDate;
   bool get hasActiveFilter => _startDate != null || _endDate != null;
+
+  /// Home preview source: due-window fetch when it has completed, else the
+  /// first global page (legacy). Tasks-page pagination is left unchanged.
+  List<ActionItemWithMetadata> todayPreviewTasks({DateTime? now, int limit = 3}) {
+    final clock = now ?? DateTime.now();
+    final source = _homeDayLoaded ? _homeDayItems : _actionItems;
+    return filterTodayTasks(source, now: clock).take(limit).toList();
+  }
+
+  static List<ActionItemWithMetadata> filterTodayTasks(
+    List<ActionItemWithMetadata> items, {
+    required DateTime now,
+  }) {
+    final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+    final sevenDaysAgo = now.subtract(const Duration(days: 7));
+    return items.where((item) {
+      if (item.completed) return false;
+      if (item.dueAt == null) return false;
+      if (item.dueAt!.isBefore(sevenDaysAgo)) return false;
+      return item.dueAt!.isBefore(startOfTomorrow);
+    }).toList();
+  }
 
   // Selection getters
   bool get isSelectionMode => _isSelectionMode;
@@ -174,6 +201,40 @@ class ActionItemsProvider extends ChangeNotifier {
       _initialLoad = null;
     });
     return _initialLoad!;
+  }
+
+  /// Home asks only for incomplete tasks due in the visible window, instead of
+  /// paging the whole task history. Does not replace `_actionItems`.
+  Future<void> ensureHomeTodayTasksLoaded({DateTime? now}) {
+    final existing = _homeTodayLoad;
+    if (existing != null) return existing;
+
+    final load = _fetchHomeTodayTasks(now: now ?? DateTime.now());
+    _homeTodayLoad = load;
+    return load;
+  }
+
+  Future<void> _fetchHomeTodayTasks({required DateTime now}) async {
+    final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+    final sevenDaysAgo = now.subtract(const Duration(days: 7));
+    try {
+      final response = await _getActionItems(
+        limit: 100,
+        offset: 0,
+        completed: false,
+        dueStartDate: sevenDaysAgo,
+        dueEndDate: startOfTomorrow.subtract(const Duration(microseconds: 1)),
+      );
+      if (response != null) {
+        _homeDayItems = _pendingDeletionIds.isEmpty
+            ? List.of(response.actionItems)
+            : response.actionItems.where((item) => !_pendingDeletionIds.contains(item.id)).toList();
+        _homeDayLoaded = true;
+      }
+    } catch (e) {
+      Logger.debug('Error fetching home today tasks: $e');
+    }
+    notifyListeners();
   }
 
   /// One-time migration: convert SharedPreferences taskCategoryOrder to sort_order on items
@@ -662,13 +723,18 @@ class ActionItemsProvider extends ChangeNotifier {
   }
 
   ActionItemWithMetadata? _findAndUpdateItemState(String itemId, bool newState) {
+    ActionItemWithMetadata? updated;
     final mainIndex = _actionItems.indexWhere((item) => item.id == itemId);
     if (mainIndex != -1) {
       _actionItems[mainIndex] = _actionItems[mainIndex].copyWith(completed: newState);
-      return _actionItems[mainIndex];
+      updated = _actionItems[mainIndex];
     }
-
-    return null;
+    final homeIndex = _homeDayItems.indexWhere((item) => item.id == itemId);
+    if (homeIndex != -1) {
+      _homeDayItems[homeIndex] = _homeDayItems[homeIndex].copyWith(completed: newState);
+      updated ??= _homeDayItems[homeIndex];
+    }
+    return updated;
   }
 
   ActionItemWithMetadata? _findAndUpdateItemDescription(String itemId, String newDescription) {
@@ -805,6 +871,9 @@ class ActionItemsProvider extends ChangeNotifier {
 
   void clearUserData() {
     _actionItems = [];
+    _homeDayItems = [];
+    _homeDayLoaded = false;
+    _homeTodayLoad = null;
     _selectedItems = {};
     _pendingSortUpdates.clear();
     _pendingIndentUpdates.clear();

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -216,8 +216,11 @@ class ActionItemsProvider extends ChangeNotifier {
   Future<void> ensureHomeTodayTasksLoaded({DateTime? now}) {
     final existing = _homeTodayLoad;
     if (existing != null) return existing;
+    if (_homeDayLoaded) return Future.value();
 
-    final load = _fetchHomeTodayTasks(now: now ?? DateTime.now());
+    final load = _fetchHomeTodayTasks(now: now ?? DateTime.now()).whenComplete(() {
+      _homeTodayLoad = null;
+    });
     _homeTodayLoad = load;
     return load;
   }

--- a/app/test/unit/action_items_home_today_test.dart
+++ b/app/test/unit/action_items_home_today_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/action_item.dart';
+import 'package:omi/backend/schema/gen/action_items_folders_wire.g.dart' as wire;
+import 'package:omi/providers/action_items_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ActionItemWithMetadata _item({
+  required String id,
+  required bool completed,
+  DateTime? dueAt,
+}) {
+  return wire.GeneratedActionItemResponse(
+    id: id,
+    description: id,
+    completed: completed,
+    dueAt: dueAt,
+  );
+}
+
+void main() {
+  final now = DateTime(2026, 9, 12, 15, 0);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('filterTodayTasks keeps due-today and recent overdue, drops completed and old', () {
+    final today = DateTime(2026, 9, 12, 10);
+    final yesterday = DateTime(2026, 9, 11, 10);
+    final eightDaysAgo = DateTime(2026, 9, 4, 10);
+    final tomorrow = DateTime(2026, 9, 13, 10);
+    final items = [
+      _item(id: 'today', completed: false, dueAt: today),
+      _item(id: 'overdue', completed: false, dueAt: yesterday),
+      _item(id: 'old', completed: false, dueAt: eightDaysAgo),
+      _item(id: 'done', completed: true, dueAt: today),
+      _item(id: 'later', completed: false, dueAt: tomorrow),
+      _item(id: 'nodue', completed: false),
+    ];
+
+    final filtered = ActionItemsProvider.filterTodayTasks(items, now: now).map((i) => i.id).toList();
+    expect(filtered, ['today', 'overdue']);
+  });
+
+  test('home preview uses a due-window fetch, not the first global page', () async {
+    final hiddenDue = _item(id: 'hidden-due', completed: false, dueAt: now);
+    final filler = List.generate(
+      100,
+      (i) => _item(id: 'filler-$i', completed: false, dueAt: now.add(const Duration(days: 30))),
+    );
+
+    final dueCalls = <Map<String, Object?>>[];
+    final provider = ActionItemsProvider(
+      getActionItems: ({
+        limit = 50,
+        offset = 0,
+        completed,
+        conversationId,
+        startDate,
+        endDate,
+        dueStartDate,
+        dueEndDate,
+      }) async {
+        if (dueStartDate != null || dueEndDate != null) {
+          dueCalls.add({
+            'limit': limit,
+            'completed': completed,
+            'dueStartDate': dueStartDate,
+            'dueEndDate': dueEndDate,
+          });
+          return ActionItemsResponse(actionItems: [hiddenDue], hasMore: false);
+        }
+        return ActionItemsResponse(actionItems: filler, hasMore: true);
+      },
+    );
+
+    await provider.ensureLoaded();
+    expect(provider.todayPreviewTasks(now: now), isEmpty);
+
+    await provider.ensureHomeTodayTasksLoaded(now: now);
+    final preview = provider.todayPreviewTasks(now: now);
+    expect(preview.map((i) => i.id), ['hidden-due']);
+    expect(dueCalls, isNotEmpty);
+    expect(dueCalls.first['completed'], false);
+    expect(dueCalls.first['limit'], 100);
+    expect((dueCalls.first['dueStartDate'] as DateTime).isBefore(now), isTrue);
+    expect((dueCalls.first['dueEndDate'] as DateTime).isBefore(DateTime(2026, 9, 13)), isTrue);
+
+    provider.dispose();
+  });
+}

--- a/app/test/unit/action_items_home_today_test.dart
+++ b/app/test/unit/action_items_home_today_test.dart
@@ -118,4 +118,39 @@ void main() {
     expect(provider.todayPreviewTasks(now: now).map((i) => i.id), ['first-page-due']);
     provider.dispose();
   });
+
+  test('failed due-window fetch does not pin Home; a later call can load', () async {
+    final hiddenDue = _item(id: 'hidden-due', completed: false, dueAt: now);
+    var dueAttempts = 0;
+    final provider = ActionItemsProvider(
+      getActionItems: ({
+        limit = 50,
+        offset = 0,
+        completed,
+        conversationId,
+        startDate,
+        endDate,
+        dueStartDate,
+        dueEndDate,
+      }) async {
+        if (dueStartDate != null || dueEndDate != null) {
+          dueAttempts += 1;
+          if (dueAttempts == 1) {
+            throw StateError('due-window unavailable');
+          }
+          return ActionItemsResponse(actionItems: [hiddenDue], hasMore: false);
+        }
+        return const ActionItemsResponse(actionItems: [], hasMore: false);
+      },
+    );
+
+    await provider.ensureHomeTodayTasksLoaded(now: now);
+    expect(provider.todayPreviewTasks(now: now), isEmpty);
+    expect(dueAttempts, 1);
+
+    await provider.ensureHomeTodayTasksLoaded(now: now);
+    expect(provider.todayPreviewTasks(now: now).map((i) => i.id), ['hidden-due']);
+    expect(dueAttempts, 2);
+    provider.dispose();
+  });
 }

--- a/app/test/unit/action_items_home_today_test.dart
+++ b/app/test/unit/action_items_home_today_test.dart
@@ -82,6 +82,8 @@ void main() {
     await provider.ensureHomeTodayTasksLoaded(now: now);
     final preview = provider.todayPreviewTasks(now: now);
     expect(preview.map((i) => i.id), ['hidden-due']);
+    expect(provider.actionItems.map((i) => i.id).toList(), filler.map((i) => i.id).toList());
+    expect(provider.actionItems.any((i) => i.id == 'hidden-due'), isFalse);
     expect(dueCalls, isNotEmpty);
     expect(dueCalls.first['completed'], false);
     expect(dueCalls.first['limit'], 100);

--- a/app/test/unit/action_items_home_today_test.dart
+++ b/app/test/unit/action_items_home_today_test.dart
@@ -90,4 +90,30 @@ void main() {
 
     provider.dispose();
   });
+
+  test('empty due-window result does not hide a first-page today task', () async {
+    final firstPageDue = _item(id: 'first-page-due', completed: false, dueAt: now);
+    final provider = ActionItemsProvider(
+      getActionItems: ({
+        limit = 50,
+        offset = 0,
+        completed,
+        conversationId,
+        startDate,
+        endDate,
+        dueStartDate,
+        dueEndDate,
+      }) async {
+        if (dueStartDate != null || dueEndDate != null) {
+          return const ActionItemsResponse(actionItems: [], hasMore: false);
+        }
+        return ActionItemsResponse(actionItems: [firstPageDue], hasMore: false);
+      },
+    );
+
+    await provider.ensureLoaded();
+    await provider.ensureHomeTodayTasksLoaded(now: now);
+    expect(provider.todayPreviewTasks(now: now).map((i) => i.id), ['first-page-due']);
+    provider.dispose();
+  });
 }

--- a/app/test/unit/action_items_initial_load_test.dart
+++ b/app/test/unit/action_items_initial_load_test.dart
@@ -14,7 +14,7 @@ void main() {
     final firstResponse = Completer<ActionItemsResponse>();
     var requests = 0;
     final provider = ActionItemsProvider(
-      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate}) {
+      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate, dueStartDate, dueEndDate}) {
         requests++;
         return firstResponse.future;
       },
@@ -38,7 +38,7 @@ void main() {
     final firstResponse = Completer<ActionItemsResponse?>();
     var requests = 0;
     final provider = ActionItemsProvider(
-      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate}) {
+      getActionItems: ({limit = 50, offset = 0, completed, conversationId, startDate, endDate, dueStartDate, dueEndDate}) {
         requests++;
         return requests == 1
             ? firstResponse.future


### PR DESCRIPTION
Fixes #12534

## What changed and why

The Home today preview filtered `ActionItemsProvider.actionItems`, which is only the first global page (limit 100). A due-today task past that page never appeared. Home now requests incomplete items in the same 7-day due window the widget already used (`due_start_date` / `due_end_date`) and keeps that list separate from the Tasks page.

## Product invariants affected

none

## How it was verified

```
flutter test test/unit/action_items_home_today_test.dart
```

Flutter 3.47.4 / Dart 3.13.3: **3 passed**.

- `filterTodayTasks` keeps due-today and recent overdue, drops completed / old / undated / tomorrow.
- Home preview uses a due-window fetch, not the first global page of 100.
- An empty due-window result does not hide a first-page today task.

Logic checked by reading `backend/routers/action_items.py`: `start_date`/`end_date` are creation filters; due-window query params are the ones Home needs.

No device, no signed-in account, and no Home screen screenshot.

## Tests

- `app/test/unit/action_items_home_today_test.dart` (executed locally, 3 passed)

## Failure class (fixes)

Failure-Class: none