### PR TITLE
fix(python-cli): render scalar and mixed lists in pretty output

### DIFF
--- a/sdks/python-cli/omi_cli/output.py
+++ b/sdks/python-cli/omi_cli/output.py
@@ -72,7 +72,7 @@ class Renderer:
             return
 
         if isinstance(data, list):
-            self._emit_table(data, columns=columns, title=title)
+            self._emit_table(coalesce_rows(data), columns=columns, title=title)
         elif isinstance(data, Mapping):
             self._emit_mapping(data, title=title)
         else:

--- a/sdks/python-cli/tests/test_output.py
+++ b/sdks/python-cli/tests/test_output.py
@@ -95,6 +95,29 @@ def test_pretty_table_respects_explicit_columns(capsys) -> None:
     assert "hidden-value" not in output
 
 
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        (["alpha", "beta"], ["alpha", "beta"]),
+        ([17, 3.5], ["17", "3.5"]),
+        ([{"id": "x"}, "y"], ["x", "y"]),
+    ],
+)
+def test_pretty_mode_renders_scalar_and_mixed_lists(data, expected, capsys) -> None:
+    Renderer(no_color=True).emit(data)
+    output = capsys.readouterr().out
+    assert "value" in output
+    for value in expected:
+        assert value in output
+
+
+def test_pretty_table_explicit_columns_do_not_expose_scalar_rows(capsys) -> None:
+    Renderer(no_color=True).emit(["alpha", "beta"], columns=["id"])
+    output = capsys.readouterr().out
+    assert "alpha" not in output
+    assert "beta" not in output
+
+
 def test_shorten_basic() -> None:
     assert shorten("abcdef", 3) == "ab…"
     assert shorten("abcdef", 10) == "abcdef"


### PR DESCRIPTION
## What changed and why

Fixes #13554. `Renderer.emit()` sent list payloads straight to `_emit_table()`, which requires Mapping rows — `emit(["a", "b"])` crashed with `AttributeError: 'str' object has no attribute 'get'` and `emit([1, 2])` with `TypeError`. Lists now go through the existing `coalesce_rows()` helper, so scalar items render under a `value` column and mixed mapping/scalar lists no longer crash. JSON mode, mapping rendering, empty lists, and explicit-column behavior are unchanged.

## Product invariants affected

none

## How it was verified

- Reproduced on main: `Renderer(no_color=True).emit(["alpha", "beta"])` raised `AttributeError`; `emit([17, 3.5])` raised `TypeError`.
- `cd sdks/python-cli && python3 -m pytest tests/test_output.py -q` → 22 passed
- `cd sdks/python-cli && python3 -m pytest -q` → 393 passed, 1 skipped
- `black --check` and `mypy` clean on the changed files.
- `make preflight` (local manifest lane) passes with this PR body.

## Tests

Regression tests in `tests/test_output.py`: `test_pretty_mode_renders_scalar_and_mixed_lists` covers string, numeric, and mixed mapping/scalar lists; `test_pretty_table_explicit_columns_do_not_expose_scalar_rows` pins explicit-column behavior on scalar rows.

## Failure class (fixes)

Failure-Class: none

---

AI disclosure: prepared with an AI coding assistant; reproduction and test runs were executed locally.
