### PR TITLE
fix(clickup): include lists inside folders in workspace list discovery

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -924,6 +924,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
 
+  - id: clickup-client-tests
+    command: ["python3", "plugins/omi-clickup-app/test_clickup_client.py"]
+    triggers: ["plugins/omi-clickup-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#13130 get_all_lists only queried the folderless-lists endpoint; lists inside folders must be enumerated per folder"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-clickup-app/clickup_client.py
+++ b/plugins/omi-clickup-app/clickup_client.py
@@ -171,22 +171,94 @@ class ClickUpClient:
             print(f"❌ Error getting lists: {e}", flush=True)
             return []
     
+    def get_folders(self, access_token: str, space_id: str) -> List[Dict]:
+        """Get all folders in a space."""
+        try:
+            headers = {"Authorization": access_token}
+            response = requests.get(
+                f"{self.base_url}/space/{space_id}/folder",
+                headers=headers,
+                params={"archived": "false"}
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                folders = data.get("folders", [])
+
+                folder_list = []
+                for folder in folders:
+                    folder_list.append({
+                        "id": folder.get("id"),
+                        "name": folder.get("name")
+                    })
+
+                return folder_list
+            else:
+                print(f"❌ Error getting folders: {response.status_code}", flush=True)
+                return []
+
+        except Exception as e:
+            print(f"❌ Error getting folders: {e}", flush=True)
+            return []
+
+    def get_folder_lists(self, access_token: str, folder_id: str) -> List[Dict]:
+        """Get all lists inside a folder."""
+        try:
+            headers = {"Authorization": access_token}
+            response = requests.get(
+                f"{self.base_url}/folder/{folder_id}/list",
+                headers=headers,
+                params={"archived": "false"}
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                lists = data.get("lists", [])
+
+                list_data = []
+                for lst in lists:
+                    list_data.append({
+                        "id": lst.get("id"),
+                        "name": lst.get("name"),
+                        "folder_id": folder_id
+                    })
+
+                return list_data
+            else:
+                print(f"❌ Error getting folder lists: {response.status_code}", flush=True)
+                return []
+
+        except Exception as e:
+            print(f"❌ Error getting folder lists: {e}", flush=True)
+            return []
+
     def get_all_lists(self, access_token: str, team_id: str) -> List[Dict]:
-        """Get all lists across all spaces in a workspace."""
+        """Get all lists across all spaces in a workspace, including lists inside folders."""
         all_lists = []
-        
+
         # Get all spaces
         spaces = self.get_spaces(access_token, team_id)
-        
+
         # Get lists for each space
         for space in spaces:
             lists = self.get_lists(access_token, space["id"])
             for lst in lists:
                 lst["space_name"] = space["name"]
                 all_lists.append(lst)
-        
+
+            # The space list endpoint returns only folderless lists; lists
+            # inside folders must be fetched per folder.
+            folders = self.get_folders(access_token, space["id"])
+            for folder in folders:
+                folder_lists = self.get_folder_lists(access_token, folder["id"])
+                for lst in folder_lists:
+                    lst["space_id"] = space["id"]
+                    lst["space_name"] = space["name"]
+                    lst["folder_name"] = folder["name"]
+                    all_lists.append(lst)
+
         return all_lists
-    
+
     def get_workspace_members(self, access_token: str, team_id: str) -> List[Dict]:
         """Get all members in a workspace."""
         try:

--- a/plugins/omi-clickup-app/clickup_client.py
+++ b/plugins/omi-clickup-app/clickup_client.py
@@ -13,6 +13,42 @@ class ClickUpClient:
         self.client_id = os.getenv("CLICKUP_CLIENT_ID")
         self.client_secret = os.getenv("CLICKUP_CLIENT_SECRET")
         self.base_url = "https://api.clickup.com/api/v2"
+
+    @staticmethod
+    def list_identity(lst: Dict) -> str:
+        """Stable display/AI name. Folder-contained lists include the folder so
+        two same-named lists in one space do not collapse to one ID."""
+        name = lst.get("name") or ""
+        folder = (lst.get("folder_name") or "").strip()
+        space = (lst.get("space_name") or "").strip()
+        if folder:
+            return f"{name} ({folder})"
+        if space:
+            return f"{name} ({space})"
+        return name
+
+    @staticmethod
+    def resolve_list(available_lists: List[Dict], spoken: str) -> Optional[Dict]:
+        """Resolve a spoken/AI list name to one list. Duplicate bare names
+        require the folder-qualified identity; they never collapse to one ID."""
+        if not spoken or not available_lists:
+            return None
+        spoken_l = spoken.strip().lower()
+        identity_hits = [
+            lst for lst in available_lists
+            if ClickUpClient.list_identity(lst).lower() == spoken_l
+        ]
+        if len(identity_hits) == 1:
+            return identity_hits[0]
+        if len(identity_hits) > 1:
+            return None
+        bare_hits = [
+            lst for lst in available_lists
+            if (lst.get("name") or "").lower() == spoken_l
+        ]
+        if len(bare_hits) == 1:
+            return bare_hits[0]
+        return None
     
     def get_authorization_url(self, redirect_uri: str, state: str) -> str:
         """Generate ClickUp OAuth authorization URL."""

--- a/plugins/omi-clickup-app/clickup_client.py
+++ b/plugins/omi-clickup-app/clickup_client.py
@@ -280,6 +280,7 @@ class ClickUpClient:
             lists = self.get_lists(access_token, space["id"])
             for lst in lists:
                 lst["space_name"] = space["name"]
+                lst["identity"] = ClickUpClient.list_identity(lst)
                 all_lists.append(lst)
 
             # The space list endpoint returns only folderless lists; lists
@@ -291,6 +292,7 @@ class ClickUpClient:
                     lst["space_id"] = space["id"]
                     lst["space_name"] = space["name"]
                     lst["folder_name"] = folder["name"]
+                    lst["identity"] = ClickUpClient.list_identity(lst)
                     all_lists.append(lst)
 
         return all_lists

--- a/plugins/omi-clickup-app/main.py
+++ b/plugins/omi-clickup-app/main.py
@@ -90,7 +90,7 @@ async def monitor_session_timeouts():
                                 if list_id:
                                     for lst in lists:
                                         if lst["id"] == list_id:
-                                            list_name = lst["name"]
+                                            list_name = ClickUpClient.list_identity(lst)
                                             break
                             
                             if list_id and task_name and len(task_name.strip()) >= 3:
@@ -248,8 +248,7 @@ async def root(uid: str = Query(None)):
     list_options = '<option value="">Select a list...</option>'
     for lst in lists:
         selected_attr = 'selected' if lst['id'] == selected_list else ''
-        space_name = lst.get('space_name', '')
-        display_name = f"{lst['name']}" + (f" ({space_name})" if space_name else "")
+        display_name = ClickUpClient.list_identity(lst)
         list_options += f'<option value="{lst["id"]}" {selected_attr}>{display_name}</option>'
     
     return HTMLResponse(content=f"""
@@ -871,7 +870,7 @@ async def process_segments(
                     # Find list name
                     for lst in lists:
                         if lst["id"] == list_id:
-                            list_name = lst["name"]
+                            list_name = ClickUpClient.list_identity(lst)
                             break
                     print(f"📌 Using default list: {list_name}", flush=True)
                 else:
@@ -971,7 +970,7 @@ async def process_segments(
                 if list_id:
                     for lst in lists:
                         if lst["id"] == list_id:
-                            list_name = lst["name"]
+                            list_name = ClickUpClient.list_identity(lst)
                             break
                     print(f"📌 Using default list: {list_name}", flush=True)
                 else:

--- a/plugins/omi-clickup-app/main.py
+++ b/plugins/omi-clickup-app/main.py
@@ -248,7 +248,7 @@ async def root(uid: str = Query(None)):
     list_options = '<option value="">Select a list...</option>'
     for lst in lists:
         selected_attr = 'selected' if lst['id'] == selected_list else ''
-        display_name = ClickUpClient.list_identity(lst)
+        display_name = lst.get("identity") or ClickUpClient.list_identity(lst)
         list_options += f'<option value="{lst["id"]}" {selected_attr}>{display_name}</option>'
     
     return HTMLResponse(content=f"""

--- a/plugins/omi-clickup-app/task_detector.py
+++ b/plugins/omi-clickup-app/task_detector.py
@@ -1,9 +1,11 @@
 import re
+from collections import Counter
 from typing import Optional, Tuple, List
 from openai import AsyncOpenAI
 import os
 from datetime import datetime
 from dotenv import load_dotenv
+from clickup_client import ClickUpClient
 
 load_dotenv()
 client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -79,18 +81,8 @@ class TaskDetector:
         current_date_str = now.strftime("%A, %B %d, %Y at %I:%M %p")
         current_iso = now.strftime("%Y-%m-%d")
         
-        # Create list mapping for AI
-        list_names = [lst["name"] for lst in available_lists]
-        list_map = {lst["name"]: lst["id"] for lst in available_lists}
-        
-        # Include space names for better context
-        list_with_spaces = []
-        for lst in available_lists:
-            space_name = lst.get("space_name", "")
-            if space_name:
-                list_with_spaces.append(f"{lst['name']} (in {space_name})")
-            else:
-                list_with_spaces.append(lst['name'])
+        list_names = [ClickUpClient.list_identity(lst) for lst in available_lists]
+        list_with_spaces = list_names
         
         # Create member mapping for AI
         member_names = []
@@ -311,37 +303,39 @@ CRITICAL RULES:
                 print(f"⚠️  No list identified in command", flush=True)
                 return None, None, task_name, description, priority, due_date, assignee_ids
             
-            # Get list ID from map (case insensitive)
-            list_id = None
-            for name, id in list_map.items():
-                if name.lower() == list_name.lower():
-                    list_id = id
-                    list_name = name  # Use exact name from map
-                    break
+            resolved = ClickUpClient.resolve_list(available_lists, list_name)
+            list_id = resolved["id"] if resolved else None
+            if resolved:
+                list_name = ClickUpClient.list_identity(resolved)
             
             if not list_id:
-                # Try fuzzy match - more flexible matching
+                # Try fuzzy match on identities. Duplicate bare names stay
+                # unresolved unless the spoken text includes the folder.
                 list_name_lower = list_name.lower()
                 best_match = None
                 best_score = 0
+                name_counts = Counter((lst.get("name") or "") for lst in available_lists)
                 
                 for lst in available_lists:
-                    name = lst["name"].lower()
+                    name = ClickUpClient.list_identity(lst).lower()
+                    bare = (lst.get("name") or "").lower()
+                    ambiguous_bare = name_counts[lst.get("name") or ""] > 1
                     
-                    # Exact match
                     if name == list_name_lower:
                         best_match = lst
                         break
+                    if bare == list_name_lower and not ambiguous_bare:
+                        best_match = lst
+                        break
+                    if ambiguous_bare and list_name_lower == bare:
+                        continue
                     
-                    # Contains match
                     if list_name_lower in name or name in list_name_lower:
-                        # Score based on length similarity
                         score = min(len(list_name_lower), len(name)) / max(len(list_name_lower), len(name))
                         if score > best_score:
                             best_score = score
                             best_match = lst
                     
-                    # Word match (e.g., "manufacturing" in "Manufacturing Tasks")
                     list_words = list_name_lower.split()
                     name_words = name.split()
                     for word in list_words:
@@ -353,7 +347,7 @@ CRITICAL RULES:
                 
                 if best_match:
                     list_id = best_match["id"]
-                    matched_name = best_match["name"]
+                    matched_name = ClickUpClient.list_identity(best_match)
                     print(f"🔍 Fuzzy matched '{list_name}' to '{matched_name}' (score: {best_score:.2f})", flush=True)
                     list_name = matched_name
             
@@ -384,7 +378,7 @@ CRITICAL RULES:
         if not available_lists:
             return None
         
-        list_names = [lst["name"] for lst in available_lists]
+        list_names = [ClickUpClient.list_identity(lst) for lst in available_lists]
         
         try:
             response = await client.chat.completions.create(
@@ -426,22 +420,16 @@ User said: "xyz123" (not in list) → NONE"""
             if matched.upper() == "NONE":
                 return None
             
-            # Find the list with this name
-            for lst in available_lists:
-                if lst["name"].lower() == matched.lower():
-                    print(f"🎯 AI matched '{spoken_list}' → {lst['name']}", flush=True)
-                    return lst
+            resolved = ClickUpClient.resolve_list(available_lists, matched)
+            if resolved:
+                print(f"🎯 AI matched '{spoken_list}' → {ClickUpClient.list_identity(resolved)}", flush=True)
+                return resolved
             
             return None
             
         except Exception as e:
             print(f"⚠️  AI list matching failed: {e}", flush=True)
-            # Fallback to simple matching
-            spoken_lower = spoken_list.lower()
-            for lst in available_lists:
-                if lst["name"].lower() == spoken_lower:
-                    return lst
-            return None
+            return ClickUpClient.resolve_list(available_lists, spoken_list)
     
     @classmethod
     def clean_content(cls, content: str) -> str:

--- a/plugins/omi-clickup-app/task_detector.py
+++ b/plugins/omi-clickup-app/task_detector.py
@@ -81,7 +81,10 @@ class TaskDetector:
         current_date_str = now.strftime("%A, %B %d, %Y at %I:%M %p")
         current_iso = now.strftime("%Y-%m-%d")
         
-        list_names = [ClickUpClient.list_identity(lst) for lst in available_lists]
+        list_names = [
+            lst.get("identity") or ClickUpClient.list_identity(lst)
+            for lst in available_lists
+        ]
         list_with_spaces = list_names
         
         # Create member mapping for AI
@@ -378,7 +381,10 @@ CRITICAL RULES:
         if not available_lists:
             return None
         
-        list_names = [ClickUpClient.list_identity(lst) for lst in available_lists]
+        list_names = [
+            lst.get("identity") or ClickUpClient.list_identity(lst)
+            for lst in available_lists
+        ]
         
         try:
             response = await client.chat.completions.create(

--- a/plugins/omi-clickup-app/test_clickup_client.py
+++ b/plugins/omi-clickup-app/test_clickup_client.py
@@ -1,0 +1,110 @@
+"""Hermetic regression tests for the ClickUp client's list discovery.
+
+The production module imports ``dotenv`` and ``requests``; both are stubbed
+so the suite runs on the standard library alone. All HTTP is faked through
+``requests.get`` — no network or credentials.
+
+Regression for #13130: ``get_all_lists`` used only the "folderless lists"
+endpoint, so a workspace whose lists all live inside folders appeared to
+have no selectable lists.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+sys.modules.setdefault("requests", types.SimpleNamespace(get=None, post=None))
+
+import clickup_client
+
+
+def _response(payload, status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = payload
+    return resp
+
+
+def _router(fixtures):
+    """Map URL suffixes to canned payloads; record every request URL."""
+    calls = []
+
+    def fake_get(url, headers=None, params=None, **kwargs):
+        calls.append(url)
+        for suffix, payload in fixtures.items():
+            if url.endswith(suffix):
+                body, status = payload if isinstance(payload, tuple) else (payload, 200)
+                return _response(body, status)
+        return _response({})
+
+    return fake_get, calls
+
+
+class GetAllListsTests(unittest.TestCase):
+    def setUp(self):
+        self.client = clickup_client.ClickUpClient()
+
+    def _run(self, fixtures):
+        fake_get, calls = _router(fixtures)
+        with patch("clickup_client.requests.get", side_effect=fake_get):
+            result = self.client.get_all_lists("token", "team-1")
+        return result, calls
+
+    def test_folder_contained_lists_are_returned(self):
+        fixtures = {
+            "/team/team-1/space": {"spaces": [{"id": "space-1", "name": "Ops"}]},
+            "/space/space-1/list": {"lists": []},
+            "/space/space-1/folder": {"folders": [{"id": "fold-1", "name": "Projects"}]},
+            "/folder/fold-1/list": {"lists": [{"id": "list-9", "name": "Sprint"}]},
+        }
+        result, calls = self._run(fixtures)
+
+        self.assertEqual(len(result), 1)
+        entry = result[0]
+        self.assertEqual(entry["id"], "list-9")
+        self.assertEqual(entry["space_id"], "space-1")
+        self.assertEqual(entry["space_name"], "Ops")
+        self.assertEqual(entry["folder_id"], "fold-1")
+        self.assertEqual(entry["folder_name"], "Projects")
+        self.assertTrue(any("/folder/fold-1/list" in url for url in calls))
+
+    def test_folderless_and_foldered_lists_coexist(self):
+        fixtures = {
+            "/team/team-1/space": {"spaces": [{"id": "space-1", "name": "Ops"}]},
+            "/space/space-1/list": {"lists": [{"id": "list-a", "name": "Inbox"}]},
+            "/space/space-1/folder": {"folders": [{"id": "fold-1", "name": "Projects"}]},
+            "/folder/fold-1/list": {"lists": [{"id": "list-b", "name": "Sprint"}]},
+        }
+        result, _ = self._run(fixtures)
+
+        self.assertEqual({lst["id"] for lst in result}, {"list-a", "list-b"})
+
+    def test_space_without_folders_still_lists_folderless(self):
+        fixtures = {
+            "/team/team-1/space": {"spaces": [{"id": "space-1", "name": "Ops"}]},
+            "/space/space-1/list": {"lists": [{"id": "list-a", "name": "Inbox"}]},
+            "/space/space-1/folder": {"folders": []},
+        }
+        result, _ = self._run(fixtures)
+
+        self.assertEqual([lst["id"] for lst in result], ["list-a"])
+
+    def test_failed_folder_list_request_drops_only_that_folder(self):
+        fixtures = {
+            "/team/team-1/space": {"spaces": [{"id": "space-1", "name": "Ops"}]},
+            "/space/space-1/list": {"lists": [{"id": "list-a", "name": "Inbox"}]},
+            "/space/space-1/folder": {
+                "folders": [{"id": "fold-bad", "name": "Broken"}, {"id": "fold-ok", "name": "Fine"}]
+            },
+            "/folder/fold-bad/list": ({"err": "denied"}, 403),
+            "/folder/fold-ok/list": {"lists": [{"id": "list-b", "name": "Sprint"}]},
+        }
+        result, _ = self._run(fixtures)
+
+        self.assertEqual({lst["id"] for lst in result}, {"list-a", "list-b"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-clickup-app/test_clickup_client.py
+++ b/plugins/omi-clickup-app/test_clickup_client.py
@@ -120,11 +120,10 @@ class GetAllListsTests(unittest.TestCase):
             "/folder/fold-b/list": {"lists": [{"id": "list-2", "name": "Sprint"}]},
         }
         result, _ = self._run(fixtures)
-        by_ident = {
-            clickup_client.ClickUpClient.list_identity(lst): lst["id"] for lst in result
-        }
+        by_ident = {lst["identity"]: lst["id"] for lst in result}
         self.assertEqual(by_ident["Sprint (Projects)"], "list-1")
         self.assertEqual(by_ident["Sprint (Archive)"], "list-2")
+        self.assertEqual(len(by_ident), 2)
         self.assertEqual(
             clickup_client.ClickUpClient.resolve_list(result, "Sprint (Projects)")["id"],
             "list-1",

--- a/plugins/omi-clickup-app/test_clickup_client.py
+++ b/plugins/omi-clickup-app/test_clickup_client.py
@@ -37,7 +37,7 @@ def _router(fixtures):
             if url.endswith(suffix):
                 body, status = payload if isinstance(payload, tuple) else (payload, 200)
                 return _response(body, status)
-        return _response({})
+        return _response({}, 404)
 
     return fake_get, calls
 
@@ -104,6 +104,48 @@ class GetAllListsTests(unittest.TestCase):
         result, _ = self._run(fixtures)
 
         self.assertEqual({lst["id"] for lst in result}, {"list-a", "list-b"})
+
+    def test_duplicate_list_names_in_two_folders_keep_distinct_identities(self):
+        fixtures = {
+            "/team/team-1/space": {"spaces": [{"id": "space-1", "name": "Ops"}]},
+            "/space/space-1/list": {"lists": []},
+            "/space/space-1/folder": {
+                "folders": [
+                    {"id": "fold-a", "name": "Projects"},
+                    {"id": "fold-b", "name": "Archive"},
+                ]
+            },
+            "/folder/fold-a/list": {"lists": [{"id": "list-1", "name": "Sprint"}]},
+            "/folder/fold-b/list": {"lists": [{"id": "list-2", "name": "Sprint"}]},
+        }
+        result, _ = self._run(fixtures)
+        by_ident = {
+            clickup_client.ClickUpClient.list_identity(lst): lst["id"] for lst in result
+        }
+        self.assertEqual(by_ident["Sprint (Projects)"], "list-1")
+        self.assertEqual(by_ident["Sprint (Archive)"], "list-2")
+        self.assertEqual(
+            clickup_client.ClickUpClient.resolve_list(result, "Sprint (Projects)")["id"],
+            "list-1",
+        )
+        self.assertIsNone(clickup_client.ClickUpClient.resolve_list(result, "Sprint"))
+
+    def test_unique_bare_list_name_still_resolves(self):
+        lists = [
+            {"id": "list-a", "name": "Inbox", "space_name": "Ops"},
+            {"id": "list-b", "name": "Sprint", "folder_name": "Projects", "space_name": "Ops"},
+        ]
+        hit = clickup_client.ClickUpClient.resolve_list(lists, "Inbox")
+        self.assertEqual(hit["id"], "list-a")
+        self.assertEqual(
+            clickup_client.ClickUpClient.list_identity(lists[0]),
+            "Inbox (Ops)",
+        )
+
+    def test_unknown_fixture_url_is_not_an_empty_200(self):
+        fake_get, _ = _router({"/known": {"ok": True}})
+        resp = fake_get("https://api.clickup.com/api/v2/space/x/unknown")
+        self.assertEqual(resp.status_code, 404)
 
 
 if __name__ == "__main__":

--- a/plugins/omi-clickup-app/test_clickup_client.py
+++ b/plugins/omi-clickup-app/test_clickup_client.py
@@ -37,7 +37,7 @@ def _router(fixtures):
             if url.endswith(suffix):
                 body, status = payload if isinstance(payload, tuple) else (payload, 200)
                 return _response(body, status)
-        return _response({}, 404)
+        raise AssertionError(f"Unexpected URL not covered by fixtures: {url}")
 
     return fake_get, calls
 
@@ -144,8 +144,8 @@ class GetAllListsTests(unittest.TestCase):
 
     def test_unknown_fixture_url_is_not_an_empty_200(self):
         fake_get, _ = _router({"/known": {"ok": True}})
-        resp = fake_get("https://api.clickup.com/api/v2/space/x/unknown")
-        self.assertEqual(resp.status_code, 404)
+        with self.assertRaises(AssertionError):
+            fake_get("https://api.clickup.com/api/v2/space/x/unknown")
 
 
 if __name__ == "__main__":

--- a/plugins/omi-clickup-app/test_clickup_client.py
+++ b/plugins/omi-clickup-app/test_clickup_client.py
@@ -68,6 +68,7 @@ class GetAllListsTests(unittest.TestCase):
         self.assertEqual(entry["space_name"], "Ops")
         self.assertEqual(entry["folder_id"], "fold-1")
         self.assertEqual(entry["folder_name"], "Projects")
+        self.assertEqual(entry["identity"], "Sprint (Projects)")
         self.assertTrue(any("/folder/fold-1/list" in url for url in calls))
 
     def test_folderless_and_foldered_lists_coexist(self):


### PR DESCRIPTION
## What changed and why

Fixes #13130. `ClickUpClient.get_all_lists()` only called the space-level `/space/{id}/list` endpoint — which ClickUp documents as **folderless lists** — so lists inside folders were never returned, and a workspace using only folder-contained lists showed no selectable lists during OAuth setup and `/refresh`. The client now also enumerates `/space/{id}/folder` and fetches `/folder/{folder_id}/list` per folder, carrying `space_id`, `space_name`, `folder_id`, and `folder_name`.

## Product invariants affected

none

## How it was verified

- Reproduced the omission offline against the unmodified production client: a folder-only workspace returned `[]` and `/folder/*/list` was never requested.
- `python3 plugins/omi-clickup-app/test_clickup_client.py` → 4 tests pass (3 fail against the pre-fix client).
- Tests are hermetic: stdlib `unittest`, `dotenv`/`requests` stubbed, all HTTP faked — runs with `python3 -S`.
- `scripts/pr-preflight --pr-body-file` (local lane) passes.

## Tests

New `plugins/omi-clickup-app/test_clickup_client.py` covers: folder-contained lists returned with space/folder metadata, folderless+foldered coexistence, folderless-only spaces, and a failed folder-list request dropping only that folder. Registered in `.github/checks-manifest.yaml` as `clickup-client-tests` (local + ci lanes).

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

The `clickup-client-tests` manifest entry runs the new hermetic test file; it would have caught #13130, where folder-contained lists silently vanished from setup and refresh. It is not a shared primitive — it exercises this client's own discovery contract through the existing per-plugin `python3 test_*.py` manifest lane.

---

AI disclosure: prepared with an AI coding assistant; reproduction and test runs were executed locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

