### PR TITLE
fix(arxiv): leave search_query unencoded for httpx form encoding

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: omi-arxiv-tests
+    command: ["python3", "plugins/omi-arxiv-app/test_main.py"]
+    triggers: ["plugins/omi-arxiv-app/**"]
+    lanes: ["local", "ci"]
+    reason: "arXiv search_query must stay unencoded so httpx form-encoding keeps AND/spaces as +, not %2B"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/plugins/omi-arxiv-app/main.py
+++ b/plugins/omi-arxiv-app/main.py
@@ -12,7 +12,6 @@ import asyncio
 import re
 import time
 from typing import Any, Optional
-from urllib.parse import quote_plus
 import xml.etree.ElementTree as ET
 
 import httpx
@@ -220,14 +219,17 @@ def _build_search_query(payload: dict[str, Any]) -> Optional[str]:
     category = _safe_category(payload.get("category"))
     parts = []
     if query:
-        parts.append(f"all:{quote_plus(query)}")
+        parts.append(f"all:{query}")
     if title:
-        parts.append(f"ti:{quote_plus(title)}")
+        parts.append(f"ti:{title}")
     if author:
-        parts.append(f"au:{quote_plus(author)}")
+        parts.append(f"au:{author}")
     if category:
         parts.append(f"cat:{category}")
-    return "+AND+".join(parts) if parts else None
+    # Leave spaces and boolean AND unencoded. httpx/urlencode form-encodes
+    # spaces as `+`; pre-quoting with quote_plus turns those pluses into `%2B`,
+    # which arXiv treats as a literal character and returns an empty feed.
+    return " AND ".join(parts) if parts else None
 
 
 @app.get("/")
@@ -404,7 +406,7 @@ async def search_author(payload: dict[str, Any]):
         entries = _parse_entries(
             await _request_arxiv(
                 {
-                    "search_query": f"au:{quote_plus(author)}",
+                    "search_query": f"au:{author}",
                     "start": 0,
                     "max_results": limit,
                     "sortBy": "submittedDate",

--- a/plugins/omi-arxiv-app/test_main.py
+++ b/plugins/omi-arxiv-app/test_main.py
@@ -1,0 +1,140 @@
+import asyncio
+import sys
+import types
+import unittest
+from urllib.parse import urlencode
+
+
+class DummyFastAPI:
+    def __init__(self, **_kwargs):
+        self.routes = []
+
+    def get(self, path, **_kwargs):
+        return self._route("GET", path)
+
+    def post(self, path, **_kwargs):
+        return self._route("POST", path)
+
+    def _route(self, method, path):
+        def decorator(func):
+            self.routes.append((method, path, func))
+            return func
+
+        return decorator
+
+
+class DummyBaseModel:
+    def __init__(self, **kwargs):
+        self.result = None
+        self.error = None
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def install_dependency_stubs():
+    fastapi = types.ModuleType("fastapi")
+    fastapi.FastAPI = DummyFastAPI
+    sys.modules.setdefault("fastapi", fastapi)
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class DummyHTMLResponse:
+        def __init__(self, content, **_kwargs):
+            self.content = content
+
+    responses.HTMLResponse = DummyHTMLResponse
+    sys.modules.setdefault("fastapi.responses", responses)
+    fastapi.responses = responses
+
+    pydantic = types.ModuleType("pydantic")
+    pydantic.BaseModel = DummyBaseModel
+    sys.modules.setdefault("pydantic", pydantic)
+
+    httpx = types.ModuleType("httpx")
+    httpx.HTTPError = Exception
+    httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+    httpx.AsyncClient = object
+    sys.modules.setdefault("httpx", httpx)
+
+
+install_dependency_stubs()
+import main
+
+
+ATOM_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2401.01234</id>
+    <title>Attention Is All You Need</title>
+    <published>2024-01-01T00:00:00Z</published>
+    <updated>2024-01-02T00:00:00Z</updated>
+    <summary>A transformer paper.</summary>
+    <author><name>Ada Lovelace</name></author>
+    <category term="cs.AI" />
+  </entry>
+</feed>
+"""
+
+
+class ArxivSearchQueryEncodingTest(unittest.TestCase):
+    def test_multi_word_query_is_not_prequoted(self):
+        query = main._build_search_query({"query": "machine learning"})
+        self.assertEqual(query, "all:machine learning")
+        encoded = urlencode({"search_query": query})
+        self.assertIn("machine+learning", encoded)
+        self.assertNotIn("%2B", encoded)
+
+    def test_field_join_uses_boolean_and_with_spaces(self):
+        query = main._build_search_query(
+            {"query": "transformer", "title": "attention", "author": "Vaswani"}
+        )
+        self.assertEqual(
+            query, "all:transformer AND ti:attention AND au:Vaswani"
+        )
+        encoded = urlencode({"search_query": query})
+        self.assertIn("+AND+", encoded)
+        self.assertNotIn("%2BAND%2B", encoded)
+
+    def test_quoted_phrase_is_not_percent_encoded_twice(self):
+        query = main._build_search_query({"query": '"quantum criticality"'})
+        self.assertEqual(query, 'all:"quantum criticality"')
+        encoded = urlencode({"search_query": query})
+        self.assertIn("%22quantum+criticality%22", encoded)
+        self.assertNotIn("%2522", encoded)
+
+    def test_search_papers_passes_unencoded_query_to_arxiv(self):
+        captured = {}
+
+        async def fake_request(params):
+            captured.update(params)
+            return ATOM_FEED
+
+        main._request_arxiv = fake_request
+        result = asyncio.run(
+            main.search_papers({"query": "machine learning", "title": "attention"})
+        )
+        self.assertIsNone(result.error)
+        self.assertEqual(
+            captured["search_query"],
+            "all:machine learning AND ti:attention",
+        )
+        self.assertIn("Attention Is All You Need", result.result)
+
+    def test_search_author_passes_unencoded_author_name(self):
+        captured = {}
+
+        async def fake_request(params):
+            captured.update(params)
+            return ATOM_FEED
+
+        main._request_arxiv = fake_request
+        result = asyncio.run(main.search_author({"author": "Yann LeCun"}))
+        self.assertIsNone(result.error)
+        self.assertEqual(captured["search_query"], "au:Yann LeCun")
+        encoded = urlencode({"search_query": captured["search_query"]})
+        self.assertIn("Yann+LeCun", encoded)
+        self.assertNotIn("%2B", encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-arxiv-app/test_main.py
+++ b/plugins/omi-arxiv-app/test_main.py
@@ -1,64 +1,79 @@
+"""Hermetic arXiv search_query encoding regressions.
+
+Import the production module with framework-only stubs, then exercise the
+query builder and chat-tool handlers. No network, credentials, or
+third-party runtime packages are required.
+"""
+
 import asyncio
+import importlib.util
+from pathlib import Path
 import sys
-import types
+from types import ModuleType
 import unittest
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 
-class DummyFastAPI:
-    def __init__(self, **_kwargs):
-        self.routes = []
+def load_app():
+    class DummyFastAPI:
+        def __init__(self, **_kwargs):
+            self.routes = []
 
-    def get(self, path, **_kwargs):
-        return self._route("GET", path)
+        def get(self, path, **_kwargs):
+            return self._route("GET", path)
 
-    def post(self, path, **_kwargs):
-        return self._route("POST", path)
+        def post(self, path, **_kwargs):
+            return self._route("POST", path)
 
-    def _route(self, method, path):
-        def decorator(func):
-            self.routes.append((method, path, func))
-            return func
+        def _route(self, method, path):
+            def decorator(func):
+                self.routes.append((method, path, func))
+                return func
 
-        return decorator
+            return decorator
 
-
-class DummyBaseModel:
-    def __init__(self, **kwargs):
-        self.result = None
-        self.error = None
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
-
-def install_dependency_stubs():
-    fastapi = types.ModuleType("fastapi")
-    fastapi.FastAPI = DummyFastAPI
-    sys.modules.setdefault("fastapi", fastapi)
-
-    responses = types.ModuleType("fastapi.responses")
+    class DummyBaseModel:
+        def __init__(self, **kwargs):
+            self.result = None
+            self.error = None
+            for key, value in kwargs.items():
+                setattr(self, key, value)
 
     class DummyHTMLResponse:
         def __init__(self, content, **_kwargs):
             self.content = content
 
+    fastapi = ModuleType("fastapi")
+    fastapi.FastAPI = DummyFastAPI
+    responses = ModuleType("fastapi.responses")
     responses.HTMLResponse = DummyHTMLResponse
-    sys.modules.setdefault("fastapi.responses", responses)
     fastapi.responses = responses
-
-    pydantic = types.ModuleType("pydantic")
+    pydantic = ModuleType("pydantic")
     pydantic.BaseModel = DummyBaseModel
-    sys.modules.setdefault("pydantic", pydantic)
-
-    httpx = types.ModuleType("httpx")
+    httpx = ModuleType("httpx")
     httpx.HTTPError = Exception
     httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
     httpx.AsyncClient = object
-    sys.modules.setdefault("httpx", httpx)
+
+    spec = importlib.util.spec_from_file_location(
+        "arxiv_app", Path(__file__).with_name("main.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(
+        sys.modules,
+        {
+            "httpx": httpx,
+            "fastapi": fastapi,
+            "fastapi.responses": responses,
+            "pydantic": pydantic,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
 
 
-install_dependency_stubs()
-import main
+app = load_app()
 
 
 ATOM_FEED = """<?xml version="1.0" encoding="UTF-8"?>
@@ -78,14 +93,14 @@ ATOM_FEED = """<?xml version="1.0" encoding="UTF-8"?>
 
 class ArxivSearchQueryEncodingTest(unittest.TestCase):
     def test_multi_word_query_is_not_prequoted(self):
-        query = main._build_search_query({"query": "machine learning"})
+        query = app._build_search_query({"query": "machine learning"})
         self.assertEqual(query, "all:machine learning")
         encoded = urlencode({"search_query": query})
         self.assertIn("machine+learning", encoded)
         self.assertNotIn("%2B", encoded)
 
     def test_field_join_uses_boolean_and_with_spaces(self):
-        query = main._build_search_query(
+        query = app._build_search_query(
             {"query": "transformer", "title": "attention", "author": "Vaswani"}
         )
         self.assertEqual(
@@ -96,7 +111,7 @@ class ArxivSearchQueryEncodingTest(unittest.TestCase):
         self.assertNotIn("%2BAND%2B", encoded)
 
     def test_quoted_phrase_is_not_percent_encoded_twice(self):
-        query = main._build_search_query({"query": '"quantum criticality"'})
+        query = app._build_search_query({"query": '"quantum criticality"'})
         self.assertEqual(query, 'all:"quantum criticality"')
         encoded = urlencode({"search_query": query})
         self.assertIn("%22quantum+criticality%22", encoded)
@@ -109,10 +124,10 @@ class ArxivSearchQueryEncodingTest(unittest.TestCase):
             captured.update(params)
             return ATOM_FEED
 
-        main._request_arxiv = fake_request
-        result = asyncio.run(
-            main.search_papers({"query": "machine learning", "title": "attention"})
-        )
+        with patch.object(app, "_request_arxiv", fake_request):
+            result = asyncio.run(
+                app.search_papers({"query": "machine learning", "title": "attention"})
+            )
         self.assertIsNone(result.error)
         self.assertEqual(
             captured["search_query"],
@@ -127,8 +142,8 @@ class ArxivSearchQueryEncodingTest(unittest.TestCase):
             captured.update(params)
             return ATOM_FEED
 
-        main._request_arxiv = fake_request
-        result = asyncio.run(main.search_author({"author": "Yann LeCun"}))
+        with patch.object(app, "_request_arxiv", fake_request):
+            result = asyncio.run(app.search_author({"author": "Yann LeCun"}))
         self.assertIsNone(result.error)
         self.assertEqual(captured["search_query"], "au:Yann LeCun")
         encoded = urlencode({"search_query": captured["search_query"]})


### PR DESCRIPTION
## Summary

- `search_papers` and `search_author` pre-quoted `search_query` with `quote_plus` and joined fields with `+AND+`.
- httpx then form-encodes params, so those pluses become `%2B`. arXiv treats `%2B` as a literal plus and returns an empty Atom feed.
- The helpers now pass unencoded `all:machine learning` / `au:Yann LeCun` / ` AND ` joins and let the HTTP client apply form encoding once.

Fixes #13574

## Verification

- `python3 plugins/omi-arxiv-app/test_main.py`: 5 tests pass.
- Behavioral cases: multi-word query, query+title+author AND join, quoted phrase (`%22` once, not `%2522`), and author names with spaces. Encoded query strings contain `+` / `+AND+` and must not contain `%2B`.
- No live arXiv. Production helpers plus `urlencode` / a stubbed `_request_arxiv`.
- Manifest entry `omi-arxiv-tests` is registered for local/CI.
- Backend Hermetic Merge Gate: out of scope (plugin-only).

## Product invariants affected

none

Failure-Class: none

Why isn't this a shared primitive instead? The query string is local to this plugin's arXiv Atom client. Other plugins do not share this builder.

Proposed US$25 under the contribution guide, payable through the documented private PayPal process after acceptance and merge. I am not assuming assignment or payment.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

