### PR TITLE
fix(linear): resolve identifier-targeted tools via exact issue(id)

### DIFF
--- a/plugins/omi-linear-app/issue_lookup.py
+++ b/plugins/omi-linear-app/issue_lookup.py
@@ -1,0 +1,76 @@
+"""Exact Linear issue lookup for identifier-targeted chat tools.
+
+``searchIssues(term:, first: 1)`` can return a *different* issue (ENG-1234
+when the user asked for ENG-123). Linear's ``issue(id:)`` accepts the
+shorthand identifier and is exact.
+"""
+
+from typing import Any, Callable, Dict
+
+ISSUE_BY_ID_QUERY = """
+query($id: String!) {
+    issue(id: $id) {
+        id
+        identifier
+        title
+        description
+        priority
+        estimate
+        url
+        createdAt
+        updatedAt
+        state {
+            name
+            type
+        }
+        assignee {
+            name
+        }
+        creator {
+            name
+        }
+        team {
+            id
+            name
+        }
+        project {
+            name
+        }
+        labels {
+            nodes {
+                name
+            }
+        }
+    }
+}
+"""
+
+
+def resolve_issue_by_identifier(
+    graphql_fn: Callable[..., Dict[str, Any]],
+    uid: str,
+    identifier: str,
+) -> Dict[str, Any]:
+    """Return ``{"issue": ...}`` or ``{"error": ...}``. Never uses searchIssues."""
+    ident = (identifier or "").strip()
+    if not ident:
+        return {"error": "Issue identifier is required (e.g., ENG-123)"}
+
+    wanted = ident.upper()
+    result = graphql_fn(uid, ISSUE_BY_ID_QUERY, {"id": wanted})
+    if "error" in result:
+        err = str(result["error"])
+        lowered = err.lower()
+        if "not found" in lowered or "could not find" in lowered:
+            return {"error": f"Could not find issue: {identifier}"}
+        return {"error": err}
+
+    issue = result.get("issue")
+    if not issue:
+        return {"error": f"Could not find issue: {identifier}"}
+
+    got = (issue.get("identifier") or "").upper()
+    if got and got != wanted:
+        return {"error": f"Could not find issue: {identifier}"}
+
+    return {"issue": issue}

--- a/plugins/omi-linear-app/main.py
+++ b/plugins/omi-linear-app/main.py
@@ -35,6 +35,7 @@ from models import (
     LinearUser,
     WorkflowState,
 )
+from issue_lookup import resolve_issue_by_identifier
 
 load_dotenv()
 
@@ -735,34 +736,14 @@ async def tool_update_issue_status(request: Request):
         if not get_linear_tokens(uid):
             return ChatToolResponse(error="Please connect your Linear account first in the app settings.")
         
-        # Search for the issue by identifier using searchIssues
-        search_query = """
-        query($term: String!) {
-            searchIssues(term: $term, first: 1) {
-                nodes {
-                    id
-                    identifier
-                    title
-                    team {
-                        id
-                    }
-                }
-            }
-        }
-        """
+        looked = resolve_issue_by_identifier(linear_graphql_request, uid, issue_identifier)
+        if "error" in looked:
+            err = looked["error"]
+            if err.startswith("Could not find issue") or err.startswith("Issue identifier"):
+                return ChatToolResponse(error=err)
+            return ChatToolResponse(error=f"Failed to find issue: {err}")
         
-        result = linear_graphql_request(uid, search_query, {
-            "term": issue_identifier.upper()
-        })
-        
-        if "error" in result:
-            return ChatToolResponse(error=f"Failed to find issue: {result['error']}")
-        
-        issues = result.get("searchIssues", {}).get("nodes", [])
-        if not issues:
-            return ChatToolResponse(error=f"Could not find issue: {issue_identifier}")
-        
-        issue = issues[0]
+        issue = looked["issue"]
         team_id = issue["team"]["id"]
         issue_id = issue["id"]
         
@@ -942,57 +923,14 @@ async def tool_get_issue(request: Request):
         if not get_linear_tokens(uid):
             return ChatToolResponse(error="Please connect your Linear account first in the app settings.")
         
-        query = """
-        query($term: String!) {
-            searchIssues(term: $term, first: 1) {
-                nodes {
-                    id
-                    identifier
-                    title
-                    description
-                    priority
-                    estimate
-                    state {
-                        name
-                        type
-                    }
-                    assignee {
-                        name
-                    }
-                    creator {
-                        name
-                    }
-                    team {
-                        name
-                    }
-                    project {
-                        name
-                    }
-                    labels {
-                        nodes {
-                            name
-                        }
-                    }
-                    url
-                    createdAt
-                    updatedAt
-                }
-            }
-        }
-        """
+        looked = resolve_issue_by_identifier(linear_graphql_request, uid, issue_identifier)
+        if "error" in looked:
+            err = looked["error"]
+            if err.startswith("Could not find issue") or err.startswith("Issue identifier"):
+                return ChatToolResponse(error=err)
+            return ChatToolResponse(error=f"Failed to get issue: {err}")
         
-        result = linear_graphql_request(uid, query, {
-            "term": issue_identifier.upper()
-        })
-        
-        if "error" in result:
-            return ChatToolResponse(error=f"Failed to get issue: {result['error']}")
-        
-        issues = result.get("searchIssues", {}).get("nodes", [])
-        if not issues:
-            return ChatToolResponse(error=f"Could not find issue: {issue_identifier}")
-        
-        issue = issues[0]
+        issue = looked["issue"]
         
         # Format the issue details
         priority_map = {0: "No priority", 1: "🔴 Urgent", 2: "🟠 High", 3: "🟡 Medium", 4: "🔵 Low"}
@@ -1065,31 +1003,14 @@ async def tool_add_comment(request: Request):
         if not get_linear_tokens(uid):
             return ChatToolResponse(error="Please connect your Linear account first in the app settings.")
         
-        # First, get the issue ID using search
-        query = """
-        query($term: String!) {
-            searchIssues(term: $term, first: 1) {
-                nodes {
-                    id
-                    identifier
-                    title
-                }
-            }
-        }
-        """
+        looked = resolve_issue_by_identifier(linear_graphql_request, uid, issue_identifier)
+        if "error" in looked:
+            err = looked["error"]
+            if err.startswith("Could not find issue") or err.startswith("Issue identifier"):
+                return ChatToolResponse(error=err)
+            return ChatToolResponse(error=f"Failed to find issue: {err}")
         
-        result = linear_graphql_request(uid, query, {
-            "term": issue_identifier.upper()
-        })
-        
-        if "error" in result:
-            return ChatToolResponse(error=f"Failed to find issue: {result['error']}")
-        
-        issues = result.get("searchIssues", {}).get("nodes", [])
-        if not issues:
-            return ChatToolResponse(error=f"Could not find issue: {issue_identifier}")
-        
-        issue = issues[0]
+        issue = looked["issue"]
         
         # Add the comment
         mutation = """

--- a/plugins/omi-linear-app/test_issue_lookup.py
+++ b/plugins/omi-linear-app/test_issue_lookup.py
@@ -1,0 +1,90 @@
+"""Hermetic tests for exact Linear issue lookup (#13162).
+
+No network, Linear credentials, FastAPI, or Redis. The production
+``searchIssues(term:, first: 1)`` path is never used.
+"""
+
+import unittest
+
+import issue_lookup
+
+
+class ResolveIssueByIdentifierTests(unittest.TestCase):
+    def test_uses_issue_id_query_not_searchissues(self):
+        captured = {}
+
+        def fake_graphql(uid, query, variables=None):
+            captured["uid"] = uid
+            captured["query"] = query
+            captured["variables"] = variables
+            return {
+                "issue": {
+                    "id": "uuid-123",
+                    "identifier": "ENG-123",
+                    "title": "Exact",
+                    "team": {"id": "team-1", "name": "Eng"},
+                }
+            }
+
+        result = issue_lookup.resolve_issue_by_identifier(
+            fake_graphql, "user-1", "eng-123"
+        )
+        self.assertEqual(result["issue"]["id"], "uuid-123")
+        self.assertIn("issue(id: $id)", captured["query"])
+        self.assertNotIn("searchIssues", captured["query"])
+        self.assertEqual(captured["variables"], {"id": "ENG-123"})
+        self.assertEqual(captured["uid"], "user-1")
+
+    def test_prefix_hit_from_search_would_be_rejected_here(self):
+        def fake_graphql(uid, query, variables=None):
+            return {
+                "issue": {
+                    "id": "uuid-1234",
+                    "identifier": "ENG-1234",
+                    "title": "Wrong neighbour",
+                    "team": {"id": "team-1", "name": "Eng"},
+                }
+            }
+
+        result = issue_lookup.resolve_issue_by_identifier(
+            fake_graphql, "user-1", "ENG-123"
+        )
+        self.assertEqual(result["error"], "Could not find issue: ENG-123")
+
+    def test_missing_issue_is_not_found(self):
+        def fake_graphql(uid, query, variables=None):
+            return {"issue": None}
+
+        result = issue_lookup.resolve_issue_by_identifier(
+            fake_graphql, "user-1", "ENG-123"
+        )
+        self.assertEqual(result["error"], "Could not find issue: ENG-123")
+
+    def test_entity_not_found_graphql_error(self):
+        def fake_graphql(uid, query, variables=None):
+            return {"error": "Entity not found: Issue"}
+
+        result = issue_lookup.resolve_issue_by_identifier(
+            fake_graphql, "user-1", "ENG-123"
+        )
+        self.assertEqual(result["error"], "Could not find issue: ENG-123")
+
+    def test_transport_error_is_passed_through(self):
+        def fake_graphql(uid, query, variables=None):
+            return {"error": "Request failed: timeout"}
+
+        result = issue_lookup.resolve_issue_by_identifier(
+            fake_graphql, "user-1", "ENG-123"
+        )
+        self.assertEqual(result["error"], "Request failed: timeout")
+
+    def test_empty_identifier(self):
+        def fake_graphql(*_a, **_k):
+            self.fail("must not call GraphQL")
+
+        result = issue_lookup.resolve_issue_by_identifier(fake_graphql, "user-1", "  ")
+        self.assertIn("Issue identifier is required", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why

Fixes #13162. `tool_get_issue`, `tool_update_issue_status`, and `tool_add_comment` resolved `issue_identifier` with `searchIssues(term:, first: 1)` and took `nodes[0]`. Requesting `ENG-123` can therefore operate on `ENG-1234`. Linear documents exact shorthand lookup as `issue(id: "ENG-123")`. The three tools now share `resolve_issue_by_identifier`, which uses that query and rejects a mismatched identifier. Ordinary `searchIssues` search/list is unchanged.

## How it was verified

- Reproduced the mismatch offline: a stub that returns `ENG-1234` as the first search hit is exactly what the old path would accept; the new resolver rejects it.
- `python3 plugins/omi-linear-app/test_issue_lookup.py` → 6 passed (exact `issue(id:)` query, prefix-neighbour rejected, missing/null, GraphQL not-found, transport error, empty identifier).
- Tests are hermetic: stdlib `unittest`, no network, no Linear credentials.

## Tests

New `plugins/omi-linear-app/issue_lookup.py` + `test_issue_lookup.py`.

AI disclosure: prepared with an AI coding assistant; the test run was executed locally.

#13303 is still CONFLICTING; this branch is based on current main.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

