### PR TITLE
fix(twitter): tolerate non-dict transcript segments in process_segments

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -924,6 +924,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
 
+  - id: twitter-segment-shape-tests
+    command: ["python3", "plugins/omi-twitter-app/test_main_simple.py"]
+    triggers: ["plugins/omi-twitter-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "a JSON list of raw-string transcript segments crashed process_segments with AttributeError on seg.get, producing a 500 instead of processing the webhook"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-twitter-app/main_simple.py
+++ b/plugins/omi-twitter-app/main_simple.py
@@ -692,7 +692,7 @@ async def process_segments(
     """
     
     # Extract text from segments
-    segment_texts = [seg.get("text", "") for seg in segments]
+    segment_texts = [seg.get("text", "") if isinstance(seg, dict) else str(seg) for seg in segments]
     full_text = " ".join(segment_texts)
     
     session_id = session["session_id"]

--- a/plugins/omi-twitter-app/test_main_simple.py
+++ b/plugins/omi-twitter-app/test_main_simple.py
@@ -97,9 +97,22 @@ def _install_module_stubs():
     sys.modules["dotenv"] = dotenv
 
 
+_STUBBED_MODULES = ("fastapi", "fastapi.responses", "tweepy", "openai", "dotenv")
+_saved_modules = {name: sys.modules.get(name) for name in _STUBBED_MODULES}
 _install_module_stubs()
-import main_simple  # noqa: E402
-from simple_storage import SimpleSessionStorage, sessions  # noqa: E402
+try:
+    import main_simple  # noqa: E402
+    from simple_storage import SimpleSessionStorage, sessions  # noqa: E402
+finally:
+    # Bound names inside main_simple keep referencing the stub objects after
+    # import, so restore the original sys.modules entries to avoid
+    # contaminating other tests in a shared process.
+    for _name, _original in _saved_modules.items():
+        if _original is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
+    del _name, _original, _saved_modules
 
 
 class ProcessSegmentsTests(unittest.TestCase):

--- a/plugins/omi-twitter-app/test_main_simple.py
+++ b/plugins/omi-twitter-app/test_main_simple.py
@@ -1,0 +1,150 @@
+"""Hermetic regression tests for plugins/omi-twitter-app/main_simple.py.
+
+Standard library only: fastapi, tweepy, openai, and dotenv are replaced
+with minimal stubs before importing the module under test so the suite
+runs without site-packages.
+
+Covers the non-dict-segment crash: OMI may POST a JSON list of raw strings
+(a documented payload shape in the webhook), and `process_segments` used
+to call seg.get() unconditionally, raising AttributeError and producing a
+500 instead of processing the transcript.
+"""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+os.environ.setdefault("STORAGE_DIR", "/tmp/omi-twitter-test-storage")
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def _install_module_stubs():
+    fastapi = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code=None, detail=None):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return lambda f: f
+
+        def post(self, *args, **kwargs):
+            return lambda f: f
+
+    class Request:
+        pass
+
+    def Query(default=None, **kwargs):
+        return default
+
+    fastapi.FastAPI = FastAPI
+    fastapi.Request = Request
+    fastapi.HTTPException = HTTPException
+    fastapi.Query = Query
+    sys.modules["fastapi"] = fastapi
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class _Resp:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    responses.HTMLResponse = _Resp
+    responses.RedirectResponse = _Resp
+    responses.JSONResponse = _Resp
+    sys.modules["fastapi.responses"] = responses
+
+    tweepy = types.ModuleType("tweepy")
+
+    class TweepyException(Exception):
+        pass
+
+    class Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class OAuth2UserHandler:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    tweepy.TweepyException = TweepyException
+    tweepy.Client = Client
+    tweepy.OAuth2UserHandler = OAuth2UserHandler
+    sys.modules["tweepy"] = tweepy
+
+    openai = types.ModuleType("openai")
+
+    class AsyncOpenAI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    openai.AsyncOpenAI = AsyncOpenAI
+    sys.modules["openai"] = openai
+
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dotenv
+
+
+_install_module_stubs()
+import main_simple  # noqa: E402
+from simple_storage import SimpleSessionStorage, sessions  # noqa: E402
+
+
+class ProcessSegmentsTests(unittest.TestCase):
+    def setUp(self):
+        sessions.clear()
+        self.session = SimpleSessionStorage.get_or_create_session("sess-1", "u1")
+        self.user = {"uid": "u1", "access_token": "tok"}
+
+    def _run(self, segs):
+        return asyncio.run(main_simple.process_segments(self.session, segs, self.user))
+
+    def test_string_segment_does_not_crash(self):
+        # Bare-string list: previously AttributeError on seg.get("text").
+        result = self._run(["just some words"])
+        self.assertEqual(result, "listening")
+
+    def test_string_segment_with_trigger_starts_recording(self):
+        result = self._run(["tweet now buy the dip"])
+        self.assertEqual(result, "collecting_1")
+        self.assertEqual(self.session["tweet_mode"], "recording")
+        self.assertEqual(self.session["accumulated_text"], "buy the dip")
+
+    def test_mixed_dict_and_string_segments(self):
+        result = self._run([{"text": "hello "}, "world"])
+        self.assertEqual(result, "listening")
+
+    def test_recording_collects_three_segments(self):
+        self._run(["tweet now first part"])
+        r2 = self._run(["second part"])
+        self.assertEqual(r2, "collecting_2")
+
+        # Third segment completes collection; stub the AI + post path.
+        with mock.patch.object(
+            main_simple.tweet_detector,
+            "ai_extract_tweet_from_segments",
+            new=mock.AsyncMock(return_value="cleaned tweet text"),
+        ), mock.patch.object(
+            main_simple.twitter_client,
+            "post_tweet",
+            new=mock.AsyncMock(return_value={"success": True, "tweet_id": "42"}),
+        ):
+            r3 = self._run(["third part"])
+        self.assertIn("Tweet posted", r3)
+        self.assertEqual(self.session["tweet_mode"], "idle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `plugins/omi-twitter-app/main_simple.py`: `process_segments` called `seg.get("text")` unconditionally, so a webhook payload that is a JSON list of raw strings — or any list mixing dicts and strings — raised `AttributeError` and the endpoint returned a 500. The debug log a few lines above already guarded non-dict segments; the extraction path did not.
- Coerce non-dict segments to `str` so their text still feeds trigger detection and tweet collection.
- Added `plugins/omi-twitter-app/test_main_simple.py` (hermetic, stdlib-only; stubs fastapi/tweepy/openai/dotenv) and registered it in `.github/checks-manifest.yaml`.

## Verification
- `python3 -S plugins/omi-twitter-app/test_main_simple.py` — 4 tests pass with no site-packages.
- All 4 tests error on the unfixed module (verified via stash), confirming real regression coverage.
- Exercised the real path: bare-string segment no longer crashes; "tweet now" in a string segment starts recording; the 3-segment collection still posts via the AI-extraction + post seam.

Failure-Class: none

---

*This PR was authored by an automated agent on behalf of @Da7em-T.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

