### PR TITLE
fix(twitter-chat-tools): validate max_results bounds and URL-encode path params

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -924,6 +924,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
 
+  - id: twitter-chat-tools-input-tests
+    command: ["python3", "plugins/omi-twitter-chat-tools-app/test_main.py"]
+    triggers: ["plugins/omi-twitter-chat-tools-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "out-of-range or non-integer max_results was sent to Twitter unclamped below the documented minimum, and tweet_id/username reached request paths unencoded"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-twitter-chat-tools-app/main.py
+++ b/plugins/omi-twitter-chat-tools-app/main.py
@@ -11,7 +11,7 @@ import hashlib
 import base64
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 import requests
 from dotenv import load_dotenv
@@ -173,6 +173,16 @@ def twitter_api_request(uid: str, method: str, endpoint: str, params: dict = Non
     except Exception as e:
         log(f"Twitter API request error: {e}")
         return {"error": str(e)}
+
+
+def _parse_max_results(body: dict, default: int = 10, minimum: int = 5, maximum: int = 100) -> Optional[int]:
+    """Parse max_results from a tool request body and clamp it to the
+    Twitter API's documented bounds for the calling endpoint."""
+    try:
+        value = int(body.get("max_results", default))
+    except (TypeError, ValueError):
+        return None
+    return max(minimum, min(value, maximum))
 
 
 def format_tweet(tweet: dict, includes: dict = None) -> str:
@@ -511,10 +521,12 @@ async def tool_get_timeline(request: Request):
         log(f"=== GET_TIMELINE ===")
 
         uid = body.get("uid")
-        max_results = min(body.get("max_results", 10), 100)
+        max_results = _parse_max_results(body)
 
         if not uid:
             return ChatToolResponse(error="User ID is required")
+        if max_results is None:
+            return ChatToolResponse(error="max_results must be an integer")
 
         access_token = get_valid_access_token(uid)
         if not access_token:
@@ -563,10 +575,12 @@ async def tool_get_my_tweets(request: Request):
         log(f"=== GET_MY_TWEETS ===")
 
         uid = body.get("uid")
-        max_results = min(body.get("max_results", 10), 100)
+        max_results = _parse_max_results(body)
 
         if not uid:
             return ChatToolResponse(error="User ID is required")
+        if max_results is None:
+            return ChatToolResponse(error="max_results must be an integer")
 
         access_token = get_valid_access_token(uid)
         if not access_token:
@@ -627,10 +641,12 @@ async def tool_get_mentions(request: Request):
     try:
         body = await request.json()
         uid = body.get("uid")
-        max_results = min(body.get("max_results", 10), 100)
+        max_results = _parse_max_results(body)
 
         if not uid:
             return ChatToolResponse(error="User ID is required")
+        if max_results is None:
+            return ChatToolResponse(error="max_results must be an integer")
 
         access_token = get_valid_access_token(uid)
         if not access_token:
@@ -678,10 +694,12 @@ async def tool_search_tweets(request: Request):
         body = await request.json()
         uid = body.get("uid")
         query = body.get("query")
-        max_results = min(body.get("max_results", 10), 100)
+        max_results = _parse_max_results(body, minimum=10)
 
         if not uid:
             return ChatToolResponse(error="User ID is required")
+        if max_results is None:
+            return ChatToolResponse(error="max_results must be an integer")
 
         if not query:
             return ChatToolResponse(error="Search query is required")
@@ -780,7 +798,7 @@ async def tool_unlike_tweet(request: Request):
         if not twitter_user_id:
             return ChatToolResponse(error="Could not get your Twitter user ID.")
 
-        result = twitter_api_request(uid, "DELETE", f"/users/{twitter_user_id}/likes/{tweet_id}")
+        result = twitter_api_request(uid, "DELETE", f"/users/{twitter_user_id}/likes/{quote(str(tweet_id), safe='')}")
 
         if result and "error" in result:
             return ChatToolResponse(error=f"Failed to unlike tweet: {result.get('error', 'Unknown error')}")
@@ -846,7 +864,7 @@ async def tool_delete_tweet(request: Request):
         if not access_token:
             return ChatToolResponse(error="Please connect your Twitter account first in the app settings.")
 
-        result = twitter_api_request(uid, "DELETE", f"/tweets/{tweet_id}")
+        result = twitter_api_request(uid, "DELETE", f"/tweets/{quote(str(tweet_id), safe='')}")
 
         if result and "error" in result:
             return ChatToolResponse(error=f"Failed to delete tweet: {result.get('error', 'Unknown error')}")
@@ -875,7 +893,7 @@ async def tool_get_user_profile(request: Request):
 
         if username:
             # Look up by username
-            result = twitter_api_request(uid, "GET", f"/users/by/username/{username}", params={
+            result = twitter_api_request(uid, "GET", f"/users/by/username/{quote(str(username), safe='')}", params={
                 "user.fields": "description,public_metrics,created_at,profile_image_url,verified"
             })
         else:

--- a/plugins/omi-twitter-chat-tools-app/main.py
+++ b/plugins/omi-twitter-chat-tools-app/main.py
@@ -180,7 +180,7 @@ def _parse_max_results(body: dict, default: int = 10, minimum: int = 5, maximum:
     Twitter API's documented bounds for the calling endpoint."""
     try:
         value = int(body.get("max_results", default))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     return max(minimum, min(value, maximum))
 

--- a/plugins/omi-twitter-chat-tools-app/test_main.py
+++ b/plugins/omi-twitter-chat-tools-app/test_main.py
@@ -119,6 +119,17 @@ class _EndpointCase(unittest.TestCase):
                 "params": params or {},
                 "json_data": json_data or {},
             }
+            if endpoint.startswith("/users/by/username/") or endpoint == "/users/me":
+                return {
+                    "data": {
+                        "name": "Ada",
+                        "username": "ada",
+                        "description": "",
+                        "verified": False,
+                        "public_metrics": {},
+                        "created_at": "2020-01-01T00:00:00.000Z",
+                    }
+                }
             return {"data": []}
 
         self._patches = [
@@ -140,6 +151,7 @@ class MaxResultsBoundsTests(_EndpointCase):
         self.assertEqual(main._parse_max_results({"max_results": "20"}), 20)
         self.assertIsNone(main._parse_max_results({"max_results": "abc"}))
         self.assertIsNone(main._parse_max_results({"max_results": None}))
+        self.assertIsNone(main._parse_max_results({"max_results": 1e309}))
         # Search endpoint has a higher documented minimum.
         self.assertEqual(
             main._parse_max_results({"max_results": 2}, minimum=10), 10
@@ -173,6 +185,14 @@ class MaxResultsBoundsTests(_EndpointCase):
         )
         self.assertIsNotNone(resp.error)
 
+    def test_overflowing_max_results_returns_error(self):
+        resp = _run(
+            main.tool_get_timeline(
+                _FakeRequest({"uid": "u1", "max_results": 1e309})
+            )
+        )
+        self.assertIsNotNone(resp.error)
+
 
 class PathInterpolationTests(_EndpointCase):
     def test_tweet_id_is_url_encoded_in_unlike_path(self):
@@ -194,11 +214,13 @@ class PathInterpolationTests(_EndpointCase):
         self.assertEqual(self.captured["endpoint"], "/tweets/1%3Fuser_id%3Devil")
 
     def test_username_is_url_encoded_in_profile_path(self):
-        _run(
+        resp = _run(
             main.tool_get_user_profile(
                 _FakeRequest({"uid": "u1", "username": "a/b"})
             )
         )
+        self.assertIsNone(resp.error)
+        self.assertIsNotNone(resp.result)
         self.assertEqual(self.captured["endpoint"], "/users/by/username/a%2Fb")
 
 

--- a/plugins/omi-twitter-chat-tools-app/test_main.py
+++ b/plugins/omi-twitter-chat-tools-app/test_main.py
@@ -1,0 +1,206 @@
+"""Hermetic regression tests for plugins/omi-twitter-chat-tools-app/main.py.
+
+Standard library only: requests, dotenv, fastapi, and pydantic are replaced
+with minimal stubs before importing the module under test so the suite
+runs without site-packages.
+
+Covers two boundary defects:
+- max_results was only upper-clamped (`min(v, 100)`), so 0 / negative /
+  non-integer values were sent to Twitter (whose documented minimum is 5
+  for timelines/mentions/tweets and 10 for recent search) or raised a
+  TypeError inside min().
+- tweet_id and username were interpolated into request paths unencoded,
+  so a value containing '/' or '?' rewrote the target endpoint.
+"""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def _install_module_stubs():
+    requests = types.ModuleType("requests")
+    requests.get = requests.post = requests.delete = lambda *a, **k: None
+    sys.modules["requests"] = requests
+
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dotenv
+
+    fastapi = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code=None, detail=None):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return lambda f: f
+
+        def post(self, *args, **kwargs):
+            return lambda f: f
+
+    class Request:
+        pass
+
+    def Query(default=None, **kwargs):
+        return default
+
+    fastapi.FastAPI = FastAPI
+    fastapi.Request = Request
+    fastapi.HTTPException = HTTPException
+    fastapi.Query = Query
+    sys.modules["fastapi"] = fastapi
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class _Resp:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    responses.HTMLResponse = _Resp
+    responses.RedirectResponse = _Resp
+    responses.JSONResponse = _Resp
+    sys.modules["fastapi.responses"] = responses
+
+    pydantic = types.ModuleType("pydantic")
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            for klass in reversed(type(self).__mro__):
+                for field in getattr(klass, "__annotations__", {}):
+                    if field in kwargs:
+                        setattr(self, field, kwargs[field])
+                    elif hasattr(type(self), field):
+                        setattr(self, field, getattr(type(self), field))
+                    else:
+                        setattr(self, field, None)
+
+    pydantic.BaseModel = BaseModel
+    sys.modules["pydantic"] = pydantic
+
+
+_install_module_stubs()
+import main  # noqa: E402
+
+
+class _FakeRequest:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _EndpointCase(unittest.TestCase):
+    """Shared scaffolding: authenticated user, captured API request."""
+
+    def setUp(self):
+        self.captured = {}
+
+        def fake_api_request(uid, method, endpoint, params=None, json_data=None):
+            self.captured = {
+                "method": method,
+                "endpoint": endpoint,
+                "params": params or {},
+                "json_data": json_data or {},
+            }
+            return {"data": []}
+
+        self._patches = [
+            mock.patch.object(main, "get_valid_access_token", lambda uid: "tok"),
+            mock.patch.object(main, "get_user_id", lambda uid: "tw-uid"),
+            mock.patch.object(main, "twitter_api_request", fake_api_request),
+        ]
+        for patcher in self._patches:
+            patcher.start()
+        self.addCleanup(lambda: [p.stop() for p in self._patches])
+
+
+class MaxResultsBoundsTests(_EndpointCase):
+    def test_parse_helper_clamps_to_bounds(self):
+        self.assertEqual(main._parse_max_results({}), 10)
+        self.assertEqual(main._parse_max_results({"max_results": 0}), 5)
+        self.assertEqual(main._parse_max_results({"max_results": -3}), 5)
+        self.assertEqual(main._parse_max_results({"max_results": 500}), 100)
+        self.assertEqual(main._parse_max_results({"max_results": "20"}), 20)
+        self.assertIsNone(main._parse_max_results({"max_results": "abc"}))
+        self.assertIsNone(main._parse_max_results({"max_results": None}))
+        # Search endpoint has a higher documented minimum.
+        self.assertEqual(
+            main._parse_max_results({"max_results": 2}, minimum=10), 10
+        )
+
+    def test_timeline_sends_clamped_max_results(self):
+        _run(main.tool_get_timeline(_FakeRequest({"uid": "u1", "max_results": 0})))
+        self.assertEqual(self.captured["params"]["max_results"], 5)
+
+    def test_mentions_sends_clamped_max_results(self):
+        _run(main.tool_get_mentions(_FakeRequest({"uid": "u1", "max_results": 999})))
+        self.assertEqual(self.captured["params"]["max_results"], 100)
+
+    def test_my_tweets_sends_clamped_max_results(self):
+        _run(main.tool_get_my_tweets(_FakeRequest({"uid": "u1", "max_results": 1})))
+        self.assertEqual(self.captured["params"]["max_results"], 5)
+
+    def test_search_enforces_minimum_of_10(self):
+        _run(
+            main.tool_search_tweets(
+                _FakeRequest({"uid": "u1", "query": "ai", "max_results": 3})
+            )
+        )
+        self.assertEqual(self.captured["params"]["max_results"], 10)
+
+    def test_non_integer_max_results_returns_error(self):
+        resp = _run(
+            main.tool_get_timeline(
+                _FakeRequest({"uid": "u1", "max_results": "many"})
+            )
+        )
+        self.assertIsNotNone(resp.error)
+
+
+class PathInterpolationTests(_EndpointCase):
+    def test_tweet_id_is_url_encoded_in_unlike_path(self):
+        _run(
+            main.tool_unlike_tweet(
+                _FakeRequest({"uid": "u1", "tweet_id": "123/../admin"})
+            )
+        )
+        self.assertEqual(
+            self.captured["endpoint"], "/users/tw-uid/likes/123%2F..%2Fadmin"
+        )
+
+    def test_tweet_id_is_url_encoded_in_delete_path(self):
+        _run(
+            main.tool_delete_tweet(
+                _FakeRequest({"uid": "u1", "tweet_id": "1?user_id=evil"})
+            )
+        )
+        self.assertEqual(self.captured["endpoint"], "/tweets/1%3Fuser_id%3Devil")
+
+    def test_username_is_url_encoded_in_profile_path(self):
+        _run(
+            main.tool_get_user_profile(
+                _FakeRequest({"uid": "u1", "username": "a/b"})
+            )
+        )
+        self.assertEqual(self.captured["endpoint"], "/users/by/username/a%2Fb")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `plugins/omi-twitter-chat-tools-app/main.py`: `max_results` was only upper-clamped (`min(v, 100)`), so 0/negative values were sent to Twitter below its documented minimum (5 for timelines/mentions/user tweets, 10 for recent search) and rejected with a 400; non-integer values raised `TypeError` inside `min()` and surfaced as a generic failure. A shared `_parse_max_results` helper now coerces to int, returns a validation error for bad input, and clamps per endpoint.
- `tweet_id` and `username` were interpolated into request paths unencoded in `unlike_tweet`, `delete_tweet`, and `get_user_profile` — a value containing `/` or `?` rewrote the target endpoint. They are now percent-encoded.
- Added `plugins/omi-twitter-chat-tools-app/test_main.py` (hermetic, stdlib-only; stubs requests/dotenv/fastapi/pydantic) and registered it in `.github/checks-manifest.yaml`.

## Verification
- `python3 -S plugins/omi-twitter-chat-tools-app/test_main.py` — 9 tests pass with no site-packages.
- 8 of 9 tests fail/error on the unfixed module (verified via stash), confirming real regression coverage.
- Exercised the real handlers end-to-end via stubbed seams: captured params show clamped `max_results` (5/10/100 bounds) and percent-encoded path segments (`123%2F..%2Fadmin`, `a%2Fb`).

Failure-Class: none

---

*This PR was authored by an automated agent on behalf of @Da7em-T.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

