### PR TITLE
fix(python-sdk): raise ConnectionError when BLE listeners disconnect

### DIFF
--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -22,6 +22,46 @@ class Device:
 
 PacketHandler = Callable[[bytes], None]
 AsyncPacketHandler = Callable[[bytes], Union[None, Awaitable[None]]]
+DisconnectCallback = Callable[[BleakClient], None]
+
+
+def _client_with_disconnect(address: str, on_disconnect: DisconnectCallback) -> BleakClient:
+    """Prefer BleakClient(disconnected_callback=...); fall back to set_disconnected_callback."""
+    try:
+        return BleakClient(address, disconnected_callback=on_disconnect)
+    except TypeError:
+        client = BleakClient(address)
+        setter = getattr(client, "set_disconnected_callback", None)
+        if setter is not None:
+            setter(on_disconnect)
+        return client
+
+
+async def _wait_while_connected(disconnected: asyncio.Event, idle_seconds: float) -> None:
+    """Wait until Bleak reports disconnect. Idle sleep is only a wake/cancel hook, not the signal."""
+    while not disconnected.is_set():
+        disconnect_task = asyncio.create_task(disconnected.wait())
+        sleep_task = asyncio.create_task(asyncio.sleep(idle_seconds))
+        try:
+            done, _pending = await asyncio.wait(
+                {disconnect_task, sleep_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            disconnect_task.cancel()
+            sleep_task.cancel()
+            await asyncio.gather(disconnect_task, sleep_task, return_exceptions=True)
+            raise
+        for task in (disconnect_task, sleep_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(disconnect_task, sleep_task, return_exceptions=True)
+        if sleep_task in done:
+            if sleep_task.cancelled():
+                raise asyncio.CancelledError()
+            exc = sleep_task.exception()
+            if exc is not None:
+                raise exc
 
 
 async def scan(timeout: float = 5.0) -> List[Device]:
@@ -41,7 +81,7 @@ async def listen(
     char_uuid: str = AUDIO_DATA_UUID,
     service_uuid: Optional[str] = None,
 ) -> None:
-    """Connect and notify on audio characteristic until cancelled."""
+    """Connect and notify on audio characteristic until cancelled or the device disconnects."""
 
     async def _handler(_sender, data: bytearray) -> None:
         raw = bytes(data)
@@ -49,7 +89,12 @@ async def listen(
         if inspect.isawaitable(result):
             await result
 
-    async with BleakClient(device_id) as client:
+    disconnected = asyncio.Event()
+
+    def _on_disconnect(_client: BleakClient) -> None:
+        disconnected.set()
+
+    async with _client_with_disconnect(device_id, _on_disconnect) as client:
         services = getattr(client, "services", None)
         if services is not None and service_uuid:
             service = services.get_service(service_uuid)
@@ -61,8 +106,8 @@ async def listen(
             await client.start_notify(characteristic, _handler)
         else:
             await client.start_notify(char_uuid, _handler)
-        while True:
-            await asyncio.sleep(3600)
+        await _wait_while_connected(disconnected, 3600)
+        raise ConnectionError(f"Device {device_id} disconnected")
 
 
 async def listen_payload(

--- a/sdks/python/omi/ble.py
+++ b/sdks/python/omi/ble.py
@@ -25,15 +25,33 @@ AsyncPacketHandler = Callable[[bytes], Union[None, Awaitable[None]]]
 DisconnectCallback = Callable[[BleakClient], None]
 
 
+def _signature_accepts_disconnect_kwarg(cls) -> bool:
+    try:
+        inspect.signature(cls).bind("probe-address", disconnected_callback=lambda *_a: None)
+        return True
+    except TypeError:
+        return False
+
+
 def _client_with_disconnect(address: str, on_disconnect: DisconnectCallback) -> BleakClient:
-    """Prefer BleakClient(disconnected_callback=...); fall back to set_disconnected_callback."""
+    """Prefer BleakClient(disconnected_callback=...); fall back to set_disconnected_callback.
+
+    Constructor TypeErrors that are not a missing-keyword signature mismatch are re-raised.
+    A client with neither callback API is an error: hanging on idle sleep is the bug this
+    helper exists to prevent.
+    """
     try:
         return BleakClient(address, disconnected_callback=on_disconnect)
-    except TypeError:
+    except TypeError as exc:
+        if _signature_accepts_disconnect_kwarg(BleakClient):
+            raise
         client = BleakClient(address)
         setter = getattr(client, "set_disconnected_callback", None)
-        if setter is not None:
-            setter(on_disconnect)
+        if setter is None:
+            raise TypeError(
+                "BleakClient provides no disconnected_callback; cannot signal peripheral drop"
+            ) from exc
+        setter(on_disconnect)
         return client
 
 

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -1,9 +1,9 @@
 import asyncio
 from typing import Callable, Any
-from bleak import BleakScanner, BleakClient
+from bleak import BleakScanner
 
 # Re-export for callers that want the default Omi audio stream UUID.
-from .ble import _wait_while_connected
+from .ble import _client_with_disconnect, _wait_while_connected
 from .constants import AUDIO_DATA_UUID  # noqa: F401
 
 
@@ -29,18 +29,10 @@ async def listen_to_omi(
     """
     disconnected = asyncio.Event()
 
-    def _on_disconnect(_client: BleakClient) -> None:
+    def _on_disconnect(_client) -> None:
         disconnected.set()
 
-    try:
-        client = BleakClient(mac_address, disconnected_callback=_on_disconnect)
-    except TypeError:
-        client = BleakClient(mac_address)
-        setter = getattr(client, "set_disconnected_callback", None)
-        if setter is not None:
-            setter(_on_disconnect)
-
-    async with client:
+    async with _client_with_disconnect(mac_address, _on_disconnect) as client:
         print(f"Connected to {mac_address}")
         await client.start_notify(char_uuid, data_handler)
         print("Listening for data...")

--- a/sdks/python/omi/bluetooth.py
+++ b/sdks/python/omi/bluetooth.py
@@ -3,6 +3,7 @@ from typing import Callable, Any
 from bleak import BleakScanner, BleakClient
 
 # Re-export for callers that want the default Omi audio stream UUID.
+from .ble import _wait_while_connected
 from .constants import AUDIO_DATA_UUID  # noqa: F401
 
 
@@ -26,8 +27,22 @@ async def listen_to_omi(
         char_uuid: UUID of the audio characteristic (use AUDIO_DATA_UUID)
         data_handler: Callback function to handle incoming audio data
     """
-    async with BleakClient(mac_address) as client:
+    disconnected = asyncio.Event()
+
+    def _on_disconnect(_client: BleakClient) -> None:
+        disconnected.set()
+
+    try:
+        client = BleakClient(mac_address, disconnected_callback=_on_disconnect)
+    except TypeError:
+        client = BleakClient(mac_address)
+        setter = getattr(client, "set_disconnected_callback", None)
+        if setter is not None:
+            setter(_on_disconnect)
+
+    async with client:
         print(f"Connected to {mac_address}")
         await client.start_notify(char_uuid, data_handler)
         print("Listening for data...")
-        await asyncio.sleep(99999)
+        await _wait_while_connected(disconnected, 99999)
+        raise ConnectionError(f"Device {mac_address} disconnected")

--- a/sdks/python/tests/test_ble_disconnect.py
+++ b/sdks/python/tests/test_ble_disconnect.py
@@ -55,6 +55,27 @@ class LegacyBleakClient:
         self.notify_handler = handler
 
 
+class BareBleakClient:
+    """Rejects the keyword and has no setter — must not hang on idle sleep."""
+
+    def __init__(self, address: str):
+        self.address = address
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    async def start_notify(self, _char_uuid, _handler):
+        return None
+
+
+class InnerTypeErrorClient:
+    def __init__(self, address: str, disconnected_callback=None):
+        raise TypeError("address must be a string")
+
+
 class FailingNotifyClient(DisconnectingBleakClient):
     async def start_notify(self, _char_uuid, _handler):
         raise RuntimeError("start_notify failed")
@@ -105,7 +126,7 @@ def test_listen_payload_raises_connection_error_on_disconnect():
 def test_listen_to_omi_raises_connection_error_on_disconnect():
     async def _test():
         DisconnectingBleakClient.instances.clear()
-        with patch("omi.bluetooth.BleakClient", new=DisconnectingBleakClient):
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
             task = asyncio.create_task(
                 listen_to_omi("AA:BB:CC:DD:EE:FF", "char-uuid", lambda _sender, _data: None)
             )
@@ -149,7 +170,7 @@ def test_listen_legacy_client_fallback():
 def test_listen_to_omi_legacy_client_fallback():
     async def _test():
         LegacyBleakClient.instances.clear()
-        with patch("omi.bluetooth.BleakClient", new=LegacyBleakClient):
+        with patch("omi.ble.BleakClient", new=LegacyBleakClient):
             task = asyncio.create_task(listen_to_omi("legacy-omi", "char-uuid", lambda _s, _d: None))
             await asyncio.sleep(0)
             client = LegacyBleakClient.instances[-1]
@@ -157,6 +178,33 @@ def test_listen_to_omi_legacy_client_fallback():
             client.disconnected_callback(client)
             with pytest.raises(ConnectionError, match="Device legacy-omi disconnected"):
                 await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_raises_when_no_disconnect_api():
+    async def _test():
+        with patch("omi.ble.BleakClient", new=BareBleakClient):
+            with pytest.raises(TypeError, match="no disconnected_callback"):
+                await listen("bare-1", lambda _data: None)
+
+    asyncio.run(_test())
+
+
+def test_listen_to_omi_raises_when_no_disconnect_api():
+    async def _test():
+        with patch("omi.ble.BleakClient", new=BareBleakClient):
+            with pytest.raises(TypeError, match="no disconnected_callback"):
+                await listen_to_omi("bare-omi", "char-uuid", lambda _s, _d: None)
+
+    asyncio.run(_test())
+
+
+def test_listen_reraises_constructor_typeerror_when_signature_accepts_callback():
+    async def _test():
+        with patch("omi.ble.BleakClient", new=InnerTypeErrorClient):
+            with pytest.raises(TypeError, match="address must be a string"):
+                await listen("bad-addr", lambda _data: None)
 
     asyncio.run(_test())
 

--- a/sdks/python/tests/test_ble_disconnect.py
+++ b/sdks/python/tests/test_ble_disconnect.py
@@ -1,0 +1,171 @@
+"""Hermetic disconnect signaling for BLE listeners (issue #13290)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from omi.ble import listen, listen_payload
+from omi.bluetooth import listen_to_omi
+from omi.constants import PACKET_HEADER_BYTES
+
+
+class DisconnectingBleakClient:
+    instances: list["DisconnectingBleakClient"] = []
+
+    def __init__(self, address: str, disconnected_callback=None, **_kwargs):
+        self.address = address
+        self.disconnected_callback = disconnected_callback
+        self.notify_handler = None
+        DisconnectingBleakClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    async def start_notify(self, _char_uuid, handler):
+        self.notify_handler = handler
+
+
+class LegacyBleakClient:
+    """Constructor rejects disconnected_callback; only set_disconnected_callback exists."""
+
+    instances: list["LegacyBleakClient"] = []
+
+    def __init__(self, address: str):
+        self.address = address
+        self.disconnected_callback = None
+        self.notify_handler = None
+        LegacyBleakClient.instances.append(self)
+
+    def set_disconnected_callback(self, callback):
+        self.disconnected_callback = callback
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    async def start_notify(self, _char_uuid, handler):
+        self.notify_handler = handler
+
+
+class FailingNotifyClient(DisconnectingBleakClient):
+    async def start_notify(self, _char_uuid, _handler):
+        raise RuntimeError("start_notify failed")
+
+
+def test_listen_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        packets: list[bytes] = []
+
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen("device-123", packets.append))
+            await asyncio.sleep(0)
+            client = DisconnectingBleakClient.instances[-1]
+            assert client.disconnected_callback is not None
+            assert client.notify_handler is not None
+
+            await client.notify_handler("sender", bytearray(b"audio-data"))
+            assert packets == [b"audio-data"]
+
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device device-123 disconnected"):
+                await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_payload_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        payloads: list[bytes] = []
+
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen_payload("device-456", payloads.append))
+            await asyncio.sleep(0)
+            client = DisconnectingBleakClient.instances[-1]
+            packet = b"\x00" * PACKET_HEADER_BYTES + b"\x03\x04"
+            await client.notify_handler("sender", bytearray(packet))
+            assert payloads == [b"\x03\x04"]
+
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device device-456 disconnected"):
+                await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_to_omi_raises_connection_error_on_disconnect():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        with patch("omi.bluetooth.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(
+                listen_to_omi("AA:BB:CC:DD:EE:FF", "char-uuid", lambda _sender, _data: None)
+            )
+            await asyncio.sleep(0)
+            client = DisconnectingBleakClient.instances[-1]
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device AA:BB:CC:DD:EE:FF disconnected"):
+                await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_clean_cancellation():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        with patch("omi.ble.BleakClient", new=DisconnectingBleakClient):
+            task = asyncio.create_task(listen("device-789", lambda _data: None))
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    asyncio.run(_test())
+
+
+def test_listen_legacy_client_fallback():
+    async def _test():
+        LegacyBleakClient.instances.clear()
+        with patch("omi.ble.BleakClient", new=LegacyBleakClient):
+            task = asyncio.create_task(listen("legacy-123", lambda _data: None))
+            await asyncio.sleep(0)
+            client = LegacyBleakClient.instances[-1]
+            assert client.disconnected_callback is not None
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device legacy-123 disconnected"):
+                await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_to_omi_legacy_client_fallback():
+    async def _test():
+        LegacyBleakClient.instances.clear()
+        with patch("omi.bluetooth.BleakClient", new=LegacyBleakClient):
+            task = asyncio.create_task(listen_to_omi("legacy-omi", "char-uuid", lambda _s, _d: None))
+            await asyncio.sleep(0)
+            client = LegacyBleakClient.instances[-1]
+            assert client.disconnected_callback is not None
+            client.disconnected_callback(client)
+            with pytest.raises(ConnectionError, match="Device legacy-omi disconnected"):
+                await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_test())
+
+
+def test_listen_propagates_start_notify_errors():
+    async def _test():
+        DisconnectingBleakClient.instances.clear()
+        with patch("omi.ble.BleakClient", new=FailingNotifyClient):
+            with pytest.raises(RuntimeError, match="start_notify failed"):
+                await listen("device-fail", lambda _data: None)
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary

Fixes #13290.

`listen()`, `listen_payload()`, and `listen_to_omi()` waited on a fixed `asyncio.sleep` after `start_notify` and never registered Bleak's `disconnected_callback`. A peripheral drop left callers pending until cancel or the sleep ended.

Both listeners now:

- pass `disconnected_callback` into `BleakClient`, with `set_disconnected_callback` for constructors that reject the keyword
- raise `ConnectionError` once that callback fires
- keep service-scoped characteristic resolution and awaitable packet handlers as they are on current `main`
- still treat task cancellation as `CancelledError`, and still propagate `start_notify` errors

Idle `asyncio.sleep` remains only as a wake/cancel hook so existing callback and service-scope tests keep working; it is not the disconnect signal.

## Verification

From `sdks/python` with a mocked Bleak client (no adapter, no live device):

```
python -m pytest tests/test_ble_disconnect.py tests/test_ble_callbacks.py tests/test_ble_service_scope.py tests/test_ble_api.py -q
```

17 passed.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

