### PR TITLE
fix(typescript-sdk): reject unsupported Whisper sampleRate

### DIFF
--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -102,6 +102,66 @@ describe('createWhisperTranscriber', () => {
 
     expect(transcripts).toEqual(['final transcript']);
   });
+
+  test('rejects explicit unsupported sample rate', () => {
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 8000,
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 44100,
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+  });
+
+  test('accepts explicit 16000 Hz or omitted sample rate', () => {
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+        sampleRate: 16000,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      createWhisperTranscriber({
+        runner: () => 'test',
+        onTranscript: () => {},
+      }),
+    ).not.toThrow();
+  });
+
+  test('createTranscriber rejects unsupported sampleRate for whisper before any PCM is buffered', () => {
+    let runnerCalls = 0;
+    expect(() =>
+      createTranscriber('whisper', {
+        sampleRate: 8000,
+        whisperRunner: () => {
+          runnerCalls += 1;
+          return 'should-not-run';
+        },
+        onTranscript: () => {},
+      }),
+    ).toThrow('Whisper requires 16000 Hz PCM; resample audio before transcription');
+    expect(runnerCalls).toBe(0);
+  });
+
+  test('createTranscriber accepts explicit 16000 Hz sampleRate for whisper', () => {
+    expect(() =>
+      createTranscriber('whisper', {
+        sampleRate: 16000,
+        whisperRunner: () => 'test',
+        onTranscript: () => {},
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe('parakeetWsUrl', () => {

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -102,7 +102,11 @@ export function createWhisperTranscriber(opts: {
   runner: (pcm: Uint8Array) => Promise<string> | string;
   onTranscript: TranscriptHandler;
   batchSeconds?: number;
+  sampleRate?: number;
 }): StreamingTranscriber {
+  if (opts.sampleRate !== undefined && opts.sampleRate !== 16000) {
+    throw new Error('Whisper requires 16000 Hz PCM; resample audio before transcription');
+  }
   const batchBytes = (opts.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
@@ -157,7 +161,11 @@ export function createTranscriber(
   }
   if (engine === 'whisper') {
     if (!opts.whisperRunner) throw new Error('Whisper requires whisperRunner');
-    return createWhisperTranscriber({ runner: opts.whisperRunner, onTranscript: opts.onTranscript });
+    return createWhisperTranscriber({
+      runner: opts.whisperRunner,
+      onTranscript: opts.onTranscript,
+      sampleRate: opts.sampleRate,
+    });
   }
   throw new Error(`Unknown engine ${engine}`);
 }


### PR DESCRIPTION
## Summary

Fixes #13122.

`createTranscriber()` already accepts `sampleRate`, but the Whisper branch dropped it and batched PCM at a hard-coded 16 kHz. Five seconds of explicit 8 kHz mono s16le (80,000 bytes) therefore never flushed; ten seconds (160,000 bytes) did, because the window was still measured as 16 kHz.

The device PCM contract is 16 kHz. An explicit unsupported rate is now rejected at construction instead of being silently ignored. Omitted `sampleRate` and explicit `16000` keep the existing 16 kHz batching. Deepgram/Parakeet URL handling is unchanged.

## Verification

From `sdks/device/typescript`:

```
bun test src/stt/index.test.ts
```

18 passed (existing STT suite plus the sampleRate cases). Node 22 strip-types contract checks also passed: 8 kHz/44.1 kHz throw before the Whisper runner is invoked.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

