### PR TITLE
fix(iq-rating): bound 429 retries in memories/conversations fetch loops

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -924,6 +924,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
 
+  - id: iq-rating-rate-limit-tests
+    command: ["python3", "plugins/iq_rating/test_main.py"]
+    triggers: ["plugins/iq_rating/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "unbounded 429 retry loops in fetch_all_memories/fetch_all_conversations could pin a background thread forever; now bounded by RATE_LIMIT_MAX_RETRIES"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/iq_rating/main.py
+++ b/plugins/iq_rating/main.py
@@ -61,6 +61,10 @@ DB_PATH = Path(os.getenv("IQ_RATING_DB_PATH", Path(__file__).parent / "iq_rating
 # background thread forever
 RATE_LIMIT_MAX_RETRIES = 3
 
+
+class RateLimitExhausted(RuntimeError):
+    """A paginated fetch stopped because consecutive HTTP 429 retries were spent."""
+
 # In-memory cache for quick access
 _cache = {}
 _cache_loading = set()
@@ -334,6 +338,7 @@ def fetch_all_memories(uid: str) -> List[dict]:
             response = requests.get(url, params=params, headers=headers, timeout=30)
             
             if response.status_code == 200:
+                rate_limit_retries = 0
                 data = response.json()
                 memories = data if isinstance(data, list) else data.get("memories", [])
                 
@@ -350,7 +355,7 @@ def fetch_all_memories(uid: str) -> List[dict]:
                 rate_limit_retries += 1
                 if rate_limit_retries > RATE_LIMIT_MAX_RETRIES:
                     logger.error("Rate limit retries exhausted while fetching memories")
-                    break
+                    raise RateLimitExhausted("memories")
                 logger.warning("Rate limited, waiting 2 seconds...")
                 time.sleep(2)
                 continue
@@ -360,6 +365,8 @@ def fetch_all_memories(uid: str) -> List[dict]:
         
         logger.info(f"Fetched {len(all_memories)} total memories")
         return all_memories
+    except RateLimitExhausted:
+        raise
     except Exception as e:
         logger.error(f"Error fetching memories: {e}")
         return []
@@ -384,6 +391,7 @@ def fetch_all_conversations(uid: str) -> List[dict]:
             response = requests.get(url, params=params, headers=headers, timeout=30)
             
             if response.status_code == 200:
+                rate_limit_retries = 0
                 data = response.json()
                 conversations = data if isinstance(data, list) else data.get("conversations", [])
                 
@@ -400,7 +408,7 @@ def fetch_all_conversations(uid: str) -> List[dict]:
                 rate_limit_retries += 1
                 if rate_limit_retries > RATE_LIMIT_MAX_RETRIES:
                     logger.error("Rate limit retries exhausted while fetching conversations")
-                    break
+                    raise RateLimitExhausted("conversations")
                 logger.warning("Rate limited, waiting 2 seconds...")
                 time.sleep(2)
                 continue
@@ -410,6 +418,8 @@ def fetch_all_conversations(uid: str) -> List[dict]:
         
         logger.info(f"Fetched {len(all_conversations)} total conversations")
         return all_conversations
+    except RateLimitExhausted:
+        raise
     except Exception as e:
         logger.error(f"Error fetching conversations: {e}")
         return []
@@ -1216,8 +1226,13 @@ def load_and_process_user_data(uid: str) -> List[dict]:
         else:
             # Fetch fresh data from API (only once!)
             logger.info("Fetching fresh data from OMI API...")
-            memories = fetch_all_memories(uid)
-            conversations = fetch_all_conversations(uid)
+            try:
+                memories = fetch_all_memories(uid)
+                conversations = fetch_all_conversations(uid)
+            except RateLimitExhausted:
+                logger.error("Incomplete API fetch; not persisting partial user data")
+                set_cached_people(uid, [])
+                return []
             
             # Store raw data permanently
             store_raw_data(uid, memories, conversations)

--- a/plugins/iq_rating/main.py
+++ b/plugins/iq_rating/main.py
@@ -55,7 +55,11 @@ async def require_omi_credentials() -> None:
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 
 # Database path
-DB_PATH = Path(__file__).parent / "iq_rating.db"
+DB_PATH = Path(os.getenv("IQ_RATING_DB_PATH", Path(__file__).parent / "iq_rating.db"))
+
+# Bound HTTP 429 retries so a persistently rate-limited upstream cannot pin a
+# background thread forever
+RATE_LIMIT_MAX_RETRIES = 3
 
 # In-memory cache for quick access
 _cache = {}
@@ -317,6 +321,7 @@ def fetch_all_memories(uid: str) -> List[dict]:
         all_memories = []
         offset = 0
         limit = 100
+        rate_limit_retries = 0
         
         while True:
             url = f"{OMI_BASE_API_URL}/v2/integrations/{OMI_APP_ID}/memories"
@@ -342,6 +347,10 @@ def fetch_all_memories(uid: str) -> List[dict]:
                 
                 offset += limit
             elif response.status_code == 429:
+                rate_limit_retries += 1
+                if rate_limit_retries > RATE_LIMIT_MAX_RETRIES:
+                    logger.error("Rate limit retries exhausted while fetching memories")
+                    break
                 logger.warning("Rate limited, waiting 2 seconds...")
                 time.sleep(2)
                 continue
@@ -362,6 +371,7 @@ def fetch_all_conversations(uid: str) -> List[dict]:
         all_conversations = []
         offset = 0
         limit = 100
+        rate_limit_retries = 0
         
         while True:
             url = f"{OMI_BASE_API_URL}/v2/integrations/{OMI_APP_ID}/conversations"
@@ -387,6 +397,10 @@ def fetch_all_conversations(uid: str) -> List[dict]:
                 
                 offset += limit
             elif response.status_code == 429:
+                rate_limit_retries += 1
+                if rate_limit_retries > RATE_LIMIT_MAX_RETRIES:
+                    logger.error("Rate limit retries exhausted while fetching conversations")
+                    break
                 logger.warning("Rate limited, waiting 2 seconds...")
                 time.sleep(2)
                 continue

--- a/plugins/iq_rating/test_main.py
+++ b/plugins/iq_rating/test_main.py
@@ -1,28 +1,28 @@
 """Hermetic regression tests for plugins/iq_rating/main.py.
 
-Standard library only: requests, fastapi, and pydantic-free surfaces are
-stubbed before importing the module under test; IQ_RATING_DB_PATH points
-at a temp directory and time.sleep is patched out, so no network, no
-sleeps, and no repo-tree side effects.
+Stubs are scoped with patch.dict; the module is loaded under a unique name
+so a shared test runner cannot bind a leftover `main` or leak fastapi/requests.
+IQ_RATING_DB_PATH lives in a TemporaryDirectory that is removed on exit.
+time.sleep is patched, so no network and no real waits.
 
 Covers the unbounded 429 retry loop: fetch_all_memories and
-fetch_all_conversations retried `continue` forever on persistent 429s,
-pinning the background thread that load_and_process_user_data spawns per
-request. They now give up after RATE_LIMIT_MAX_RETRIES.
+fetch_all_conversations retried `continue` forever on persistent 429s.
+They now raise RateLimitExhausted after RATE_LIMIT_MAX_RETRIES consecutive
+failures, and load_and_process_user_data does not persist a partial fetch.
 """
 
+from __future__ import annotations
+
+import atexit
+import importlib.util
 import os
 import sys
 import tempfile
 import types
 import unittest
+from pathlib import Path
 from unittest import mock
-
-os.environ["IQ_RATING_DB_PATH"] = os.path.join(
-    tempfile.mkdtemp(prefix="iq-rating-test-"), "test.db"
-)
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from unittest.mock import patch
 
 
 class _Resp:
@@ -35,63 +35,72 @@ class _Resp:
         return self._payload
 
 
-def _install_module_stubs():
-    requests = types.ModuleType("requests")
-    requests.get = requests.post = lambda *a, **k: _Resp(500)
-    sys.modules["requests"] = requests
-
-    fastapi = types.ModuleType("fastapi")
-
-    class HTTPException(Exception):
-        def __init__(self, status_code=None, detail=None):
-            super().__init__(detail)
-            self.status_code = status_code
-            self.detail = detail
-
-    class APIRouter:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def post(self, *args, **kwargs):
-            return lambda f: f
-
-        def get(self, *args, **kwargs):
-            return lambda f: f
-
-        def on_event(self, *args, **kwargs):
-            return lambda f: f
-
-    class FastAPI:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def include_router(self, *args, **kwargs):
-            pass
-
-    fastapi.APIRouter = APIRouter
-    fastapi.FastAPI = FastAPI
-    fastapi.HTTPException = HTTPException
-    fastapi.Query = lambda default=None, **kwargs: default
-    sys.modules["fastapi"] = fastapi
-
-    responses = types.ModuleType("fastapi.responses")
-
-    class _R:
-        def __init__(self, *args, **kwargs):
-            pass
-
-    responses.HTMLResponse = _R
-    responses.JSONResponse = _R
-    sys.modules["fastapi.responses"] = responses
+def _module(name, **attributes):
+    value = types.ModuleType(name)
+    value.__dict__.update(attributes)
+    return value
 
 
-_install_module_stubs()
-import main  # noqa: E402
+class _HTTPException(Exception):
+    def __init__(self, status_code=None, detail=None):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class _APIRouter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def post(self, *args, **kwargs):
+        return lambda f: f
+
+    def get(self, *args, **kwargs):
+        return lambda f: f
+
+    def on_event(self, *args, **kwargs):
+        return lambda f: f
+
+
+class _FastAPI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def include_router(self, *args, **kwargs):
+        pass
+
+
+class _R:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+_TMPDIR = tempfile.TemporaryDirectory(prefix="iq-rating-test-")
+atexit.register(_TMPDIR.cleanup)
+os.environ["IQ_RATING_DB_PATH"] = os.path.join(_TMPDIR.name, "test.db")
+
+_stubs = {
+    "requests": _module("requests", get=lambda *a, **k: _Resp(500), post=lambda *a, **k: _Resp(500)),
+    "fastapi": _module(
+        "fastapi",
+        APIRouter=_APIRouter,
+        FastAPI=_FastAPI,
+        HTTPException=_HTTPException,
+        Query=lambda default=None, **kwargs: default,
+    ),
+    "fastapi.responses": _module("fastapi.responses", HTMLResponse=_R, JSONResponse=_R),
+}
+
+_spec = importlib.util.spec_from_file_location(
+    "iq_rating_under_test", Path(__file__).with_name("main.py")
+)
+main = importlib.util.module_from_spec(_spec)
+with patch.dict(sys.modules, _stubs):
+    _spec.loader.exec_module(main)
 
 
 class RateLimitRetryTests(unittest.TestCase):
     def setUp(self):
-        # No real sleeping: hermetic and fast.
         self._sleep = mock.patch.object(main.time, "sleep", lambda s: None)
         self._sleep.start()
         self.addCleanup(self._sleep.stop)
@@ -104,7 +113,8 @@ class RateLimitRetryTests(unittest.TestCase):
             return _Resp(429)
 
         with mock.patch.object(main.requests, "get", always_429):
-            self.assertEqual(main.fetch_all_memories("u1"), [])
+            with self.assertRaises(main.RateLimitExhausted):
+                main.fetch_all_memories("u1")
         self.assertEqual(len(calls), 1 + main.RATE_LIMIT_MAX_RETRIES)
 
     def test_conversations_gives_up_after_bounded_429s(self):
@@ -115,7 +125,8 @@ class RateLimitRetryTests(unittest.TestCase):
             return _Resp(429)
 
         with mock.patch.object(main.requests, "get", always_429):
-            self.assertEqual(main.fetch_all_conversations("u1"), [])
+            with self.assertRaises(main.RateLimitExhausted):
+                main.fetch_all_conversations("u1")
         self.assertEqual(len(calls), 1 + main.RATE_LIMIT_MAX_RETRIES)
 
     def test_memories_recovers_when_429_clears(self):
@@ -145,6 +156,47 @@ class RateLimitRetryTests(unittest.TestCase):
             result = main.fetch_all_memories("u1")
         self.assertEqual(len(result), 101)
         self.assertEqual(pages, [0, 100])
+
+    def test_memories_does_not_return_partial_page_on_exhaustion(self):
+        calls = []
+
+        def first_page_then_429(*args, **kwargs):
+            calls.append(kwargs["params"]["offset"])
+            if kwargs["params"]["offset"] == 0 and calls.count(0) == 1:
+                return _Resp(200, [{"id": i} for i in range(100)])
+            return _Resp(429)
+
+        with mock.patch.object(main.requests, "get", first_page_then_429):
+            with self.assertRaises(main.RateLimitExhausted):
+                main.fetch_all_memories("u1")
+
+    def test_memories_resets_retry_budget_after_successful_page(self):
+        calls = []
+
+        def page_then_intermittent_429(*args, **kwargs):
+            offset = kwargs["params"]["offset"]
+            calls.append(offset)
+            if offset == 0:
+                return _Resp(200, [{"id": i} for i in range(100)])
+            # Three consecutive 429s on page 2, then a short page.
+            page2_attempts = calls.count(100)
+            if page2_attempts <= 3:
+                return _Resp(429)
+            return _Resp(200, [{"id": 100}])
+
+        with mock.patch.object(main.requests, "get", page_then_intermittent_429):
+            result = main.fetch_all_memories("u1")
+        self.assertEqual(len(result), 101)
+
+    def test_load_and_process_does_not_persist_on_exhaustion(self):
+        uid = "no-persist-u"
+
+        def always_429(*args, **kwargs):
+            return _Resp(429)
+
+        with mock.patch.object(main.requests, "get", always_429):
+            self.assertEqual(main.load_and_process_user_data(uid), [])
+        self.assertFalse(main.has_user_data(uid))
 
 
 if __name__ == "__main__":

--- a/plugins/iq_rating/test_main.py
+++ b/plugins/iq_rating/test_main.py
@@ -75,9 +75,25 @@ class _R:
         pass
 
 
+_PREV_DB = os.environ.get("IQ_RATING_DB_PATH")
 _TMPDIR = tempfile.TemporaryDirectory(prefix="iq-rating-test-")
-atexit.register(_TMPDIR.cleanup)
 os.environ["IQ_RATING_DB_PATH"] = os.path.join(_TMPDIR.name, "test.db")
+_cleaned_tmp = False
+
+
+def _restore_env_and_tmpdir() -> None:
+    global _cleaned_tmp
+    if _cleaned_tmp:
+        return
+    _cleaned_tmp = True
+    _TMPDIR.cleanup()
+    if _PREV_DB is None:
+        os.environ.pop("IQ_RATING_DB_PATH", None)
+    else:
+        os.environ["IQ_RATING_DB_PATH"] = _PREV_DB
+
+
+atexit.register(_restore_env_and_tmpdir)
 
 _stubs = {
     "requests": _module("requests", get=lambda *a, **k: _Resp(500), post=lambda *a, **k: _Resp(500)),
@@ -100,6 +116,10 @@ with patch.dict(sys.modules, _stubs):
 
 
 class RateLimitRetryTests(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        _restore_env_and_tmpdir()
+
     def setUp(self):
         self._sleep = mock.patch.object(main.time, "sleep", lambda s: None)
         self._sleep.start()

--- a/plugins/iq_rating/test_main.py
+++ b/plugins/iq_rating/test_main.py
@@ -1,0 +1,151 @@
+"""Hermetic regression tests for plugins/iq_rating/main.py.
+
+Standard library only: requests, fastapi, and pydantic-free surfaces are
+stubbed before importing the module under test; IQ_RATING_DB_PATH points
+at a temp directory and time.sleep is patched out, so no network, no
+sleeps, and no repo-tree side effects.
+
+Covers the unbounded 429 retry loop: fetch_all_memories and
+fetch_all_conversations retried `continue` forever on persistent 429s,
+pinning the background thread that load_and_process_user_data spawns per
+request. They now give up after RATE_LIMIT_MAX_RETRIES.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+os.environ["IQ_RATING_DB_PATH"] = os.path.join(
+    tempfile.mkdtemp(prefix="iq-rating-test-"), "test.db"
+)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+def _install_module_stubs():
+    requests = types.ModuleType("requests")
+    requests.get = requests.post = lambda *a, **k: _Resp(500)
+    sys.modules["requests"] = requests
+
+    fastapi = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code=None, detail=None):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, *args, **kwargs):
+            return lambda f: f
+
+        def get(self, *args, **kwargs):
+            return lambda f: f
+
+        def on_event(self, *args, **kwargs):
+            return lambda f: f
+
+    class FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def include_router(self, *args, **kwargs):
+            pass
+
+    fastapi.APIRouter = APIRouter
+    fastapi.FastAPI = FastAPI
+    fastapi.HTTPException = HTTPException
+    fastapi.Query = lambda default=None, **kwargs: default
+    sys.modules["fastapi"] = fastapi
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class _R:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    responses.HTMLResponse = _R
+    responses.JSONResponse = _R
+    sys.modules["fastapi.responses"] = responses
+
+
+_install_module_stubs()
+import main  # noqa: E402
+
+
+class RateLimitRetryTests(unittest.TestCase):
+    def setUp(self):
+        # No real sleeping: hermetic and fast.
+        self._sleep = mock.patch.object(main.time, "sleep", lambda s: None)
+        self._sleep.start()
+        self.addCleanup(self._sleep.stop)
+
+    def test_memories_gives_up_after_bounded_429s(self):
+        calls = []
+
+        def always_429(*args, **kwargs):
+            calls.append(args)
+            return _Resp(429)
+
+        with mock.patch.object(main.requests, "get", always_429):
+            self.assertEqual(main.fetch_all_memories("u1"), [])
+        self.assertEqual(len(calls), 1 + main.RATE_LIMIT_MAX_RETRIES)
+
+    def test_conversations_gives_up_after_bounded_429s(self):
+        calls = []
+
+        def always_429(*args, **kwargs):
+            calls.append(args)
+            return _Resp(429)
+
+        with mock.patch.object(main.requests, "get", always_429):
+            self.assertEqual(main.fetch_all_conversations("u1"), [])
+        self.assertEqual(len(calls), 1 + main.RATE_LIMIT_MAX_RETRIES)
+
+    def test_memories_recovers_when_429_clears(self):
+        calls = []
+
+        def flaky(*args, **kwargs):
+            calls.append(args)
+            if len(calls) < 3:
+                return _Resp(429)
+            return _Resp(200, [{"id": "m1"}])
+
+        with mock.patch.object(main.requests, "get", flaky):
+            self.assertEqual(main.fetch_all_memories("u1"), [{"id": "m1"}])
+        self.assertEqual(len(calls), 3)
+
+    def test_memories_paginates_until_short_page(self):
+        pages = []
+
+        def paged(*args, **kwargs):
+            offset = kwargs["params"]["offset"]
+            pages.append(offset)
+            if offset == 0:
+                return _Resp(200, [{"id": i} for i in range(100)])
+            return _Resp(200, [{"id": 100}])
+
+        with mock.patch.object(main.requests, "get", paged):
+            result = main.fetch_all_memories("u1")
+        self.assertEqual(len(result), 101)
+        self.assertEqual(pages, [0, 100])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/iq_rating/test_main.py
+++ b/plugins/iq_rating/test_main.py
@@ -198,6 +198,20 @@ class RateLimitRetryTests(unittest.TestCase):
             self.assertEqual(main.load_and_process_user_data(uid), [])
         self.assertFalse(main.has_user_data(uid))
 
+    def test_load_and_process_does_not_persist_partial_pages(self):
+        uid = "partial-u"
+        calls = []
+
+        def first_page_then_429(*args, **kwargs):
+            calls.append(kwargs["params"]["offset"])
+            if kwargs["params"]["offset"] == 0 and calls.count(0) == 1:
+                return _Resp(200, [{"id": i} for i in range(100)])
+            return _Resp(429)
+
+        with mock.patch.object(main.requests, "get", first_page_then_429):
+            self.assertEqual(main.load_and_process_user_data(uid), [])
+        self.assertFalse(main.has_user_data(uid))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `plugins/iq_rating/main.py`: `fetch_all_memories` and `fetch_all_conversations` retried `continue` on every HTTP 429 inside `while True` with no cap. Both run on a background thread spawned per request by `load_and_process_user_data`, so a persistently rate-limited upstream pinned a thread forever per call. Both now give up after `RATE_LIMIT_MAX_RETRIES` (3), matching the existing error path.
- `IQ_RATING_DB_PATH` env var can now override the SQLite location — `init_db()` runs at import time, so the module previously always wrote `iq_rating.db` into the repo tree; the override makes it importable in tests without side effects.
- Added `plugins/iq_rating/test_main.py` (hermetic, stdlib-only: requests/fastapi stubbed, `time.sleep` patched out, DB in tmpdir) and registered it in `.github/checks-manifest.yaml`.

## Verification
- `python3 -S plugins/iq_rating/test_main.py` — 4 tests pass with no site-packages: bounded 429 give-up for both fetchers, recovery after transient 429s, and multi-page pagination.
- On the unfixed module the persistent-429 case never returns (verified: 11 calls and counting, vs 4 calls with the cap).

Failure-Class: none

---

*This PR was authored by an automated agent on behalf of @Da7em-T.*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

