### PR TITLE
feat(cli): rename a local auth profile without recreating credentials

### DIFF
--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -161,13 +161,15 @@ def profile_rename(
 ) -> None:
     ctx = _ctx(typer_ctx)
     config = ctx.load_config()
+    dest = new.strip()
     try:
         config.rename_profile(old, new)
     except KeyError as exc:
         raise UsageError(message=str(exc)) from exc
     except ValueError as exc:
         raise UsageError(message=str(exc)) from exc
-    cfg.save(config)
+    if old != dest:
+        cfg.save(config)
     if ctx.renderer.json_mode:
         ctx.renderer.emit(
             {

--- a/sdks/python-cli/omi_cli/commands/config.py
+++ b/sdks/python-cli/omi_cli/commands/config.py
@@ -151,3 +151,31 @@ def profile_delete(
     config.delete_profile(name)
     cfg.save(config)
     ctx.renderer.success(f"Deleted profile [bold]{escape(name)}[/bold].")
+
+
+@profile_app.command("rename", help="Rename a local profile without recreating its credentials.")
+def profile_rename(
+    typer_ctx: typer.Context,
+    old: str = typer.Argument(..., help="Current profile name."),
+    new: str = typer.Argument(..., help="New profile name."),
+) -> None:
+    ctx = _ctx(typer_ctx)
+    config = ctx.load_config()
+    try:
+        config.rename_profile(old, new)
+    except KeyError as exc:
+        raise UsageError(message=str(exc)) from exc
+    except ValueError as exc:
+        raise UsageError(message=str(exc)) from exc
+    cfg.save(config)
+    if ctx.renderer.json_mode:
+        ctx.renderer.emit(
+            {
+                "active_profile": config.active_profile,
+                "profiles": config.list_profiles(),
+            }
+        )
+        return
+    ctx.renderer.success(
+        f"Renamed profile [bold]{escape(old)}[/bold] → [bold]{escape(new.strip())}[/bold]."
+    )

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -173,10 +173,10 @@ class Config:
         dest = new.strip()
         if not dest:
             raise ValueError("new profile name cannot be blank")
-        if old == dest:
-            return
         if old not in self.profiles:
             raise KeyError(f"No such profile: '{old}'")
+        if old == dest:
+            return
         if dest in self.profiles:
             raise ValueError(f"profile '{dest}' already exists")
         profile = self.profiles.pop(old)

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -163,6 +163,28 @@ class Config:
         if self.active_profile == name:
             self.active_profile = DEFAULT_PROFILE_NAME
 
+    def rename_profile(self, old: str, new: str) -> None:
+        """Rename a profile in place, keeping credentials and extra keys.
+
+        Updates ``active_profile`` when the renamed profile is the active one.
+        Identical names are a no-op. Blank destination names and collisions
+        raise ``ValueError``; a missing source raises ``KeyError``.
+        """
+        dest = new.strip()
+        if not dest:
+            raise ValueError("new profile name cannot be blank")
+        if old == dest:
+            return
+        if old not in self.profiles:
+            raise KeyError(f"No such profile: '{old}'")
+        if dest in self.profiles:
+            raise ValueError(f"profile '{dest}' already exists")
+        profile = self.profiles.pop(old)
+        profile.name = dest
+        self.profiles[dest] = profile
+        if self.active_profile == old:
+            self.active_profile = dest
+
     def list_profiles(self) -> list[str]:
         return sorted(self.profiles.keys())
 

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -497,6 +497,9 @@ def test_rename_profile_dataclass_contract(tmp_path: Path) -> None:
     with pytest.raises(KeyError, match="No such profile: 'missing'"):
         config.rename_profile("missing", "target")
 
+    with pytest.raises(KeyError, match="No such profile: 'ghost'"):
+        config.rename_profile("ghost", "ghost")
+
     with pytest.raises(ValueError, match="cannot be blank"):
         config.rename_profile("work-new", "   ")
 
@@ -542,8 +545,14 @@ def test_config_profile_rename_cli_command(config_path: Path, cli_runner) -> Non
     assert res_missing.exit_code != 0
     assert "No such profile" in res_missing.stderr
 
+    before_noop = config_path.read_bytes()
     res_self = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "final-profile"])
     assert res_self.exit_code == 0
+    assert config_path.read_bytes() == before_noop
+
+    res_missing_same = cli_runner.invoke(app, ["config", "profile", "rename", "ghost", "ghost"])
+    assert res_missing_same.exit_code != 0
+    assert "No such profile" in res_missing_same.stderr
 
     config_with_two = cfg.load()
     p2 = config_with_two.get_profile("other-profile")

--- a/sdks/python-cli/tests/test_config.py
+++ b/sdks/python-cli/tests/test_config.py
@@ -463,3 +463,92 @@ def test_active_profile_non_string_diagnostics_succeed(config_path: Path, cli_ru
 
     result_path = cli_runner.invoke(app, ["config", "path"])
     assert result_path.exit_code == 0, result_path.output
+
+
+def test_rename_profile_dataclass_contract(tmp_path: Path) -> None:
+    config = cfg.Config(path=tmp_path / "config.toml")
+    p1 = cfg.Profile(
+        name="work",
+        auth_method="api_key",
+        api_key="omi_dev_secret123",
+        api_base="https://api.work.omi.local",
+        extra={"custom_key": "val"},
+    )
+    p2 = cfg.Profile(name="personal", auth_method="oauth", id_token="tok123")
+    config.set_profile(p1)
+    config.set_profile(p2)
+    config.active_profile = "work"
+
+    config.rename_profile("work", "work-new")
+    assert "work" not in config.profiles
+    assert "work-new" in config.profiles
+    assert config.active_profile == "work-new"
+    renamed = config.profiles["work-new"]
+    assert renamed.name == "work-new"
+    assert renamed.api_key == "omi_dev_secret123"
+    assert renamed.api_base == "https://api.work.omi.local"
+    assert renamed.extra == {"custom_key": "val"}
+
+    config.rename_profile("personal", "personal-renamed")
+    assert "personal" not in config.profiles
+    assert "personal-renamed" in config.profiles
+    assert config.active_profile == "work-new"
+
+    with pytest.raises(KeyError, match="No such profile: 'missing'"):
+        config.rename_profile("missing", "target")
+
+    with pytest.raises(ValueError, match="cannot be blank"):
+        config.rename_profile("work-new", "   ")
+
+    with pytest.raises(ValueError, match="already exists"):
+        config.rename_profile("work-new", "personal-renamed")
+
+    config.rename_profile("work-new", "work-new")
+    assert "work-new" in config.profiles
+
+    config.rename_profile("work-new", "work-ü")
+    assert "work-ü" in config.profiles
+    assert config.active_profile == "work-ü"
+
+
+def test_config_profile_rename_cli_command(config_path: Path, cli_runner) -> None:
+    config = cfg.load()
+    p = config.get_profile("old-profile")
+    p.auth_method = "api_key"
+    p.api_key = "omi_dev_testkey"
+    config.set_profile(p)
+    config.active_profile = "old-profile"
+    cfg.save(config)
+
+    res = cli_runner.invoke(app, ["config", "profile", "rename", "old-profile", "new-profile"])
+    assert res.exit_code == 0, res.output
+    assert "Renamed profile" in res.stderr
+
+    reloaded = cfg.load()
+    assert "old-profile" not in reloaded.profiles
+    assert "new-profile" in reloaded.profiles
+    assert reloaded.active_profile == "new-profile"
+    assert reloaded.profiles["new-profile"].api_key == "omi_dev_testkey"
+
+    res_json = cli_runner.invoke(app, ["--json", "config", "profile", "rename", "new-profile", "final-profile"])
+    assert res_json.exit_code == 0, res_json.output
+    data = json.loads(res_json.stdout)
+    assert data["active_profile"] == "final-profile"
+    assert "final-profile" in data["profiles"]
+    assert "new-profile" not in data["profiles"]
+    assert set(data.keys()) == {"active_profile", "profiles"}
+
+    res_missing = cli_runner.invoke(app, ["config", "profile", "rename", "does-not-exist", "foo"])
+    assert res_missing.exit_code != 0
+    assert "No such profile" in res_missing.stderr
+
+    res_self = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "final-profile"])
+    assert res_self.exit_code == 0
+
+    config_with_two = cfg.load()
+    p2 = config_with_two.get_profile("other-profile")
+    config_with_two.set_profile(p2)
+    cfg.save(config_with_two)
+    res_collision = cli_runner.invoke(app, ["config", "profile", "rename", "final-profile", "other-profile"])
+    assert res_collision.exit_code != 0
+    assert "already exists" in res_collision.stderr


### PR DESCRIPTION
## Summary

Fixes #13195.

`omi config profile rename OLD NEW` renames a local auth profile in place: credentials, `api_base`, and extra keys stay on the same object. When the renamed profile is active, `active_profile` follows. Blank destination names and collisions are rejected before `save()`. Identical names are a no-op. JSON mode emits only `active_profile` and the profile-name list (no credentials).

The issue proposed a US\$10 PayPal bounty under the omi contributor program; this PR does not add a label.

## Verification

From `sdks/python-cli`:

```
python -m pytest tests/test_config.py -q
```

35 passed, 1 skipped (existing Windows-only case).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

