### PR TITLE
fix(cli): reject non-finite goal metric values before HTTP

### DIFF
--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Optional
 
 import typer
@@ -22,6 +23,18 @@ def _ctx(typer_ctx: typer.Context) -> "AppContext":
     if obj is None:  # pragma: no cover
         raise RuntimeError("AppContext not initialized")
     return obj  # type: ignore[no-any-return]
+
+
+def _require_finite(label: str, value: Optional[float]) -> Optional[float]:
+    """Reject NaN/Inf before any HTTP client is opened."""
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        raise UsageError(
+            message=f"{label} must be a finite number",
+            detail="NaN, Infinity, and out-of-range exponents are rejected before a request is sent.",
+        )
+    return value
 
 
 _LIST_COLUMNS = ["id", "title", "goal_type", "current_value", "target_value", "unit", "is_active"]
@@ -89,6 +102,10 @@ def create_goal(
     ),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    target_value = _require_finite("--target", target_value)
+    current_value = _require_finite("--current", current_value)
+    min_value = _require_finite("--min", min_value)
+    max_value = _require_finite("--max", max_value)
     has_metrics = any(value is not None for value in (target_value, goal_type, current_value, min_value, max_value))
     if unit is not None and not has_metrics:
         # The backend only persists ``unit`` on metric-backed goals; sending it on a
@@ -136,6 +153,10 @@ def update_goal(
     ctx = _ctx(typer_ctx)
     if clear_unit and unit is not None:
         raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
+    target_value = _require_finite("--target", target_value)
+    current_value = _require_finite("--current", current_value)
+    min_value = _require_finite("--min", min_value)
+    max_value = _require_finite("--max", max_value)
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -169,6 +190,7 @@ def update_progress(
     current_value: float = typer.Argument(..., help="New progress value."),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    current_value = _require_finite("current_value", current_value)
     with ctx.make_client() as client:
         # The progress endpoint takes current_value as a query param.
         result = client.patch(f"/v1/dev/user/goals/{goal_id}/progress", params={"current_value": current_value})

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -207,3 +207,30 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
     assert not respx_mock.calls
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf", "1e309"])
+def test_goal_create_rejects_non_finite_target(config_path, cli_runner, value: str) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "x", "--target", value])
+    assert result.exit_code != 0
+    combined = (result.stderr + result.stdout).lower()
+    assert "finite" in combined
+
+
+@pytest.mark.parametrize("flag", ["--current", "--min", "--max"])
+def test_goal_create_rejects_non_finite_metric_flags(config_path, cli_runner, flag: str) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "create", "x", "--target", "1", flag, "nan"])
+    assert result.exit_code != 0
+    assert "finite" in (result.stderr + result.stdout).lower()
+
+
+def test_goal_update_rejects_non_finite_current(config_path, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "update", "g1", "--current", "inf"])
+    assert result.exit_code != 0
+    assert "finite" in (result.stderr + result.stdout).lower()
+
+
+def test_goal_progress_rejects_nan(config_path, cli_runner) -> None:
+    result = cli_runner.invoke(app, ["--json", "goal", "progress", "g1", "nan"])
+    assert result.exit_code != 0
+    assert "finite" in (result.stderr + result.stdout).lower()


### PR DESCRIPTION
## Summary
- Validate `--target`/`--current`/`--min`/`--max` on `goal create`/`goal update`, and the `goal progress` value, with `math.isfinite` before `make_client()`.
- NaN, Infinity, and overflow exponents (`1e309`) now fail locally with a `UsageError` instead of reaching httpx inconsistently.

Fixes #13010

## Why this PR
#13113 is APPROVED but CONFLICTING against current `main`. This is a current-main replacement of that contract only (no docs/mdx churn).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_goal.py` — 26 passed (includes `nan`/`inf`/`-inf`/`1e309` on create, metric flags, update, and progress)
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

