### PR TITLE
fix(cli): keep existing config directory permissions on save

### DIFF
--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -235,6 +235,24 @@ def load(path: Optional[Path] = None) -> Config:
     return Config(path=p, active_profile=active, profiles=profiles, extra=extra)
 
 
+def _ensure_private_config_parents(path: Path) -> None:
+    """Create missing config directories as ``0o700`` without chmod'ing existing ones.
+
+    ``OMI_CONFIG`` may point at a shared directory the user already locked down
+    (or opened) themselves. Newly created ancestors still get owner-only access.
+    """
+    missing: list[Path] = []
+    directory = path.parent
+    while not directory.exists():
+        missing.append(directory)
+        parent = directory.parent
+        if parent == directory:
+            break
+        directory = parent
+    for directory in reversed(missing):
+        directory.mkdir(mode=0o700, exist_ok=True)
+
+
 def save(config: Config) -> None:
     """Persist the config to disk with secure (owner-only) permissions.
 
@@ -252,13 +270,7 @@ def save(config: Config) -> None:
             f"refusing to overwrite {config.path}: {config.load_error}. "
             "Fix or remove the config file and try again."
         )
-    config.path.parent.mkdir(parents=True, exist_ok=True)
-    # Tighten parent dir perms too — credentials live underneath. Best-effort:
-    # don't fail if the user has a custom mode they want to keep.
-    try:
-        os.chmod(config.path.parent, 0o700)
-    except OSError:
-        pass
+    _ensure_private_config_parents(config.path)
 
     payload: dict[str, Any] = {
         **config.extra,

--- a/sdks/python-cli/omi_cli/config.py
+++ b/sdks/python-cli/omi_cli/config.py
@@ -250,7 +250,11 @@ def _ensure_private_config_parents(path: Path) -> None:
             break
         directory = parent
     for directory in reversed(missing):
-        directory.mkdir(mode=0o700, exist_ok=True)
+        old_umask = os.umask(0o077)
+        try:
+            directory.mkdir(mode=0o700, exist_ok=True)
+        finally:
+            os.umask(old_umask)
 
 
 def save(config: Config) -> None:

--- a/sdks/python-cli/tests/test_config_directory.py
+++ b/sdks/python-cli/tests/test_config_directory.py
@@ -53,3 +53,15 @@ def test_failed_save_does_not_chmod_parent(tmp_path, monkeypatch) -> None:
     with pytest.raises(ValueError):
         cfg.save(cfg.Config(path=tmp_path / "config.toml"))
     assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o750
+
+
+def test_new_directory_is_traversable_under_restrictive_umask(tmp_path) -> None:
+    path = tmp_path / "nested" / "config.toml"
+    old_umask = os.umask(0o177)
+    try:
+        cfg.save(cfg.Config(path=path))
+    finally:
+        os.umask(old_umask)
+    assert path.is_file()
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600

--- a/sdks/python-cli/tests/test_config_directory.py
+++ b/sdks/python-cli/tests/test_config_directory.py
@@ -1,0 +1,55 @@
+import os
+import stat
+
+import pytest
+
+from omi_cli import config as cfg
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX directory modes")
+
+
+@pytest.mark.parametrize("mode", [0o750, 0o775, 0o2770])
+@pytest.mark.parametrize("symlink", [False, True])
+def test_save_preserves_existing_parent(tmp_path, mode, symlink) -> None:
+    directory = tmp_path / "shared"
+    directory.mkdir()
+    directory.chmod(mode)
+    before = stat.S_IMODE(directory.stat().st_mode)
+    parent = directory
+    if symlink:
+        parent = tmp_path / "link"
+        parent.symlink_to(directory, target_is_directory=True)
+    path = parent / "config.toml"
+    cfg.save(cfg.Config(path=path))
+    assert stat.S_IMODE(directory.stat().st_mode) == before
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("parts", [(".omi",), (".config", "omi", "profiles")])
+def test_new_directory_and_file_are_private(tmp_path, monkeypatch, parts) -> None:
+    path = tmp_path.joinpath(*parts, "config.toml")
+    original = cfg.tomli_w.dump
+
+    def inspect(payload, handle):
+        assert stat.S_IMODE(os.fstat(handle.fileno()).st_mode) == 0o600
+        original(payload, handle)
+
+    monkeypatch.setattr(cfg.tomli_w, "dump", inspect)
+    cfg.save(cfg.Config(path=path))
+    for parent in path.parents:
+        if parent == tmp_path:
+            break
+        assert stat.S_IMODE(parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_failed_save_does_not_chmod_parent(tmp_path, monkeypatch) -> None:
+    tmp_path.chmod(0o750)
+
+    def fail(*args):
+        raise ValueError("synthetic failure")
+
+    monkeypatch.setattr(cfg.tomli_w, "dump", fail)
+    with pytest.raises(ValueError):
+        cfg.save(cfg.Config(path=tmp_path / "config.toml"))
+    assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o750


### PR DESCRIPTION
## Summary
- `config.save()` no longer `chmod`s an already-existing parent directory selected through `OMI_CONFIG`.
- Missing ancestor directories are still created as `0o700`; credential files remain owner-only `0o600`.
- A failed TOML dump does not mutate the existing parent's mode (including via symlink).

Fixes #13034

## Why this PR
#13106 is APPROVED but CONFLICTING against current `main`. This is a current-main replacement of that contract only (no README churn).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_config_directory.py tests/test_config.py` — existing parent modes `0750`/`0775`/`02770` preserved (direct + symlink); new ancestors `0700`; failed dump leaves `0750`
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

