### PR TITLE
fix(cli): let OMI_API_KEY override a saved cloud credential

### DIFF
--- a/sdks/python-cli/omi_cli/commands/auth.py
+++ b/sdks/python-cli/omi_cli/commands/auth.py
@@ -205,11 +205,12 @@ def whoami(typer_ctx: typer.Context) -> None:
     # identifies the user implicitly (the count belongs to *this* user).
     with ctx.make_client() as client:
         memories = client.get("/v1/dev/user/memories", params={"limit": 1})
+    verified = ctx.cloud_profile()
     payload = {
         "profile": ctx.profile_name,
-        "credential": ctx.get_profile().masked_credential(),
-        "auth_method": ctx.get_profile().auth_method,
-        "api_base": ctx.get_profile().api_base,
+        "credential": verified.masked_credential(),
+        "auth_method": verified.auth_method,
+        "api_base": verified.api_base,
         "owns_memories": isinstance(memories, list),
     }
     ctx.renderer.emit(payload, title="omi whoami")

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Optional
 
 import click
@@ -77,21 +77,23 @@ class AppContext:
         profile = config.get_profile(self.profile_name)
         if self.api_base_override:
             profile.api_base = self.api_base_override
-        # Allow OMI_API_KEY to take effect even if the on-disk profile has no key.
-        # Validate the prefix here so an obviously-bad env value fails fast with the
-        # same friendly UsageError the paste flow uses, instead of bouncing off the
-        # API as a cryptic 401.
-        env_key = os.environ.get(cfg.ENV_API_KEY)
-        if env_key and not profile.api_key:
-            profile.auth_method = "api_key"
-            profile.api_key = validate_api_key_format(env_key)
         env_base = os.environ.get(cfg.ENV_API_BASE)
         if env_base and not self.api_base_override:
             profile.api_base = env_base
         return profile
 
     def make_client(self) -> OmiClient:
-        return OmiClient(self.get_profile(), verbose=self.verbose)
+        profile = self.get_profile()
+        env_key = os.environ.get(cfg.ENV_API_KEY)
+        if env_key:
+            # Per-command override for cloud API only. Do not mutate the
+            # in-memory saved profile (auth status / local Desktop keep it).
+            profile = replace(
+                profile,
+                auth_method="api_key",
+                api_key=validate_api_key_format(env_key),
+            )
+        return OmiClient(profile, verbose=self.verbose)
 
     def make_local_client(self) -> LocalOmiClient:
         profile = self.get_profile()

--- a/sdks/python-cli/omi_cli/main.py
+++ b/sdks/python-cli/omi_cli/main.py
@@ -82,18 +82,21 @@ class AppContext:
             profile.api_base = env_base
         return profile
 
-    def make_client(self) -> OmiClient:
+    def cloud_profile(self) -> cfg.Profile:
+        """Saved profile plus a non-empty ``OMI_API_KEY`` override for cloud calls."""
         profile = self.get_profile()
         env_key = os.environ.get(cfg.ENV_API_KEY)
         if env_key:
-            # Per-command override for cloud API only. Do not mutate the
-            # in-memory saved profile (auth status / local Desktop keep it).
+            # Do not mutate the in-memory saved profile (auth status / local Desktop keep it).
             profile = replace(
                 profile,
                 auth_method="api_key",
                 api_key=validate_api_key_format(env_key),
             )
-        return OmiClient(profile, verbose=self.verbose)
+        return profile
+
+    def make_client(self) -> OmiClient:
+        return OmiClient(self.cloud_profile(), verbose=self.verbose)
 
     def make_local_client(self) -> LocalOmiClient:
         profile = self.get_profile()

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -137,6 +137,10 @@ def test_env_key_overrides_saved_key_without_persisting(
     assert result.exit_code == 0, result.output
     assert route.calls.last.request.headers["Authorization"] == f"Bearer {env_key}"
     assert config_path.read_bytes() == original_config
+    if operation == "whoami":
+        payload = json.loads(result.stdout)
+        assert payload["credential"] == f"{env_key[:6]}…{env_key[-4:]}"
+        assert payload["credential"] != authed_profile.masked_credential()
 
 
 def test_invalid_env_key_does_not_fall_back_to_saved_account(

--- a/sdks/python-cli/tests/test_main.py
+++ b/sdks/python-cli/tests/test_main.py
@@ -116,3 +116,75 @@ def test_module_entry_point_honors_json_error_contract(config_path, monkeypatch,
     assert result.returncode == 1
     payload = json.loads(result.stderr)
     assert "error" in payload
+
+
+@pytest.mark.parametrize("operation", ["list", "create", "whoami"])
+def test_env_key_overrides_saved_key_without_persisting(
+    operation, authed_profile, config_path, cli_runner, monkeypatch, respx_mock
+) -> None:
+    env_key = "omi_dev_" + "e" * 32
+    original_config = config_path.read_bytes()
+    monkeypatch.setenv("OMI_API_KEY", env_key)
+    if operation in ("list", "whoami"):
+        route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
+        args = ["auth", "whoami"] if operation == "whoami" else ["memory", "list"]
+    else:
+        route = respx_mock.post("/v1/dev/user/memories").respond(json={"id": "synthetic"})
+        args = ["memory", "create", "synthetic test memory"]
+
+    result = cli_runner.invoke(app, ["--json", *args])
+
+    assert result.exit_code == 0, result.output
+    assert route.calls.last.request.headers["Authorization"] == f"Bearer {env_key}"
+    assert config_path.read_bytes() == original_config
+
+
+def test_invalid_env_key_does_not_fall_back_to_saved_account(
+    authed_profile, cli_runner, monkeypatch, respx_mock
+) -> None:
+    monkeypatch.setenv("OMI_API_KEY", "invalid-key")
+    route = respx_mock.get("/v1/dev/user/memories").respond(json=[])
+
+    result = cli_runner.invoke(app, ["--json", "memory", "list"])
+
+    assert result.exit_code == 1
+    assert not route.called
+    assert "developer key" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("command", ["status", "tools"])
+def test_local_commands_ignore_invalid_cloud_key(
+    command, authed_profile, config_path, cli_runner, monkeypatch
+) -> None:
+    import respx
+
+    from omi_cli import config as cfg
+
+    config = cfg.load()
+    profile = config.get_profile()
+    profile.local_api_url = "http://127.0.0.1:47778"
+    profile.local_token = "synthetic-local-token"
+    cfg.save(config)
+    original_config = config_path.read_bytes()
+    monkeypatch.setenv("OMI_API_KEY", "invalid-cloud-key")
+    with respx.mock(base_url=profile.local_api_url) as router:
+        if command == "status":
+            route = router.post("/v1/local/tool").respond(
+                json={"ok": True, "result": json.dumps({"ok": True})}
+            )
+        else:
+            route = router.get("/v1/local/tools").respond(json={"ok": True, "tools": []})
+        result = cli_runner.invoke(app, ["--json", "local", command])
+
+    assert result.exit_code == 0, result.output
+    assert route.calls.last.request.headers["Authorization"] == "Bearer synthetic-local-token"
+    assert config_path.read_bytes() == original_config
+
+
+def test_auth_status_reports_saved_profile_despite_invalid_env_key(
+    authed_profile, cli_runner, monkeypatch
+) -> None:
+    monkeypatch.setenv("OMI_API_KEY", "invalid-cloud-key")
+    result = cli_runner.invoke(app, ["--json", "auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["credential"] == authed_profile.masked_credential()


### PR DESCRIPTION
## Summary
- A non-empty `OMI_API_KEY` now wins for Developer API requests even when the selected profile already has a key.
- Invalid overrides fail before HTTP (`UsageError`) instead of silently using the saved account.
- The override is applied on a copied profile, so `auth status` and local Desktop commands keep the saved credential and the on-disk config is unchanged.

Fixes #12980

## Why this PR
#13002 is APPROVED but CONFLICTING against current `main` (the conflict surface includes unrelated `.github/scripts` churn). This is a current-main replacement of the CLI contract only.

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_main.py tests/test_auth_api_key.py` — 34 passed (list/create/whoami override, invalid env does not fall back, local status/tools ignore invalid cloud key, auth status still reports the saved profile)
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

