### PR TITLE
fix(ci): unwrap bash -c payloads in structured-string sink checker

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -138,13 +138,13 @@ checks:
     lanes: ["local", "ci"]
     reason: "base-derived oversized-file checks must reject growth and stale approvals while ratcheting reductions down automatically"
   - id: structured-string-sink-registry
-    command: ["python3", ".github/scripts/check_structured_string_sinks.py"]
-    triggers: [".github/workflows/**", ".github/actions/**", ".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", ".github/checks-manifest.yaml"]
+    command: ["bash", "scripts/run-structured-string-sinks.sh"]
+    triggers: [".github/workflows/**", ".github/actions/**", ".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", "scripts/run-structured-string-sinks.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "#10337 registers the three delimiter, argv, and executable workflow sinks that blocked deploys in #9986, #9947, and #9945"
   - id: structured-string-sink-registry-tests
-    command: ["python3", ".github/scripts/test_check_structured_string_sinks.py"]
-    triggers: [".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/test_check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", ".github/checks-manifest.yaml"]
+    command: ["bash", "scripts/run-structured-string-sink-tests.sh"]
+    triggers: [".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/test_check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", "scripts/run-structured-string-sink-tests.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "every registered sink must keep a paired historical mutation fixture proving the checker rejects the incident grammar"
   - id: desktop-release-manifest-v1

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -137,6 +137,16 @@ checks:
     triggers: [".github/scripts/check_product_file_line_count_ratchet.py", ".github/scripts/test_check_product_file_line_count_ratchet.py", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "base-derived oversized-file checks must reject growth and stale approvals while ratcheting reductions down automatically"
+  - id: structured-string-sink-registry
+    command: ["python3", ".github/scripts/check_structured_string_sinks.py"]
+    triggers: [".github/workflows/**", ".github/actions/**", ".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#10337 registers the three delimiter, argv, and executable workflow sinks that blocked deploys in #9986, #9947, and #9945"
+  - id: structured-string-sink-registry-tests
+    command: ["python3", ".github/scripts/test_check_structured_string_sinks.py"]
+    triggers: [".github/structured-string-sinks/**", ".github/scripts/check_structured_string_sinks.py", ".github/scripts/test_check_structured_string_sinks.py", ".github/scripts/fixtures/structured_string_sinks/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "every registered sink must keep a paired historical mutation fixture proving the checker rejects the incident grammar"
   - id: desktop-release-manifest-v1
     command: ["python3", ".github/scripts/test_desktop_release_manifest.py"]
     triggers: [".github/schemas/desktop-release-manifest-v1.schema.json", ".github/scripts/desktop_release_manifest.py", ".github/scripts/test_desktop_release_manifest.py", ".github/scripts/fixtures/desktop_release_manifest/**"]

--- a/.github/scripts/check_structured_string_sinks.py
+++ b/.github/scripts/check_structured_string_sinks.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Validate the repository's finite registry of structured-string workflow sinks.
+
+This is deliberately not a general shell or workflow linter. Each check is
+activated by an explicit registry entry that names one real sink, its grammar,
+and the historical fixture that proves the check can fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Iterator
+
+import yaml
+
+SCHEMA_VERSION = 1
+SUPPORTED_KINDS = {"action-delimited-map", "script-split-argv", "script-interpreter"}
+GITHUB_EXPRESSION_RE = re.compile(r"\$\{\{.*?}}")
+
+
+@dataclass(frozen=True)
+class Violation:
+    entry_id: str
+    path: str
+    message: str
+
+    def render(self) -> str:
+        return f"{self.path}: [{self.entry_id}] {self.message}"
+
+
+def repository_root(explicit: str | None = None) -> Path:
+    return Path(explicit).resolve() if explicit else Path(__file__).resolve().parents[2]
+
+
+def registry_directory(root: Path, explicit: str | None = None) -> Path:
+    return Path(explicit).resolve() if explicit else root / ".github" / "structured-string-sinks"
+
+
+def _safe_relative_path(raw: object, *, field: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{field} must be a non-empty repository-relative path")
+    relative = raw.strip()
+    path = PurePosixPath(relative)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{field} must be a safe repository-relative path: {relative!r}")
+    return relative
+
+
+def _non_empty_string(raw: object, *, field: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return raw.strip()
+
+
+def _string_list(raw: object, *, field: str) -> list[str]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"{field} must be a non-empty list")
+    values = [_non_empty_string(value, field=f"{field}[]") for value in raw]
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field} must not contain duplicates")
+    return values
+
+
+def _delimiter_list(raw: object, *, field: str) -> list[str]:
+    if not isinstance(raw, list) or not raw or not all(isinstance(value, str) and value for value in raw):
+        raise ValueError(f"{field} must be a non-empty list of non-empty delimiters")
+    if len(raw) != len(set(raw)):
+        raise ValueError(f"{field} must not contain duplicates")
+    return list(raw)
+
+
+def validate_entry(entry: object, *, source: Path, root: Path) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"{source}: registry document must be a JSON object")
+    if entry.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{source}: schema_version must be {SCHEMA_VERSION}")
+
+    entry_id = _non_empty_string(entry.get("id"), field=f"{source}: id")
+    kind = _non_empty_string(entry.get("kind"), field=f"{source}: kind")
+    if kind not in SUPPORTED_KINDS:
+        raise ValueError(f"{source}: {entry_id}: unsupported kind {kind!r}")
+    _non_empty_string(entry.get("failure_class"), field=f"{source}: failure_class")
+    _non_empty_string(entry.get("safe_encoding"), field=f"{source}: safe_encoding")
+
+    evidence_prs = entry.get("evidence_prs")
+    if (
+        not isinstance(evidence_prs, list)
+        or not evidence_prs
+        or not all(isinstance(number, int) and number > 0 for number in evidence_prs)
+    ):
+        raise ValueError(f"{source}: {entry_id}: evidence_prs must contain positive PR numbers")
+
+    scope = entry.get("scope")
+    if not isinstance(scope, dict):
+        raise ValueError(f"{source}: {entry_id}: scope must be an object")
+    _string_list(scope.get("globs"), field=f"{source}: {entry_id}: scope.globs")
+
+    fixtures = entry.get("fixtures")
+    if not isinstance(fixtures, dict):
+        raise ValueError(f"{source}: {entry_id}: fixtures must be an object")
+    for outcome in ("passing", "failing"):
+        relative = _safe_relative_path(fixtures.get(outcome), field=f"{source}: {entry_id}: fixtures.{outcome}")
+        if not (root / relative).is_file():
+            raise ValueError(f"{source}: {entry_id}: missing {outcome} fixture {relative}")
+
+    if "allowlist" in entry:
+        raise ValueError(
+            f"{source}: {entry_id}: bare allowlist is forbidden; name an owner and reason on the exact exemption"
+        )
+
+    if kind == "action-delimited-map":
+        selector = entry.get("selector")
+        grammar = entry.get("grammar")
+        dynamic_values = entry.get("dynamic_values")
+        if not isinstance(selector, dict) or not isinstance(grammar, dict):
+            raise ValueError(f"{source}: {entry_id}: action entry requires selector and grammar objects")
+        _non_empty_string(selector.get("uses"), field=f"{source}: {entry_id}: selector.uses")
+        _non_empty_string(selector.get("input"), field=f"{source}: {entry_id}: selector.input")
+        _non_empty_string(
+            grammar.get("assignment_delimiter"), field=f"{source}: {entry_id}: grammar.assignment_delimiter"
+        )
+        _delimiter_list(grammar.get("pair_delimiters"), field=f"{source}: {entry_id}: grammar.pair_delimiters")
+        escape = _non_empty_string(grammar.get("escape"), field=f"{source}: {entry_id}: grammar.escape")
+        if len(escape) != 1:
+            raise ValueError(f"{source}: {entry_id}: grammar.escape must be one character")
+        if not isinstance(dynamic_values, dict):
+            raise ValueError(f"{source}: {entry_id}: dynamic_values must name its policy owner and reason")
+        _non_empty_string(dynamic_values.get("owner"), field=f"{source}: {entry_id}: dynamic_values.owner")
+        reason = _non_empty_string(dynamic_values.get("reason"), field=f"{source}: {entry_id}: dynamic_values.reason")
+        if len(reason) < 20:
+            raise ValueError(f"{source}: {entry_id}: dynamic_values.reason must explain the safety boundary")
+    else:
+        command = _non_empty_string(entry.get("command"), field=f"{source}: {entry_id}: command")
+        if "/" in command:
+            raise ValueError(f"{source}: {entry_id}: command must be a basename, not a path")
+        if kind == "script-split-argv":
+            _string_list(entry.get("split_options"), field=f"{source}: {entry_id}: split_options")
+        if kind == "script-interpreter":
+            _string_list(entry.get("interpreters"), field=f"{source}: {entry_id}: interpreters")
+
+    return entry
+
+
+def load_registry(root: Path, directory: Path | None = None) -> list[dict[str, Any]]:
+    registry_dir = directory or registry_directory(root)
+    paths = sorted(registry_dir.glob("*.json"))
+    if not paths:
+        raise ValueError(f"no structured-string sink entries found in {registry_dir}")
+    entries: list[dict[str, Any]] = []
+    ids: set[str] = set()
+    for path in paths:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise ValueError(f"{path}: cannot load registry entry: {error}") from error
+        entry = validate_entry(raw, source=path, root=root)
+        entry_id = str(entry["id"])
+        if entry_id in ids:
+            raise ValueError(f"{path}: duplicate registry id {entry_id!r}")
+        ids.add(entry_id)
+        entries.append(entry)
+    return entries
+
+
+def _iter_mappings(value: object) -> Iterator[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _iter_mappings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_mappings(child)
+
+
+def _load_yaml(path: Path) -> object:
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as error:
+        raise ValueError(f"{path}: cannot parse YAML: {error}") from error
+
+
+def _display_path(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _contains_unescaped(text: str, delimiter: str, escape: str) -> bool:
+    start = 0
+    while True:
+        index = text.find(delimiter, start)
+        if index < 0:
+            return False
+        escapes = 0
+        cursor = index - 1
+        while cursor >= 0 and text[cursor] == escape:
+            escapes += 1
+            cursor -= 1
+        if escapes % 2 == 0:
+            return True
+        start = index + len(delimiter)
+
+
+def _check_action_delimited_map(entry: dict[str, Any], path: Path, document: object, root: Path) -> list[Violation]:
+    selector = entry["selector"]
+    grammar = entry["grammar"]
+    assignment = str(grammar["assignment_delimiter"])
+    escape = str(grammar["escape"])
+    value_delimiters = [delimiter for delimiter in grammar["pair_delimiters"] if delimiter != "\n"]
+    violations: list[Violation] = []
+    display = _display_path(path, root)
+
+    for mapping in _iter_mappings(document):
+        if mapping.get("uses") != selector["uses"]:
+            continue
+        inputs = mapping.get("with")
+        if not isinstance(inputs, dict) or selector["input"] not in inputs:
+            continue
+        raw = inputs[selector["input"]]
+        if not isinstance(raw, str):
+            violations.append(
+                Violation(
+                    str(entry["id"]),
+                    display,
+                    f"{selector['uses']} input {selector['input']} must be a string",
+                )
+            )
+            continue
+        for line_number, raw_line in enumerate(raw.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line or GITHUB_EXPRESSION_RE.fullmatch(line):
+                continue
+            if assignment not in line:
+                violations.append(
+                    Violation(
+                        str(entry["id"]),
+                        display,
+                        f"{selector['input']} entry {line_number} is neither a dynamic producer nor a {assignment!r} assignment",
+                    )
+                )
+                continue
+            name, value = line.split(assignment, 1)
+            literal_value = GITHUB_EXPRESSION_RE.sub("", value)
+            for delimiter in value_delimiters:
+                if _contains_unescaped(literal_value, str(delimiter), escape):
+                    violations.append(
+                        Violation(
+                            str(entry["id"]),
+                            display,
+                            f"{selector['input']} assignment {name.strip()!r} contains unescaped {delimiter!r}; {entry['safe_encoding']}",
+                        )
+                    )
+    return violations
+
+
+def _logical_shell_commands(run: str) -> Iterator[list[str]]:
+    masked = GITHUB_EXPRESSION_RE.sub("__GITHUB_EXPRESSION__", run)
+    pending = ""
+    for raw_line in masked.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        pending = f"{pending} {stripped}".strip()
+        if pending.endswith("\\"):
+            pending = pending[:-1].rstrip()
+            continue
+        try:
+            yield shlex.split(pending, posix=True)
+        except ValueError:
+            # Shell syntax outside a registered command is not this check's
+            # responsibility. If the registered basename is visible, fail
+            # closed with a diagnostic instead of silently skipping it.
+            if ".sh" in pending:
+                yield ["__UNPARSEABLE__", pending]
+        pending = ""
+    if pending:
+        try:
+            yield shlex.split(pending, posix=True)
+        except ValueError:
+            if ".sh" in pending:
+                yield ["__UNPARSEABLE__", pending]
+
+
+def _command_basename(token: str) -> str:
+    return token.rstrip(";,|").rsplit("/", 1)[-1]
+
+
+def _registered_invocations(document: object, command: str) -> Iterator[tuple[list[str], int]]:
+    for mapping in _iter_mappings(document):
+        run = mapping.get("run")
+        if not isinstance(run, str) or command not in run:
+            continue
+        for tokens in _logical_shell_commands(run):
+            if tokens and tokens[0] == "__UNPARSEABLE__" and command in tokens[1]:
+                yield tokens, 0
+                continue
+            for index, token in enumerate(tokens):
+                if _command_basename(token) == command:
+                    yield tokens, index
+
+
+def _check_script_split_argv(entry: dict[str, Any], path: Path, document: object, root: Path) -> list[Violation]:
+    display = _display_path(path, root)
+    violations: list[Violation] = []
+    for tokens, command_index in _registered_invocations(document, str(entry["command"])):
+        if tokens and tokens[0] == "__UNPARSEABLE__":
+            violations.append(Violation(str(entry["id"]), display, f"could not parse registered command: {tokens[1]}"))
+            continue
+        arguments = tokens[command_index + 1 :]
+        for option in entry["split_options"]:
+            joined = f"{option}="
+            if any(argument.startswith(joined) for argument in arguments):
+                violations.append(
+                    Violation(
+                        str(entry["id"]),
+                        display,
+                        f"{entry['command']} received joined argument {joined}<value>; {entry['safe_encoding']}",
+                    )
+                )
+    return violations
+
+
+def _check_script_interpreter(entry: dict[str, Any], path: Path, document: object, root: Path) -> list[Violation]:
+    display = _display_path(path, root)
+    allowed = set(entry["interpreters"])
+    violations: list[Violation] = []
+    for tokens, command_index in _registered_invocations(document, str(entry["command"])):
+        if tokens and tokens[0] == "__UNPARSEABLE__":
+            violations.append(Violation(str(entry["id"]), display, f"could not parse registered command: {tokens[1]}"))
+            continue
+        interpreter = tokens[command_index - 1] if command_index > 0 else ""
+        if interpreter not in allowed:
+            violations.append(
+                Violation(
+                    str(entry["id"]),
+                    display,
+                    f"{entry['command']} is invoked without an explicit {sorted(allowed)} interpreter; {entry['safe_encoding']}",
+                )
+            )
+    return violations
+
+
+def check_entry_paths(entry: dict[str, Any], paths: Iterable[Path], root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for path in sorted(set(paths)):
+        document = _load_yaml(path)
+        if entry["kind"] == "action-delimited-map":
+            violations.extend(_check_action_delimited_map(entry, path, document, root))
+        elif entry["kind"] == "script-split-argv":
+            violations.extend(_check_script_split_argv(entry, path, document, root))
+        elif entry["kind"] == "script-interpreter":
+            violations.extend(_check_script_interpreter(entry, path, document, root))
+    return violations
+
+
+def entry_paths(entry: dict[str, Any], root: Path) -> list[Path]:
+    paths: set[Path] = set()
+    for pattern in entry["scope"]["globs"]:
+        paths.update(path for path in root.glob(pattern) if path.is_file())
+    if not paths:
+        raise ValueError(f"{entry['id']}: scope matched no files")
+    return sorted(paths)
+
+
+def count_entry_matches(entry: dict[str, Any], paths: Iterable[Path]) -> int:
+    matches = 0
+    for path in sorted(set(paths)):
+        document = _load_yaml(path)
+        if entry["kind"] == "action-delimited-map":
+            selector = entry["selector"]
+            matches += sum(
+                1
+                for mapping in _iter_mappings(document)
+                if mapping.get("uses") == selector["uses"]
+                and isinstance(mapping.get("with"), dict)
+                and selector["input"] in mapping["with"]
+            )
+        else:
+            matches += sum(1 for _ in _registered_invocations(document, str(entry["command"])))
+    return matches
+
+
+def check_repository(root: Path, entries: Iterable[dict[str, Any]]) -> list[Violation]:
+    violations: list[Violation] = []
+    for entry in entries:
+        paths = entry_paths(entry, root)
+        if count_entry_matches(entry, paths) == 0:
+            raise ValueError(f"{entry['id']}: registered scope matched files but no sink invocation")
+        violations.extend(check_entry_paths(entry, paths, root))
+    return violations
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", help="repository root (defaults to this script's repository)")
+    parser.add_argument("--registry-dir", help="registry directory (defaults to .github/structured-string-sinks)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    root = repository_root(args.root)
+    try:
+        entries = load_registry(root, registry_directory(root, args.registry_dir))
+        violations = check_repository(root, entries)
+    except ValueError as error:
+        print(f"structured-string sink registry error: {error}", file=sys.stderr)
+        return 2
+    if violations:
+        for violation in violations:
+            print(violation.render(), file=sys.stderr)
+        print(f"FAIL: {len(violations)} structured-string sink violation(s)", file=sys.stderr)
+        return 1
+    print(f"OK: {len(entries)} registered structured-string sinks are grammar-safe.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_structured_string_sinks.py
+++ b/.github/scripts/check_structured_string_sinks.py
@@ -260,6 +260,47 @@ def _check_action_delimited_map(entry: dict[str, Any], path: Path, document: obj
     return violations
 
 
+SHELL_INTERPRETERS = frozenset({"bash", "sh", "zsh"})
+_SHELL_C_RECURSION_CAP = 3
+
+
+def _command_basename(token: str) -> str:
+    return token.rstrip(";,|").rsplit("/", 1)[-1]
+
+
+def _expand_shell_c_payloads(tokens: list[str], *, depth: int = 0) -> Iterator[list[str]]:
+    yield tokens
+    if depth >= _SHELL_C_RECURSION_CAP:
+        return
+    if not tokens or _command_basename(tokens[0]) not in SHELL_INTERPRETERS:
+        return
+    for index, token in enumerate(tokens[1:], start=1):
+        if token != "-c" or index + 1 >= len(tokens):
+            continue
+        payload = tokens[index + 1]
+        try:
+            inner_tokens = shlex.split(payload, posix=True)
+        except ValueError:
+            if ".sh" in payload:
+                yield ["__UNPARSEABLE__", payload]
+            return
+        yield from _expand_shell_c_payloads(inner_tokens, depth=depth + 1)
+        return
+
+
+def _yield_logical_tokens(pending: str) -> Iterator[list[str]]:
+    try:
+        tokens = shlex.split(pending, posix=True)
+    except ValueError:
+        # Shell syntax outside a registered command is not this check's
+        # responsibility. If the registered basename is visible, fail
+        # closed with a diagnostic instead of silently skipping it.
+        if ".sh" in pending:
+            yield ["__UNPARSEABLE__", pending]
+        return
+    yield from _expand_shell_c_payloads(tokens)
+
+
 def _logical_shell_commands(run: str) -> Iterator[list[str]]:
     masked = GITHUB_EXPRESSION_RE.sub("__GITHUB_EXPRESSION__", run)
     pending = ""
@@ -271,25 +312,10 @@ def _logical_shell_commands(run: str) -> Iterator[list[str]]:
         if pending.endswith("\\"):
             pending = pending[:-1].rstrip()
             continue
-        try:
-            yield shlex.split(pending, posix=True)
-        except ValueError:
-            # Shell syntax outside a registered command is not this check's
-            # responsibility. If the registered basename is visible, fail
-            # closed with a diagnostic instead of silently skipping it.
-            if ".sh" in pending:
-                yield ["__UNPARSEABLE__", pending]
+        yield from _yield_logical_tokens(pending)
         pending = ""
     if pending:
-        try:
-            yield shlex.split(pending, posix=True)
-        except ValueError:
-            if ".sh" in pending:
-                yield ["__UNPARSEABLE__", pending]
-
-
-def _command_basename(token: str) -> str:
-    return token.rstrip(";,|").rsplit("/", 1)[-1]
+        yield from _yield_logical_tokens(pending)
 
 
 def _registered_invocations(document: object, command: str) -> Iterator[tuple[list[str], int]]:

--- a/.github/scripts/check_structured_string_sinks.py
+++ b/.github/scripts/check_structured_string_sinks.py
@@ -261,31 +261,62 @@ def _check_action_delimited_map(entry: dict[str, Any], path: Path, document: obj
 
 
 SHELL_INTERPRETERS = frozenset({"bash", "sh", "zsh"})
+SHELL_SEGMENT_BOUNDARIES = frozenset({"|", "||", "&&", ";", "&"})
 _SHELL_C_RECURSION_CAP = 3
+_SHELL_OPERATOR_SPLIT_RE = re.compile(r"(\&\&|\|\||[|;&])")
 
 
 def _command_basename(token: str) -> str:
-    return token.rstrip(";,|").rsplit("/", 1)[-1]
+    for part in _SHELL_OPERATOR_SPLIT_RE.split(token):
+        if part and part not in SHELL_SEGMENT_BOUNDARIES:
+            return part.rstrip(";,|&").rsplit("/", 1)[-1]
+    return token.rstrip(";,|&").rsplit("/", 1)[-1]
+
+
+def _token_is_command_position(tokens: list[str], index: int) -> bool:
+    if index == 0:
+        return True
+    previous = tokens[index - 1]
+    if previous in SHELL_SEGMENT_BOUNDARIES or previous == "-c":
+        return True
+    if _command_basename(previous) in SHELL_INTERPRETERS:
+        return True
+    return any(previous.endswith(operator) for operator in SHELL_SEGMENT_BOUNDARIES)
+
+
+def _command_fragments_at_position(token: str, *, at_command_position: bool) -> Iterator[str]:
+    is_command = at_command_position
+    for part in _SHELL_OPERATOR_SPLIT_RE.split(token):
+        if not part:
+            continue
+        if part in SHELL_SEGMENT_BOUNDARIES:
+            is_command = True
+            continue
+        if is_command:
+            yield part
+        is_command = False
 
 
 def _expand_shell_c_payloads(tokens: list[str], *, depth: int = 0) -> Iterator[list[str]]:
-    yield tokens
     if depth >= _SHELL_C_RECURSION_CAP:
+        yield tokens
         return
-    if not tokens or _command_basename(tokens[0]) not in SHELL_INTERPRETERS:
-        return
-    for index, token in enumerate(tokens[1:], start=1):
-        if token != "-c" or index + 1 >= len(tokens):
-            continue
-        payload = tokens[index + 1]
-        try:
-            inner_tokens = shlex.split(payload, posix=True)
-        except ValueError:
-            if ".sh" in payload:
-                yield ["__UNPARSEABLE__", payload]
+    if tokens and _command_basename(tokens[0]) in SHELL_INTERPRETERS:
+        for index, token in enumerate(tokens[1:], start=1):
+            if token != "-c" or index + 1 >= len(tokens):
+                continue
+            payload = tokens[index + 1]
+            try:
+                inner_tokens = shlex.split(payload, posix=True)
+            except ValueError:
+                if ".sh" in payload:
+                    yield ["__UNPARSEABLE__", payload]
+                else:
+                    yield tokens
+                return
+            yield from _expand_shell_c_payloads(inner_tokens, depth=depth + 1)
             return
-        yield from _expand_shell_c_payloads(inner_tokens, depth=depth + 1)
-        return
+    yield tokens
 
 
 def _yield_logical_tokens(pending: str) -> Iterator[list[str]]:
@@ -327,9 +358,19 @@ def _registered_invocations(document: object, command: str) -> Iterator[tuple[li
             if tokens and tokens[0] == "__UNPARSEABLE__" and command in tokens[1]:
                 yield tokens, 0
                 continue
+            seen: set[tuple[tuple[str, ...], int]] = set()
             for index, token in enumerate(tokens):
-                if _command_basename(token) == command:
+                if not _token_is_command_position(tokens, index):
+                    continue
+                for fragment in _command_fragments_at_position(token, at_command_position=True):
+                    if _command_basename(fragment) != command:
+                        continue
+                    key = (tuple(tokens), index)
+                    if key in seen:
+                        break
+                    seen.add(key)
                     yield tokens, index
+                    break
 
 
 def _check_script_split_argv(entry: dict[str, Any], path: Path, document: object, root: Path) -> list[Violation]:

--- a/.github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.fail.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.fail.yml
@@ -1,0 +1,11 @@
+# Historical bad input from repair PR #9986.
+name: deploy env historical failure
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          service: backend
+          env_vars: |-
+            STT_PRERECORDED_MODEL=parakeet,modulate-velma-2

--- a/.github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.pass.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.pass.yml
@@ -1,0 +1,10 @@
+name: deploy env fixture
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          service: backend
+          env_vars: |-
+            STT_PRERECORDED_MODEL=parakeet\,modulate-velma-2

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.fail.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.fail.yml
@@ -1,0 +1,10 @@
+# Historical joined-argument shape exposed by #9945 and repaired in #9947.
+name: probe argv historical failure
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project=test-project \
+            --region us-central1

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.pass.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.pass.yml
@@ -1,0 +1,9 @@
+name: probe argv fixture
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project test-project \
+            --region us-central1

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-interpreter.fail.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-interpreter.fail.yml
@@ -1,0 +1,8 @@
+# bash -c wrapper evasion tracked by #12860; direct execution inside -c must fail.
+name: probe bash-c interpreter historical failure
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash -c 'backend/scripts/probe-llm-gateway-from-cloud-run.sh --project test-project'

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-interpreter.pass.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-interpreter.pass.yml
@@ -1,0 +1,7 @@
+name: probe bash-c interpreter fixture
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash -c 'bash backend/scripts/probe-llm-gateway-from-cloud-run.sh --project test-project'

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-wrap.fail.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-wrap.fail.yml
@@ -1,0 +1,8 @@
+# bash -c wrapper evasion tracked by #12860; joined argv must still fail.
+name: probe bash-c wrap historical failure
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash -c 'bash backend/scripts/probe-llm-gateway-from-cloud-run.sh --project=test-project'

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-wrap.pass.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-wrap.pass.yml
@@ -1,0 +1,7 @@
+name: probe bash-c wrap fixture
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash -c 'bash backend/scripts/probe-llm-gateway-from-cloud-run.sh --project test-project'

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.fail.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.fail.yml
@@ -1,0 +1,9 @@
+# Historical direct-execution shape from the #9943 failure, repaired in #9945.
+name: probe interpreter historical failure
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project test-project

--- a/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.pass.yml
+++ b/.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.pass.yml
@@ -1,0 +1,8 @@
+name: probe interpreter fixture
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |-
+          bash backend/scripts/probe-llm-gateway-from-cloud-run.sh \
+            --project test-project

--- a/.github/scripts/test_check_structured_string_sinks.py
+++ b/.github/scripts/test_check_structured_string_sinks.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Behavioral and mutation tests for the structured-string sink registry."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIR.parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_structured_string_sinks", SCRIPT_DIR / "check_structured_string_sinks.py"
+)
+assert SPEC and SPEC.loader
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+class StructuredStringSinkRegistryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.entries = CHECKER.load_registry(REPOSITORY_ROOT)
+
+    def test_registry_covers_all_three_historical_failure_classes(self) -> None:
+        by_id = {entry["id"]: entry for entry in self.entries}
+        self.assertEqual(
+            set(by_id),
+            {
+                "deploy-cloudrun-env-vars-v3",
+                "llm-gateway-probe-split-argv",
+                "llm-gateway-probe-explicit-interpreter",
+            },
+        )
+        self.assertEqual(
+            {entry["failure_class"] for entry in self.entries},
+            {
+                "FC-deploy-input-serialization",
+                "FC-workflow-script-input-contract",
+                "FC-workflow-executable-assumption",
+            },
+        )
+        evidence = {number for entry in self.entries for number in entry["evidence_prs"]}
+        self.assertTrue({9986, 9943, 9945, 9947}.issubset(evidence))
+
+    def test_every_historical_bad_fixture_fails_and_paired_fixture_passes(self) -> None:
+        for entry in self.entries:
+            with self.subTest(entry=entry["id"], outcome="passing"):
+                passing = REPOSITORY_ROOT / entry["fixtures"]["passing"]
+                self.assertEqual(CHECKER.check_entry_paths(entry, [passing], REPOSITORY_ROOT), [])
+            with self.subTest(entry=entry["id"], outcome="failing"):
+                failing = REPOSITORY_ROOT / entry["fixtures"]["failing"]
+                violations = CHECKER.check_entry_paths(entry, [failing], REPOSITORY_ROOT)
+                self.assertEqual(len(violations), 1)
+                self.assertEqual(violations[0].entry_id, entry["id"])
+                self.assertIn(str(entry["evidence_prs"][-1]), failing.read_text(encoding="utf-8"))
+
+    def test_checked_in_repository_satisfies_every_registered_grammar(self) -> None:
+        self.assertEqual(CHECKER.check_repository(REPOSITORY_ROOT, self.entries), [])
+
+    def test_registered_scope_cannot_silently_match_zero_sinks(self) -> None:
+        entry = json.loads(json.dumps(next(entry for entry in self.entries if entry["kind"] == "script-split-argv")))
+        entry["command"] = "retired-command-that-does-not-exist.sh"
+        with self.assertRaisesRegex(ValueError, "matched files but no sink invocation"):
+            CHECKER.check_repository(REPOSITORY_ROOT, [entry])
+
+    def test_even_escape_run_does_not_hide_a_raw_delimiter(self) -> None:
+        entry = next(entry for entry in self.entries if entry["kind"] == "action-delimited-map")
+        self.assertFalse(CHECKER._contains_unescaped(r"one\,two", ",", "\\"))
+        self.assertTrue(CHECKER._contains_unescaped(r"one\\,two", ",", "\\"))
+
+    def test_registry_rejects_bare_allowlist_and_ownerless_dynamic_exemption(self) -> None:
+        original = next(entry for entry in self.entries if entry["kind"] == "action-delimited-map")
+        fixture_root = REPOSITORY_ROOT
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "entry.json"
+            bare = json.loads(json.dumps(original))
+            bare["allowlist"] = [".github/workflows/example.yml"]
+            with self.assertRaisesRegex(ValueError, "bare allowlist is forbidden"):
+                CHECKER.validate_entry(bare, source=source, root=fixture_root)
+
+            ownerless = json.loads(json.dumps(original))
+            ownerless["dynamic_values"]["owner"] = ""
+            with self.assertRaisesRegex(ValueError, "dynamic_values.owner"):
+                CHECKER.validate_entry(ownerless, source=source, root=fixture_root)
+
+    def test_registry_requires_both_fixture_polarities(self) -> None:
+        original = json.loads(json.dumps(self.entries[0]))
+        original["fixtures"].pop("failing")
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "entry.json"
+            with self.assertRaisesRegex(ValueError, "fixtures.failing"):
+                CHECKER.validate_entry(original, source=source, root=REPOSITORY_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_check_structured_string_sinks.py
+++ b/.github/scripts/test_check_structured_string_sinks.py
@@ -97,15 +97,89 @@ class StructuredStringSinkRegistryTests(unittest.TestCase):
                 CHECKER.validate_entry(original, source=source, root=REPOSITORY_ROOT)
 
     def test_bash_c_payload_exposes_registered_sink_violations(self) -> None:
-        entry = next(entry for entry in self.entries if entry["id"] == "llm-gateway-probe-split-argv")
         fixture_dir = REPOSITORY_ROOT / ".github/scripts/fixtures/structured_string_sinks"
-        passing = fixture_dir / "llm-gateway-probe-bash-c-wrap.pass.yml"
-        failing = fixture_dir / "llm-gateway-probe-bash-c-wrap.fail.yml"
-        self.assertEqual(CHECKER.check_entry_paths(entry, [passing], REPOSITORY_ROOT), [])
-        violations = CHECKER.check_entry_paths(entry, [failing], REPOSITORY_ROOT)
-        self.assertEqual(len(violations), 1)
-        self.assertEqual(violations[0].entry_id, entry["id"])
-        self.assertIn("12860", failing.read_text(encoding="utf-8"))
+        cases = (
+            (
+                "llm-gateway-probe-split-argv",
+                "llm-gateway-probe-bash-c-wrap.pass.yml",
+                "llm-gateway-probe-bash-c-wrap.fail.yml",
+            ),
+            (
+                "llm-gateway-probe-explicit-interpreter",
+                "llm-gateway-probe-bash-c-interpreter.pass.yml",
+                "llm-gateway-probe-bash-c-interpreter.fail.yml",
+            ),
+        )
+        for entry_id, passing_name, failing_name in cases:
+            entry = next(entry for entry in self.entries if entry["id"] == entry_id)
+            passing = fixture_dir / passing_name
+            failing = fixture_dir / failing_name
+            with self.subTest(entry=entry_id):
+                self.assertEqual(CHECKER.check_entry_paths(entry, [passing], REPOSITORY_ROOT), [])
+                violations = CHECKER.check_entry_paths(entry, [failing], REPOSITORY_ROOT)
+                self.assertEqual(len(violations), 1)
+                self.assertEqual(violations[0].entry_id, entry["id"])
+                self.assertIn("12860", failing.read_text(encoding="utf-8"))
+
+    def test_registered_command_in_data_position_is_not_an_invocation(self) -> None:
+        entry = next(entry for entry in self.entries if entry["id"] == "llm-gateway-probe-split-argv")
+        with tempfile.TemporaryDirectory() as temporary:
+            fixture = Path(temporary) / "data-only.yml"
+            fixture.write_text(
+                "\n".join(
+                    [
+                        "name: probe path passed as data",
+                        "jobs:",
+                        "  probe:",
+                        "    runs-on: ubuntu-latest",
+                        "    steps:",
+                        "      - run: echo backend/scripts/probe-llm-gateway-from-cloud-run.sh",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(CHECKER.check_entry_paths(entry, [fixture], REPOSITORY_ROOT), [])
+
+    def test_adjacent_shell_operator_does_not_hide_registered_command(self) -> None:
+        entry = next(entry for entry in self.entries if entry["id"] == "llm-gateway-probe-explicit-interpreter")
+        with tempfile.TemporaryDirectory() as temporary:
+            fixture = Path(temporary) / "adjacent-operator.yml"
+            fixture.write_text(
+                "\n".join(
+                    [
+                        "name: probe adjacent operator",
+                        "jobs:",
+                        "  probe:",
+                        "    runs-on: ubuntu-latest",
+                        "    steps:",
+                        "      - run: backend/scripts/probe-llm-gateway-from-cloud-run.sh&& echo ok",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            violations = CHECKER.check_entry_paths(entry, [fixture], REPOSITORY_ROOT)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].entry_id, entry["id"])
+
+    def test_bash_c_expansion_does_not_duplicate_violations(self) -> None:
+        entry = next(entry for entry in self.entries if entry["id"] == "llm-gateway-probe-explicit-interpreter")
+        with tempfile.TemporaryDirectory() as temporary:
+            fixture = Path(temporary) / "exact-payload.yml"
+            fixture.write_text(
+                "\n".join(
+                    [
+                        "name: probe exact bash-c payload",
+                        "jobs:",
+                        "  probe:",
+                        "    runs-on: ubuntu-latest",
+                        "    steps:",
+                        "      - run: bash -c probe-llm-gateway-from-cloud-run.sh",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            violations = CHECKER.check_entry_paths(entry, [fixture], REPOSITORY_ROOT)
+            self.assertEqual(len(violations), 1)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_check_structured_string_sinks.py
+++ b/.github/scripts/test_check_structured_string_sinks.py
@@ -96,6 +96,17 @@ class StructuredStringSinkRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "fixtures.failing"):
                 CHECKER.validate_entry(original, source=source, root=REPOSITORY_ROOT)
 
+    def test_bash_c_payload_exposes_registered_sink_violations(self) -> None:
+        entry = next(entry for entry in self.entries if entry["id"] == "llm-gateway-probe-split-argv")
+        fixture_dir = REPOSITORY_ROOT / ".github/scripts/fixtures/structured_string_sinks"
+        passing = fixture_dir / "llm-gateway-probe-bash-c-wrap.pass.yml"
+        failing = fixture_dir / "llm-gateway-probe-bash-c-wrap.fail.yml"
+        self.assertEqual(CHECKER.check_entry_paths(entry, [passing], REPOSITORY_ROOT), [])
+        violations = CHECKER.check_entry_paths(entry, [failing], REPOSITORY_ROOT)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].entry_id, entry["id"])
+        self.assertIn("12860", failing.read_text(encoding="utf-8"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/structured-string-sinks/deploy-cloudrun-env-vars-v3.json
+++ b/.github/structured-string-sinks/deploy-cloudrun-env-vars-v3.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "deploy-cloudrun-env-vars-v3",
+  "kind": "action-delimited-map",
+  "failure_class": "FC-deploy-input-serialization",
+  "evidence_prs": [9986],
+  "safe_encoding": "backslash-escape commas and backslashes in each value before flattening the map",
+  "scope": {
+    "globs": [
+      ".github/actions/*/action.yml",
+      ".github/actions/*/action.yaml",
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml"
+    ]
+  },
+  "selector": {
+    "uses": "google-github-actions/deploy-cloudrun@v3",
+    "input": "env_vars"
+  },
+  "grammar": {
+    "assignment_delimiter": "=",
+    "pair_delimiters": [",", "\n"],
+    "escape": "\\"
+  },
+  "dynamic_values": {
+    "owner": "backend deploy runtime serializers and their workflow contract tests",
+    "reason": "GitHub expressions resolve after this static check; their producing renderer owns separator encoding, while this entry validates every literal fragment at the action boundary."
+  },
+  "fixtures": {
+    "passing": ".github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.pass.yml",
+    "failing": ".github/scripts/fixtures/structured_string_sinks/deploy-cloudrun-env-vars.fail.yml"
+  }
+}

--- a/.github/structured-string-sinks/llm-gateway-probe-explicit-interpreter.json
+++ b/.github/structured-string-sinks/llm-gateway-probe-explicit-interpreter.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "id": "llm-gateway-probe-explicit-interpreter",
+  "kind": "script-interpreter",
+  "failure_class": "FC-workflow-executable-assumption",
+  "evidence_prs": [9943, 9945],
+  "safe_encoding": "invoke the checked-in 100644 probe through bash instead of assuming executable mode",
+  "scope": {
+    "globs": [
+      ".github/actions/*/action.yml",
+      ".github/actions/*/action.yaml",
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml"
+    ]
+  },
+  "command": "probe-llm-gateway-from-cloud-run.sh",
+  "interpreters": ["bash"],
+  "fixtures": {
+    "passing": ".github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.pass.yml",
+    "failing": ".github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-interpreter.fail.yml"
+  }
+}

--- a/.github/structured-string-sinks/llm-gateway-probe-split-argv.json
+++ b/.github/structured-string-sinks/llm-gateway-probe-split-argv.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "llm-gateway-probe-split-argv",
+  "kind": "script-split-argv",
+  "failure_class": "FC-workflow-script-input-contract",
+  "evidence_prs": [9945, 9947],
+  "safe_encoding": "pass every registered option and value as two shell arguments, for example --project test-project",
+  "scope": {
+    "globs": [
+      ".github/actions/*/action.yml",
+      ".github/actions/*/action.yaml",
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml"
+    ]
+  },
+  "command": "probe-llm-gateway-from-cloud-run.sh",
+  "split_options": [
+    "--project",
+    "--region",
+    "--image",
+    "--gateway-url",
+    "--network",
+    "--subnet",
+    "--vpc-egress",
+    "--token-secret",
+    "--name-suffix",
+    "--lane"
+  ],
+  "fixtures": {
+    "passing": ".github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.pass.yml",
+    "failing": ".github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-argv.fail.yml"
+  }
+}

--- a/scripts/run-structured-string-sink-tests.sh
+++ b/scripts/run-structured-string-sink-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run the structured-string-sink registry self-tests with the repository's locked
+# PyYAML dependency, for the same reason as the checker wrapper beside it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
+
+if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
+  || ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
+  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
+    echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
+    exit 1
+  fi
+fi
+
+exec "$BACKEND_PYTHON" "$ROOT_DIR/.github/scripts/test_check_structured_string_sinks.py" "$@"

--- a/scripts/run-structured-string-sink-tests.sh
+++ b/scripts/run-structured-string-sink-tests.sh
@@ -9,7 +9,7 @@ source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
 
 if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
   || ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
-  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  VENV_PATH=.venv "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
   if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
     echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
     exit 1

--- a/scripts/run-structured-string-sinks.sh
+++ b/scripts/run-structured-string-sinks.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run the structured-string-sink registry checker with the repository's locked
+# PyYAML dependency. Bare python3 on a hosted runner has no PyYAML, so resolve the
+# canonical backend interpreter the same way the apt-network-bounds guard does.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
+
+if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
+  || ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
+  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
+    echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
+    exit 1
+  fi
+fi
+
+exec "$BACKEND_PYTHON" "$ROOT_DIR/.github/scripts/check_structured_string_sinks.py" "$@"

--- a/scripts/run-structured-string-sinks.sh
+++ b/scripts/run-structured-string-sinks.sh
@@ -10,7 +10,7 @@ source "$ROOT_DIR/scripts/dev-harness/_resolve_python.sh"
 
 if ! BACKEND_PYTHON="$(dev_harness_canonical_python)" \
   || ! "$BACKEND_PYTHON" -c "import yaml" >/dev/null 2>&1; then
-  "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
+  VENV_PATH=.venv "$ROOT_DIR/backend/scripts/sync-python-deps.sh"
   if ! BACKEND_PYTHON="$(dev_harness_canonical_python)"; then
     echo "FAIL: dependency sync did not create the canonical backend/.venv interpreter." >&2
     exit 1


### PR DESCRIPTION
## What changed and why

Fixes #12860. The structured-string sink checker (#12408 / #10337) tokenized each logical `run:` line with `shlex.split` and matched registered sinks by basename. When a sink was wrapped as `bash -c 'scripts/probe-....sh --project=...'`, the payload stayed one token, so neither the split-argv nor interpreter rules could see the violation.

This PR has two layers:

1. **#12408 registry (still open on `main`)** — introduces the finite structured-string sink checker with three registered entries and manifest wiring:
   - `deploy-cloudrun-env-vars-v3` (`action-delimited-map`, evidence #9986)
   - `llm-gateway-probe-split-argv` (`script-split-argv`, evidence #9945, #9947)
   - `llm-gateway-probe-explicit-interpreter` (`script-interpreter`, evidence #9943, #9945)
2. **#12860 hardening** — unwraps known shell `-c` payloads before applying the existing rules; tightens command-position/operator matching; adds bash -c paired fixtures for both script sink kinds.

If #12408 lands first, this branch should rebase to the fix-only commits.

## Product invariants affected

none

## How it was verified

```bash
python3 .github/scripts/test_check_structured_string_sinks.py -v
# → 11 tests passed

python3 .github/scripts/check_structured_string_sinks.py
# → OK: 3 registered structured-string sinks are grammar-safe.
```

## Tests

- `test_bash_c_payload_exposes_registered_sink_violations` — split-argv and interpreter bash -c wrap fixtures
- `test_registered_command_in_data_position_is_not_an_invocation` — script path as echo argument is ignored
- `test_adjacent_shell_operator_does_not_hide_registered_command` — `script.sh&& echo` still flagged
- `test_bash_c_expansion_does_not_duplicate_violations` — exact `-c` payload yields one violation
- Paired fixtures under `.github/scripts/fixtures/structured_string_sinks/llm-gateway-probe-bash-c-*`

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

This PR introduces the #12408 structured-string sink registry (three entries, two manifest checks). Each entry guards a known historical deploy/workflow serialization failure:

| Entry | Would have caught | Why not a shared primitive |
| --- | --- | --- |
| `deploy-cloudrun-env-vars-v3` | #9986 unescaped comma in Cloud Run `env_vars` | Grammar is action-input specific (`deploy-cloudrun@v3` flattening) |
| `llm-gateway-probe-split-argv` | #9947 joined `--project=<value>` | Probe script argv contract is distinct from Cloud Run map grammar |
| `llm-gateway-probe-explicit-interpreter` | #9945 direct execution of checked-in `100644` probe | Executable-bit assumption is a separate boundary from argv splitting |

The #12860 commit extends the shared shell tokenizer used by both script entries; it adds no fourth registry entry.