### PR TITLE
test(sdk): BLE callback exception propagation for listen paths

### DIFF
--- a/sdks/python/tests/test_ble_callbacks.py
+++ b/sdks/python/tests/test_ble_callbacks.py
@@ -186,3 +186,58 @@ def test_listen_payload_awaits_futures_and_custom_awaitables():
                         pass
 
     asyncio.run(_test())
+
+
+@pytest.mark.parametrize("listen_fn", [listen, listen_payload])
+def test_callback_exceptions_propagate(listen_fn):
+    async def _test():
+        client_instance = MockBleakClient("fake-device")
+        loop = asyncio.get_running_loop()
+
+        async def coro_handler(_data: bytes) -> None:
+            raise ValueError("coro error")
+
+        def future_handler(_data: bytes):
+            fut = loop.create_future()
+            loop.call_soon(fut.set_exception, ValueError("future error"))
+            return fut
+
+        class FailingAwaitable:
+            def __await__(self):
+                async def _run():
+                    raise ValueError("custom error")
+
+                return _run().__await__()
+
+        def custom_handler(_data: bytes):
+            return FailingAwaitable()
+
+        def sync_handler(_data: bytes) -> None:
+            raise ValueError("sync error")
+
+        handlers = [
+            ("sync", sync_handler, "sync error"),
+            ("coro", coro_handler, "coro error"),
+            ("future", future_handler, "future error"),
+            ("custom", custom_handler, "custom error"),
+        ]
+
+        with patch("omi.ble.BleakClient", return_value=client_instance):
+            for _name, handler, message in handlers:
+                if listen_fn is listen_payload:
+                    packet = b"\x00" * PACKET_HEADER_BYTES + b"\x03\x04"
+                else:
+                    packet = b"\x00\x01\x02\x03\x04"
+
+                async def fake_sleep(_sec, expected_message=message, current_handler=handler):
+                    with pytest.raises(ValueError, match=expected_message):
+                        await client_instance.notify_handler("sender", bytearray(packet))
+                    raise asyncio.CancelledError()
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    try:
+                        await listen_fn("fake-device", handler)
+                    except asyncio.CancelledError:
+                        pass
+
+    asyncio.run(_test())


### PR DESCRIPTION
## What changed and why

Issue #12948 reported that `listen()` and `listen_payload()` used `asyncio.iscoroutine()` instead of honoring the `AsyncPacketHandler` contract (`Awaitable[None]`). The core fix — replacing those checks with `inspect.isawaitable()` — landed on `main` in #13089 (Fixes #12949).

This PR closes #12948 by adding the remaining behavioural coverage called out in the issue: exception propagation for sync callbacks, coroutines, Futures, and custom awaitables on both listen paths. BLE transport remains mocked; no hardware required.

Fixes #12948

## Product invariants affected

none

## How it was verified

```bash
PYTHONPATH=sdks/python pytest sdks/python/tests/test_ble_callbacks.py -v
# 4 passed

PYTHONPATH=sdks/python pytest sdks/python/tests/ -v
# 32 passed
```

## Tests

- Extended `sdks/python/tests/test_ble_callbacks.py` with `test_callback_exceptions_propagate`, parametrized over `listen` and `listen_payload`, covering sync, coroutine, Future, and custom-awaitable handlers that raise.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

