### PR TITLE
fix(cli): keep ambiguous SQL display tables as raw text

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -345,8 +345,12 @@ def _normalize_sql_result(result: Any) -> Any:
         return {"text": result}
 
     columns = [part.strip() for part in header.split("|")] if "|" in header else [header.strip()]
+    if len(set(columns)) != len(columns):
+        return {"text": result}
     rows = []
     for line in data_lines:
+        if line.lstrip().startswith("Result truncated after "):
+            return {"text": result}
         values = [part.strip() for part in line.split("|")] if "|" in line else [line.strip()]
         if len(values) != len(columns):
             return {"text": result}

--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -349,7 +349,10 @@ def _normalize_sql_result(result: Any) -> Any:
         return {"text": result}
     rows = []
     for line in data_lines:
-        if line.lstrip().startswith("Result truncated after "):
+        if re.fullmatch(
+            r"Result truncated after \d+ row\(s\) to protect chat context\. Refine the projection or aggregate the result\.",
+            line.strip(),
+        ):
             return {"text": result}
         values = [part.strip() for part in line.split("|")] if "|" in line else [line.strip()]
         if len(values) != len(columns):

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -389,6 +389,39 @@ def test_sql_json_falls_back_to_raw_text_when_cells_contain_pipes_or_newlines(co
     assert json.loads(result_empty_cont.stdout) == {"text": sql_text_empty_cont}
 
 
+@pytest.mark.parametrize(
+    "table",
+    [
+        "preview\n--------------------\nleft | right\n\n1 row(s)",
+        "preview\n--------------------\nline one\nline two\n\n1 row(s)",
+        "preview\n--------------------\n\n\n1 row(s)",
+        "x | x\n--------------------\na | b\n\n1 row(s)",
+        "x\n--------------------\na\nResult truncated after 1 row(s) to protect chat context. Refine the projection or aggregate the result.\n\n2 row(s)",
+    ],
+)
+def test_sql_json_preserves_ambiguous_or_truncated_tables(config_path: Path, cli_runner, table: str) -> None:
+    _configure_local_profile(config_path)
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(table)))
+        result = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 1"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"text": table}
+
+
+def test_sql_json_keeps_unambiguous_tables_structured(config_path: Path, cli_runner) -> None:
+    _configure_local_profile(config_path)
+    table = "id | name\n--------------------\n1 | café\n\n1 row(s)"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(table)))
+        result = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 1"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "columns": ["id", "name"],
+        "rows": [{"id": "1", "name": "café"}],
+        "row_count": 1,
+    }
+
+
 def test_task_commands_route_to_local_tools(config_path: Path, cli_runner) -> None:
     _configure_local_profile(config_path)
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -422,6 +422,20 @@ def test_sql_json_keeps_unambiguous_tables_structured(config_path: Path, cli_run
     }
 
 
+def test_sql_json_keeps_cell_that_only_starts_like_truncation_notice(config_path: Path, cli_runner) -> None:
+    _configure_local_profile(config_path)
+    table = "preview\n--------------------\nResult truncated after lunch\n\n1 row(s)"
+    with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:
+        router.post("/v1/local/tool").mock(return_value=httpx.Response(200, json=_tool_response(table)))
+        result = cli_runner.invoke(app, ["--json", "local", "sql", "SELECT 1"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "columns": ["preview"],
+        "rows": [{"preview": "Result truncated after lunch"}],
+        "row_count": 1,
+    }
+
+
 def test_task_commands_route_to_local_tools(config_path: Path, cli_runner) -> None:
     _configure_local_profile(config_path)
     with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:


### PR DESCRIPTION
## Summary
- Current `main` already falls back to `{"text": ...}` when pipe/newline/empty-cell parsing disagrees with the footer row count.
- Duplicate column names still overwrote cells (`x | x` → one key), and a Desktop `Result truncated after …` notice was stored as a fake data row.
- Those remaining ambiguous tables now keep the raw display text. Unambiguous tables keep the structured `columns`/`rows`/`row_count` shape.

Fixes #12988

## Why this PR
#13107 is APPROVED but CONFLICTING against current `main` (it also churns the README). This is a current-main replacement of the remaining contract only.

## Test plan
- [x] Reproduced remaining holes on `d5cbd54`: duplicate headers returned `{"x": "b"}`; truncation notice became a second row
- [x] `PYTHONPATH=. pytest tests/test_local.py tests/test_local_sql_errors.py` — 67 passed
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

