### PR TITLE
fix(composio): stop Notion pagination when the cursor cannot advance

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: composio-notion-pagination-tests
+    command: ["python3", "plugins/composio/test_notion_pagination.py"]
+    triggers: ["plugins/composio/**"]
+    lanes: ["local", "ci"]
+    reason: "extract_all_pages looped on has_more without checking next_cursor, so a missing or repeated cursor re-fetched the same Notion page forever inside an async handler"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/plugins/composio/src/notion.py
+++ b/plugins/composio/src/notion.py
@@ -159,6 +159,7 @@ async def extract_all_pages(access_token: str, uid: str):
                     all_blocks = []
                     has_more = True
                     next_cursor = None
+                    seen_cursors = set()
 
                     while has_more:
                         # Prepare URL and params for pagination
@@ -181,6 +182,17 @@ async def extract_all_pages(access_token: str, uid: str):
                         # Check if there are more blocks
                         has_more = blocks_data.get("has_more", False)
                         next_cursor = blocks_data.get("next_cursor")
+
+                        # has_more without a fresh cursor cannot advance to
+                        # the next page; requesting again would re-fetch the
+                        # same page forever inside this async handler.
+                        if has_more and (not next_cursor or next_cursor in seen_cursors):
+                            logger.error(
+                                f"Pagination stalled for page {page_id}: has_more without a fresh cursor"
+                            )
+                            has_more = False
+                        elif next_cursor:
+                            seen_cursors.add(next_cursor)
 
                         if has_more:
                             logger.info(

--- a/plugins/composio/src/notion.py
+++ b/plugins/composio/src/notion.py
@@ -176,17 +176,18 @@ async def extract_all_pages(access_token: str, uid: str):
                         blocks_response.raise_for_status()
                         blocks_data = blocks_response.json()
 
-                        # Add blocks to our collection
-                        all_blocks.extend(blocks_data.get("results", []))
-
-                        # Check if there are more blocks
+                        results = blocks_data.get("results", [])
                         has_more = blocks_data.get("has_more", False)
                         next_cursor = blocks_data.get("next_cursor")
 
-                        # has_more without a fresh cursor cannot advance to
-                        # the next page; requesting again would re-fetch the
-                        # same page forever inside this async handler.
-                        if has_more and (not next_cursor or next_cursor in seen_cursors):
+                        # A repeated next_cursor means this response is a
+                        # stalled re-fetch of a page already stored. A
+                        # missing cursor still needs the first page stored.
+                        stalled_repeat = bool(has_more and next_cursor and next_cursor in seen_cursors)
+                        if not stalled_repeat:
+                            all_blocks.extend(results)
+
+                        if has_more and (not next_cursor or stalled_repeat):
                             logger.error(
                                 f"Pagination stalled for page {page_id}: has_more without a fresh cursor"
                             )

--- a/plugins/composio/test_notion_pagination.py
+++ b/plugins/composio/test_notion_pagination.py
@@ -3,12 +3,8 @@
 Standard library only: requests, fastapi, pydantic, and the src.db /
 src.omi_api siblings are replaced with minimal stubs before importing the
 module under test so the suite runs without site-packages (the manifest
-lane runs plain python3). sys.modules is restored after import.
-
-Covers the unbounded pagination loop in extract_all_pages: `while has_more`
-re-requested the blocks/children endpoint whenever Notion returned
-has_more=true, even when next_cursor was missing or repeated - so a stalled
-cursor re-fetched the same page forever inside an async handler.
+lane runs plain python3). Stubs and the imported `src.notion` module are
+scoped to a context manager so pytest collection cannot leak fakes.
 """
 
 import asyncio
@@ -16,6 +12,7 @@ import os
 import sys
 import types
 import unittest
+from contextlib import contextmanager
 from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -130,17 +127,26 @@ def _install_module_stubs():
     sys.modules["src.omi_api"] = omi_api
 
 
-_saved_modules = {name: sys.modules.get(name) for name in _STUBBED_MODULES}
-_install_module_stubs()
-try:
-    import src.notion as notion  # noqa: E402
-finally:
-    for _name, _original in _saved_modules.items():
-        if _original is None:
-            sys.modules.pop(_name, None)
+@contextmanager
+def _isolated_notion_import():
+    saved = {name: sys.modules.get(name) for name in _STUBBED_MODULES}
+    saved_notion = sys.modules.get("src.notion")
+    _install_module_stubs()
+    try:
+        import src.notion as notion_mod  # noqa: E402
+
+        yield notion_mod
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+        if saved_notion is None:
+            sys.modules.pop("src.notion", None)
         else:
-            sys.modules[_name] = _original
-    del _name, _original, _saved_modules
+            sys.modules["src.notion"] = saved_notion
+
 
 _PAGE = {"id": "page-1", "properties": {"title": {"title": [{"plain_text": "Doc"}]}}}
 _BLOCK = {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "hello world of testing"}]}}
@@ -158,7 +164,7 @@ class _Resp:
         pass
 
 
-def _run(children_pages):
+def _run(notion, children_pages, captured_facts=None):
     """Run extract_all_pages with canned children pages; count GET calls.
 
     children_pages: list of payloads returned in order by requests.get.
@@ -174,24 +180,41 @@ def _run(children_pages):
     def fake_post(url, json=None, headers=None):
         return _Resp({"results": [_PAGE]})
 
+    async def capture_fact(uid, fact_text, **kwargs):
+        if captured_facts is not None:
+            captured_facts.append(fact_text)
+        return {"success": True}
+
     with mock.patch.object(notion.requests, "post", side_effect=fake_post), mock.patch.object(
         notion.requests, "get", side_effect=fake_get
-    ), mock.patch.object(notion.asyncio, "sleep", new=mock.AsyncMock()):
+    ), mock.patch.object(notion, "store_fact", side_effect=capture_fact), mock.patch.object(
+        notion.asyncio, "sleep", new=mock.AsyncMock()
+    ):
         return asyncio.run(notion.extract_all_pages("tok", "u1")), get_calls
 
 
 class NotionPaginationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._cm = _isolated_notion_import()
+        cls.notion = cls._cm.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._cm.__exit__(None, None, None)
+
     def test_single_page_no_more(self):
-        facts, calls = _run([{"results": [_BLOCK], "has_more": False, "next_cursor": None}])
+        facts, calls = _run(self.notion, [{"results": [_BLOCK], "has_more": False, "next_cursor": None}])
         self.assertEqual(len(calls), 1)
         self.assertEqual(facts, 1)
 
     def test_two_pages_then_done(self):
         facts, calls = _run(
+            self.notion,
             [
                 {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
                 {"results": [_BLOCK], "has_more": False, "next_cursor": None},
-            ]
+            ],
         )
         self.assertEqual(len(calls), 2)
         self.assertEqual(calls[1].get("start_cursor"), "c2")
@@ -200,19 +223,33 @@ class NotionPaginationTests(unittest.TestCase):
 
     def test_has_more_without_cursor_stops(self):
         # Old code re-requested page one forever.
-        facts, calls = _run([{"results": [_BLOCK], "has_more": True, "next_cursor": None}])
+        facts, calls = _run(self.notion, [{"results": [_BLOCK], "has_more": True, "next_cursor": None}])
         self.assertEqual(len(calls), 1)
         self.assertEqual(facts, 1)
 
-    def test_repeating_cursor_stops(self):
+    def test_repeating_cursor_stops_without_duplicating_blocks(self):
+        captured = []
         facts, calls = _run(
+            self.notion,
             [
                 {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
                 {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
-            ]
+            ],
+            captured_facts=captured,
         )
         self.assertEqual(len(calls), 2)
         self.assertEqual(facts, 1)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(captured[0].count("hello world of testing"), 1)
+
+
+class NotionImportIsolationTests(unittest.TestCase):
+    def test_src_notion_is_dropped_when_the_context_exits(self):
+        self.assertNotIn("src.notion", sys.modules)
+        with _isolated_notion_import() as mod:
+            self.assertIsNotNone(mod)
+            self.assertIn("src.notion", sys.modules)
+        self.assertNotIn("src.notion", sys.modules)
 
 
 if __name__ == "__main__":

--- a/plugins/composio/test_notion_pagination.py
+++ b/plugins/composio/test_notion_pagination.py
@@ -1,0 +1,219 @@
+"""Hermetic regression tests for plugins/composio/src/notion.py pagination.
+
+Standard library only: requests, fastapi, pydantic, and the src.db /
+src.omi_api siblings are replaced with minimal stubs before importing the
+module under test so the suite runs without site-packages (the manifest
+lane runs plain python3). sys.modules is restored after import.
+
+Covers the unbounded pagination loop in extract_all_pages: `while has_more`
+re-requested the blocks/children endpoint whenever Notion returned
+has_more=true, even when next_cursor was missing or repeated - so a stalled
+cursor re-fetched the same page forever inside an async handler.
+"""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_STUBBED_MODULES = (
+    "requests",
+    "requests.exceptions",
+    "requests.utils",
+    "fastapi",
+    "fastapi.responses",
+    "fastapi.templating",
+    "pydantic",
+    "src.db",
+    "src.omi_api",
+)
+
+
+def _install_module_stubs():
+    requests = types.ModuleType("requests")
+
+    class _RequestException(Exception):
+        pass
+
+    exceptions = types.ModuleType("requests.exceptions")
+    exceptions.RequestException = _RequestException
+    exceptions.HTTPError = type("HTTPError", (_RequestException,), {})
+    requests.exceptions = exceptions
+    requests.post = lambda *a, **k: None
+    requests.get = lambda *a, **k: None
+    utils = types.ModuleType("requests.utils")
+    utils.quote = lambda s, safe="": s
+    requests.utils = utils
+    sys.modules["requests"] = requests
+    sys.modules["requests.exceptions"] = exceptions
+    sys.modules["requests.utils"] = utils
+
+    fastapi = types.ModuleType("fastapi")
+
+    class APIRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return lambda f: f
+
+        def post(self, *args, **kwargs):
+            return lambda f: f
+
+    class HTTPException(Exception):
+        pass
+
+    class Request:
+        pass
+
+    def Form(default=None, **kwargs):
+        return default
+
+    def Depends(dependency=None, **kwargs):
+        return dependency
+
+    class BackgroundTasks:
+        pass
+
+    status = types.SimpleNamespace(HTTP_200_OK=200)
+
+    fastapi.APIRouter = APIRouter
+    fastapi.HTTPException = HTTPException
+    fastapi.Request = Request
+    fastapi.Form = Form
+    fastapi.Depends = Depends
+    fastapi.BackgroundTasks = BackgroundTasks
+    fastapi.status = status
+    sys.modules["fastapi"] = fastapi
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class _Resp:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    responses.HTMLResponse = _Resp
+    responses.RedirectResponse = _Resp
+    sys.modules["fastapi.responses"] = responses
+
+    templating = types.ModuleType("fastapi.templating")
+    templating.Jinja2Templates = lambda *a, **k: types.SimpleNamespace(TemplateResponse=lambda *a, **k: None)
+    sys.modules["fastapi.templating"] = templating
+
+    pydantic = types.ModuleType("pydantic")
+
+    class BaseModel:
+        def __init__(self, **data):
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    pydantic.BaseModel = BaseModel
+    pydantic.Field = lambda *a, **k: (k["default_factory"]() if "default_factory" in k else k.get("default"))
+    sys.modules["pydantic"] = pydantic
+
+    db = types.ModuleType("src.db")
+    db.store_notion_credentials = lambda *a, **k: None
+    db.get_notion_credentials = lambda *a, **k: None
+    db.store_memory = lambda *a, **k: None
+    sys.modules["src.db"] = db
+
+    omi_api = types.ModuleType("src.omi_api")
+
+    async def store_fact(*a, **k):
+        return {"success": True}
+
+    omi_api.store_fact = store_fact
+    sys.modules["src.omi_api"] = omi_api
+
+
+_saved_modules = {name: sys.modules.get(name) for name in _STUBBED_MODULES}
+_install_module_stubs()
+try:
+    import src.notion as notion  # noqa: E402
+finally:
+    for _name, _original in _saved_modules.items():
+        if _original is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
+    del _name, _original, _saved_modules
+
+_PAGE = {"id": "page-1", "properties": {"title": {"title": [{"plain_text": "Doc"}]}}}
+_BLOCK = {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "hello world of testing"}]}}
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+def _run(children_pages):
+    """Run extract_all_pages with canned children pages; count GET calls.
+
+    children_pages: list of payloads returned in order by requests.get.
+    """
+    get_calls = []
+
+    def fake_get(url, params=None, headers=None):
+        get_calls.append(params)
+        if len(get_calls) > len(children_pages):
+            raise AssertionError(f"unbounded pagination: {len(get_calls)} children requests")
+        return _Resp(children_pages[len(get_calls) - 1])
+
+    def fake_post(url, json=None, headers=None):
+        return _Resp({"results": [_PAGE]})
+
+    with mock.patch.object(notion.requests, "post", side_effect=fake_post), mock.patch.object(
+        notion.requests, "get", side_effect=fake_get
+    ), mock.patch.object(notion.asyncio, "sleep", new=mock.AsyncMock()):
+        return asyncio.run(notion.extract_all_pages("tok", "u1")), get_calls
+
+
+class NotionPaginationTests(unittest.TestCase):
+    def test_single_page_no_more(self):
+        facts, calls = _run([{"results": [_BLOCK], "has_more": False, "next_cursor": None}])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(facts, 1)
+
+    def test_two_pages_then_done(self):
+        facts, calls = _run(
+            [
+                {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
+                {"results": [_BLOCK], "has_more": False, "next_cursor": None},
+            ]
+        )
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1].get("start_cursor"), "c2")
+        # Both fetched blocks merge into a single stored chunk.
+        self.assertEqual(facts, 1)
+
+    def test_has_more_without_cursor_stops(self):
+        # Old code re-requested page one forever.
+        facts, calls = _run([{"results": [_BLOCK], "has_more": True, "next_cursor": None}])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(facts, 1)
+
+    def test_repeating_cursor_stops(self):
+        facts, calls = _run(
+            [
+                {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
+                {"results": [_BLOCK], "has_more": True, "next_cursor": "c2"},
+            ]
+        )
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(facts, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`extract_all_pages` paginates Notion `blocks/children` with:

```python
while has_more:
    ... request ...
    has_more = blocks_data.get("has_more", False)
    next_cursor = blocks_data.get("next_cursor")
```

If the API returns `has_more=true` with a missing or repeated `next_cursor`, the loop re-requests the same page **forever** — a synchronous `requests` loop inside an `async` handler, pinning the event loop for the whole worker.

## Changes

- Track consumed cursors (`seen_cursors`); stop when `has_more` is true but `next_cursor` is absent or already used, and log the stall.
- Fresh cursors are still followed; normal multi-page imports are unchanged.
- New `test_notion_pagination.py` — hermetic stdlib-only suite (heavy deps stubbed, `sys.modules` restored after import). Registered `composio-notion-pagination-tests` in `.github/checks-manifest.yaml`.

## Verification

- `python3 plugins/composio/test_notion_pagination.py` — 4 tests pass, including under `python3 -S`.
- Pre-fix: both stall cases keep re-requesting (an injected call cap trips at the 2nd/3rd identical request). Post-fix: the loop stops after the last fetchable page.

Failure-Class: none

_Disclosure: this PR was prepared with AI assistance (Devin)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

