### PR TITLE
fix(cli): allow clearing an action item due date

### DIFF
--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -121,18 +121,24 @@ def update_action_item(
     description: Optional[str] = typer.Option(None, "--description"),
     completed: Optional[bool] = typer.Option(None, "--completed/--open"),
     due_at: Optional[datetime] = typer.Option(None, "--due-at", formats=ISO_DATETIME_FORMATS),
+    clear_due_at: bool = typer.Option(False, "--clear-due-at", help="Remove the due date."),
 ) -> None:
     ctx = _ctx(typer_ctx)
+    if clear_due_at and due_at is not None:
+        raise UsageError(message="Conflicting options", detail="--due-at and --clear-due-at are mutually exclusive.")
     body: dict[str, object] = {}
     if description is not None:
         body["description"] = description
     if completed is not None:
         body["completed"] = completed
-    if due_at is not None:
+    if clear_due_at:
+        body["due_at"] = None
+    elif due_at is not None:
         body["due_at"] = due_at.isoformat()
     if not body:
         raise UsageError(
-            message="No fields to update", detail="Provide --description, --completed/--open, or --due-at."
+            message="No fields to update",
+            detail="Provide --description, --completed/--open, or --due-at/--clear-due-at.",
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/action-items/{action_item_id}", json_body=body)

--- a/sdks/python-cli/tests/test_clear_due_date.py
+++ b/sdks/python-cli/tests/test_clear_due_date.py
@@ -1,0 +1,37 @@
+import json
+import sys
+
+import pytest
+
+from omi_cli.main import app, main
+
+
+@pytest.mark.parametrize(
+    ("options", "body"),
+    [
+        (["--clear-due-at"], {"due_at": None}),
+        (["--due-at", "2026-09-10T12:00:00"], {"due_at": "2026-09-10T12:00:00"}),
+        (["--description", "call"], {"description": "call"}),
+        (["--clear-due-at", "--open"], {"due_at": None, "completed": False}),
+    ],
+)
+def test_due_date_update_states(authed_profile, respx_mock, cli_runner, options, body) -> None:
+    route = respx_mock.patch("/v1/dev/user/action-items/a1").respond(json={"id": "a1", **body})
+    result = cli_runner.invoke(app, ["--json", "action-item", "update", "a1", *options])
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content) == body
+
+
+def test_conflicting_due_date_flags(authed_profile, respx_mock, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["omi", "--json", "action-item", "update", "a1", "--due-at", "2026-09-10", "--clear-due-at"],
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert "--clear-due-at" in json.loads(output.err)["detail"]
+    assert not respx_mock.calls


### PR DESCRIPTION
## Summary
- `omi action-item update ID --clear-due-at` PATCHes `due_at: null`.
- `--due-at` and `--clear-due-at` are mutually exclusive.
- Omitting both still leaves the due date unchanged.

Fixes #13031

## Why this PR
#13110 is APPROVED but CONFLICTING against current `main` (docs/README churn). This is a current-main replacement of the CLI contract only.

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_clear_due_date.py tests/test_action_item.py tests/test_datetime_options.py` — 75 passed
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

