### PR TITLE
fix(slack): tolerate non-dict transcript segments in process_segments

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -918,6 +918,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "#13156 executes the Slack client and chat handler to prevent unresolved explicit channels from widening search scope"
 
+  - id: slack-segments-tests
+    command: ["python3", "plugins/omi-slack-app/test_segments.py"]
+    triggers: ["plugins/omi-slack-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "process_segments called seg.get(\"text\") on every transcript segment, so a non-dict segment crashed the realtime webhook with AttributeError"
+
   - id: notion-page-content-tests
     command: ["python3", "plugins/omi-notion-app/test_main.py"]
     triggers: ["plugins/omi-notion-app/**"]

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -922,7 +922,7 @@ checks:
     command: ["python3", "plugins/omi-slack-app/test_segments.py"]
     triggers: ["plugins/omi-slack-app/**", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
-    reason: "process_segments called seg.get(\"text\") on every transcript segment, so a non-dict segment crashed the realtime webhook with AttributeError"
+    reason: "process_segments called seg.get(\"text\") on every transcript segment, so a non-dict segment crashed the realtime webhook with AttributeError; list_channels also re-requested forever when Slack returned a repeated next_cursor"
 
   - id: notion-page-content-tests
     command: ["python3", "plugins/omi-notion-app/test_main.py"]

--- a/plugins/omi-slack-app/main.py
+++ b/plugins/omi-slack-app/main.py
@@ -737,7 +737,7 @@ async def process_segments(
     For test interface: processes the entire text immediately.
     """
     # Extract text from segments
-    segment_texts = [seg.get("text", "") for seg in segments]
+    segment_texts = [seg.get("text", "") if isinstance(seg, dict) else str(seg) for seg in segments]
     full_text = " ".join(segment_texts)
     
     session_id = session["session_id"]

--- a/plugins/omi-slack-app/main.py
+++ b/plugins/omi-slack-app/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 import os
 import sys
 from dotenv import load_dotenv
-from typing import List, Dict, Any
+from typing import List, Any
 import secrets
 import asyncio
 
@@ -723,7 +723,7 @@ async def webhook(
 
 async def process_segments(
     session: dict,
-    segments: List[Dict[str, Any]],
+    segments: List[Any],
     user: dict
 ) -> str:
     """

--- a/plugins/omi-slack-app/slack_client.py
+++ b/plugins/omi-slack-app/slack_client.py
@@ -97,7 +97,8 @@ class SlackClient:
         try:
             cursor = None
             page_count = 0
-            
+            seen_cursors = set()
+
             while True:
                 # Get channels with pagination
                 params = {
@@ -136,9 +137,15 @@ class SlackClient:
                 # Check if there are more pages
                 response_metadata = result.get("response_metadata", {})
                 cursor = response_metadata.get("next_cursor")
-                
+
+                if cursor and cursor in seen_cursors:
+                    print("⚠️  Pagination stalled: repeated cursor, stopping", flush=True)
+                    break
+
                 if not cursor:
                     break
+
+                seen_cursors.add(cursor)
             
             # Log summary
             public_channels = [c for c in channels if not c.get("is_private")]

--- a/plugins/omi-slack-app/test_segments.py
+++ b/plugins/omi-slack-app/test_segments.py
@@ -1,0 +1,99 @@
+"""Hermetic regression for non-dict transcript segments in process_segments.
+
+Omi's realtime webhook can deliver transcript segments as raw strings; the
+debug print already guards with isinstance, but the extraction comprehension
+called seg.get("text") on every segment and crashed the handler with
+AttributeError for any non-dict segment.
+"""
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+class Response:
+    def __init__(self, content, status_code=200, **kwargs):
+        self.content = content
+        self.status_code = status_code
+
+
+def load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ProcessSegmentsTests(unittest.TestCase):
+    def setUp(self):
+        framework = types.ModuleType("fastapi")
+        app = Mock()
+        for method in ("get", "post", "on_event"):
+            getattr(app, method).side_effect = lambda *a, **k: lambda f: f
+        framework.FastAPI = lambda **kwargs: app
+        framework.Request = object
+        framework.HTTPException = Exception
+        framework.Query = lambda *a, **k: None
+        responses = types.ModuleType("fastapi.responses")
+        responses.HTMLResponse = responses.RedirectResponse = responses.JSONResponse = Response
+        storage = types.ModuleType("simple_storage")
+        storage.SimpleUserStorage = Mock()
+        self.session_storage = Mock()
+        self.session_storage.get_session_idle_time = Mock(return_value=None)
+        storage.SimpleSessionStorage = self.session_storage
+        detector = types.ModuleType("message_detector")
+        self.detector = Mock()
+        detector.MessageDetector = Mock(return_value=self.detector)
+        dotenv = types.ModuleType("dotenv")
+        dotenv.load_dotenv = lambda: None
+        slack = types.ModuleType("slack_sdk")
+        slack.WebClient = Mock()
+        errors = types.ModuleType("slack_sdk.errors")
+        errors.SlackApiError = Exception
+        modules = {"fastapi": framework, "fastapi.responses": responses,
+                   "simple_storage": storage, "message_detector": detector,
+                   "dotenv": dotenv, "requests": types.ModuleType("requests"),
+                   "slack_sdk": slack, "slack_sdk.errors": errors}
+        originals = {name: sys.modules.get(name) for name in modules}
+        sys.modules.update(modules)
+        try:
+            client_mod = load("slack_client_under_test", "slack_client.py")
+            with patch.dict(sys.modules, {"slack_client": client_mod}):
+                self.handler = load("slack_handler_under_test", "main.py")
+        finally:
+            for name, original in originals.items():
+                if original is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = original
+
+    def process(self, segments):
+        session = {"session_id": "omi_session_u1", "uid": "u1", "message_mode": "idle"}
+        user = {"uid": "u1", "access_token": "token"}
+        return asyncio.run(self.handler.process_segments(session, segments, user))
+
+    def test_dict_segments_still_work(self):
+        self.detector.detect_trigger.return_value = False
+        self.assertEqual(self.process([{"text": "hello world"}]), "listening")
+
+    def test_string_segments_do_not_crash(self):
+        self.detector.detect_trigger.return_value = False
+        self.assertEqual(self.process(["hello world"]), "listening")
+
+    def test_mixed_segments_do_not_crash(self):
+        self.detector.detect_trigger.return_value = False
+        self.assertEqual(self.process([{"text": "hi"}, "raw string", 42]), "listening")
+
+    def test_trigger_in_string_segment_starts_recording(self):
+        self.detector.detect_trigger.side_effect = lambda text: "send slack" in text
+        self.detector.extract_message_content.return_value = "hello team"
+        result = self.process(["send slack hello team"])
+        self.assertEqual(result, "collecting_1")
+        self.detector.extract_message_content.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-slack-app/test_segments.py
+++ b/plugins/omi-slack-app/test_segments.py
@@ -83,6 +83,13 @@ class ProcessSegmentsTests(unittest.TestCase):
         self.detector.detect_trigger.return_value = False
         self.assertEqual(self.process(["hello world"]), "listening")
 
+    def test_process_segments_annotation_allows_non_dicts(self):
+        import typing
+
+        hints = typing.get_type_hints(self.handler.process_segments)
+        self.assertEqual(typing.get_origin(hints["segments"]), list)
+        self.assertEqual(typing.get_args(hints["segments"]), (typing.Any,))
+
     def test_mixed_segments_do_not_crash(self):
         self.detector.detect_trigger.return_value = False
         self.assertEqual(self.process([{"text": "hi"}, "raw string", 42]), "listening")

--- a/plugins/omi-slack-app/test_segments.py
+++ b/plugins/omi-slack-app/test_segments.py
@@ -95,5 +95,62 @@ class ProcessSegmentsTests(unittest.TestCase):
         self.detector.extract_message_content.assert_called_once()
 
 
+class ListChannelsPaginationTests(unittest.TestCase):
+    """list_channels looped forever when Slack kept returning the same cursor."""
+
+    def setUp(self):
+        slack = types.ModuleType("slack_sdk")
+        self.sdk = Mock()
+        slack.WebClient = Mock(return_value=self.sdk)
+        errors = types.ModuleType("slack_sdk.errors")
+        errors.SlackApiError = Exception
+        dotenv = types.ModuleType("dotenv")
+        dotenv.load_dotenv = lambda: None
+        modules = {"slack_sdk": slack, "slack_sdk.errors": errors,
+                   "requests": types.ModuleType("requests"), "dotenv": dotenv}
+        originals = {name: sys.modules.get(name) for name in modules}
+        sys.modules.update(modules)
+        try:
+            self.client_mod = load("slack_client_pages", "slack_client.py")
+        finally:
+            for name, original in originals.items():
+                if original is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = original
+
+    def test_repeated_cursor_stops(self):
+        self.sdk.conversations_list.side_effect = [
+            {"ok": True, "channels": [{"id": "C1", "name": "a"}],
+             "response_metadata": {"next_cursor": "abc"}},
+            {"ok": True, "channels": [{"id": "C2", "name": "b"}],
+             "response_metadata": {"next_cursor": "abc"}},
+        ]
+        channels = self.client_mod.SlackClient().list_channels("tok")
+        self.assertEqual(self.sdk.conversations_list.call_count, 2)
+        self.assertEqual(len(channels), 2)
+
+    def test_empty_cursor_stops(self):
+        self.sdk.conversations_list.return_value = {
+            "ok": True, "channels": [{"id": "C1", "name": "a"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+        channels = self.client_mod.SlackClient().list_channels("tok")
+        self.assertEqual(self.sdk.conversations_list.call_count, 1)
+        self.assertEqual(len(channels), 1)
+
+    def test_fresh_cursor_followed(self):
+        self.sdk.conversations_list.side_effect = [
+            {"ok": True, "channels": [{"id": "C1", "name": "a"}],
+             "response_metadata": {"next_cursor": "p2"}},
+            {"ok": True, "channels": [{"id": "C2", "name": "b"}],
+             "response_metadata": {"next_cursor": ""}},
+        ]
+        channels = self.client_mod.SlackClient().list_channels("tok")
+        self.assertEqual(self.sdk.conversations_list.call_count, 2)
+        second_call_params = self.sdk.conversations_list.call_args.kwargs
+        self.assertEqual(second_call_params["cursor"], "p2")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The realtime transcript webhook extracts text with:

```python
segment_texts = [seg.get("text", "") for seg in segments]
```

The debug print 40 lines above already guards `isinstance(seg, dict)`, but the extraction comprehension does not — a raw string segment (a shape Omi can deliver) raises `AttributeError`, and the route returns 500 for the transcript POST.

## Changes

- `process_segments` now coerces non-dict segments with `str(seg)`, matching the existing guard.
- New `test_segments.py` — hermetic stdlib-only suite reusing this plugin's stub boundary (`sys.modules` restored after import). Registered `slack-segments-tests` in `.github/checks-manifest.yaml`.

## Verification

- `python3 -S plugins/omi-slack-app/test_segments.py` — 4 tests pass.
- Pre-fix: all 3 non-dict cases fail with `AttributeError: 'str' object has no attribute 'get'`.

Failure-Class: none

_Disclosure: this PR was prepared with AI assistance (Devin)._

_Update: same PR now also bounds `list_channels` pagination — a repeated `next_cursor` re-requested the same page forever; the loop now stops on a repeat (3 more tests)._