### PR TITLE
fix(cli): redact every screenshot base64 alias on export

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -238,6 +238,9 @@ def _same_file(source: Path, output: Path) -> bool:
         return False
 
 
+_SCREENSHOT_PAYLOAD_KEYS = ("image_base64", "base64", "data_base64", "data")
+
+
 def _write_screenshot_result(result: Any, output: Path) -> Path:
     output = output.expanduser()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -262,7 +265,7 @@ def _write_screenshot_result(result: Any, output: Path) -> Path:
                 shutil.copyfile(source, output)
                 return output
 
-        encoded = _first_string(result, ("image_base64", "base64", "data_base64", "data"))
+        encoded = _first_string(result, _SCREENSHOT_PAYLOAD_KEYS)
         if encoded:
             output.write_bytes(_decode_base64_payload(encoded))
             return output
@@ -280,10 +283,12 @@ def _redact_screenshot_payload(result: Any) -> Any:
     if not isinstance(result, Mapping):
         return result
     redacted = dict(result)
-    image_payload = redacted.pop("image_base64", None)
-    if image_payload is not None:
-        redacted["image_base64_redacted"] = True
-        redacted["image_base64_chars"] = len(str(image_payload))
+    for key in _SCREENSHOT_PAYLOAD_KEYS:
+        image_payload = redacted.get(key)
+        if isinstance(image_payload, str) and image_payload:
+            del redacted[key]
+            redacted[f"{key}_redacted"] = True
+            redacted[f"{key}_chars"] = len(image_payload)
     return redacted
 
 

--- a/sdks/python-cli/tests/test_screenshot_aliases.py
+++ b/sdks/python-cli/tests/test_screenshot_aliases.py
@@ -1,0 +1,49 @@
+import base64
+import json
+
+import pytest
+import respx
+
+from omi_cli.main import app
+from tests.test_local import FAKE_LOCAL_URL, _configure_local_profile
+
+
+@pytest.mark.parametrize("key", ["image_base64", "base64", "data_base64", "data"])
+@pytest.mark.parametrize("write_file", [False, True])
+def test_screenshot_alias_output(config_path, cli_runner, tmp_path, key, write_file) -> None:
+    _configure_local_profile(config_path)
+    encoded = base64.b64encode(b"synthetic pixels").decode()
+    response = {key: encoded, "screenshot_id": "9"}
+    output = tmp_path / "shot.jpg"
+    args = ["--json", "local", "screenshot", "9"]
+    if write_file:
+        args += ["--output", str(output)]
+    with respx.mock(base_url=FAKE_LOCAL_URL) as router:
+        router.post("/v1/local/tool").respond(json={"ok": True, "name": "get_screenshot", **response})
+        result = cli_runner.invoke(app, args)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    if write_file:
+        assert output.read_bytes() == b"synthetic pixels"
+        assert encoded not in result.stdout
+        assert payload["result"][key + "_redacted"] is True
+        assert payload["result"][key + "_chars"] == len(encoded)
+        assert key not in payload["result"]
+    else:
+        assert payload[key] == encoded
+
+
+@pytest.mark.parametrize("metadata", [None, "", 7, {"width": 100}, [1, 2]])
+def test_screenshot_output_preserves_non_payload_data(config_path, cli_runner, tmp_path, metadata) -> None:
+    _configure_local_profile(config_path)
+    encoded = base64.b64encode(b"synthetic pixels").decode()
+    output = tmp_path / "shot.jpg"
+    with respx.mock(base_url=FAKE_LOCAL_URL) as router:
+        router.post("/v1/local/tool").respond(json={"ok": True, "name": "get_screenshot", "image_base64": encoded, "data": metadata})
+        result = cli_runner.invoke(app, ["--json", "local", "screenshot", "9", "--output", str(output)])
+    assert result.exit_code == 0, result.output
+    assert output.read_bytes() == b"synthetic pixels"
+    payload = json.loads(result.stdout)["result"]
+    assert payload["data"] == metadata
+    assert "data_redacted" not in payload
+    assert "image_base64" not in payload


### PR DESCRIPTION
## Summary
- `local screenshot --output` already writes `image_base64` / `base64` / `data_base64` / `data`.
- Printed JSON now redacts those same string payloads (`*_redacted` / `*_chars`) instead of repeating the image.
- Omitting `--output` still prints the raw payload. Non-string `data` metadata is left alone.

Fixes #13025

## Why this PR
#13108 is APPROVED but CONFLICTING against current `main`. This is a current-main replacement of the CLI contract only (no README churn).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_screenshot_aliases.py tests/test_local.py tests/test_local_screenshot_encoding.py` — 67 passed
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

