### PR TITLE
fix(cli): apply --days to exact screen-search SQL fallback

### DIFF
--- a/sdks/python-cli/omi_cli/commands/local.py
+++ b/sdks/python-cli/omi_cli/commands/local.py
@@ -126,7 +126,9 @@ def search_screen(
         if ctx.renderer.json_mode:
             result = _normalize_screen_search(result, args)
             if isinstance(result, Mapping) and not result.get("results"):
-                result = _add_exact_screen_fallback(client, result, query=query, app_filter=app_filter, limit=limit)
+                result = _add_exact_screen_fallback(
+                    client, result, query=query, app_filter=app_filter, limit=limit, days=days
+                )
     ctx.renderer.emit(result, title="search_screen_history")
 
 
@@ -427,6 +429,7 @@ def _add_exact_screen_fallback(
     query: str,
     app_filter: Optional[str],
     limit: int,
+    days: int,
 ) -> dict[str, Any]:
     next_payload = dict(payload)
     escaped_query = _sql_like_literal(query)
@@ -439,12 +442,12 @@ def _add_exact_screen_fallback(
         escaped_app = _sql_like_literal(app_filter)
         where_clause = f"(appName LIKE '%{escaped_app}%' ESCAPE '!') AND ({' OR '.join(query_clauses)})"
     else:
-        where_clause = " OR ".join(query_clauses)
+        where_clause = "(" + " OR ".join(query_clauses) + ")"
 
     sql = (
         "SELECT id AS screenshot_id, timestamp, appName AS app_name, isIndexed AS is_indexed "
         "FROM screenshots "
-        f"WHERE {where_clause} "
+        f"WHERE {where_clause} AND timestamp >= datetime('now', '-{int(days)} days') "
         "ORDER BY timestamp DESC "
         f"LIMIT {limit}"
     )

--- a/sdks/python-cli/tests/test_local.py
+++ b/sdks/python-cli/tests/test_local.py
@@ -247,6 +247,7 @@ def test_search_screen_no_results_is_structured_in_json(config_path: Path, cli_r
     }
     assert bodies[1]["name"] == "execute_sql"
     assert "appName LIKE '%Discord%'" in bodies[1]["arguments"]["query"]
+    assert "timestamp >= datetime('now', '-1 days')" in bodies[1]["arguments"]["query"]
     payload = json.loads(result.stdout)
     assert payload["results"] == []
     assert payload["query"] == "Discord"
@@ -271,6 +272,7 @@ def test_search_screen_exact_fallback_constrains_app_filter(config_path: Path, c
     assert result.exit_code == 0, result.output
     fallback_query = json.loads(route.calls[1].request.content)["arguments"]["query"]
     assert "WHERE (appName LIKE '%Discord%' ESCAPE '!') AND" in fallback_query
+    assert "timestamp >= datetime('now', '-7 days')" in fallback_query
 
 
 @pytest.mark.parametrize("literal,decoy", [("50%", "500"), ("a_b", "axb"), ("a!b", "ab"), ("it's", "its")])
@@ -300,7 +302,7 @@ def test_search_screen_fallback_matches_literal_text(
             rows = [dict(row) for row in db.execute(body["arguments"]["query"])]
             return httpx.Response(200, json=_tool_response({"rows": rows}))
 
-        args = ["--json", "local", "search-screen", "notes" if field == "app_filter" else literal]
+        args = ["--json", "local", "search-screen", "notes" if field == "app_filter" else literal, "--days", "365"]
         if field == "app_filter":
             args.extend(["--app", literal])
         with respx.mock(base_url=FAKE_LOCAL_URL, assert_all_called=True) as router:

--- a/sdks/python-cli/tests/test_search_days.py
+++ b/sdks/python-cli/tests/test_search_days.py
@@ -1,0 +1,40 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from omi_cli.main import app
+from tests.test_local import FAKE_LOCAL_URL, _configure_local_profile, _tool_response
+
+
+@pytest.mark.parametrize("days", [1, 7, 30])
+@pytest.mark.parametrize("app_filter", [None, "Browser"])
+def test_exact_search_sql_honors_days_window(config_path, cli_runner, days, app_filter) -> None:
+    _configure_local_profile(config_path)
+    empty = 'No matching screen-history results for "needle".'
+    table = (
+        "screenshot_id | timestamp | app_name | is_indexed\n"
+        "--------------------------------------------------------------------------------\n"
+        "42 | 2026-09-12T00:00:00Z | Browser | 1\n\n"
+        "1 row(s)"
+    )
+    args = ["--json", "local", "search-screen", "needle", "--days", str(days)]
+    if app_filter:
+        args += ["--app", app_filter]
+    with respx.mock(base_url=FAKE_LOCAL_URL) as router:
+        route = router.post("/v1/local/tool").mock(
+            side_effect=[
+                httpx.Response(200, json=_tool_response(empty)),
+                httpx.Response(200, json=_tool_response(table)),
+            ]
+        )
+        result = cli_runner.invoke(app, args)
+    assert result.exit_code == 0, result.output
+    sql = json.loads(route.calls[1].request.content)["arguments"]["query"]
+    assert f"timestamp >= datetime('now', '-{days} days')" in sql
+    if app_filter:
+        assert "AND (" in sql or ") AND" in sql
+    else:
+        assert sql.count("(") >= 1
+    assert json.loads(result.stdout)["suggested_screenshot_ids"] == ["42"]

--- a/sdks/python-cli/tests/test_search_days.py
+++ b/sdks/python-cli/tests/test_search_days.py
@@ -33,8 +33,19 @@ def test_exact_search_sql_honors_days_window(config_path, cli_runner, days, app_
     assert result.exit_code == 0, result.output
     sql = json.loads(route.calls[1].request.content)["arguments"]["query"]
     assert f"timestamp >= datetime('now', '-{days} days')" in sql
+    assert ") AND timestamp >=" in sql
     if app_filter:
-        assert "AND (" in sql or ") AND" in sql
+        assert "ESCAPE '!') AND (" in sql
+        assert "appName LIKE '%needle%'" in sql
+        assert "windowTitle LIKE '%needle%'" in sql
+        assert "ocrText LIKE '%needle%'" in sql
     else:
-        assert sql.count("(") >= 1
+        assert "WHERE (" in sql
+        assert " OR ".join(
+            [
+                "appName LIKE '%needle%' ESCAPE '!'",
+                "windowTitle LIKE '%needle%' ESCAPE '!'",
+                "ocrText LIKE '%needle%' ESCAPE '!'",
+            ]
+        ) in sql
     assert json.loads(result.stdout)["suggested_screenshot_ids"] == ["42"]


### PR DESCRIPTION
## Summary
- Exact app/window/OCR SQL fallback for `omi --json local search-screen` now uses the same rolling `--days` window as semantic search.
- OR clauses are parenthesized so the timestamp bound applies to every match path.

Fixes #12968

## Why this PR
#13109 is APPROVED but CONFLICTING against current `main`. This is a current-main replacement of the CLI contract only (no README churn).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_search_days.py tests/test_local.py` — 56 passed
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

