### PR TITLE
fix(mcp): URL-encode resource ids in request paths

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: mcp-path-param-encoding-tests
+    command: ["python3", "mcp/tests/test_path_param_encoding.py"]
+    triggers: ["mcp/**"]
+    lanes: ["local", "ci"]
+    reason: "delete_memory, edit_memory, and get_conversation_by_id interpolated raw tool-argument ids into the request path, so '/' or '?' in an id rewrote the target endpoint"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/mcp/src/mcp_server_omi/server.py
+++ b/mcp/src/mcp_server_omi/server.py
@@ -3,6 +3,7 @@ from enum import Enum
 import json
 from typing import List, Optional
 from datetime import datetime, timedelta
+from urllib.parse import quote
 import requests
 import logging
 from mcp.server import Server
@@ -192,7 +193,7 @@ def create_memory(api_key: str, content: str, category: MemoryCategory) -> dict:
 
 def delete_memory(api_key: str, memory_id: str) -> dict:
     response = requests.delete(
-        f"{base_url}memories/{memory_id}",
+        f"{base_url}memories/{quote(memory_id, safe='')}",
         headers={"Authorization": f"Bearer {api_key}"},
     )
     return _response_json(response)
@@ -200,7 +201,7 @@ def delete_memory(api_key: str, memory_id: str) -> dict:
 
 def edit_memory(api_key: str, memory_id: str, content: str) -> dict:
     response = requests.patch(
-        f"{base_url}memories/{memory_id}",
+        f"{base_url}memories/{quote(memory_id, safe='')}",
         headers={"Authorization": f"Bearer {api_key}"},
         params={"value": content},
     )
@@ -257,7 +258,7 @@ def get_conversations(
 
 def get_conversation_by_id(api_key: str, conversation_id: str) -> dict:
     response = requests.get(
-        f"{base_url}conversations/{conversation_id}",
+        f"{base_url}conversations/{quote(conversation_id, safe='')}",
         headers={"Authorization": f"Bearer {api_key}"},
     )
     return _response_json(response)

--- a/mcp/tests/test_path_param_encoding.py
+++ b/mcp/tests/test_path_param_encoding.py
@@ -1,0 +1,113 @@
+"""Hermetic regression: resource ids must be URL-encoded in request paths.
+
+delete_memory, edit_memory, and get_conversation_by_id interpolated the raw
+tool argument into the URL path, so an id containing '/', '?', '#', or '%'
+rewrote the request target - hitting a different endpoint or a 404.
+"""
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+def load_server():
+    """Import server.py with the mcp/pydantic/requests boundaries stubbed."""
+    mcp = types.ModuleType("mcp")
+    mcp_server = types.ModuleType("mcp.server")
+    mcp_server.Server = Mock
+    mcp_stdio = types.ModuleType("mcp.server.stdio")
+    mcp_stdio.stdio_server = Mock()
+    mcp_types = types.ModuleType("mcp.types")
+    mcp_types.TextContent = Mock
+    mcp_types.Tool = Mock
+    mcp.server = mcp_server
+    mcp_server.stdio = mcp_stdio
+
+    pydantic = types.ModuleType("pydantic")
+
+    class BaseModel:
+        pass
+
+    pydantic.BaseModel = BaseModel
+    pydantic.Field = lambda **kwargs: kwargs.get("default")
+
+    requests = types.ModuleType("requests")
+    requests.Response = object
+    requests.HTTPError = Exception
+    requests.get = requests.post = requests.delete = requests.patch = Mock()
+
+    modules = {
+        "mcp": mcp,
+        "mcp.server": mcp_server,
+        "mcp.server.stdio": mcp_stdio,
+        "mcp.types": mcp_types,
+        "pydantic": pydantic,
+        "requests": requests,
+    }
+    originals = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "server_under_test",
+            Path(__file__).resolve().parents[1] / "src" / "mcp_server_omi" / "server.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+    return module
+
+
+class PathParamEncodingTests(unittest.TestCase):
+    def setUp(self):
+        self.server = load_server()
+        self.captured = {}
+
+        def fake_response(url=None, **kwargs):
+            self.captured["url"] = url
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {}
+            return response
+
+        self.fake_response = fake_response
+
+    def url_of(self, method, operation):
+        with patch.object(self.server.requests, method, side_effect=self.fake_response):
+            operation()
+        return self.captured["url"]
+
+    def test_delete_memory_encodes_id(self):
+        url = self.url_of(
+            "delete", lambda: self.server.delete_memory("k", "a/b?c#d")
+        )
+        self.assertIn("memories/a%2Fb%3Fc%23d", url)
+        self.assertNotIn("memories/a/b", url)
+
+    def test_edit_memory_encodes_id(self):
+        url = self.url_of(
+            "patch", lambda: self.server.edit_memory("k", "a/b", "content")
+        )
+        self.assertIn("memories/a%2Fb", url)
+
+    def test_get_conversation_encodes_id(self):
+        url = self.url_of(
+            "get", lambda: self.server.get_conversation_by_id("k", "x/y?z")
+        )
+        self.assertIn("conversations/x%2Fy%3Fz", url)
+
+    def test_normal_ids_pass_through(self):
+        url = self.url_of(
+            "delete", lambda: self.server.delete_memory("k", "abc-123_DEF")
+        )
+        self.assertIn("memories/abc-123_DEF", url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three REST helpers interpolate raw tool arguments into the request path:

```python
requests.delete(f"{base_url}memories/{memory_id}", ...)
```

MCP tool arguments are model-generated; an id containing `/`, `?`, `#`, or `%` rewrites the request target — `delete_memory("k", "a/b?c")` sends DELETE to `.../memories/a/b` with `?c` as a query string.

## Changes

- `memory_id` and `conversation_id` path parameters now pass through `urllib.parse.quote(safe="")`.
- New `test_path_param_encoding.py` — hermetic stdlib-only (mcp/pydantic/requests stubbed, `sys.modules` restored after import). Registered `mcp-path-param-encoding-tests` in `.github/checks-manifest.yaml`.

## Verification

- `python3 -S mcp/tests/test_path_param_encoding.py` — 4 tests pass.
- Pre-fix: 3 tests fail; the captured URL shows `conversations/x/y?z` — the `?` literally becomes a query delimiter.

Failure-Class: none

_Disclosure: this PR was prepared with AI assistance (Devin)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

