### PR TITLE
fix(typescript-sdk): release BLE resources when audio setup fails

### DIFF
--- a/sdks/device/typescript/src/ble/cleanup.test.ts
+++ b/sdks/device/typescript/src/ble/cleanup.test.ts
@@ -38,7 +38,7 @@ test('releases the peripheral when connectAsync fails', async () => {
 
 test('releases the peripheral when discovery fails', async () => {
   let disconnected = 0;
-  const { characteristic, peripheral } = fixture({
+  const { peripheral } = fixture({
     discoverSomeServicesAndCharacteristicsAsync: async () => {
       throw new Error('synthetic discovery error');
     },
@@ -47,7 +47,6 @@ test('releases the peripheral when discovery fails', async () => {
     },
   });
   await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /discovery error/);
-  characteristic.emit('data', new Uint8Array([1, 2, 3]));
   assert.equal(disconnected, 1);
 });
 

--- a/sdks/device/typescript/src/ble/cleanup.test.ts
+++ b/sdks/device/typescript/src/ble/cleanup.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+
+import { listenOnConnectedPeripheral } from './noble.ts';
+
+const AUDIO_UUID = '19b10001e8f2537e4f6cd104768a1214';
+
+function fixture(overrides: Record<string, unknown> = {}) {
+  const characteristic = Object.assign(new EventEmitter(), {
+    uuid: AUDIO_UUID,
+    subscribeAsync: async () => {},
+    unsubscribeAsync: async () => {},
+  });
+  const peripheral = {
+    state: 'connected',
+    discoverSomeServicesAndCharacteristicsAsync: async () => ({ characteristics: [characteristic] }),
+    disconnectAsync: async () => {},
+    ...overrides,
+  };
+  return { characteristic, peripheral };
+}
+
+test('releases the peripheral when connectAsync fails', async () => {
+  let disconnected = 0;
+  const { peripheral } = fixture({
+    state: 'disconnected',
+    connectAsync: async () => {
+      throw new Error('synthetic connect error');
+    },
+    disconnectAsync: async () => {
+      disconnected += 1;
+    },
+  });
+  await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /connect error/);
+  assert.equal(disconnected, 1);
+});
+
+test('releases the peripheral when discovery fails', async () => {
+  let disconnected = 0;
+  const { characteristic, peripheral } = fixture({
+    discoverSomeServicesAndCharacteristicsAsync: async () => {
+      throw new Error('synthetic discovery error');
+    },
+    disconnectAsync: async () => {
+      disconnected += 1;
+    },
+  });
+  await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /discovery error/);
+  characteristic.emit('data', new Uint8Array([1, 2, 3]));
+  assert.equal(disconnected, 1);
+});
+
+test('releases the peripheral when the audio characteristic is missing', async () => {
+  let disconnected = 0;
+  const { peripheral } = fixture({
+    discoverSomeServicesAndCharacteristicsAsync: async () => ({ characteristics: [] }),
+    disconnectAsync: async () => {
+      disconnected += 1;
+    },
+  });
+  await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /not found/);
+  assert.equal(disconnected, 1);
+});
+
+test('unsubscribes and disconnects when subscribe fails', async () => {
+  let disconnected = 0;
+  let unsubscribed = 0;
+  const { characteristic, peripheral } = fixture({
+    disconnectAsync: async () => {
+      disconnected += 1;
+    },
+  });
+  characteristic.subscribeAsync = async () => {
+    throw new Error('synthetic subscribe error');
+  };
+  characteristic.unsubscribeAsync = async () => {
+    unsubscribed += 1;
+  };
+  await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /subscribe error/);
+  assert.equal(characteristic.listenerCount('data'), 0);
+  assert.equal(unsubscribed, 1);
+  assert.equal(disconnected, 1);
+});
+
+test('cleanup failures preserve the setup error', async () => {
+  const { characteristic, peripheral } = fixture();
+  characteristic.subscribeAsync = async () => {
+    throw new Error('subscribe failed');
+  };
+  characteristic.unsubscribeAsync = async () => {
+    throw new Error('unsubscribe failed');
+  };
+  peripheral.disconnectAsync = async () => {
+    throw new Error('disconnect failed');
+  };
+  await assert.rejects(() => listenOnConnectedPeripheral(peripheral, 'test-device', () => {}), /subscribe failed/);
+});
+
+test('successful session shares one cleanup operation', async () => {
+  let disconnected = 0;
+  let unsubscribed = 0;
+  const packets: number[][] = [];
+  const { characteristic, peripheral } = fixture({
+    disconnectAsync: async () => {
+      disconnected += 1;
+    },
+  });
+  characteristic.unsubscribeAsync = async () => {
+    unsubscribed += 1;
+  };
+  const session = await listenOnConnectedPeripheral(peripheral, 'test-device', (packet) => packets.push([...packet]));
+  characteristic.emit('data', new Uint8Array([3, 4]));
+  assert.deepEqual(packets, [[3, 4]]);
+  await Promise.all([session.disconnect(), session.disconnect()]);
+  characteristic.emit('data', new Uint8Array([5]));
+  assert.deepEqual(packets, [[3, 4]]);
+  assert.equal(unsubscribed, 1);
+  assert.equal(disconnected, 1);
+});

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -118,53 +118,17 @@ export async function scanForDevices(timeoutMs = 5000): Promise<ScannedDevice[]>
 }
 
 /**
- * Connect to device, subscribe to Omi audio notifications.
- * Returns a handle that disconnects and unsubscribes.
+ * Subscribe to Omi audio on an already-acquired peripheral.
+ * Setup failures release listeners and disconnect the peripheral.
  */
-export async function connectAndListen(
+export async function listenOnConnectedPeripheral(
+  peripheral: any,
   deviceId: string,
   onPacket: (u8: Uint8Array) => void
 ): Promise<{ disconnect(): Promise<void> }> {
-  const noble = await loadNoble();
-  await ensurePoweredOn(noble);
-
-  let peripheral: any;
-  if (typeof noble.connectAsync === 'function') {
-    peripheral = await noble.connectAsync(deviceId);
-  } else {
-    throw new Error('noble.connectAsync unavailable');
-  }
-
-  // Some bindings return already-connected peripheral; ensure connected.
-  if (peripheral.state !== 'connected' && typeof peripheral.connectAsync === 'function') {
-    await peripheral.connectAsync();
-  }
-
-  const wantService = asUuid(OMI_SERVICE_UUID);
-  const wantChar = asUuid(AUDIO_DATA_UUID);
-
-  let characteristics: any[] = [];
-  if (typeof peripheral.discoverSomeServicesAndCharacteristicsAsync === 'function') {
-    const found = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
-      [wantService],
-      [wantChar]
-    );
-    characteristics = found.characteristics ?? [];
-  } else {
-    const found = await peripheral.discoverAllServicesAndCharacteristicsAsync();
-    characteristics = found.characteristics ?? [];
-  }
-
-  const audioChar =
-    characteristics.find((c) => asUuid(String(c.uuid)) === wantChar) ??
-    characteristics.find((c) => asUuid(String(c.uuid)).includes(wantChar.slice(0, 8)));
-
-  if (!audioChar) {
-    await peripheral.disconnectAsync?.();
-    throw new Error(
-      `Audio characteristic ${AUDIO_DATA_UUID} not found on ${deviceId} (service ${OMI_SERVICE_UUID})`
-    );
-  }
+  let audioChar: any;
+  let subscriptionAttempted = false;
+  let cleanupPromise: Promise<void> | undefined;
 
   const onData = (data: ArrayBufferView | ArrayBuffer | number[]) => {
     const u8 =
@@ -177,27 +141,77 @@ export async function connectAndListen(
             : new Uint8Array(data);
     onPacket(u8);
   };
-  audioChar.on?.('data', onData);
-  await audioChar.subscribeAsync();
 
-  let closed = false;
-  return {
-    async disconnect() {
-      if (closed) return;
-      closed = true;
+  const disconnect = (): Promise<void> => {
+    cleanupPromise ??= (async () => {
       try {
-        audioChar.removeListener?.('data', onData);
-        await audioChar.unsubscribeAsync?.();
+        audioChar?.removeListener?.('data', onData);
+        if (subscriptionAttempted) await audioChar?.unsubscribeAsync?.();
       } catch {
-        /* ignore */
+        // Disconnection must still run if the subscription is already gone.
       }
       try {
         await peripheral.disconnectAsync?.();
       } catch {
-        /* ignore */
+        // Cleanup must not replace the error that caused setup to fail.
       }
-    },
+    })();
+    return cleanupPromise;
   };
+
+  try {
+    if (peripheral.state !== 'connected' && typeof peripheral.connectAsync === 'function') {
+      await peripheral.connectAsync();
+    }
+
+    const wantChar = asUuid(AUDIO_DATA_UUID);
+    let characteristics: any[] = [];
+    if (typeof peripheral.discoverSomeServicesAndCharacteristicsAsync === 'function') {
+      const found = await peripheral.discoverSomeServicesAndCharacteristicsAsync(
+        [asUuid(OMI_SERVICE_UUID)],
+        [wantChar]
+      );
+      characteristics = found.characteristics ?? [];
+    } else {
+      const found = await peripheral.discoverAllServicesAndCharacteristicsAsync();
+      characteristics = found.characteristics ?? [];
+    }
+
+    audioChar =
+      characteristics.find((c) => asUuid(String(c.uuid)) === wantChar) ??
+      characteristics.find((c) => asUuid(String(c.uuid)).includes(wantChar.slice(0, 8)));
+    if (!audioChar) {
+      throw new Error(
+        `Audio characteristic ${AUDIO_DATA_UUID} not found on ${deviceId} (service ${OMI_SERVICE_UUID})`
+      );
+    }
+
+    audioChar.on?.('data', onData);
+    subscriptionAttempted = true;
+    await audioChar.subscribeAsync();
+    return { disconnect };
+  } catch (error) {
+    await disconnect();
+    throw error;
+  }
+}
+
+/**
+ * Connect to device, subscribe to Omi audio notifications.
+ * Returns a handle that disconnects and unsubscribes.
+ */
+export async function connectAndListen(
+  deviceId: string,
+  onPacket: (u8: Uint8Array) => void
+): Promise<{ disconnect(): Promise<void> }> {
+  const noble = await loadNoble();
+  await ensurePoweredOn(noble);
+
+  if (typeof noble.connectAsync !== 'function') {
+    throw new Error('noble.connectAsync unavailable');
+  }
+  const peripheral = await noble.connectAsync(deviceId);
+  return listenOnConnectedPeripheral(peripheral, deviceId, onPacket);
 }
 
 /** Exposed for tests / fail-fast import check. */


### PR DESCRIPTION
## Summary
- Failed BLE audio setup (connect, discovery, missing characteristic, subscribe) now runs a shared `disconnect` that removes the `data` listener and disconnects the peripheral.
- Cleanup errors do not replace the setup error. Concurrent `disconnect()` calls share one cleanup promise.

Fixes #13003

## Why this PR
#13116 is APPROVED but CONFLICTING against current `main` (checks-manifest/README plus older UUID passing). This replacement keeps current-main `asUuid` discovery and tests `listenOnConnectedPeripheral` with Node's test runner (no bun, no manifest churn).

## Test plan
- [x] `node --experimental-strip-types --test sdks/device/typescript/src/ble/cleanup.test.ts` — 6 passed
- [ ] CI on this PR
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

