### PR TITLE
fix(hive): tolerate malformed errors payloads in tool handlers

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: hive-errors-payload-tests
+    command: ["python3", "plugins/omi-hive-app/test_errors_payload.py"]
+    triggers: ["plugins/omi-hive-app/**"]
+    lanes: ["local", "ci"]
+    reason: "tool handlers indexed result[\"errors\"][0] on presence alone, so an empty or non-list errors payload surfaced 'list index out of range' instead of the API error"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/plugins/omi-hive-app/main.py
+++ b/plugins/omi-hive-app/main.py
@@ -787,7 +787,7 @@ async def tool_hive_create_task(request: Request):
         result = hive_rest_request(uid, "POST", "actions/create", data=create_data)
         
         if "errors" in result:
-            error_msg = result["errors"][0].get("message", "Unknown error")
+            error_msg = get_graphql_error(result) or "Unknown error"
             return ChatToolResponse(error=f"Failed to create task: {error_msg}")
         
         success_msg = f"✅ Created task **{task_name}** in project **{target_project.name}**!"
@@ -903,7 +903,7 @@ async def tool_hive_update_task_status(request: Request):
         result = hive_rest_request(uid, "PUT", f"actions/{task_id}", data={"status": hive_status})
         
         if "errors" in result:
-            error_msg = result["errors"][0].get("message", "Unknown error")
+            error_msg = get_graphql_error(result) or "Unknown error"
             return ChatToolResponse(error=f"Failed to update task: {error_msg}")
             
         return ChatToolResponse(

--- a/plugins/omi-hive-app/test_errors_payload.py
+++ b/plugins/omi-hive-app/test_errors_payload.py
@@ -1,0 +1,173 @@
+"""Hermetic regression for malformed `errors` payloads in Hive tool handlers.
+
+tool_hive_create_task and tool_hive_update_task_status checked
+`"errors" in result` then indexed `result["errors"][0]` - an empty list
+or a non-list errors value crashed the error path itself, and the generic
+except returned "list index out of range" instead of the API error.
+The module's own get_graphql_error helper already encodes the correct
+contract, so both handlers now use it.
+"""
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+
+
+def load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, PLUGIN_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ChatToolResponse:
+    def __init__(self, result=None, error=None):
+        self.result = result
+        self.error = error
+
+
+class HiveProject:
+    def __init__(self, id=None, name=None, **kw):
+        self.id = id
+        self.name = name
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class HiveTask:
+    def __init__(self, id=None, name=None, project_id=None, **kw):
+        self.id = id
+        self.name = name
+        self.project_id = project_id
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class ErrorsPayloadTests(unittest.TestCase):
+    def setUp(self):
+        fastapi = types.ModuleType("fastapi")
+        app = Mock()
+        for method in ("get", "post", "mount", "on_event"):
+            getattr(app, method).side_effect = lambda *a, **k: lambda f: f
+        fastapi.FastAPI = lambda **kwargs: app
+        fastapi.Request = object
+        fastapi.HTTPException = Exception
+        fastapi.Query = fastapi.Form = lambda *a, **k: None
+        responses = types.ModuleType("fastapi.responses")
+        responses.HTMLResponse = responses.RedirectResponse = responses.JSONResponse = object
+        staticfiles = types.ModuleType("fastapi.staticfiles")
+        staticfiles.StaticFiles = Mock()
+        templating = types.ModuleType("fastapi.templating")
+        templating.Jinja2Templates = Mock()
+
+        db = types.ModuleType("db")
+        db.store_hive_credentials = db.delete_hive_credentials = Mock()
+        db.get_hive_credentials = Mock(return_value={"workspace_id": "w1"})
+        db.is_connected = Mock(return_value=True)
+        db.store_default_project = Mock()
+        db.get_default_project = Mock(return_value={"id": "p1", "name": "Default"})
+        db.get_user_settings = Mock()
+
+        models = types.ModuleType("models")
+        models.ChatToolResponse = ChatToolResponse
+        models.HiveProject = HiveProject
+        models.HiveTask = HiveTask
+        models.HiveAction = Mock
+
+        dotenv = types.ModuleType("dotenv")
+        dotenv.load_dotenv = lambda: None
+
+        modules = {
+            "fastapi": fastapi,
+            "fastapi.responses": responses,
+            "fastapi.staticfiles": staticfiles,
+            "fastapi.templating": templating,
+            "db": db,
+            "models": models,
+            "dotenv": dotenv,
+            "requests": types.ModuleType("requests"),
+        }
+        originals = {name: sys.modules.get(name) for name in modules}
+        sys.modules.update(modules)
+        try:
+            self.module = load("hive_main_under_test", "main.py")
+        finally:
+            for name, original in originals.items():
+                if original is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = original
+
+    def run_tool(self, handler_name, body, rest_result):
+        handler = getattr(self.module, handler_name)
+
+        async def fake_json():
+            return body
+
+        request = Mock()
+        request.json = fake_json
+        with patch.object(
+            self.module, "hive_rest_request", return_value=rest_result
+        ):
+            return asyncio.run(handler(request))
+
+    def test_create_task_empty_errors_returns_clean_error(self):
+        result = self.run_tool(
+            "tool_hive_create_task",
+            {"uid": "u1", "task_name": "t", "project_id": "p1"},
+            {"errors": []},
+        )
+        self.assertIsNotNone(result.error)
+        self.assertNotIn("list index", result.error)
+
+    def test_create_task_non_list_errors(self):
+        result = self.run_tool(
+            "tool_hive_create_task",
+            {"uid": "u1", "task_name": "t", "project_id": "p1"},
+            {"errors": {"message": "boom"}},
+        )
+        self.assertIsNotNone(result.error)
+
+    def test_create_task_populated_errors_surfaces_message(self):
+        result = self.run_tool(
+            "tool_hive_create_task",
+            {"uid": "u1", "task_name": "t", "project_id": "p1"},
+            {"errors": [{"message": "invalid project"}]},
+        )
+        self.assertIn("invalid project", result.error)
+
+    def test_create_task_success_unchanged(self):
+        result = self.run_tool(
+            "tool_hive_create_task",
+            {"uid": "u1", "task_name": "t", "project_id": "p1"},
+            {"id": "a1"},
+        )
+        self.assertIsNone(result.error)
+        self.assertIn("Created task", result.result)
+
+    def test_update_task_empty_errors_returns_clean_error(self):
+        result = self.run_tool(
+            "tool_hive_update_task_status",
+            {"uid": "u1", "task_name": "t", "task_id": "a1", "status": "completed"},
+            {"errors": []},
+        )
+        self.assertIsNotNone(result.error)
+        self.assertNotIn("list index", result.error)
+
+    def test_update_task_populated_errors_surfaces_message(self):
+        result = self.run_tool(
+            "tool_hive_update_task_status",
+            {"uid": "u1", "task_name": "t", "task_id": "a1", "status": "completed"},
+            {"errors": [{"message": "not allowed"}]},
+        )
+        self.assertIn("not allowed", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-hive-app/test_errors_payload.py
+++ b/plugins/omi-hive-app/test_errors_payload.py
@@ -123,8 +123,7 @@ class ErrorsPayloadTests(unittest.TestCase):
             {"uid": "u1", "task_name": "t", "project_id": "p1"},
             {"errors": []},
         )
-        self.assertIsNotNone(result.error)
-        self.assertNotIn("list index", result.error)
+        self.assertEqual(result.error, "Failed to create task: Unknown error")
 
     def test_create_task_non_list_errors(self):
         result = self.run_tool(
@@ -132,7 +131,7 @@ class ErrorsPayloadTests(unittest.TestCase):
             {"uid": "u1", "task_name": "t", "project_id": "p1"},
             {"errors": {"message": "boom"}},
         )
-        self.assertIsNotNone(result.error)
+        self.assertEqual(result.error, "Failed to create task: Unknown error")
 
     def test_create_task_populated_errors_surfaces_message(self):
         result = self.run_tool(
@@ -157,8 +156,7 @@ class ErrorsPayloadTests(unittest.TestCase):
             {"uid": "u1", "task_name": "t", "task_id": "a1", "status": "completed"},
             {"errors": []},
         )
-        self.assertIsNotNone(result.error)
-        self.assertNotIn("list index", result.error)
+        self.assertEqual(result.error, "Failed to update task: Unknown error")
 
     def test_update_task_populated_errors_surfaces_message(self):
         result = self.run_tool(


### PR DESCRIPTION
## Summary

Both Hive tool handlers check `"errors" in result` then index `result["errors"][0]`:

```python
if "errors" in result:
    error_msg = result["errors"][0].get("message", "Unknown error")
```

An empty (`"errors": []`) or non-list errors payload crashes the error path — `IndexError`/`TypeError` — and the enclosing `except Exception` returns `Failed to create task: list index out of range` to the user instead of the API error.

## Changes

- Both handlers keep `"errors" in result` as the failure signal but extract the message via the module's own `get_graphql_error` helper (already guards empty/non-list), falling back to `"Unknown error"`.
- New `test_errors_payload.py` — hermetic stdlib-only. Registered `hive-errors-payload-tests` in `.github/checks-manifest.yaml`.

## Verification

- `python3 -S plugins/omi-hive-app/test_errors_payload.py` — 6 tests pass.
- Pre-fix: both empty-errors cases leak `list index out of range` into the error field.

Failure-Class: none

_Disclosure: this PR was prepared with AI assistance (Devin)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

