### PR TITLE
fix(github-app): redact access token from git stderr before surfacing

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: github-app-token-redaction-tests
+    command: ["python3", "plugins/omi-github-app/test_token_redaction.py"]
+    triggers: ["plugins/omi-github-app/**"]
+    lanes: ["local", "ci"]
+    reason: "run_claude_code_on_repo embedded the user's GitHub token in the clone URL and returned git stderr verbatim, leaking the credential on clone/push failure"
   - id: go-device-sdk-tests
     command: ["go", "-C", "sdks/device/go", "test", "-race", "./..."]
     triggers: ["sdks/device/go/**"]

--- a/plugins/omi-github-app/claude_code_agentic.py
+++ b/plugins/omi-github-app/claude_code_agentic.py
@@ -51,12 +51,19 @@ def run_agentic_claude_on_repo(
 
             # Clone repo with auth
             auth_url = repo_url.replace('https://', f'https://{github_token}@')
-            clone_result = subprocess.run(
-                ['git', 'clone', auth_url, tmpdir],
-                capture_output=True,
-                text=True,
-                timeout=60
-            )
+            try:
+                clone_result = subprocess.run(
+                    ['git', 'clone', auth_url, tmpdir],
+                    capture_output=True,
+                    text=True,
+                    timeout=60
+                )
+            except subprocess.TimeoutExpired as e:
+                logger.error("Clone timed out: %s", _redact(str(e), github_token))
+                return {
+                    'success': False,
+                    'message': f'Failed to clone repo: {_redact(str(e), github_token)}'
+                }
 
             if clone_result.returncode != 0:
                 return {
@@ -297,10 +304,11 @@ Start by exploring the repository structure."""
             }
 
     except Exception as e:
-        logger.error(f"Error: {e}", exc_info=True)
+        safe = _redact(str(e), github_token)
+        logger.error("Error: %s", safe)
         return {
             'success': False,
-            'message': str(e)
+            'message': safe
         }
 
 

--- a/plugins/omi-github-app/claude_code_agentic.py
+++ b/plugins/omi-github-app/claude_code_agentic.py
@@ -14,6 +14,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _redact(text: Optional[str], token: str) -> str:
+    """Remove the access token from git stderr before it reaches logs or tool responses."""
+    if not text:
+        return ""
+    return text.replace(token, "***") if token else text
+
+
 def run_agentic_claude_on_repo(
     repo_url: str,
     feature_description: str,
@@ -54,7 +61,7 @@ def run_agentic_claude_on_repo(
             if clone_result.returncode != 0:
                 return {
                     'success': False,
-                    'message': f'Failed to clone repo: {clone_result.stderr}'
+                    'message': f'Failed to clone repo: {_redact(clone_result.stderr, github_token)}'
                 }
 
             logger.info(f"Cloned successfully, creating branch {branch_name}")
@@ -279,7 +286,7 @@ Start by exploring the repository structure."""
             if push_result.returncode != 0:
                 return {
                     'success': False,
-                    'message': f'Failed to push: {push_result.stderr}'
+                    'message': f'Failed to push: {_redact(push_result.stderr, github_token)}'
                 }
 
             return {

--- a/plugins/omi-github-app/claude_code_cli.py
+++ b/plugins/omi-github-app/claude_code_cli.py
@@ -13,6 +13,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _redact(text: Optional[str], token: str) -> str:
+    """Remove the access token from git stderr before it reaches logs or tool responses."""
+    if not text:
+        return ""
+    return text.replace(token, "***") if token else text
+
+
 def run_claude_code_on_repo(
     repo_url: str,
     feature_description: str,
@@ -50,7 +57,7 @@ def run_claude_code_on_repo(
             if clone_result.returncode != 0:
                 return {
                     'success': False,
-                    'message': f'Failed to clone repo: {clone_result.stderr}'
+                    'message': f'Failed to clone repo: {_redact(clone_result.stderr, github_token)}'
                 }
 
             logger.info(f"Cloned successfully, creating branch {branch_name}")
@@ -157,7 +164,7 @@ def run_claude_code_on_repo(
             if push_result.returncode != 0:
                 return {
                     'success': False,
-                    'message': f'Failed to push: {push_result.stderr}'
+                    'message': f'Failed to push: {_redact(push_result.stderr, github_token)}'
                 }
 
             logger.info(f"Successfully pushed to branch {branch_name}")

--- a/plugins/omi-github-app/claude_code_cli.py
+++ b/plugins/omi-github-app/claude_code_cli.py
@@ -47,12 +47,22 @@ def run_claude_code_on_repo(
 
             # Clone repo with auth
             auth_url = repo_url.replace('https://', f'https://{github_token}@')
-            clone_result = subprocess.run(
-                ['git', 'clone', auth_url, tmpdir],
-                capture_output=True,
-                text=True,
-                timeout=60
-            )
+            try:
+                clone_result = subprocess.run(
+                    ['git', 'clone', auth_url, tmpdir],
+                    capture_output=True,
+                    text=True,
+                    timeout=60
+                )
+            except subprocess.TimeoutExpired as e:
+                # TimeoutExpired.cmd includes the authenticated URL; never
+                # surface or log it. The completed-process path below cannot
+                # run when clone is still hung.
+                logger.error("Clone timed out: %s", _redact(str(e), github_token))
+                return {
+                    'success': False,
+                    'message': f'Failed to clone repo: {_redact(str(e), github_token)}'
+                }
 
             if clone_result.returncode != 0:
                 return {
@@ -177,10 +187,11 @@ def run_claude_code_on_repo(
             }
 
     except Exception as e:
-        logger.error(f"Error running Claude Code: {e}", exc_info=True)
+        safe = _redact(str(e), github_token)
+        logger.error("Error running Claude Code: %s", safe)
         return {
             'success': False,
-            'message': f'Failed to run Claude Code: {str(e)}'
+            'message': f'Failed to run Claude Code: {safe}'
         }
 
 

--- a/plugins/omi-github-app/test_token_redaction.py
+++ b/plugins/omi-github-app/test_token_redaction.py
@@ -98,7 +98,42 @@ class TokenRedactionTests(unittest.TestCase):
         ])
         self.assertIn("repository not found", result["message"])
 
-    def test_redact_helper_edges(self):
+    def test_clone_timeout_redacts_token_from_message_and_logs(self):
+        import subprocess as sp
+
+        def fake_run(cmd, **kwargs):
+            raise sp.TimeoutExpired(cmd=cmd, timeout=60)
+
+        with patch.object(self.module.subprocess, "run", side_effect=fake_run):
+            with patch.object(self.module.logger, "error") as logged:
+                result = self.module.run_claude_code_on_repo(
+                    repo_url="https://github.com/o/r.git",
+                    feature_description="add a button",
+                    branch_name="b1",
+                    github_token="ghp_SECRET123",
+                    anthropic_key="sk-ant",
+                )
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+        self.assertIn("Failed to clone repo:", result["message"])
+        joined = " ".join(str(c) for c in logged.call_args_list)
+        self.assertNotIn("ghp_SECRET123", joined)
+
+    def test_unexpected_exception_redacts_token(self):
+        def fake_run(cmd, **kwargs):
+            raise RuntimeError("clone died https://ghp_SECRET123@github.com/o/r.git")
+
+        with patch.object(self.module.subprocess, "run", side_effect=fake_run):
+            result = self.module.run_claude_code_on_repo(
+                repo_url="https://github.com/o/r.git",
+                feature_description="add a button",
+                branch_name="b1",
+                github_token="ghp_SECRET123",
+                anthropic_key="sk-ant",
+            )
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+        self.assertIn("***", result["message"])
         redact = self.module._redact
         self.assertEqual(redact(None, "tok"), "")
         self.assertEqual(redact("no secret here", "tok"), "no secret here")
@@ -130,6 +165,24 @@ class AgenticTokenRedactionTests(unittest.TestCase):
         self.assertFalse(result["success"])
         self.assertNotIn("ghp_SECRET123", result["message"])
         self.assertIn("***", result["message"])
+
+    def test_agentic_clone_timeout_redacts_token(self):
+        import subprocess as sp
+
+        def fake_run(cmd, **kwargs):
+            raise sp.TimeoutExpired(cmd=cmd, timeout=60)
+
+        with patch.object(self.module.subprocess, "run", side_effect=fake_run):
+            result = self.module.run_agentic_claude_on_repo(
+                repo_url="https://github.com/o/r.git",
+                feature_description="add a button",
+                branch_name="b1",
+                github_token="ghp_SECRET123",
+                anthropic_key="sk-ant",
+            )
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+        self.assertIn("Failed to clone repo:", result["message"])
 
     def test_agentic_redact_helper(self):
         redact = self.module._redact

--- a/plugins/omi-github-app/test_token_redaction.py
+++ b/plugins/omi-github-app/test_token_redaction.py
@@ -23,6 +23,27 @@ def load():
     return module
 
 
+def load_agentic():
+    """Load claude_code_agentic with the anthropic import boundary stubbed."""
+    anthropic = types.ModuleType("anthropic")
+    anthropic.Anthropic = Mock
+    original = sys.modules.get("anthropic")
+    sys.modules["anthropic"] = anthropic
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "claude_code_agentic_under_test",
+            Path(__file__).with_name("claude_code_agentic.py"),
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        if original is None:
+            sys.modules.pop("anthropic", None)
+        else:
+            sys.modules["anthropic"] = original
+    return module
+
+
 class Completed:
     def __init__(self, returncode=0, stdout="", stderr=""):
         self.returncode = returncode
@@ -83,6 +104,36 @@ class TokenRedactionTests(unittest.TestCase):
         self.assertEqual(redact("no secret here", "tok"), "no secret here")
         self.assertEqual(redact("tok tok", "tok"), "*** ***")
         self.assertEqual(redact("anything", ""), "anything")
+
+
+class AgenticTokenRedactionTests(unittest.TestCase):
+    """Same leak exists in the agentic variant's clone/push error paths."""
+
+    def setUp(self):
+        self.module = load_agentic()
+
+    def test_agentic_clone_failure_redacts_token(self):
+        with patch.object(
+            self.module.subprocess, "run",
+            return_value=Completed(
+                returncode=128,
+                stderr="fatal: could not read 'https://ghp_SECRET123@github.com/o/r.git'",
+            ),
+        ):
+            result = self.module.run_agentic_claude_on_repo(
+                repo_url="https://github.com/o/r.git",
+                feature_description="add a button",
+                branch_name="b1",
+                github_token="ghp_SECRET123",
+                anthropic_key="sk-ant",
+            )
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+        self.assertIn("***", result["message"])
+
+    def test_agentic_redact_helper(self):
+        redact = self.module._redact
+        self.assertEqual(redact("fatal: https://tok@x", "tok"), "fatal: https://***@x")
 
 
 if __name__ == "__main__":

--- a/plugins/omi-github-app/test_token_redaction.py
+++ b/plugins/omi-github-app/test_token_redaction.py
@@ -1,0 +1,89 @@
+"""Hermetic regression: git stderr must not leak the GitHub access token.
+
+run_claude_code_on_repo builds an authenticated clone URL by embedding the
+user's token, and returned clone/push stderr verbatim in the tool response
+message. git echoes the remote URL (including the token) on failure, so the
+error path leaked the credential to users and logs.
+"""
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def load():
+    spec = importlib.util.spec_from_file_location(
+        "claude_code_cli_under_test",
+        Path(__file__).with_name("claude_code_cli.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Completed:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TokenRedactionTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load()
+
+    def run_with_git(self, outputs):
+        """Drive the function with a scripted sequence of git results."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return outputs[len(calls) - 1]
+
+        with patch.object(self.module.subprocess, "run", side_effect=fake_run):
+            return self.module.run_claude_code_on_repo(
+                repo_url="https://github.com/o/r.git",
+                feature_description="add a button",
+                branch_name="b1",
+                github_token="ghp_SECRET123",
+                anthropic_key="sk-ant",
+            ), calls
+
+    def test_clone_failure_redacts_token(self):
+        result, _ = self.run_with_git([
+            Completed(returncode=128, stderr="fatal: could not read 'https://ghp_SECRET123@github.com/o/r.git'")
+        ])
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+        self.assertIn("***", result["message"])
+
+    def test_push_failure_redacts_token(self):
+        result, _ = self.run_with_git([
+            Completed(),  # clone
+            Completed(),  # checkout -b
+            Completed(stdout=""),  # claude-code run
+            Completed(stdout=""),  # git status --porcelain -> no changes
+            Completed(stdout="HEAD branch: main"),  # remote show
+            Completed(returncode=1, stderr="fatal: 'https://ghp_SECRET123@github.com/o/r.git' denied"),
+        ])
+        self.assertFalse(result["success"])
+        self.assertNotIn("ghp_SECRET123", result["message"])
+
+    def test_non_secret_stderr_passes_through(self):
+        result, _ = self.run_with_git([
+            Completed(returncode=128, stderr="fatal: repository not found")
+        ])
+        self.assertIn("repository not found", result["message"])
+
+    def test_redact_helper_edges(self):
+        redact = self.module._redact
+        self.assertEqual(redact(None, "tok"), "")
+        self.assertEqual(redact("no secret here", "tok"), "no secret here")
+        self.assertEqual(redact("tok tok", "tok"), "*** ***")
+        self.assertEqual(redact("anything", ""), "anything")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`run_claude_code_on_repo` builds an authenticated clone URL:

```python
auth_url = repo_url.replace('https://', f'https://{github_token}@')
```

On clone or push failure it returned `stderr` verbatim — and git echoes the remote URL on failure (`fatal: could not read 'https://<token>@github.com/...'`), so the user's GitHub access token was surfaced in the tool response message and in logs.

## Changes

- New `_redact()` strips the token from stderr before it is returned.
- New `test_token_redaction.py` — hermetic stdlib-only (git scripted via a subprocess stub). Registered `github-app-token-redaction-tests` in `.github/checks-manifest.yaml`.

## Verification

- `python3 -S plugins/omi-github-app/test_token_redaction.py` — 4 tests pass.
- Pre-fix: 3 tests fail with `ghp_SECRET123` visible in the returned message.

Failure-Class: none

_Disclosure: this PR was prepared with AI assistance (Devin)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

