### PR TITLE
fix(python-sdk): bind callable transcribe on the package

### DIFF
--- a/sdks/python/omi/__init__.py
+++ b/sdks/python/omi/__init__.py
@@ -17,6 +17,9 @@ from .constants import (
     PACKET_HEADER_BYTES,
     PCM_SAMPLE_RATE_HZ,
 )
+# Bind the function on the package so `from omi import transcribe` is not the
+# same-named submodule (which is not callable).
+from .transcribe import transcribe
 
 __all__ = [
     "constants",
@@ -52,8 +55,4 @@ def __getattr__(name: str):
         from .decoder import OmiOpusDecoder
 
         return OmiOpusDecoder
-    if name == "transcribe":
-        from .transcribe import transcribe
-
-        return transcribe
     raise AttributeError(name)

--- a/sdks/python/tests/test_public_api.py
+++ b/sdks/python/tests/test_public_api.py
@@ -1,0 +1,81 @@
+"""Public `transcribe` export must be the async function, not the submodule."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class TestTranscribeExport(unittest.TestCase):
+    def run_fresh(self, setup: str) -> None:
+        source = setup + textwrap.dedent(
+            r"""
+            import asyncio
+            import sys
+
+            assert callable(transcribe), type(transcribe)
+            assert not ({'bleak', 'opuslib', 'whisper', 'websockets'} & set(sys.modules))
+
+            class TranscriptReceived(Exception):
+                pass
+
+            async def main():
+                audio = asyncio.Queue()
+                pcm = b'\x00\x00' * (16000 * 5)
+                audio.put_nowait(pcm)
+                received = []
+
+                def runner(data):
+                    assert data == pcm
+                    return 'local transcript'
+
+                def on_transcript(text):
+                    received.append(text)
+                    raise TranscriptReceived
+
+                try:
+                    await transcribe(audio, '', on_transcript, engine='whisper', runner=runner)
+                except TranscriptReceived:
+                    pass
+                assert received == ['local transcript'], received
+
+            asyncio.run(main())
+            """
+        )
+        env = dict(os.environ)
+        env['PYTHONPATH'] = str(Path(__file__).resolve().parents[1])
+        result = subprocess.run(
+            [sys.executable, '-S', '-c', source],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_documented_from_import(self) -> None:
+        self.run_fresh('from omi import transcribe\n')
+
+    def test_repeated_package_attribute(self) -> None:
+        self.run_fresh(
+            'import omi\n'
+            'first = omi.transcribe\n'
+            'transcribe = omi.transcribe\n'
+            'assert first is transcribe\n'
+        )
+
+    def test_submodule_import_does_not_replace_public_function(self) -> None:
+        self.run_fresh(
+            'from omi.transcribe import transcribe as direct\n'
+            'from omi import transcribe\n'
+            'assert transcribe is direct\n'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `from omi import transcribe` now binds the async `transcribe` function instead of the same-named submodule.
- Optional BLE/STT packages stay unloaded until a caller actually runs an engine.

Fixes #12950

## Why this PR
#12956 is APPROVED but CONFLICTING against current `main` (checks-manifest plus docs). This replacement is `__init__.py` plus a fresh-interpreter regression. Reproduced on `d5cbd54`: `callable(transcribe)` was `False` before the bind.

## Test plan
- [x] `PYTHONPATH=. python3 -S -c 'from omi import transcribe; print(callable(transcribe))'` — `True`
- [x] `PYTHONPATH=. python3 -m pytest tests/test_public_api.py tests/test_constants.py tests/test_stt_engines.py tests/test_platform_markers.py tests/test_ble_api.py -q` — 13 passed
- [ ] CI on this PR
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

