### PR TITLE
fix(device-ts): end BLE scans when the adapter stays quiet

### DIFF
--- a/sdks/device/typescript/src/ble/noble-scan-mock.mjs
+++ b/sdks/device/typescript/src/ble/noble-scan-mock.mjs
@@ -1,0 +1,32 @@
+export let starts = 0;
+export let stops = 0;
+export let discoverImpl = async function* () {
+  await new Promise(() => {});
+};
+
+export function resetAdapter() {
+  starts = 0;
+  stops = 0;
+  discoverImpl = async function* () {
+    await new Promise(() => {});
+  };
+}
+
+export function setDiscoverImpl(fn) {
+  discoverImpl = fn;
+}
+
+const adapter = {
+  state: 'poweredOn',
+  async startScanningAsync() {
+    starts += 1;
+  },
+  async stopScanningAsync() {
+    stops += 1;
+  },
+  async *discoverAsync() {
+    yield* discoverImpl();
+  },
+};
+
+export default adapter;

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -78,19 +78,33 @@ export async function scanForDevices(timeoutMs = 5000): Promise<ScannedDevice[]>
 
   await noble.startScanningAsync([], false);
 
+  const record = (peripheral: any) => {
+    const id = String(peripheral.id || peripheral.address || '');
+    if (!id) return;
+    byId.set(id, {
+      id,
+      name: String(peripheral.advertisement?.localName || peripheral.advertisement?.name || ''),
+      rssi: Number(peripheral.rssi ?? 0) || 0,
+    });
+  };
+
   try {
+    const timeLeftMs = () => Math.max(0, deadline - Date.now());
     if (typeof noble.discoverAsync === 'function') {
-      for await (const peripheral of noble.discoverAsync()) {
-        const id = String(peripheral.id || peripheral.address || '');
-        if (id) {
-          byId.set(id, {
-            id,
-            name: String(peripheral.advertisement?.localName || peripheral.advertisement?.name || ''),
-            rssi: Number(peripheral.rssi ?? 0) || 0,
-          });
+      // Deadline is independent of the next advertisement. A quiet
+      // discoverAsync() iterator would otherwise hang forever.
+      const collect = (async () => {
+        for await (const peripheral of noble.discoverAsync()) {
+          record(peripheral);
+          if (Date.now() >= deadline) break;
         }
-        if (Date.now() >= deadline) break;
-      }
+      })();
+      await Promise.race([
+        collect,
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, timeLeftMs());
+        }),
+      ]);
     } else {
       await new Promise<void>((resolve) => {
         const onDiscover = (peripheral: any) => {

--- a/sdks/device/typescript/src/ble/noble.ts
+++ b/sdks/device/typescript/src/ble/noble.ts
@@ -99,12 +99,15 @@ export async function scanForDevices(timeoutMs = 5000): Promise<ScannedDevice[]>
           if (Date.now() >= deadline) break;
         }
       })();
-      await Promise.race([
-        collect,
-        new Promise<void>((resolve) => {
-          setTimeout(resolve, timeLeftMs());
-        }),
-      ]);
+      let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+      const deadlineElapsed = new Promise<void>((resolve) => {
+        deadlineTimer = setTimeout(resolve, timeLeftMs());
+      });
+      try {
+        await Promise.race([collect, deadlineElapsed]);
+      } finally {
+        if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      }
     } else {
       await new Promise<void>((resolve) => {
         const onDiscover = (peripheral: any) => {

--- a/sdks/device/typescript/src/ble/scan-timeout.node-test.ts
+++ b/sdks/device/typescript/src/ble/scan-timeout.node-test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression for #12989: scanForDevices must end when the adapter stays quiet.
+ * Native Noble is replaced; the exported scan function is the production path.
+ */
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const mockUrl = pathToFileURL(
+  join(dirname(fileURLToPath(import.meta.url)), 'noble-scan-mock.mjs')
+).href;
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === '@stoprocent/noble') {
+      return { url: mockUrl, shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const mock = await import('./noble-scan-mock.mjs');
+const { scanForDevices } = await import('./noble.ts');
+
+async function withDeadline(work, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(label)), ms);
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test('quiet adapter still ends the scan and stops Noble', async () => {
+  mock.resetAdapter();
+  const devices = await withDeadline(scanForDevices(40), 1000, 'scan hung on a quiet adapter');
+  assert.deepEqual(devices, []);
+  assert.equal(mock.starts, 1);
+  assert.equal(mock.stops, 1);
+});
+
+test('keeps advertisements found before the adapter goes quiet', async () => {
+  mock.resetAdapter();
+  mock.setDiscoverImpl(async function* () {
+    yield { id: 'cv1', advertisement: { localName: 'Omi' }, rssi: -70 };
+    await new Promise(() => {});
+  });
+  const devices = await withDeadline(
+    scanForDevices(40),
+    1000,
+    'scan hung after the first advertisement'
+  );
+  assert.deepEqual(devices, [{ id: 'cv1', name: 'Omi', rssi: -70 }]);
+  assert.equal(mock.stops, 1);
+});

--- a/sdks/device/typescript/src/ble/scan-timeout.test.ts
+++ b/sdks/device/typescript/src/ble/scan-timeout.test.ts
@@ -58,3 +58,19 @@ test('keeps advertisements found before the adapter goes quiet', async () => {
   assert.deepEqual(devices, [{ id: 'cv1', name: 'Omi', rssi: -70 }]);
   assert.equal(mock.stops, 1);
 });
+
+test('returns as soon as discovery ends without waiting for the unused deadline', async () => {
+  mock.resetAdapter();
+  mock.setDiscoverImpl(async function* () {
+    yield { id: 'only', advertisement: { localName: 'Omi' }, rssi: -40 };
+  });
+  const started = Date.now();
+  const devices = await withDeadline(
+    scanForDevices(5000),
+    1000,
+    'scan waited on an unused 5s deadline'
+  );
+  assert.ok(Date.now() - started < 1000);
+  assert.deepEqual(devices, [{ id: 'only', name: 'Omi', rssi: -40 }]);
+  assert.equal(mock.stops, 1);
+});


### PR DESCRIPTION
## Summary
- `scanForDevices` now races advertisement collection against the requested timeout.
- A quiet `discoverAsync()` iterator no longer leaves the scan pending, and `stopScanningAsync()` still runs in `finally`.
- Advertisements received before the adapter goes silent are returned.

Fixes #12989

## Why this PR
#12994 is APPROVED but CONFLICTING against current `main` (README plus checks-manifest). This replacement is the scan path plus a Node regression. No bun, no manifest, no docs. Does not mix the separate BLE-listen cleanup in #13606.

## Test plan
- [x] `node --experimental-strip-types --test sdks/device/typescript/src/ble/scan-timeout.node-test.ts` — 2 passed
- [ ] CI on this PR
- [ ] Maintainer review

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

