### PR TITLE
fix(backend): URL-encode the Twitter handle in social.py API calls

### DIFF
--- a/backend/scripts/select_backend_unit_tests.py
+++ b/backend/scripts/select_backend_unit_tests.py
@@ -259,6 +259,11 @@ AREA_TESTS = (
         ('tests/unit/test_apps_*.py', 'tests/unit/test_app_*.py', 'tests/unit/test_create_persona_user_none.py'),
     ),
     (
+        ('backend/utils/social.py',),
+        (),
+        ('tests/unit/test_social_*.py',),
+    ),
+    (
         ('backend/routers/folders', 'backend/services/folders/', 'backend/utils/folders'),
         (),
         ('tests/unit/test_folder_*.py',),

--- a/backend/tests/unit/test_social_handle_encoding.py
+++ b/backend/tests/unit/test_social_handle_encoding.py
@@ -1,0 +1,184 @@
+"""Regression tests for utils/social.py Twitter URL construction.
+
+The RapidAPI helpers interpolated the user-supplied ``handle`` into the
+query string without percent-encoding, so a handle containing ``&``, ``#``
+or ``%`` corrupted the request (e.g. ``screenname=a&b=1`` injected a second
+query parameter). These tests stub the heavy backend modules so the file
+runs hermetically under ``python3`` or pytest.
+"""
+
+import asyncio
+import sys
+import types
+import unittest
+from unittest.mock import Mock
+
+
+def _install_stubs():
+    """Return {name: original} after registering lightweight stub modules."""
+    stubs = {}
+
+    pydantic = types.ModuleType("pydantic")
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    pydantic.BaseModel = BaseModel
+    stubs["pydantic"] = pydantic
+
+    ulid = types.ModuleType("ulid")
+    ulid.ULID = lambda: "01TESTULID"
+    stubs["ulid"] = ulid
+
+    database = types.ModuleType("database")
+    database.__path__ = []
+    db_apps = types.ModuleType("database.apps")
+    for name in (
+        "update_app_in_db",
+        "upsert_app_to_db",
+        "get_persona_by_id_db",
+        "get_persona_by_username_twitter_handle_db",
+    ):
+        setattr(db_apps, name, Mock())
+    db_redis = types.ModuleType("database.redis_db")
+    db_redis.delete_generic_cache = Mock()
+    db_redis.save_username = Mock()
+    stubs["database"] = database
+    stubs["database.apps"] = db_apps
+    stubs["database.redis_db"] = db_redis
+
+    utils = types.ModuleType("utils")
+    utils.__path__ = []
+    llm = types.ModuleType("utils.llm")
+    llm.__path__ = []
+    persona = types.ModuleType("utils.llm.persona")
+    persona.generate_twitter_persona_prompt = Mock()
+    conversations = types.ModuleType("utils.conversations")
+    conversations.__path__ = []
+    memories = types.ModuleType("utils.conversations.memories")
+    memories.process_twitter_memories = Mock()
+    executors = types.ModuleType("utils.executors")
+    executors.db_executor = Mock()
+    executors.llm_executor = Mock()
+    executors.postprocess_executor = Mock()
+    executors.run_blocking = Mock()
+    stubs["utils"] = utils
+    stubs["utils.llm"] = llm
+    stubs["utils.llm.persona"] = persona
+    stubs["utils.conversations"] = conversations
+    stubs["utils.conversations.memories"] = memories
+    stubs["utils.executors"] = executors
+
+    return stubs
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+def _make_httpx(captured):
+    httpx = types.ModuleType("httpx")
+
+    class Timeout:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class AsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None):
+            captured.append(url)
+            return _FakeResponse(
+                {
+                    "name": "n",
+                    "profile": "p",
+                    "rest_id": "1",
+                    "avatar": "",
+                    "desc": "",
+                    "friends": 0,
+                    "sub_count": 0,
+                    "id": "1",
+                }
+            )
+
+    httpx.Timeout = Timeout
+    httpx.AsyncClient = AsyncClient
+    return httpx
+
+
+def _load_social(captured):
+    stubs = _install_stubs()
+    stubs["httpx"] = _make_httpx(captured)
+    originals = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        sys.modules.pop("utils.social", None)
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("utils.social", "utils/social.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+class TwitterHandleEncodingTests(unittest.TestCase):
+    def test_profile_url_encodes_ampersand(self):
+        captured = []
+        social = _load_social(captured)
+        asyncio.run(social.get_twitter_profile("foo&x=1"))
+        self.assertTrue(captured)
+        self.assertIn("screenname=foo%26x%3D1", captured[0])
+
+    def test_profile_url_encodes_fragment(self):
+        captured = []
+        social = _load_social(captured)
+        asyncio.run(social.get_twitter_profile("foo#bar"))
+        self.assertIn("screenname=foo%23bar", captured[0])
+
+    def test_profile_url_keeps_plain_handle(self):
+        captured = []
+        social = _load_social(captured)
+        asyncio.run(social.get_twitter_profile("jack"))
+        self.assertIn("screenname=jack", captured[0])
+        self.assertNotIn("%", captured[0])
+
+    def test_timeline_url_encodes_ampersand(self):
+        captured = []
+        social = _load_social(captured)
+
+        # Timeline returns a dict of tweets; keep the payload minimal.
+        social.TwitterTimeline = Mock(return_value=Mock())
+        try:
+            asyncio.run(social.get_twitter_timeline("a&b=1"))
+        except Exception:
+            pass  # parsing details are irrelevant; the URL is what we assert
+        self.assertTrue(captured)
+        self.assertIn("screenname=a%26b%3D1", captured[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_social_handle_encoding.py
+++ b/backend/tests/unit/test_social_handle_encoding.py
@@ -3,15 +3,20 @@
 The RapidAPI helpers interpolated the user-supplied ``handle`` into the
 query string without percent-encoding, so a handle containing ``&``, ``#``
 or ``%`` corrupted the request (e.g. ``screenname=a&b=1`` injected a second
-query parameter). These tests stub the heavy backend modules so the file
-runs hermetically under ``python3`` or pytest.
+query parameter). Stubs go through ``testing.import_isolation`` so a stub-fed
+``utils.social`` cannot leak into a shared pytest process.
 """
 
 import asyncio
-import sys
 import types
 import unittest
+from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import Mock
+
+from testing.import_isolation import load_module_fresh, stub_modules
+
+_BACKEND = Path(__file__).resolve().parents[2]
 
 
 def _install_stubs():
@@ -124,58 +129,43 @@ def _make_httpx(captured):
     return httpx
 
 
-def _load_social(captured):
+@contextmanager
+def loaded_social(captured):
     stubs = _install_stubs()
     stubs["httpx"] = _make_httpx(captured)
-    originals = {name: sys.modules.get(name) for name in stubs}
-    sys.modules.update(stubs)
-    try:
-        sys.modules.pop("utils.social", None)
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location("utils.social", "utils/social.py")
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-    finally:
-        for name, original in originals.items():
-            if original is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = original
+    with stub_modules(stubs):
+        yield load_module_fresh("utils.social", str(_BACKEND / "utils" / "social.py"))
 
 
 class TwitterHandleEncodingTests(unittest.TestCase):
     def test_profile_url_encodes_ampersand(self):
         captured = []
-        social = _load_social(captured)
-        asyncio.run(social.get_twitter_profile("foo&x=1"))
+        with loaded_social(captured) as social:
+            asyncio.run(social.get_twitter_profile("foo&x=1"))
         self.assertTrue(captured)
         self.assertIn("screenname=foo%26x%3D1", captured[0])
 
     def test_profile_url_encodes_fragment(self):
         captured = []
-        social = _load_social(captured)
-        asyncio.run(social.get_twitter_profile("foo#bar"))
+        with loaded_social(captured) as social:
+            asyncio.run(social.get_twitter_profile("foo#bar"))
         self.assertIn("screenname=foo%23bar", captured[0])
 
     def test_profile_url_keeps_plain_handle(self):
         captured = []
-        social = _load_social(captured)
-        asyncio.run(social.get_twitter_profile("jack"))
+        with loaded_social(captured) as social:
+            asyncio.run(social.get_twitter_profile("jack"))
         self.assertIn("screenname=jack", captured[0])
         self.assertNotIn("%", captured[0])
 
     def test_timeline_url_encodes_ampersand(self):
         captured = []
-        social = _load_social(captured)
-
-        # Timeline returns a dict of tweets; keep the payload minimal.
-        social.TwitterTimeline = Mock(return_value=Mock())
-        try:
-            asyncio.run(social.get_twitter_timeline("a&b=1"))
-        except Exception:
-            pass  # parsing details are irrelevant; the URL is what we assert
+        with loaded_social(captured) as social:
+            social.TwitterTimeline = Mock(return_value=Mock())
+            try:
+                asyncio.run(social.get_twitter_timeline("a&b=1"))
+            except Exception:
+                pass  # parsing details are irrelevant; the URL is what we assert
         self.assertTrue(captured)
         self.assertIn("screenname=a%26b%3D1", captured[0])
 

--- a/backend/utils/social.py
+++ b/backend/utils/social.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 from datetime import datetime, timezone
 from typing import Dict, Any, Callable, List, Awaitable, cast
+from urllib.parse import quote
 
 from pydantic import BaseModel
 from ulid import ULID
@@ -86,7 +87,7 @@ async def async_with_retry(operation_name: str, func: Callable[[], Awaitable[Any
 
 async def get_twitter_profile(handle: str) -> TwitterProfile:
     """Fetch Twitter profile for a user and return structured data"""
-    url = f"https://{rapid_api_host}/screenname.php?screenname={handle}"
+    url = f"https://{rapid_api_host}/screenname.php?screenname={quote(handle, safe='')}"
 
     headers = cast(Dict[str, str], {"X-RapidAPI-Key": rapid_api_key, "X-RapidAPI-Host": rapid_api_host})
 
@@ -121,7 +122,7 @@ def create_memories_from_twitter_tweets(uid: str, persona_id: str, tweets: List[
 async def get_twitter_timeline(handle: str) -> TwitterTimeline:
     """Fetch Twitter timeline for a user and return structured data"""
     logger.info(f"Fetching Twitter timeline for {handle}...")
-    url = f"https://{rapid_api_host}/timeline.php?screenname={handle}"
+    url = f"https://{rapid_api_host}/timeline.php?screenname={quote(handle, safe='')}"
 
     headers = cast(Dict[str, str], {"X-RapidAPI-Key": rapid_api_key, "X-RapidAPI-Host": rapid_api_host})
 


### PR DESCRIPTION
## Summary

- `get_twitter_profile` / `get_twitter_timeline` interpolated the caller-supplied `handle` into the RapidAPI query string without encoding — `handle=a&b=1` sent `screenname=a` plus an injected `b=1` parameter. The handle is user-controlled (authenticated apps endpoint query param, persona config).
- Both URLs now use `quote(handle, safe="")`.
- `backend/utils/social.py` had no AREA_TESTS mapping; added one binding it to `tests/unit/test_social_*.py` so future changes select this suite narrowly.

## Verification

- `backend/tests/unit/test_social_handle_encoding.py` — 4 hermetic cases (stubbed backend modules, captured outgoing URL). 3 fail on the unencoded code (`screenname=a&b=1` verbatim); all 4 pass with the fix under `python3 -S`.
- `scripts/select_backend_unit_tests.py` with the changed-files list selects the new test.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

