### PR TITLE
fix(go-sdk): Deepgram Stop sends CloseStream and drains finals

### DIFF
--- a/sdks/device/go/omidevice/stt/closestream_test.go
+++ b/sdks/device/go/omidevice/stt/closestream_test.go
@@ -1,0 +1,206 @@
+package stt
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type hijackPipe struct {
+	net.Conn
+	reader *bufio.Reader
+	header http.Header
+}
+
+func (w *hijackPipe) Header() http.Header { return w.header }
+func (w *hijackPipe) WriteHeader(int)     {}
+func (w *hijackPipe) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.Conn, bufio.NewReadWriter(w.reader, bufio.NewWriter(w.Conn)), nil
+}
+
+// In-memory WebSocket upgrade over net.Pipe. No live provider, credentials, or audio hardware.
+func pipeDialer(t *testing.T, handle func(*websocket.Conn) error) (*websocket.Dialer, <-chan error) {
+	t.Helper()
+	client, server := net.Pipe()
+	dialer := &websocket.Dialer{
+		NetDialTLSContext: func(context.Context, string, string) (net.Conn, error) { return client, nil },
+		NetDialContext:    func(context.Context, string, string) (net.Conn, error) { return client, nil },
+	}
+	t.Cleanup(func() { client.Close(); server.Close() })
+	done := make(chan error, 1)
+	go func() {
+		defer server.Close()
+		reader := bufio.NewReader(server)
+		request, err := http.ReadRequest(reader)
+		if err != nil {
+			done <- err
+			return
+		}
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(&hijackPipe{Conn: server, reader: reader, header: http.Header{}}, request, nil)
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		done <- handle(conn)
+	}()
+	return dialer, done
+}
+
+func TestDeepgramStopSendsCloseStreamAndDrains(t *testing.T) {
+	dialer, done := pipeDialer(t, func(conn *websocket.Conn) error {
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		var message map[string]string
+		if json.Unmarshal(payload, &message) != nil || message["type"] != "CloseStream" {
+			return errors.New("Deepgram Stop sent " + string(payload) + `; want JSON CloseStream`)
+		}
+		if err := conn.WriteJSON(map[string]any{
+			"channel": map[string]any{"alternatives": []any{map[string]string{"transcript": "last words"}}},
+		}); err != nil {
+			return err
+		}
+		return conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second),
+		)
+	})
+	got := make(chan string, 1)
+	stream, err := newDeepgram(dialer, "synthetic", 16000, func(text string) { got <- text })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case text := <-got:
+		if text != "last words" {
+			t.Fatalf("transcript %q", text)
+		}
+	default:
+		t.Fatal("Stop returned before final transcript delivery")
+	}
+	if err := stream.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.AppendPCM([]byte{1, 2}); err == nil {
+		t.Fatal("accepted audio after Stop")
+	}
+}
+
+func TestParakeetStopStillSendsFinalize(t *testing.T) {
+	dialer, done := pipeDialer(t, func(conn *websocket.Conn) error {
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		if string(payload) != "finalize" {
+			return errors.New("Parakeet Stop sent " + string(payload) + "; want finalize")
+		}
+		return nil
+	})
+	stream, err := newParakeet(dialer, "http://synthetic.test", 16000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeepgramStopTimesOutAndClosesTransport(t *testing.T) {
+	dialer, done := pipeDialer(t, func(conn *websocket.Conn) error {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return err
+		}
+		_, _, err := conn.ReadMessage()
+		if err == nil {
+			return errors.New("client left transport open")
+		}
+		return nil
+	})
+	stream, err := newDeepgram(dialer, "synthetic", 16000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream.(*wsTranscriber).shutdownTimeout = 0
+	if err := stream.Stop(); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("got %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewDeepgramPublicStopUsesCloseStream(t *testing.T) {
+	client, server := net.Pipe()
+	t.Cleanup(func() { client.Close(); server.Close() })
+	serverDone := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(server)
+		request, err := http.ReadRequest(reader)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		conn, err := (&websocket.Upgrader{}).Upgrade(&hijackPipe{Conn: server, reader: reader, header: http.Header{}}, request, nil)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		var message map[string]string
+		if json.Unmarshal(payload, &message) != nil || message["type"] != "CloseStream" {
+			serverDone <- errors.New(`Deepgram Stop sent "` + string(payload) + `"; want JSON CloseStream`)
+			return
+		}
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second),
+		)
+		serverDone <- nil
+	}()
+	old := websocket.DefaultDialer
+	dialer := *old
+	dialer.Proxy = nil
+	dialer.NetDialContext = func(context.Context, string, string) (net.Conn, error) { return client, nil }
+	dialer.NetDialTLSContext = dialer.NetDialContext
+	websocket.DefaultDialer = &dialer
+	t.Cleanup(func() { websocket.DefaultDialer = old })
+
+	stream, err := NewDeepgram("synthetic", 16000, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sdks/device/go/omidevice/stt/closestream_test.go
+++ b/sdks/device/go/omidevice/stt/closestream_test.go
@@ -142,9 +142,44 @@ func TestDeepgramStopTimesOutAndClosesTransport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stream.(*wsTranscriber).shutdownTimeout = 0
+	stream.(*wsTranscriber).shutdownTimeout = 50 * time.Millisecond
 	if err := stream.Stop(); err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("got %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeepgramStopFromTranscriptHandlerDoesNotDeadlock(t *testing.T) {
+	release := make(chan struct{})
+	dialer, done := pipeDialer(t, func(conn *websocket.Conn) error {
+		<-release
+		if err := conn.WriteJSON(map[string]any{
+			"channel": map[string]any{"alternatives": []any{map[string]string{"transcript": "from handler"}}},
+		}); err != nil {
+			return err
+		}
+		_, _, _ = conn.ReadMessage()
+		return nil
+	})
+	stopped := make(chan error, 1)
+	var stream StreamingTranscriber
+	var err error
+	stream, err = newDeepgram(dialer, "synthetic", 16000, func(string) {
+		stopped <- stream.Stop()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop from transcript handler deadlocked")
 	}
 	if err := <-done; err != nil {
 		t.Fatal(err)

--- a/sdks/device/go/omidevice/stt/parakeet_test.go
+++ b/sdks/device/go/omidevice/stt/parakeet_test.go
@@ -87,6 +87,10 @@ func testTranscriberReadiness(t *testing.T, parakeet bool) {
 			if err != nil {
 				return
 			}
+			if kind == websocket.TextMessage {
+				// Provider shutdown (Deepgram CloseStream or Parakeet finalize).
+				return
+			}
 			if kind == websocket.BinaryMessage {
 				select {
 				case received <- data:

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -82,29 +84,78 @@ func ParakeetWSURL(apiURL string, sampleRate int) string {
 }
 
 type wsTranscriber struct {
-	conn  *websocket.Conn
-	ready atomic.Bool
+	conn            *websocket.Conn
+	ready           atomic.Bool
+	writeMu         sync.Mutex
+	stopped         bool
+	stopOnce        sync.Once
+	stopErr         error
+	closeMessage    []byte
+	readDone        <-chan error
+	shutdownTimeout time.Duration
+	writeTimeout    time.Duration
 }
 
 func (t *wsTranscriber) AppendPCM(pcm []byte) error {
-	if t.conn == nil {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	if t.conn == nil || t.stopped {
 		return fmt.Errorf("not connected")
 	}
 	if !t.ready.Load() {
 		return nil
 	}
+	if t.writeTimeout > 0 {
+		if err := t.conn.SetWriteDeadline(time.Now().Add(t.writeTimeout)); err != nil {
+			return err
+		}
+	}
 	return t.conn.WriteMessage(websocket.BinaryMessage, pcm)
 }
 
 func (t *wsTranscriber) Stop() error {
-	if t.conn == nil {
-		return nil
-	}
-	_ = t.conn.WriteMessage(websocket.TextMessage, []byte("finalize"))
-	return t.conn.Close()
+	t.stopOnce.Do(func() {
+		if t.conn == nil {
+			return
+		}
+		defer t.conn.Close()
+		t.writeMu.Lock()
+		t.stopped = true
+		if t.writeTimeout > 0 {
+			_ = t.conn.SetWriteDeadline(time.Now().Add(t.writeTimeout))
+		}
+		err := t.conn.WriteMessage(websocket.TextMessage, t.closeMessage)
+		t.writeMu.Unlock()
+		if err != nil {
+			t.stopErr = fmt.Errorf("send stream shutdown: %w", err)
+			return
+		}
+		if t.readDone == nil {
+			return
+		}
+		if t.shutdownTimeout <= 0 {
+			t.stopErr = fmt.Errorf("timed out waiting for final transcription")
+			return
+		}
+		timer := time.NewTimer(t.shutdownTimeout)
+		defer timer.Stop()
+		select {
+		case err := <-t.readDone:
+			if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				t.stopErr = fmt.Errorf("finish stream shutdown: %w", err)
+			}
+		case <-timer.C:
+			t.stopErr = fmt.Errorf("timed out waiting for final transcription")
+		}
+	})
+	return t.stopErr
 }
 
 func NewDeepgram(apiKey string, sampleRate int, onTranscript Handler) (StreamingTranscriber, error) {
+	return newDeepgram(websocket.DefaultDialer, apiKey, sampleRate, onTranscript)
+}
+
+func newDeepgram(dialer *websocket.Dialer, apiKey string, sampleRate int, onTranscript Handler) (StreamingTranscriber, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("deepgram api key required")
 	}
@@ -117,21 +168,28 @@ func NewDeepgram(apiKey string, sampleRate int, onTranscript Handler) (Streaming
 	)
 	h := http.Header{}
 	h.Set("Authorization", "Token "+apiKey)
-	conn, _, err := websocket.DefaultDialer.Dial(u, h)
+	conn, _, err := dialer.Dial(u, h)
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn}
+	done := make(chan error, 1)
+	t := &wsTranscriber{
+		conn:            conn,
+		closeMessage:    []byte(`{"type":"CloseStream"}`),
+		readDone:        done,
+		shutdownTimeout: 5 * time.Second,
+		writeTimeout:    5 * time.Second,
+	}
 	t.ready.Store(true)
-	go readDeepgram(conn, onTranscript)
+	go func() { done <- readDeepgram(conn, onTranscript) }()
 	return t, nil
 }
 
-func readDeepgram(conn *websocket.Conn, onTranscript Handler) {
+func readDeepgram(conn *websocket.Conn, onTranscript Handler) error {
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
-			return
+			return err
 		}
 		var msg map[string]any
 		if json.Unmarshal(data, &msg) != nil {
@@ -151,6 +209,10 @@ func readDeepgram(conn *websocket.Conn, onTranscript Handler) {
 }
 
 func NewParakeet(apiURL string, sampleRate int, onTranscript Handler) (StreamingTranscriber, error) {
+	return newParakeet(websocket.DefaultDialer, apiURL, sampleRate, onTranscript)
+}
+
+func newParakeet(dialer *websocket.Dialer, apiURL string, sampleRate int, onTranscript Handler) (StreamingTranscriber, error) {
 	if apiURL == "" {
 		return nil, fmt.Errorf("parakeet api url required")
 	}
@@ -161,11 +223,16 @@ func NewParakeet(apiURL string, sampleRate int, onTranscript Handler) (Streaming
 	if _, err := url.Parse(u); err != nil {
 		return nil, err
 	}
-	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	conn, _, err := dialer.Dial(u, nil)
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn}
+	t := &wsTranscriber{
+		conn:            conn,
+		closeMessage:    []byte("finalize"),
+		shutdownTimeout: 5 * time.Second,
+		writeTimeout:    5 * time.Second,
+	}
 	// wait ready in background and stream
 	go func() {
 		for {

--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -94,6 +94,7 @@ type wsTranscriber struct {
 	readDone        <-chan error
 	shutdownTimeout time.Duration
 	writeTimeout    time.Duration
+	inCallback      atomic.Bool
 }
 
 func (t *wsTranscriber) AppendPCM(pcm []byte) error {
@@ -133,8 +134,9 @@ func (t *wsTranscriber) Stop() error {
 		if t.readDone == nil {
 			return
 		}
-		if t.shutdownTimeout <= 0 {
-			t.stopErr = fmt.Errorf("timed out waiting for final transcription")
+		// A transcript handler that calls Stop cannot wait for the reader:
+		// this goroutine *is* the reader until onTranscript returns.
+		if t.inCallback.Load() {
 			return
 		}
 		timer := time.NewTimer(t.shutdownTimeout)
@@ -181,13 +183,13 @@ func newDeepgram(dialer *websocket.Dialer, apiKey string, sampleRate int, onTran
 		writeTimeout:    5 * time.Second,
 	}
 	t.ready.Store(true)
-	go func() { done <- readDeepgram(conn, onTranscript) }()
+	go func() { done <- t.readDeepgram(onTranscript) }()
 	return t, nil
 }
 
-func readDeepgram(conn *websocket.Conn, onTranscript Handler) error {
+func (t *wsTranscriber) readDeepgram(onTranscript Handler) error {
 	for {
-		_, data, err := conn.ReadMessage()
+		_, data, err := t.conn.ReadMessage()
 		if err != nil {
 			return err
 		}
@@ -202,9 +204,14 @@ func readDeepgram(conn *websocket.Conn, onTranscript Handler) error {
 		}
 		alt, _ := alts[0].(map[string]any)
 		text, _ := alt["transcript"].(string)
-		if text != "" && onTranscript != nil {
-			onTranscript(text)
+		if text == "" || onTranscript == nil {
+			continue
 		}
+		func() {
+			t.inCallback.Store(true)
+			defer t.inCallback.Store(false)
+			onTranscript(text)
+		}()
 	}
 }
 


### PR DESCRIPTION
Fixes #13023.

`NewDeepgram(...).Stop()` sent Parakeet's plain `finalize` text frame and closed the socket immediately. Deepgram's CloseStream contract needs `{"type":"CloseStream"}` and a chance to return remaining transcription results.

This replacement keeps Parakeet on `finalize`, waits for the Deepgram reader with a 5s bound, reports shutdown errors, and rejects audio after Stop. It does not touch README or checks-manifest (those are why #13117 cannot merge).

## Validation

- Reproduced on `origin/main` `d5cbd548f6`: public `Stop` writes `finalize`.
- `go test -race -count=1 ./omidevice/stt/` passed (Go 1.23.8). Tests use a real WebSocket handshake over `net.Pipe` — no live Deepgram, credentials, or audio hardware.
- Existing Parakeet URL and readiness suites still pass.

Competing #13117 is APPROVED but CONFLICTING. AI-assisted contribution. Bounty eligibility remains a maintainer decision.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

