### PR TITLE
fix(go-sdk): keep BLE scan match when Scan returns first

### DIFF
--- a/sdks/device/go/omidevice/ble_tinygo.go
+++ b/sdks/device/go/omidevice/ble_tinygo.go
@@ -185,9 +185,15 @@ func readCodec(ctx context.Context, deviceID string) (CodecID, error) {
 	return CodecID(buf[0]), nil
 }
 
+type connectAdapter interface {
+	Scan(func(*bluetooth.Adapter, bluetooth.ScanResult)) error
+	StopScan() error
+	Connect(bluetooth.Address, bluetooth.ConnectionParams) (bluetooth.Device, error)
+}
+
 // connect finds deviceID via a short scan then Connects (matches tinygo examples;
 // CoreBluetooth identifiers are not always classic MAC strings).
-func connect(ctx context.Context, adapter *bluetooth.Adapter, deviceID string) (bluetooth.Device, error) {
+func connect(ctx context.Context, adapter connectAdapter, deviceID string) (bluetooth.Device, error) {
 	want := strings.ToLower(deviceID)
 	found := make(chan bluetooth.Address, 1)
 
@@ -196,14 +202,14 @@ func connect(ctx context.Context, adapter *bluetooth.Adapter, deviceID string) (
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- adapter.Scan(func(a *bluetooth.Adapter, res bluetooth.ScanResult) {
+		errCh <- adapter.Scan(func(_ *bluetooth.Adapter, res bluetooth.ScanResult) {
 			id := strings.ToLower(res.Address.String())
 			if id == want || strings.EqualFold(res.LocalName(), deviceID) {
 				select {
 				case found <- res.Address:
 				default:
 				}
-				_ = a.StopScan()
+				_ = adapter.StopScan()
 			}
 		})
 	}()
@@ -211,7 +217,6 @@ func connect(ctx context.Context, adapter *bluetooth.Adapter, deviceID string) (
 	var addr bluetooth.Address
 	select {
 	case addr = <-found:
-		// drain scan exit
 		select {
 		case <-errCh:
 		case <-time.After(2 * time.Second):
@@ -222,13 +227,18 @@ func connect(ctx context.Context, adapter *bluetooth.Adapter, deviceID string) (
 		case <-errCh:
 		case <-time.After(2 * time.Second):
 		}
-		// last resort: try Address.Set (works when ID is a parseable address)
 		addr.Set(deviceID)
 	case err := <-errCh:
 		if err != nil {
 			return bluetooth.Device{}, fmt.Errorf("omidevice: scan for connect: %w", err)
 		}
-		return bluetooth.Device{}, fmt.Errorf("omidevice: device %q not found", deviceID)
+		// Scan can return before this select runs even after the callback
+		// queued a match and called StopScan. Prefer the pending address.
+		select {
+		case addr = <-found:
+		default:
+			return bluetooth.Device{}, fmt.Errorf("omidevice: device %q not found", deviceID)
+		}
 	}
 
 	dev, err := adapter.Connect(addr, bluetooth.ConnectionParams{})

--- a/sdks/device/go/omidevice/ble_tinygo_test.go
+++ b/sdks/device/go/omidevice/ble_tinygo_test.go
@@ -1,0 +1,70 @@
+//go:build ble
+
+package omidevice
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"tinygo.org/x/bluetooth"
+)
+
+type fakeConnectAdapter struct {
+	address   bluetooth.Address
+	connected bool
+	skipMatch bool
+	scanErr   error
+}
+
+func (a *fakeConnectAdapter) Scan(callback func(*bluetooth.Adapter, bluetooth.ScanResult)) error {
+	if !a.skipMatch && a.scanErr == nil {
+		callback(nil, bluetooth.ScanResult{Address: a.address})
+	}
+	return a.scanErr
+}
+
+func (a *fakeConnectAdapter) StopScan() error { return nil }
+
+func (a *fakeConnectAdapter) Connect(address bluetooth.Address, _ bluetooth.ConnectionParams) (bluetooth.Device, error) {
+	a.connected = strings.EqualFold(address.String(), a.address.String())
+	return bluetooth.Device{}, nil
+}
+
+func TestConnectKeepsMatchWhenScanReturnsImmediately(t *testing.T) {
+	const id = "00112233-4455-6677-8899-aabbccddeeff"
+	for i := 0; i < 1000; i++ {
+		adapter := &fakeConnectAdapter{}
+		adapter.address.Set(id)
+		if _, err := connect(context.Background(), adapter, id); err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		if !adapter.connected {
+			t.Fatalf("iteration %d: scan match was discarded", i)
+		}
+	}
+}
+
+func TestConnectReportsMissingDevice(t *testing.T) {
+	adapter := &fakeConnectAdapter{skipMatch: true}
+	_, err := connect(context.Background(), adapter, "missing-device")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got %v", err)
+	}
+	if adapter.connected {
+		t.Fatal("connected without a scan match")
+	}
+}
+
+func TestConnectSurfacesScanError(t *testing.T) {
+	scanErr := errors.New("adapter offline")
+	adapter := &fakeConnectAdapter{scanErr: scanErr}
+	_, err := connect(context.Background(), adapter, "device")
+	if !errors.Is(err, scanErr) {
+		t.Fatalf("got %v", err)
+	}
+	if adapter.connected {
+		t.Fatal("connected after scan error")
+	}
+}


### PR DESCRIPTION
Fixes #13056.

`connect` queued a matching address then called `StopScan`. If `Scan` returned before the `found` receive ran, both channels were ready and the nil-error branch discarded the match, so `Listen` / `ListenPayload` / `ReadCodec` could report `device not found` after a successful callback.

This replacement drains the pending address on a nil scan error. Competing #13057 is CONFLICTING (README / checks-manifest / workflow churn); this PR is code + tests only.

## Validation

- Reproduced the select race on `origin/main` `d5cbd548f6`.
- `go test -tags ble -race -count=1 ./omidevice/` passed (Go 1.23.8). Adapter is injected; no Bluetooth hardware.
- 1000 matching-scan iterations keep the address; empty scans still return not-found; scan errors still surface.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

