### PR TITLE
fix(react-native): deliver Whisper transcripts accepted before stop

### DIFF
--- a/sdks/react-native/src/__tests__/whisper-stop.test.ts
+++ b/sdks/react-native/src/__tests__/whisper-stop.test.ts
@@ -1,0 +1,62 @@
+import { createWhisperTranscriber } from '../stt/whisper';
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('createWhisperTranscriber stop', () => {
+  test('delivers the leftover buffer after stop', async () => {
+    const got: string[] = [];
+    const transcriber = createWhisperTranscriber({
+      runner: () => 'last words',
+      onTranscript: (text) => {
+        got.push(text);
+      },
+      batchSeconds: 1,
+    });
+    transcriber.appendPcm(new Uint8Array(100));
+    transcriber.stop();
+    await wait(30);
+    expect(got).toEqual(['last words']);
+  });
+
+  test('delivers an in-flight full batch after stop', async () => {
+    const got: string[] = [];
+    let release: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const transcriber = createWhisperTranscriber({
+      runner: async () => {
+        await held;
+        return 'in flight';
+      },
+      onTranscript: (text) => {
+        got.push(text);
+      },
+      batchSeconds: 1,
+    });
+    transcriber.appendPcm(new Uint8Array(16000 * 2));
+    await wait(10);
+    transcriber.stop();
+    expect(got).toEqual([]);
+    release();
+    await wait(30);
+    expect(got).toEqual(['in flight']);
+  });
+
+  test('ignores audio appended after stop', async () => {
+    const got: string[] = [];
+    const transcriber = createWhisperTranscriber({
+      runner: () => 'should not fire',
+      onTranscript: (text) => {
+        got.push(text);
+      },
+      batchSeconds: 1,
+    });
+    transcriber.stop();
+    transcriber.appendPcm(new Uint8Array(16000 * 2));
+    await wait(20);
+    expect(got).toEqual([]);
+  });
+});

--- a/sdks/react-native/src/stt/whisper.ts
+++ b/sdks/react-native/src/stt/whisper.ts
@@ -14,13 +14,27 @@ export function createWhisperTranscriber(options: {
   const batchBytes = (options.batchSeconds ?? 5) * 16000 * 2;
   let buffer = new Uint8Array(0);
   let stopped = false;
+  let queue: Promise<void> = Promise.resolve();
 
-  async function flush() {
+  function enqueue(pcm: Uint8Array) {
+    const job = async () => {
+      let text = '';
+      try {
+        text = await options.runner(pcm);
+      } catch {
+        return;
+      }
+      if (text) options.onTranscript(text);
+    };
+    queue = queue.then(job, job);
+    return queue;
+  }
+
+  function flushBuffer() {
     if (buffer.byteLength === 0) return;
     const pcm = buffer;
     buffer = new Uint8Array(0);
-    const text = await options.runner(pcm);
-    if (text && !stopped) options.onTranscript(text);
+    return enqueue(pcm);
   }
 
   return {
@@ -32,12 +46,13 @@ export function createWhisperTranscriber(options: {
       next.set(incoming, buffer.byteLength);
       buffer = next;
       if (buffer.byteLength >= batchBytes) {
-        void flush();
+        void flushBuffer();
       }
     },
     stop() {
+      if (stopped) return;
       stopped = true;
-      void flush();
+      void flushBuffer();
     },
   };
 }


### PR DESCRIPTION
Fixes #13618.

`createWhisperTranscriber().stop()` set `stopped` before flush, then dropped leftover and in-flight batches after `await runner` because delivery required `!stopped`. Audio accepted before stop now stays queued in order. Audio after stop is ignored. Repeated `stop` is a no-op.

Competing #13048 is CONFLICTING (README / checks-manifest). This PR is the adapter plus jest coverage only.

## Validation

- Reproduced on `origin/main` `d5cbd548f6`: leftover 100-byte buffer → `onTranscript` received `[]`.
- After the fix, leftover, in-flight full batch, and post-stop ignore contracts passed with Node 22 (`--experimental-strip-types`). No device or native Whisper binary.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

