### PR TITLE
fix(web): encode share-link params in backend fetch URLs

### DIFF
--- a/web/frontend/src/__tests__/shared-api-url.test.mjs
+++ b/web/frontend/src/__tests__/shared-api-url.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { sharedApiUrl } from '../lib/shared-api-url.mjs';
+
+const BASE = 'https://api.example.com';
+
+describe('sharedApiUrl', () => {
+  it('joins fixed segments unchanged', () => {
+    assert.equal(
+      sharedApiUrl(BASE, 'v1', 'action-items', 'shared', 'tok123'),
+      'https://api.example.com/v1/action-items/shared/tok123',
+    );
+  });
+
+  it('encodes a slash inside a decoded route param', () => {
+    // Next.js hands params decoded: /tasks/a%2Fb -> params.token === 'a/b'.
+    assert.equal(
+      sharedApiUrl(BASE, 'v1', 'action-items', 'shared', 'a/b'),
+      'https://api.example.com/v1/action-items/shared/a%2Fb',
+    );
+  });
+
+  it('encodes query and fragment characters', () => {
+    assert.equal(
+      sharedApiUrl(BASE, 'v2', 'messages', 'shared', 'x?y=1'),
+      'https://api.example.com/v2/messages/shared/x%3Fy%3D1',
+    );
+    assert.equal(
+      sharedApiUrl(BASE, 'v2', 'messages', 'shared', 'x#frag'),
+      'https://api.example.com/v2/messages/shared/x%23frag',
+    );
+  });
+
+  it('encodes params in the middle of a path', () => {
+    assert.equal(
+      sharedApiUrl(BASE, 'v1', 'conversations', 'a/b', 'shared'),
+      'https://api.example.com/v1/conversations/a%2Fb/shared',
+    );
+  });
+
+  it('strips a trailing slash on the base', () => {
+    assert.equal(
+      sharedApiUrl('https://api.example.com/', 'v1', 'shared', 't'),
+      'https://api.example.com/v1/shared/t',
+    );
+  });
+});

--- a/web/frontend/src/actions/chat/get-shared-chat.ts
+++ b/web/frontend/src/actions/chat/get-shared-chat.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import envConfig from '@/src/constants/envConfig';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 
 export interface SharedChatMessage {
   id: string;
@@ -19,12 +20,15 @@ export default async function getSharedChat(
   token: string,
 ): Promise<SharedChatData | undefined> {
   try {
-    const response = await fetch(`${envConfig.API_URL}/v2/messages/shared/${token}`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      sharedApiUrl(envConfig.API_URL, 'v2', 'messages', 'shared', token),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-cache',
       },
-      cache: 'no-cache',
-    });
+    );
 
     if (!response.ok) {
       return undefined;

--- a/web/frontend/src/actions/memories/get-shared-memory.ts
+++ b/web/frontend/src/actions/memories/get-shared-memory.ts
@@ -1,15 +1,19 @@
 'use server';
 import envConfig from '@/src/constants/envConfig';
 import { Memory } from '@/src/types/memory.types';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 
 export default async function getSharedMemory(id: string) {
   try {
-    const response = await fetch(`${envConfig.API_URL}/v1/conversations/${id}/shared`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      sharedApiUrl(envConfig.API_URL, 'v1', 'conversations', id, 'shared'),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-cache',
       },
-      cache: 'no-cache',
-    });
+    );
     if (!response.ok) {
       return undefined;
     }

--- a/web/frontend/src/actions/tasks/get-shared-tasks.ts
+++ b/web/frontend/src/actions/tasks/get-shared-tasks.ts
@@ -1,5 +1,6 @@
 'use server';
 import envConfig from '@/src/constants/envConfig';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 
 export interface SharedTaskData {
   sender_name: string;
@@ -11,12 +12,15 @@ export default async function getSharedTasks(
   token: string,
 ): Promise<SharedTaskData | undefined> {
   try {
-    const response = await fetch(`${envConfig.API_URL}/v1/action-items/shared/${token}`, {
-      headers: {
-        'Content-Type': 'application/json',
+    const response = await fetch(
+      sharedApiUrl(envConfig.API_URL, 'v1', 'action-items', 'shared', token),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-cache',
       },
-      cache: 'no-cache',
-    });
+    );
     if (!response.ok) {
       return undefined;
     }

--- a/web/frontend/src/app/chat/[token]/page.tsx
+++ b/web/frontend/src/app/chat/[token]/page.tsx
@@ -1,6 +1,7 @@
 import getSharedChat from '@/src/actions/chat/get-shared-chat';
 import envConfig from '@/src/constants/envConfig';
 import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
@@ -24,7 +25,7 @@ export async function generateMetadata(
 
   try {
     const response = await fetch(
-      `${envConfig.API_URL}/v2/messages/shared/${params.token}`,
+      sharedApiUrl(envConfig.API_URL, 'v2', 'messages', 'shared', params.token),
       { next: { revalidate: 60 } },
     );
     if (response.ok) {
@@ -52,7 +53,10 @@ export async function generateMetadata(
       ...prevData.openGraph,
       title,
       type: 'website',
-      url: new URL(`/chat/${params.token}`, prevData.metadataBase).toString(),
+      url: new URL(
+        `/chat/${encodeURIComponent(params.token)}`,
+        prevData.metadataBase,
+      ).toString(),
       description,
     },
     other: {

--- a/web/frontend/src/app/memories/[id]/page.tsx
+++ b/web/frontend/src/app/memories/[id]/page.tsx
@@ -7,6 +7,7 @@ import SharedConversationInstallCta, {
 import envConfig from '@/src/constants/envConfig';
 import { DEFAULT_TITLE_MEMORY } from '@/src/constants/memory';
 import { markdownToPlainText } from '@/src/lib/markdown-to-plain-text.mjs';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 import { ParamsTypes, SearchParamsTypes } from '@/src/types/params.types';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
@@ -27,7 +28,7 @@ export async function generateMetadata(
 
   try {
     const response = await fetch(
-      `${envConfig.API_URL}/v1/conversations/${params.id}/shared`,
+      sharedApiUrl(envConfig.API_URL, 'v1', 'conversations', params.id, 'shared'),
       {
         next: {
           revalidate: 60,
@@ -54,7 +55,10 @@ export async function generateMetadata(
       'A conversation shared from Omi — open it in the app.';
 
   const ogUrl = prevData.metadataBase
-    ? new URL(`/conversations/${params.id}`, prevData.metadataBase).toString()
+    ? new URL(
+        `/conversations/${encodeURIComponent(params.id)}`,
+        prevData.metadataBase,
+      ).toString()
     : `${envConfig.WEB_URL}/conversations/${params.id}`;
 
   return {

--- a/web/frontend/src/app/recaps/[id]/page.tsx
+++ b/web/frontend/src/app/recaps/[id]/page.tsx
@@ -1,5 +1,6 @@
 import envConfig from '@/src/constants/envConfig';
 import { markdownToPlainText } from '@/src/lib/markdown-to-plain-text.mjs';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { notFound } from 'next/navigation';
 import { ParamsTypes } from '@/src/types/params.types';
@@ -46,9 +47,12 @@ interface DailySummary {
 
 async function getSharedRecap(id: string): Promise<DailySummary | null> {
   try {
-    const response = await fetch(`${envConfig.API_URL}/v1/daily-summaries/${id}/shared`, {
-      cache: 'no-cache',
-    });
+    const response = await fetch(
+      sharedApiUrl(envConfig.API_URL, 'v1', 'daily-summaries', id, 'shared'),
+      {
+        cache: 'no-cache',
+      },
+    );
     if (!response.ok) return null;
     return (await response.json()) as DailySummary;
   } catch {

--- a/web/frontend/src/app/tasks/[token]/page.tsx
+++ b/web/frontend/src/app/tasks/[token]/page.tsx
@@ -1,6 +1,7 @@
 import getSharedTasks from '@/src/actions/tasks/get-shared-tasks';
 import envConfig from '@/src/constants/envConfig';
 import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
+import { sharedApiUrl } from '@/src/lib/shared-api-url.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
@@ -24,7 +25,7 @@ export async function generateMetadata(
 
   try {
     const response = await fetch(
-      `${envConfig.API_URL}/v1/action-items/shared/${params.token}`,
+      sharedApiUrl(envConfig.API_URL, 'v1', 'action-items', 'shared', params.token),
       { next: { revalidate: 60 } },
     );
     if (response.ok) {
@@ -51,7 +52,10 @@ export async function generateMetadata(
       ...prevData.openGraph,
       title: title,
       type: 'website',
-      url: new URL(`/tasks/${params.token}`, prevData.metadataBase).toString(),
+      url: new URL(
+        `/tasks/${encodeURIComponent(params.token)}`,
+        prevData.metadataBase,
+      ).toString(),
       description: 'Open in Omi to add these tasks to your list.',
     },
     other: {

--- a/web/frontend/src/lib/shared-api-url.mjs
+++ b/web/frontend/src/lib/shared-api-url.mjs
@@ -1,0 +1,17 @@
+/**
+ * Build a backend API URL from path segments. Dynamic route params arrive
+ * already decoded by Next.js — a share token read from `/tasks/a%2Fb` is the
+ * string `a/b` — so interpolating params raw into a fetch URL misroutes the
+ * request or corrupts the query. Encoding every segment keeps the wire URL
+ * well-formed regardless of what the param contains. Kept as plain JS so
+ * node:test can assert without a TS loader.
+ *
+ * @param {string | undefined | null} base API origin, e.g. envConfig.API_URL
+ * @param {...string} segments path pieces; fixed prefixes pass unharmed
+ * @returns {string} `${base}/${segments.map(encodeURIComponent).join('/')}`
+ */
+export function sharedApiUrl(base, ...segments) {
+  const trimmed = String(base ?? '').replace(/\/+$/, '');
+  const encoded = segments.map((segment) => encodeURIComponent(segment)).join('/');
+  return `${trimmed}/${encoded}`;
+}


### PR DESCRIPTION
## Summary

- `params.token` / `params.id` arrive decoded from Next.js dynamic segments (`/tasks/a%2Fb` → `a/b`). The shared tasks, chat, memory, and recap pages — plus their server actions — interpolated them raw into backend fetch URLs: `/v1/action-items/shared/a/b` misroutes, and `?`/`#`/`%` corrupt the request.
- New `src/lib/shared-api-url.mjs` `sharedApiUrl(base, ...segments)` encodes every segment; all 7 fetch sites + the `og:url` canonicals now go through it / `encodeURIComponent`.
- Follows the existing `.mjs` helper convention so `node --test` covers it without a TS loader.

## Verification

- `node --test src/__tests__/` — 86 pass, incl. 5 new cases (`a/b`→`a%2Fb`, `x?y=1`→`x%3Fy%3D1`, `x#frag`→`x%23frag`, mid-path param, trailing-slash base).
- `tsc --noEmit`: no new errors (33 pre-existing baseline). `eslint --quiet` and pinned `prettier` clean on touched files.
- Deep links (`omi://…/tasks/{token}`) intentionally unchanged — the app's router owns that path parsing; noted here for review.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

