### PR TITLE
fix(react-native): send Deepgram CloseStream before closing Stop

### DIFF
--- a/sdks/react-native/src/__tests__/deepgram-stop.test.ts
+++ b/sdks/react-native/src/__tests__/deepgram-stop.test.ts
@@ -5,13 +5,20 @@ class FakeSocket {
   binaryType = 'arraybuffer';
   sent: unknown[] = [];
   closeCount = 0;
+  events: Array<'send' | 'close'> = [];
   onmessage: ((event: { data: string }) => void) | null = null;
+  sendError: Error | null = null;
 
   send(data: unknown) {
+    this.events.push('send');
     this.sent.push(data);
+    if (this.sendError) {
+      throw this.sendError;
+    }
   }
 
   close() {
+    this.events.push('close');
     this.closeCount += 1;
     this.readyState = 3;
   }
@@ -26,7 +33,21 @@ describe('createDeepgramTranscriber stop', () => {
       createWebSocket: () => socket as unknown as WebSocket,
     });
     transcriber.stop();
+    expect(socket.events).toEqual(['send', 'close']);
     expect(socket.sent).toEqual([JSON.stringify({ type: 'CloseStream' })]);
+    expect(socket.closeCount).toBe(1);
+  });
+
+  test('closes the socket when CloseStream send fails', () => {
+    const socket = new FakeSocket();
+    socket.sendError = new Error('synthetic send failure');
+    const transcriber = createDeepgramTranscriber({
+      apiKey: 'synthetic',
+      onTranscript: () => undefined,
+      createWebSocket: () => socket as unknown as WebSocket,
+    });
+    transcriber.stop();
+    expect(socket.events).toEqual(['send', 'close']);
     expect(socket.closeCount).toBe(1);
   });
 
@@ -39,6 +60,7 @@ describe('createDeepgramTranscriber stop', () => {
       createWebSocket: () => socket as unknown as WebSocket,
     });
     transcriber.stop();
+    expect(socket.events).toEqual(['close']);
     expect(socket.sent).toEqual([]);
     expect(socket.closeCount).toBe(1);
   });

--- a/sdks/react-native/src/__tests__/deepgram-stop.test.ts
+++ b/sdks/react-native/src/__tests__/deepgram-stop.test.ts
@@ -1,0 +1,45 @@
+import { createDeepgramTranscriber } from '../stt/deepgram';
+
+class FakeSocket {
+  readyState = 1;
+  binaryType = 'arraybuffer';
+  sent: unknown[] = [];
+  closeCount = 0;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closeCount += 1;
+    this.readyState = 3;
+  }
+}
+
+describe('createDeepgramTranscriber stop', () => {
+  test('sends CloseStream before closing the socket', () => {
+    const socket = new FakeSocket();
+    const transcriber = createDeepgramTranscriber({
+      apiKey: 'synthetic',
+      onTranscript: () => undefined,
+      createWebSocket: () => socket as unknown as WebSocket,
+    });
+    transcriber.stop();
+    expect(socket.sent).toEqual([JSON.stringify({ type: 'CloseStream' })]);
+    expect(socket.closeCount).toBe(1);
+  });
+
+  test('does not send CloseStream when the socket is already closed', () => {
+    const socket = new FakeSocket();
+    socket.readyState = 3;
+    const transcriber = createDeepgramTranscriber({
+      apiKey: 'synthetic',
+      onTranscript: () => undefined,
+      createWebSocket: () => socket as unknown as WebSocket,
+    });
+    transcriber.stop();
+    expect(socket.sent).toEqual([]);
+    expect(socket.closeCount).toBe(1);
+  });
+});

--- a/sdks/react-native/src/stt/deepgram.ts
+++ b/sdks/react-native/src/stt/deepgram.ts
@@ -39,9 +39,14 @@ export function createDeepgramTranscriber(options: {
         if (ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'CloseStream' }));
         }
-        ws.close();
       } catch {
-        // ignore
+        // CloseStream is best-effort; still tear down the socket.
+      } finally {
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
       }
     },
   };

--- a/sdks/react-native/src/stt/deepgram.ts
+++ b/sdks/react-native/src/stt/deepgram.ts
@@ -36,6 +36,9 @@ export function createDeepgramTranscriber(options: {
     },
     stop() {
       try {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'CloseStream' }));
+        }
         ws.close();
       } catch {
         // ignore


### PR DESCRIPTION
Fixes #13621.

`createDeepgramTranscriber().stop()` closed the WebSocket without sending Deepgram's CloseStream frame. Remaining transcription results can be dropped. Send `{"type":"CloseStream"}` while the socket is open, then close. Related Go device SDK issue: #13023.

## Validation

- Reproduced on `origin/main` `d5cbd548f6`: injected socket recorded `close()` and no text frame.
- After the fix, Node 22 recorded `{"type":"CloseStream"}` then `close()`. No live Deepgram, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

