### PR TITLE
fix(device-ts): send Deepgram CloseStream before closing Stop

### DIFF
--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -87,6 +87,7 @@ describe('createDeepgramTranscriber', () => {
 
   test('sends CloseStream before closing the socket', () => {
     const sent: unknown[] = [];
+    const events: Array<'send' | 'close'> = [];
     let closeCount = 0;
     class FakeWebSocket {
       binaryType: string = 'blob';
@@ -94,9 +95,11 @@ describe('createDeepgramTranscriber', () => {
       onmessage: ((event: MessageEvent) => void) | null = null;
       constructor(_url: string) {}
       send(data: unknown) {
+        events.push('send');
         sent.push(data);
       }
       close() {
+        events.push('close');
         closeCount += 1;
         this.readyState = 3;
       }
@@ -108,7 +111,67 @@ describe('createDeepgramTranscriber', () => {
     });
     transcriber.stop();
 
+    expect(events).toEqual(['send', 'close']);
     expect(sent).toEqual([JSON.stringify({ type: 'CloseStream' })]);
+    expect(closeCount).toBe(1);
+  });
+
+  test('closes the socket when CloseStream send fails', () => {
+    const events: Array<'send' | 'close'> = [];
+    let closeCount = 0;
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(_url: string) {}
+      send(_data: unknown) {
+        events.push('send');
+        throw new Error('synthetic send failure');
+      }
+      close() {
+        events.push('close');
+        closeCount += 1;
+        this.readyState = 3;
+      }
+    }
+
+    const transcriber = createDeepgramTranscriber({
+      onTranscript: () => {},
+      createWebSocket: (url: string) => new FakeWebSocket(url) as any,
+    });
+    transcriber.stop();
+
+    expect(events).toEqual(['send', 'close']);
+    expect(closeCount).toBe(1);
+  });
+
+  test('does not send CloseStream when the socket is already closed', () => {
+    const sent: unknown[] = [];
+    const events: Array<'send' | 'close'> = [];
+    let closeCount = 0;
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 3;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(_url: string) {}
+      send(data: unknown) {
+        events.push('send');
+        sent.push(data);
+      }
+      close() {
+        events.push('close');
+        closeCount += 1;
+      }
+    }
+
+    const transcriber = createDeepgramTranscriber({
+      onTranscript: () => {},
+      createWebSocket: (url: string) => new FakeWebSocket(url) as any,
+    });
+    transcriber.stop();
+
+    expect(events).toEqual(['close']);
+    expect(sent).toEqual([]);
     expect(closeCount).toBe(1);
   });
 });

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -84,6 +84,33 @@ describe('createDeepgramTranscriber', () => {
 
     expect(openedUrl).not.toInclude('token=');
   });
+
+  test('sends CloseStream before closing the socket', () => {
+    const sent: unknown[] = [];
+    let closeCount = 0;
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(_url: string) {}
+      send(data: unknown) {
+        sent.push(data);
+      }
+      close() {
+        closeCount += 1;
+        this.readyState = 3;
+      }
+    }
+
+    const transcriber = createDeepgramTranscriber({
+      onTranscript: () => {},
+      createWebSocket: (url: string) => new FakeWebSocket(url) as any,
+    });
+    transcriber.stop();
+
+    expect(sent).toEqual([JSON.stringify({ type: 'CloseStream' })]);
+    expect(closeCount).toBe(1);
+  });
 });
 
 describe('createWhisperTranscriber', () => {

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -85,7 +85,7 @@ describe('createDeepgramTranscriber', () => {
     expect(openedUrl).not.toInclude('token=');
   });
 
-  test('sends CloseStream before closing the socket', () => {
+  test('sends CloseStream before closing the socket', async () => {
     const sent: unknown[] = [];
     const events: Array<'send' | 'close'> = [];
     let closeCount = 0;
@@ -93,6 +93,7 @@ describe('createDeepgramTranscriber', () => {
       binaryType: string = 'blob';
       readyState = 1;
       onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
       constructor(_url: string) {}
       send(data: unknown) {
         events.push('send');
@@ -108,12 +109,79 @@ describe('createDeepgramTranscriber', () => {
     const transcriber = createDeepgramTranscriber({
       onTranscript: () => {},
       createWebSocket: (url: string) => new FakeWebSocket(url) as any,
+      drainTimeoutMs: 50,
     });
     transcriber.stop();
+    expect(events).toEqual(['send']);
+    await new Promise((resolve) => setTimeout(resolve, 70));
 
     expect(events).toEqual(['send', 'close']);
     expect(sent).toEqual([JSON.stringify({ type: 'CloseStream' })]);
     expect(closeCount).toBe(1);
+  });
+
+  test('closes after CloseStream when the provider closes the socket', async () => {
+    const events: Array<'send' | 'close'> = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+      constructor(_url: string) {}
+      send(data: unknown) {
+        events.push('send');
+        queueMicrotask(() => {
+          this.readyState = 3;
+          this.onclose?.({} as Event);
+        });
+      }
+      close() {
+        events.push('close');
+        this.readyState = 3;
+      }
+    }
+
+    const transcriber = createDeepgramTranscriber({
+      onTranscript: () => {},
+      createWebSocket: (url: string) => new FakeWebSocket(url) as any,
+      drainTimeoutMs: 5000,
+    });
+    transcriber.stop();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual(['send', 'close']);
+  });
+
+  test('drains a trailing transcript after CloseStream', async () => {
+    const transcripts: string[] = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+      constructor(_url: string) {}
+      send(_data: unknown) {}
+      close() {
+        this.readyState = 3;
+      }
+    }
+
+    const socket = new FakeWebSocket('');
+    const transcriber = createDeepgramTranscriber({
+      onTranscript: (text) => transcripts.push(text),
+      createWebSocket: () => socket as any,
+      drainTimeoutMs: 50,
+    });
+    transcriber.stop();
+    socket.onmessage?.({
+      data: JSON.stringify({
+        channel: { alternatives: [{ transcript: 'late ts' }] },
+      }),
+    } as MessageEvent);
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    expect(transcripts).toEqual(['late ts']);
   });
 
   test('closes the socket when CloseStream send fails', () => {

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -55,7 +55,12 @@ export function createDeepgramTranscriber(opts: {
       if (ws.readyState === 1) ws.send(chunk as any);
     },
     stop() {
-      try { ws.close(); } catch { /* ignore */ }
+      try {
+        if (ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: 'CloseStream' }));
+        }
+        ws.close();
+      } catch { /* ignore */ }
     },
   };
 }

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -59,8 +59,13 @@ export function createDeepgramTranscriber(opts: {
         if (ws.readyState === 1) {
           ws.send(JSON.stringify({ type: 'CloseStream' }));
         }
-        ws.close();
-      } catch { /* ignore */ }
+      } catch {
+        // CloseStream is best-effort; still tear down the socket.
+      } finally {
+        try {
+          ws.close();
+        } catch { /* ignore */ }
+      }
     },
   };
 }

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -38,6 +38,8 @@ export function createDeepgramTranscriber(opts: {
   /** Header-capable authenticated WebSocket factory (or an authenticated proxy).
    *  The factory owns Deepgram authentication so credentials never enter the URL. */
   createWebSocket: (url: string) => WebSocket;
+  /** How long Stop waits for Deepgram to close after CloseStream. Default 5s. */
+  drainTimeoutMs?: number;
 }): StreamingTranscriber {
   if (!opts.createWebSocket) throw new Error('Deepgram requires createWebSocket');
   const url = deepgramWsUrl(opts.sampleRate ?? 16000);
@@ -55,17 +57,39 @@ export function createDeepgramTranscriber(opts: {
       if (ws.readyState === 1) ws.send(chunk as any);
     },
     stop() {
+      let sentClose = false;
       try {
         if (ws.readyState === 1) {
           ws.send(JSON.stringify({ type: 'CloseStream' }));
+          sentClose = true;
         }
       } catch {
         // CloseStream is best-effort; still tear down the socket.
-      } finally {
+      }
+
+      let finished = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        if (timer !== undefined) clearTimeout(timer);
         try {
           ws.close();
         } catch { /* ignore */ }
+      };
+
+      if (!sentClose) {
+        finish();
+        return;
       }
+
+      const drainTimeoutMs = opts.drainTimeoutMs ?? 5000;
+      timer = setTimeout(finish, drainTimeoutMs);
+      const prevClose = ws.onclose;
+      ws.onclose = (ev) => {
+        finish();
+        if (typeof prevClose === 'function') prevClose.call(ws, ev);
+      };
     },
   };
 }


### PR DESCRIPTION
Fixes #13623.

`createDeepgramTranscriber().stop()` closed the WebSocket without sending Deepgram's CloseStream frame. Remaining transcription results can be dropped. Send `{"type":"CloseStream"}` while the socket is open, then close. Related: Go #13023, React Native #13621.

## Validation

- Reproduced on `origin/main` `d5cbd548f6`: injected socket recorded `close()` and no text frame.
- After the fix, Node 22 recorded `{"type":"CloseStream"}` then `close()`. Added a case to the existing bun `index.test.ts` suite. No live Deepgram, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

