### PR TITLE
fix(dart-sdk): drain Deepgram CloseStream and Parakeet finalize on Stop

### DIFF
--- a/sdks/device/dart/lib/stt/stt.dart
+++ b/sdks/device/dart/lib/stt/stt.dart
@@ -34,6 +34,7 @@ class DeepgramTranscriber implements StreamingTranscriber {
     required this.apiKey,
     required this.onTranscript,
     this.sampleRate = 16000,
+    this.drainTimeout = const Duration(seconds: 5),
     WebSocketChannel? channel,
   }) {
     _channel = channel ??
@@ -41,22 +42,32 @@ class DeepgramTranscriber implements StreamingTranscriber {
           Uri.parse(deepgramWsUrl(sampleRate: sampleRate)),
           headers: {'Authorization': 'Token $apiKey'},
         );
-    _sub = _channel.stream.listen((event) {
-      if (event is! String) return;
-      try {
-        final data = jsonDecode(event) as Map<String, dynamic>;
-        final alts = (data['channel'] as Map?)?['alternatives'] as List?;
-        final t = (alts?.isNotEmpty == true) ? (alts!.first as Map)['transcript'] : null;
-        if (t is String && t.isNotEmpty) onTranscript(t);
-      } catch (_) {}
-    });
+    _sub = _channel.stream.listen(
+      (event) {
+        if (event is! String) return;
+        try {
+          final data = jsonDecode(event) as Map<String, dynamic>;
+          final alts = (data['channel'] as Map?)?['alternatives'] as List?;
+          final t = (alts?.isNotEmpty == true) ? (alts!.first as Map)['transcript'] : null;
+          if (t is String && t.isNotEmpty) onTranscript(t);
+        } catch (_) {}
+      },
+      onDone: _markDrained,
+      onError: (_) => _markDrained(),
+    );
   }
 
   final String apiKey;
   final TranscriptHandler onTranscript;
   final int sampleRate;
+  final Duration drainTimeout;
   late final WebSocketChannel _channel;
   StreamSubscription? _sub;
+  final Completer<void> _drained = Completer<void>();
+
+  void _markDrained() {
+    if (!_drained.isCompleted) _drained.complete();
+  }
 
   @override
   void appendPcm(Uint8List chunk) {
@@ -65,9 +76,16 @@ class DeepgramTranscriber implements StreamingTranscriber {
 
   @override
   Future<void> stop() async {
+    var sentClose = false;
     try {
       _channel.sink.add(jsonEncode({'type': 'CloseStream'}));
+      sentClose = true;
     } catch (_) {}
+    if (sentClose) {
+      try {
+        await _drained.future.timeout(drainTimeout);
+      } catch (_) {}
+    }
     await _sub?.cancel();
     try {
       await _channel.sink.close();

--- a/sdks/device/dart/lib/stt/stt.dart
+++ b/sdks/device/dart/lib/stt/stt.dart
@@ -63,6 +63,7 @@ class DeepgramTranscriber implements StreamingTranscriber {
   final Duration drainTimeout;
   late final WebSocketChannel _channel;
   StreamSubscription? _sub;
+  bool _stopped = false;
   final Completer<void> _drained = Completer<void>();
 
   void _markDrained() {
@@ -71,11 +72,14 @@ class DeepgramTranscriber implements StreamingTranscriber {
 
   @override
   void appendPcm(Uint8List chunk) {
+    if (_stopped) return;
     _channel.sink.add(chunk);
   }
 
   @override
   Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
     var sentClose = false;
     try {
       _channel.sink.add(jsonEncode({'type': 'CloseStream'}));
@@ -127,6 +131,7 @@ class ParakeetTranscriber implements StreamingTranscriber {
   late final WebSocketChannel _channel;
   StreamSubscription? _sub;
   bool _ready = false;
+  bool _stopped = false;
   final Completer<void> _drained = Completer<void>();
 
   void _markDrained() {
@@ -141,11 +146,15 @@ class ParakeetTranscriber implements StreamingTranscriber {
 
   @override
   void appendPcm(Uint8List chunk) {
-    if (_ready) _channel.sink.add(chunk);
+    if (_stopped || !_ready) return;
+    _channel.sink.add(chunk);
   }
 
   @override
   Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
+    _ready = false;
     var sentFinalize = false;
     try {
       _channel.sink.add('finalize');

--- a/sdks/device/dart/lib/stt/stt.dart
+++ b/sdks/device/dart/lib/stt/stt.dart
@@ -69,7 +69,9 @@ class DeepgramTranscriber implements StreamingTranscriber {
       _channel.sink.add(jsonEncode({'type': 'CloseStream'}));
     } catch (_) {}
     await _sub?.cancel();
-    await _channel.sink.close();
+    try {
+      await _channel.sink.close();
+    } catch (_) {}
   }
 }
 

--- a/sdks/device/dart/lib/stt/stt.dart
+++ b/sdks/device/dart/lib/stt/stt.dart
@@ -30,9 +30,17 @@ String parakeetWsUrl(String apiUrl, {int sampleRate = 16000}) {
 }
 
 class DeepgramTranscriber implements StreamingTranscriber {
-  DeepgramTranscriber({required this.apiKey, required this.onTranscript, this.sampleRate = 16000}) {
-    final uri = Uri.parse(deepgramWsUrl(sampleRate: sampleRate));
-    _channel = IOWebSocketChannel.connect(uri, headers: {'Authorization': 'Token $apiKey'});
+  DeepgramTranscriber({
+    required this.apiKey,
+    required this.onTranscript,
+    this.sampleRate = 16000,
+    WebSocketChannel? channel,
+  }) {
+    _channel = channel ??
+        IOWebSocketChannel.connect(
+          Uri.parse(deepgramWsUrl(sampleRate: sampleRate)),
+          headers: {'Authorization': 'Token $apiKey'},
+        );
     _sub = _channel.stream.listen((event) {
       if (event is! String) return;
       try {
@@ -57,6 +65,9 @@ class DeepgramTranscriber implements StreamingTranscriber {
 
   @override
   Future<void> stop() async {
+    try {
+      _channel.sink.add(jsonEncode({'type': 'CloseStream'}));
+    } catch (_) {}
     await _sub?.cancel();
     await _channel.sink.close();
   }

--- a/sdks/device/dart/lib/stt/stt.dart
+++ b/sdks/device/dart/lib/stt/stt.dart
@@ -94,28 +94,44 @@ class DeepgramTranscriber implements StreamingTranscriber {
 }
 
 class ParakeetTranscriber implements StreamingTranscriber {
-  ParakeetTranscriber({required String apiUrl, required this.onTranscript, this.sampleRate = 16000}) {
-    final uri = Uri.parse(parakeetWsUrl(apiUrl, sampleRate: sampleRate));
-    _channel = WebSocketChannel.connect(uri);
-    _sub = _channel.stream.listen((event) {
-      if (event is! String) return;
-      try {
-        final data = jsonDecode(event) as Map<String, dynamic>;
-        if (data['type'] == 'ready') {
-          _ready = true;
-          return;
-        }
-        final text = _extract(data);
-        if (text != null && text.isNotEmpty) onTranscript(text);
-      } catch (_) {}
-    });
+  ParakeetTranscriber({
+    required String apiUrl,
+    required this.onTranscript,
+    this.sampleRate = 16000,
+    this.drainTimeout = const Duration(seconds: 5),
+    WebSocketChannel? channel,
+  }) {
+    _channel = channel ??
+        WebSocketChannel.connect(Uri.parse(parakeetWsUrl(apiUrl, sampleRate: sampleRate)));
+    _sub = _channel.stream.listen(
+      (event) {
+        if (event is! String) return;
+        try {
+          final data = jsonDecode(event) as Map<String, dynamic>;
+          if (data['type'] == 'ready') {
+            _ready = true;
+            return;
+          }
+          final text = _extract(data);
+          if (text != null && text.isNotEmpty) onTranscript(text);
+        } catch (_) {}
+      },
+      onDone: _markDrained,
+      onError: (_) => _markDrained(),
+    );
   }
 
   final TranscriptHandler onTranscript;
   final int sampleRate;
+  final Duration drainTimeout;
   late final WebSocketChannel _channel;
   StreamSubscription? _sub;
   bool _ready = false;
+  final Completer<void> _drained = Completer<void>();
+
+  void _markDrained() {
+    if (!_drained.isCompleted) _drained.complete();
+  }
 
   static String? _extract(Map<String, dynamic> data) {
     final t = data['text'] ?? data['transcript'];
@@ -130,11 +146,20 @@ class ParakeetTranscriber implements StreamingTranscriber {
 
   @override
   Future<void> stop() async {
+    var sentFinalize = false;
     try {
       _channel.sink.add('finalize');
+      sentFinalize = true;
     } catch (_) {}
+    if (sentFinalize) {
+      try {
+        await _drained.future.timeout(drainTimeout);
+      } catch (_) {}
+    }
     await _sub?.cancel();
-    await _channel.sink.close();
+    try {
+      await _channel.sink.close();
+    } catch (_) {}
   }
 }
 

--- a/sdks/device/dart/pubspec.yaml
+++ b/sdks/device/dart/pubspec.yaml
@@ -16,4 +16,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  # Imported by test/stt_test.dart; keep direct so depend_on_referenced_packages holds.
   stream_channel: ^2.1.4

--- a/sdks/device/dart/pubspec.yaml
+++ b/sdks/device/dart/pubspec.yaml
@@ -16,3 +16,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  stream_channel: ^2.1.4

--- a/sdks/device/dart/test/stt_test.dart
+++ b/sdks/device/dart/test/stt_test.dart
@@ -128,6 +128,67 @@ void main() {
     expect(channel.events, ['send', 'close']);
     expect(channel.closed, isTrue);
   });
+
+  test('Parakeet stop sends finalize before closing the socket', () async {
+    final channel = RecordingWebSocketChannel();
+    final transcriber = ParakeetTranscriber(
+      apiUrl: 'https://parakeet.example',
+      onTranscript: (_) {},
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(channel.events, ['send', 'close']);
+    expect(channel.sent, ['finalize']);
+    expect(channel.closed, isTrue);
+  });
+
+  test('Parakeet stop still closes when finalize send fails', () async {
+    final channel = RecordingWebSocketChannel(sendError: StateError('synthetic send failure'));
+    final transcriber = ParakeetTranscriber(
+      apiUrl: 'https://parakeet.example',
+      onTranscript: (_) {},
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(channel.events, ['send', 'close']);
+    expect(channel.closed, isTrue);
+  });
+
+  test('Parakeet stop drains a trailing transcript after finalize', () async {
+    final channel = RecordingWebSocketChannel(
+      trailingAfterCloseStream: jsonEncode({'text': 'final para'}),
+    );
+    final transcripts = <String>[];
+    final transcriber = ParakeetTranscriber(
+      apiUrl: 'https://parakeet.example',
+      onTranscript: transcripts.add,
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(transcripts, ['final para']);
+    expect(channel.events, ['send', 'close']);
+  });
+
+  test('Parakeet stop still closes if the provider never drains', () async {
+    final channel = RecordingWebSocketChannel(completeStreamOnCloseStream: false);
+    final transcriber = ParakeetTranscriber(
+      apiUrl: 'https://parakeet.example',
+      onTranscript: (_) {},
+      channel: channel,
+      drainTimeout: const Duration(milliseconds: 50),
+    );
+
+    await transcriber.stop();
+
+    expect(channel.events, ['send', 'close']);
+    expect(channel.closed, isTrue);
+  });
 }
 
 class RecordingWebSocketChannel extends StreamChannelMixin implements WebSocketChannel {
@@ -186,7 +247,8 @@ class _RecordingSink implements WebSocketSink {
     if (error != null) {
       throw error;
     }
-    if (event == jsonEncode({'type': 'CloseStream'}) && _parent.completeStreamOnCloseStream) {
+    if ((event == jsonEncode({'type': 'CloseStream'}) || event == 'finalize') &&
+        _parent.completeStreamOnCloseStream) {
       scheduleMicrotask(() {
         final trailing = _parent.trailingAfterCloseStream;
         if (trailing != null) {

--- a/sdks/device/dart/test/stt_test.dart
+++ b/sdks/device/dart/test/stt_test.dart
@@ -90,18 +90,68 @@ void main() {
 
     expect(transcripts, ['hello dart']);
   });
+
+  test('Deepgram stop drains a trailing transcript after CloseStream', () async {
+    final channel = RecordingWebSocketChannel(
+      trailingAfterCloseStream: jsonEncode({
+        'channel': {
+          'alternatives': [
+            {'transcript': 'final dart'},
+          ],
+        },
+      }),
+    );
+    final transcripts = <String>[];
+    final transcriber = DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: transcripts.add,
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(transcripts, ['final dart']);
+    expect(channel.events, ['send', 'close']);
+  });
+
+  test('Deepgram stop still closes if the provider never drains', () async {
+    final channel = RecordingWebSocketChannel(completeStreamOnCloseStream: false);
+    final transcriber = DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: (_) {},
+      channel: channel,
+      drainTimeout: const Duration(milliseconds: 50),
+    );
+
+    await transcriber.stop();
+
+    expect(channel.events, ['send', 'close']);
+    expect(channel.closed, isTrue);
+  });
 }
 
 class RecordingWebSocketChannel extends StreamChannelMixin implements WebSocketChannel {
-  RecordingWebSocketChannel({this.sendError});
+  RecordingWebSocketChannel({
+    this.sendError,
+    this.trailingAfterCloseStream,
+    this.completeStreamOnCloseStream = true,
+  });
 
   final Object? sendError;
+  final Object? trailingAfterCloseStream;
+  final bool completeStreamOnCloseStream;
   final sent = <Object?>[];
   final events = <String>[];
   bool closed = false;
   final _incoming = StreamController<Object?>.broadcast();
 
   void addIncoming(Object? event) => _incoming.add(event);
+
+  void closeIncoming() {
+    if (!_incoming.isClosed) {
+      _incoming.close();
+    }
+  }
 
   @override
   late final WebSocketSink sink = _RecordingSink(this);
@@ -135,6 +185,15 @@ class _RecordingSink implements WebSocketSink {
     final error = _parent.sendError;
     if (error != null) {
       throw error;
+    }
+    if (event == jsonEncode({'type': 'CloseStream'}) && _parent.completeStreamOnCloseStream) {
+      scheduleMicrotask(() {
+        final trailing = _parent.trailingAfterCloseStream;
+        if (trailing != null) {
+          _parent.addIncoming(trailing);
+        }
+        _parent.closeIncoming();
+      });
     }
   }
 

--- a/sdks/device/dart/test/stt_test.dart
+++ b/sdks/device/dart/test/stt_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi_device/omi_device.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   test('deepgramWsUrl omits api key from query string', () {
@@ -34,4 +38,102 @@ void main() {
 
     expect(transcripts, ['final transcript']);
   });
+
+  test('Deepgram stop sends CloseStream before closing the socket', () async {
+    final channel = RecordingWebSocketChannel();
+    final transcriber = DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: (_) {},
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(channel.sent, [jsonEncode({'type': 'CloseStream'})]);
+    expect(channel.closed, isTrue);
+  });
+
+  test('Deepgram still delivers transcripts until stop', () async {
+    final channel = RecordingWebSocketChannel();
+    final transcripts = <String>[];
+    DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: transcripts.add,
+      channel: channel,
+    );
+
+    channel.addIncoming(
+      jsonEncode({
+        'channel': {
+          'alternatives': [
+            {'transcript': 'hello dart'},
+          ],
+        },
+      }),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(transcripts, ['hello dart']);
+  });
+}
+
+class RecordingWebSocketChannel extends StreamChannelMixin implements WebSocketChannel {
+  RecordingWebSocketChannel() {
+    sink = _RecordingSink(this);
+  }
+
+  final sent = <Object?>[];
+  bool closed = false;
+  final _incoming = StreamController<Object?>.broadcast();
+
+  void addIncoming(Object? event) => _incoming.add(event);
+
+  @override
+  late final WebSocketSink sink;
+
+  @override
+  Stream get stream => _incoming.stream;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  String? protocol;
+
+  @override
+  int? closeCode;
+
+  @override
+  String? closeReason;
+}
+
+class _RecordingSink implements WebSocketSink {
+  _RecordingSink(this._parent);
+
+  final RecordingWebSocketChannel _parent;
+  final _done = Completer<void>();
+
+  @override
+  void add(Object? event) => _parent.sent.add(event);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future addStream(Stream stream) async {
+    await for (final event in stream) {
+      add(event);
+    }
+  }
+
+  @override
+  Future close([int? closeCode, String? closeReason]) async {
+    _parent.closed = true;
+    _parent.closeCode = closeCode;
+    _parent.closeReason = closeReason;
+    if (!_done.isCompleted) _done.complete();
+  }
+
+  @override
+  Future get done => _done.future;
 }

--- a/sdks/device/dart/test/stt_test.dart
+++ b/sdks/device/dart/test/stt_test.dart
@@ -49,7 +49,22 @@ void main() {
 
     await transcriber.stop();
 
+    expect(channel.events, ['send', 'close']);
     expect(channel.sent, [jsonEncode({'type': 'CloseStream'})]);
+    expect(channel.closed, isTrue);
+  });
+
+  test('Deepgram stop still closes when CloseStream send fails', () async {
+    final channel = RecordingWebSocketChannel(sendError: StateError('synthetic send failure'));
+    final transcriber = DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: (_) {},
+      channel: channel,
+    );
+
+    await transcriber.stop();
+
+    expect(channel.events, ['send', 'close']);
     expect(channel.closed, isTrue);
   });
 
@@ -78,18 +93,18 @@ void main() {
 }
 
 class RecordingWebSocketChannel extends StreamChannelMixin implements WebSocketChannel {
-  RecordingWebSocketChannel() {
-    sink = _RecordingSink(this);
-  }
+  RecordingWebSocketChannel({this.sendError});
 
+  final Object? sendError;
   final sent = <Object?>[];
+  final events = <String>[];
   bool closed = false;
   final _incoming = StreamController<Object?>.broadcast();
 
   void addIncoming(Object? event) => _incoming.add(event);
 
   @override
-  late final WebSocketSink sink;
+  late final WebSocketSink sink = _RecordingSink(this);
 
   @override
   Stream get stream => _incoming.stream;
@@ -114,7 +129,14 @@ class _RecordingSink implements WebSocketSink {
   final _done = Completer<void>();
 
   @override
-  void add(Object? event) => _parent.sent.add(event);
+  void add(Object? event) {
+    _parent.events.add('send');
+    _parent.sent.add(event);
+    final error = _parent.sendError;
+    if (error != null) {
+      throw error;
+    }
+  }
 
   @override
   void addError(Object error, [StackTrace? stackTrace]) {}
@@ -128,6 +150,7 @@ class _RecordingSink implements WebSocketSink {
 
   @override
   Future close([int? closeCode, String? closeReason]) async {
+    _parent.events.add('close');
     _parent.closed = true;
     _parent.closeCode = closeCode;
     _parent.closeReason = closeReason;

--- a/sdks/device/dart/test/stt_test.dart
+++ b/sdks/device/dart/test/stt_test.dart
@@ -189,6 +189,46 @@ void main() {
     expect(channel.events, ['send', 'close']);
     expect(channel.closed, isTrue);
   });
+
+  test('Parakeet rejects PCM and a second finalize while draining', () async {
+    final channel = RecordingWebSocketChannel(completeStreamOnCloseStream: false);
+    final transcriber = ParakeetTranscriber(
+      apiUrl: 'https://parakeet.example',
+      onTranscript: (_) {},
+      channel: channel,
+      drainTimeout: const Duration(milliseconds: 50),
+    );
+    channel.addIncoming(jsonEncode({'type': 'ready'}));
+    await Future<void>.delayed(Duration.zero);
+
+    transcriber.appendPcm(Uint8List.fromList([1, 2]));
+    final stop = transcriber.stop();
+    await Future<void>.delayed(Duration.zero);
+    transcriber.appendPcm(Uint8List.fromList([3, 4]));
+    await transcriber.stop();
+    await stop;
+
+    expect(channel.sent, [Uint8List.fromList([1, 2]), 'finalize']);
+  });
+
+  test('Deepgram rejects PCM and a second CloseStream while draining', () async {
+    final channel = RecordingWebSocketChannel(completeStreamOnCloseStream: false);
+    final transcriber = DeepgramTranscriber(
+      apiKey: 'fake-key',
+      onTranscript: (_) {},
+      channel: channel,
+      drainTimeout: const Duration(milliseconds: 50),
+    );
+
+    transcriber.appendPcm(Uint8List.fromList([1, 2]));
+    final stop = transcriber.stop();
+    await Future<void>.delayed(Duration.zero);
+    transcriber.appendPcm(Uint8List.fromList([3, 4]));
+    await transcriber.stop();
+    await stop;
+
+    expect(channel.sent, [Uint8List.fromList([1, 2]), jsonEncode({'type': 'CloseStream'})]);
+  });
 }
 
 class RecordingWebSocketChannel extends StreamChannelMixin implements WebSocketChannel {


### PR DESCRIPTION
Fixes #13625.
Fixes #13635.

`DeepgramTranscriber.stop()` closed the WebSocket sink without sending Deepgram's CloseStream frame. `ParakeetTranscriber.stop()` sent `finalize` then immediately cancelled the subscription and closed the sink. Remaining transcription results can be dropped. Send the shutdown frame, keep the listener live for a bounded drain (default 5s), then close. Related: Go #13023, TypeScript #13623 / #13633, Python #13626 / #13631.

## Validation

- Reproduced on `origin/main` `d5cbd548f6` with an injected `WebSocketChannel`.
- After the fix, `flutter test test/stt_test.dart` in `sdks/device/dart` is 13 passed, including trailing transcripts and a 50ms timeout path. No live Deepgram/Parakeet, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.