### PR TITLE
fix(python-sdk): send Deepgram CloseStream when run() is cancelled

### DIFF
--- a/sdks/python/omi/stt/deepgram.py
+++ b/sdks/python/omi/stt/deepgram.py
@@ -52,6 +52,7 @@ class DeepgramTranscriber:
                         asyncio.create_task(send_audio()),
                         asyncio.create_task(receive()),
                     )
+                    caller_stopped = False
                     try:
                         done, _ = await asyncio.wait(
                             tasks, return_when=asyncio.FIRST_COMPLETED
@@ -60,10 +61,18 @@ class DeepgramTranscriber:
                             task.result()
                         # A clean receive EOF must also trigger the retry loop.
                         raise ConnectionError("Deepgram connection closed")
+                    except asyncio.CancelledError:
+                        caller_stopped = True
+                        raise
                     finally:
                         for task in tasks:
                             task.cancel()
                         await asyncio.gather(*tasks, return_exceptions=True)
+                        if caller_stopped:
+                            try:
+                                await ws.send(json.dumps({"type": "CloseStream"}))
+                            except Exception:
+                                pass
             except Exception as exc:
                 print(f"Deepgram error: {exc}")
                 await asyncio.sleep(1)

--- a/sdks/python/tests/test_deepgram_lifecycle.py
+++ b/sdks/python/tests/test_deepgram_lifecycle.py
@@ -22,7 +22,7 @@ class FakeWebSocket:
         self.sent_chunks: list[bytes] = []
         self.closed = False
 
-    async def send(self, chunk: bytes) -> None:
+    async def send(self, chunk: bytes | str) -> None:
         if self.send_error:
             raise self.send_error
         self.sent_chunks.append(chunk)
@@ -223,6 +223,40 @@ def test_deepgram_caller_cancellation():
             with pytest.raises(asyncio.CancelledError):
                 await task
 
+        assert json.dumps({"type": "CloseStream"}) in fake_ws.sent_chunks
+        assert fake_ws.sent_chunks[-1] == json.dumps({"type": "CloseStream"})
         assert fake_ws.closed is True
+
+    asyncio.run(_test())
+
+
+def test_deepgram_reconnect_after_eof_does_not_send_closestream():
+    """Server EOF is a reconnect, not a client Stop — do not send CloseStream."""
+    async def _test():
+        connections = 0
+        reconnected = asyncio.Event()
+        first_ws: FakeWebSocket | None = None
+
+        def make_fake_ws(*args, **kwargs):
+            nonlocal connections, first_ws
+            connections += 1
+            if connections == 1:
+                first_ws = FakeWebSocket()
+                return first_ws
+            reconnected.set()
+            return FakeWebSocket()
+
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+        with patch("websockets.connect", side_effect=make_fake_ws), \
+             patch("asyncio.sleep", return_value=None):
+            transcriber = DeepgramTranscriber("fake-key")
+            task = asyncio.create_task(transcriber.run(queue))
+            await asyncio.wait_for(reconnected.wait(), timeout=1.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert first_ws is not None
+        assert json.dumps({"type": "CloseStream"}) not in first_ws.sent_chunks
 
     asyncio.run(_test())

--- a/sdks/python/tests/test_deepgram_lifecycle.py
+++ b/sdks/python/tests/test_deepgram_lifecycle.py
@@ -19,7 +19,7 @@ class FakeWebSocket:
         self.messages = list(messages or [])
         self.send_error = send_error
         self.receive_error = receive_error
-        self.sent_chunks: list[bytes] = []
+        self.sent_chunks: list[bytes | str] = []
         self.closed = False
 
     async def send(self, chunk: bytes | str) -> None:


### PR DESCRIPTION
Fixes #13626.

Cancelling `DeepgramTranscriber.run()` tore down the WebSocket without sending Deepgram's CloseStream frame. Remaining transcription results can be dropped. Send `{"type":"CloseStream"}` on caller cancellation, then let the connection close. Server EOF still reconnects and does not send CloseStream. Related: Go #13023, React Native #13621, TypeScript #13623, Dart #13625.

## Validation

- Reproduced on `origin/main` `d5cbd548f6` with a patched `websockets.connect` fake: cancelling `run()` closed the socket with no CloseStream frame.
- After the fix, `pytest tests/test_deepgram_lifecycle.py` is 7 passed. Caller cancel records CloseStream before close; reconnect-after-EOF does not. No live Deepgram, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

