### PR TITLE
fix(admin): encode decoded route params before doc/fetch use

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -452,6 +452,11 @@ checks:
     triggers: ["web/frontend/**", "scripts/run-web-frontend-tests.sh", "config/public-build-contract.json", ".github/actions/deploy-public-build/action.yml", ".github/workflows/gcp_frontend.yml", ".github/checks-manifest.yaml", "app/android/app/src/main/AndroidManifest.xml"]
     lanes: ["local", "ci"]
     reason: "web/frontend's node --test suite had no lane, so its guards never ran in CI and a deleted frontend test had to be re-homed into a backend pytest to keep running"
+  - id: web-admin-tests
+    command: ["bash", "scripts/run-web-admin-tests.sh"]
+    triggers: ["web/admin/lib/**", "web/admin/app/api/**", "scripts/run-web-admin-tests.sh", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "web/admin hermetic guards (e.g. Firestore doc-id rejection) had no CI lane; pure node --test files need no npm install"
   - id: web-llm-gateway-only-tests
     command: ["python3", ".github/scripts/test_check_web_llm_gateway_only.py"]
     triggers: [".github/scripts/check_web_llm_gateway_only.py", ".github/scripts/test_check_web_llm_gateway_only.py", ".github/checks-manifest.yaml"]

--- a/scripts/run-web-admin-tests.sh
+++ b/scripts/run-web-admin-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s failglob
+node --test web/admin/lib/__tests__/*.nodetest.mjs

--- a/web/admin/app/api/__tests__/route-param-encoding.test.ts
+++ b/web/admin/app/api/__tests__/route-param-encoding.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_OMI_API_URL = 'https://backend.test';
+  process.env.OMI_API_SECRET_KEY = 'secret';
+  process.env.ENCRYPTION_SECRET = 'enc-secret';
+  return {
+    docIds: [] as string[],
+    fetchUrls: [] as string[],
+    revokeTvLink: vi.fn(),
+    invalidateEnforcementCache: vi.fn(),
+    getUser: vi.fn(),
+  };
+});
+
+function makeFirestoreNode() {
+  const node: Record<string, unknown> = {};
+  node.doc = vi.fn((id: string) => {
+    mocks.docIds.push(id);
+    return node;
+  });
+  node.collection = vi.fn(() => node);
+  node.orderBy = vi.fn(() => node);
+  node.limit = vi.fn(() => node);
+  node.where = vi.fn(() => node);
+  node.get = vi.fn().mockResolvedValue({ exists: false, docs: [], data: () => ({}) });
+  node.set = vi.fn().mockResolvedValue(undefined);
+  node.update = vi.fn().mockResolvedValue(undefined);
+  node.delete = vi.fn().mockResolvedValue(undefined);
+  return node;
+}
+
+vi.mock('@/lib/auth', () => ({
+  verifyAdmin: vi.fn().mockResolvedValue({ uid: 'admin-uid' }),
+}));
+vi.mock('@/lib/firebase/admin', () => ({
+  default: { firestore: { Timestamp: { now: () => ({}) } } },
+  getDb: () => ({ collection: vi.fn(() => makeFirestoreNode()) }),
+  getAdminAuth: () => ({ getUser: mocks.getUser }),
+}));
+vi.mock('@/lib/stripe', () => ({ getStripe: vi.fn() }));
+vi.mock('@/lib/utils/user-subscription', () => ({
+  updateUserSubscriptionDetails: vi.fn(),
+}));
+vi.mock('@/lib/redis', () => ({
+  invalidateEnforcementCache: mocks.invalidateEnforcementCache,
+}));
+vi.mock('@/lib/tv-links', () => ({ revokeTvLink: mocks.revokeTvLink }));
+
+import { GET as fairUseGET } from '../omi/fair-use/user/[uid]/route';
+import { POST as resolveEventPOST } from '../omi/fair-use/user/[uid]/resolve-event/[eventId]/route';
+import {
+  DELETE as promptDELETE,
+  PATCH as promptPATCH,
+} from '../omi/desktop-prompts/[id]/route';
+import { GET as announceGET } from '../omi/announcements/[id]/route';
+import { POST as appUpdatePOST } from '../omi/apps/[app_id]/update/route';
+import { DELETE as tvLinkDELETE } from '../omi/tv-links/[id]/route';
+import { PUT as distributorPUT } from '../distributors/route';
+import { PATCH as orgPATCH } from '../organizations/[id]/route';
+import { GET as userNotifGET } from '../omi/notifications/user-notifications/route';
+
+const fakeRequest = { json: vi.fn(), url: 'https://admin.test/x' } as never;
+
+function paramsOf<T extends Record<string, string>>(value: T) {
+  return { params: Promise.resolve(value) } as never;
+}
+
+describe('admin API routes reject decoded ids that split Firestore paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.docIds.length = 0;
+    mocks.fetchUrls.length = 0;
+    mocks.revokeTvLink.mockResolvedValue(null);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        mocks.fetchUrls.push(String(input));
+        return new Response('{}', { status: 200 });
+      }),
+    );
+  });
+
+  it('fair-use user GET rejects a uid containing a slash', async () => {
+    const res = await fairUseGET(fakeRequest, paramsOf({ uid: 'a/b' }));
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('fair-use user GET accepts uids with non-slash special characters', async () => {
+    // Firebase custom-auth uids may contain ':' or '@'; the stored doc id must
+    // match the raw uid, so these must reach doc() unmodified.
+    const res = await fairUseGET(fakeRequest, paramsOf({ uid: 'google:abc@x' }));
+    expect(res.status).toBe(200);
+    expect(mocks.docIds).toContain('google:abc@x');
+  });
+
+  it('fair-use resolve-event rejects a slash in either param', async () => {
+    const req = { json: vi.fn(), url: 'https://admin.test/x?notes=n' } as never;
+    const res = await resolveEventPOST(req, paramsOf({ uid: 'u/1', eventId: 'e/2' }));
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('desktop-prompts DELETE rejects a slash-bearing prompt id', async () => {
+    const res = await promptDELETE(fakeRequest, paramsOf({ id: 'p/1' }));
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('desktop-prompts PATCH rejects a slash-bearing prompt id', async () => {
+    const req = {
+      json: vi.fn().mockResolvedValue({ active: true }),
+      url: 'https://admin.test/x',
+    } as never;
+    const res = await promptPATCH(req, paramsOf({ id: 'p/1' }));
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('announcements GET encodes id in the upstream URL', async () => {
+    await announceGET(fakeRequest, paramsOf({ id: 'ann/1' }));
+    expect(mocks.fetchUrls[0]).toContain('/v1/announcements/ann%2F1');
+    expect(mocks.fetchUrls[0]).not.toContain('/v1/announcements/ann/1');
+  });
+
+  it('tv-links DELETE rejects a slash-bearing link id', async () => {
+    const res = await tvLinkDELETE(fakeRequest, paramsOf({ id: 'l/1' }));
+    expect(res.status).toBe(400);
+    expect(mocks.revokeTvLink).not.toHaveBeenCalled();
+  });
+
+  it('distributors PUT rejects a body id containing a slash', async () => {
+    const req = { json: vi.fn().mockResolvedValue({ id: 'dist/1', name: 'x' }) } as never;
+    const res = await distributorPUT(req);
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('organizations PATCH rejects an org id containing a slash', async () => {
+    const req = { json: vi.fn().mockResolvedValue({ is_active: true }) } as never;
+    const res = await orgPATCH(req, paramsOf({ id: 'org/1' }));
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('user-notifications GET rejects a uid query param containing a slash', async () => {
+    const req = {
+      nextUrl: { searchParams: new URLSearchParams('uid=aaaaaaaaaa%2Fb') },
+    } as never;
+    const res = await userNotifGET(req);
+    expect(res.status).toBe(400);
+    expect(mocks.docIds).toEqual([]);
+  });
+
+  it('app update POST rejects a body app_id that mismatches the path param', async () => {
+    const form = new FormData();
+    form.append('app_id', 'other-app');
+    form.append('uid', 'user-1');
+    const req = { formData: vi.fn().mockResolvedValue(form) } as never;
+    const res = await appUpdatePOST(req, paramsOf({ app_id: 'my-app' }));
+    expect(res.status).toBe(400);
+    expect(mocks.fetchUrls.length).toBe(0);
+  });
+
+  it('app update POST forwards a normal app_id unchanged in the URL', async () => {
+    const form = new FormData();
+    form.append('app_id', 'my-app');
+    form.append('uid', 'user-1');
+    const req = { formData: vi.fn().mockResolvedValue(form) } as never;
+    const res = await appUpdatePOST(req, paramsOf({ app_id: 'my-app' }));
+    expect(res.status).not.toBe(400);
+    expect(mocks.fetchUrls[0]).toContain('/v1/apps/my-app');
+  });
+
+  it('app update POST encodes a special-char app_id in the upstream URL only', async () => {
+    // Mismatch check compares raw values; the id is encoded only where it is
+    // interpolated into the upstream path.
+    const form = new FormData();
+    form.append('uid', 'user-1');
+    const req = { formData: vi.fn().mockResolvedValue(form) } as never;
+    const res = await appUpdatePOST(req, paramsOf({ app_id: 'a/b' }));
+    expect(res.status).not.toBe(400);
+    expect(mocks.fetchUrls[0]).toContain('/v1/apps/a%2Fb');
+    expect(mocks.fetchUrls[0]).not.toContain('/v1/apps/a/b');
+  });
+});

--- a/web/admin/app/api/distributors/route.ts
+++ b/web/admin/app/api/distributors/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import admin, { getDb } from '@/lib/firebase/admin'
 import { verifyAdmin } from '@/lib/auth'
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs'
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
@@ -93,6 +94,10 @@ export async function PUT(request: NextRequest) {
 
     if (!id) {
       return NextResponse.json({ error: 'Missing required field: id' }, { status: 400 })
+    }
+
+    if (!isSafeDocumentId(id)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
     }
 
     const docRef = db.collection('distributors').doc(id)

--- a/web/admin/app/api/omi/announcements/[id]/route.ts
+++ b/web/admin/app/api/omi/announcements/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ id: s
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    const res = await fetch(`${OMI_API_URL}/v1/announcements/${params.id}`, {
+    const res = await fetch(`${OMI_API_URL}/v1/announcements/${encodeURIComponent(params.id)}`, {
       headers: {
         'secret-key': OMI_SECRET_KEY!,
       },
@@ -42,7 +42,7 @@ export async function PUT(request: NextRequest, props: { params: Promise<{ id: s
   try {
     const body = await request.json();
 
-    const res = await fetch(`${OMI_API_URL}/v1/announcements/${params.id}`, {
+    const res = await fetch(`${OMI_API_URL}/v1/announcements/${encodeURIComponent(params.id)}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -75,7 +75,7 @@ export async function DELETE(request: NextRequest, props: { params: Promise<{ id
     const hardDelete = url.searchParams.get('hard') === 'true';
 
     const res = await fetch(
-      `${OMI_API_URL}/v1/announcements/${params.id}?soft_delete=${!hardDelete}`,
+      `${OMI_API_URL}/v1/announcements/${encodeURIComponent(params.id)}?soft_delete=${!hardDelete}`,
       {
         method: 'DELETE',
         headers: {

--- a/web/admin/app/api/omi/apps/[app_id]/details/route.ts
+++ b/web/admin/app/api/omi/apps/[app_id]/details/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,8 +10,8 @@ export async function GET(request: NextRequest, props: { params: Promise<{ app_i
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
-  const { app_id } = params;
-  if (!app_id) {
+  const app_id = params.app_id;
+  if (!app_id || !isSafeDocumentId(app_id)) {
     return NextResponse.json({ error: 'App ID is required' }, { status: 400 });
   }
 

--- a/web/admin/app/api/omi/apps/[app_id]/update/route.ts
+++ b/web/admin/app/api/omi/apps/[app_id]/update/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest, props: { params: Promise<{ app_id: 
     const incomingForm = await req.formData();
 
     // Validate required fields
-    const appId = (incomingForm.get('app_id') as string) || params.app_id;
+    const appId = ((incomingForm.get('app_id') as string) || params.app_id) ?? '';
     const uid = (incomingForm.get('uid') as string) || '';
     if (!appId) {
       return NextResponse.json({ error: 'app_id is required' }, { status: 400 });
@@ -102,7 +102,7 @@ export async function POST(req: NextRequest, props: { params: Promise<{ app_id: 
     const authHeaderValue = `${OMI_API_SECRET_KEY_BASE}${uid}`;
 
     // FastAPI endpoint path: PATCH /v1/apps/{app_id}
-    const url = `${OMI_API_BASE_URL}/v1/apps/${appId}`;
+    const url = `${OMI_API_BASE_URL}/v1/apps/${encodeURIComponent(appId)}`;
 
     const res = await fetch(url, {
       method: 'PATCH',

--- a/web/admin/app/api/omi/desktop-prompts/[id]/route.ts
+++ b/web/admin/app/api/omi/desktop-prompts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { getDb } from "@/lib/firebase/admin";
+import { isSafeDocumentId } from "@/lib/firestore-doc-id.mjs";
 export const dynamic = "force-dynamic";
 
 // PATCH toggles/edits one remote desktop prompt; DELETE removes it. A
@@ -12,7 +13,10 @@ export async function PATCH(
 ) {
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
-  const { id } = await params;
+  const id = (await params).id;
+  if (!isSafeDocumentId(id)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
   const body = await request.json();
   const updates: Record<string, unknown> = { updated_at: Date.now() / 1000 };
   if (typeof body?.active === "boolean") updates.active = body.active;
@@ -35,7 +39,10 @@ export async function DELETE(
 ) {
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
-  const { id } = await params;
+  const id = (await params).id;
+  if (!isSafeDocumentId(id)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
   await getDb().collection("desktop_prompts").doc(id).delete();
   return NextResponse.json({ id, deleted: true });
 }

--- a/web/admin/app/api/omi/fair-use/user/[uid]/reset/route.ts
+++ b/web/admin/app/api/omi/fair-use/user/[uid]/reset/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getDb } from '@/lib/firebase/admin';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 import { invalidateEnforcementCache } from '@/lib/redis';
 
 export const dynamic = 'force-dynamic';
@@ -9,7 +10,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
-  const { uid } = await params;
+  const uid = (await params).uid;
+  if (!isSafeDocumentId(uid)) {
+    return NextResponse.json({ error: 'Invalid uid' }, { status: 400 });
+  }
   const adminUid = authResult.uid;
 
   try {

--- a/web/admin/app/api/omi/fair-use/user/[uid]/resolve-event/[eventId]/route.ts
+++ b/web/admin/app/api/omi/fair-use/user/[uid]/resolve-event/[eventId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getDb } from '@/lib/firebase/admin';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +13,9 @@ export async function POST(
   if (authResult instanceof NextResponse) return authResult;
 
   const { uid, eventId } = await params;
+  if (!isSafeDocumentId(uid) || !isSafeDocumentId(eventId)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
   const adminUid = authResult.uid;
 
   const { searchParams } = new URL(request.url);

--- a/web/admin/app/api/omi/fair-use/user/[uid]/route.ts
+++ b/web/admin/app/api/omi/fair-use/user/[uid]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getDb } from '@/lib/firebase/admin';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 
 export const dynamic = 'force-dynamic';
 
@@ -8,7 +9,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
-  const { uid } = await params;
+  const uid = (await params).uid;
+  if (!isSafeDocumentId(uid)) {
+    return NextResponse.json({ error: 'Invalid uid' }, { status: 400 });
+  }
 
   try {
     const db = getDb();

--- a/web/admin/app/api/omi/fair-use/user/[uid]/set-stage/route.ts
+++ b/web/admin/app/api/omi/fair-use/user/[uid]/set-stage/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { getDb } from '@/lib/firebase/admin';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 import { invalidateEnforcementCache } from '@/lib/redis';
 
 export const dynamic = 'force-dynamic';
@@ -11,7 +12,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
-  const { uid } = await params;
+  const uid = (await params).uid;
+  if (!isSafeDocumentId(uid)) {
+    return NextResponse.json({ error: 'Invalid uid' }, { status: 400 });
+  }
   const { searchParams } = new URL(request.url);
   const stage = searchParams.get('stage');
 

--- a/web/admin/app/api/omi/notifications/user-notifications/route.ts
+++ b/web/admin/app/api/omi/notifications/user-notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb, getAdminAuth } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 import crypto from 'crypto';
 import zlib from 'zlib';
 
@@ -109,6 +110,10 @@ export async function GET(request: NextRequest) {
     const uid = request.nextUrl.searchParams.get('uid');
     if (!uid || uid.length < 10) {
       return NextResponse.json({ error: 'Valid uid parameter required' }, { status: 400 });
+    }
+
+    if (!isSafeDocumentId(uid)) {
+      return NextResponse.json({ error: 'Invalid uid' }, { status: 400 });
     }
 
     const userRef = db.collection('users').doc(uid);

--- a/web/admin/app/api/omi/tv-links/[id]/route.ts
+++ b/web/admin/app/api/omi/tv-links/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { revokeTvLink } from "@/lib/tv-links";
+import { isSafeDocumentId } from "@/lib/firestore-doc-id.mjs";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +14,7 @@ export async function DELETE(
 
   const params = await props.params;
   const id = params?.id;
-  if (!id) {
+  if (!id || !isSafeDocumentId(id)) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
 

--- a/web/admin/app/api/organizations/[id]/route.ts
+++ b/web/admin/app/api/organizations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/firebase/admin';
 import { verifyAdmin } from '@/lib/auth';
+import { isSafeDocumentId } from '@/lib/firestore-doc-id.mjs';
 import { getStripe } from '@/lib/stripe';
 import { updateUserSubscriptionDetails } from '@/lib/utils/user-subscription';
 export const dynamic = 'force-dynamic';
@@ -41,6 +42,9 @@ export async function PATCH(request: NextRequest, props: { params: Promise<{ id:
     const body = await request.json();
     const { is_active, max_seats, organisation_name, website, employees, stripe_payment_id } = body;
     const organizationId = params.id;
+    if (!isSafeDocumentId(organizationId)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
 
     // Exclude employees from updates - employees should not be editable through this endpoint
     if (employees !== undefined) {

--- a/web/admin/lib/__tests__/firestore-doc-id.nodetest.mjs
+++ b/web/admin/lib/__tests__/firestore-doc-id.nodetest.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSafeDocumentId } from '../firestore-doc-id.mjs';
+
+test('accepts ordinary Firestore ids', () => {
+  assert.equal(isSafeDocumentId('abc123'), true);
+  assert.equal(isSafeDocumentId('user-with-dash_and.dots'), true);
+});
+
+test('accepts ids with characters encodeURIComponent would rewrite', () => {
+  // Firebase uids from custom auth may contain these; the stored doc id must
+  // match the raw value, so they must pass through unchanged.
+  assert.equal(isSafeDocumentId('google:abc123'), true);
+  assert.equal(isSafeDocumentId('user@example.com'), true);
+  assert.equal(isSafeDocumentId('uid+plus@x'), true);
+  assert.equal(isSafeDocumentId('uid?query'), true);
+  assert.equal(isSafeDocumentId('uid%40x'), true);
+  assert.equal(isSafeDocumentId('user name'), true);
+});
+
+test('rejects ids that split a Firestore path', () => {
+  assert.equal(isSafeDocumentId('a/b'), false);
+  assert.equal(isSafeDocumentId('a/b/c/d'), false);
+});
+
+test('rejects empty and Firestore-reserved ids', () => {
+  assert.equal(isSafeDocumentId(''), false);
+  assert.equal(isSafeDocumentId('.'), false);
+  assert.equal(isSafeDocumentId('..'), false);
+  assert.equal(isSafeDocumentId('__name__'), false);
+  assert.equal(isSafeDocumentId('__x__'), false);
+});
+
+test('rejects non-strings', () => {
+  assert.equal(isSafeDocumentId(undefined), false);
+  assert.equal(isSafeDocumentId(null), false);
+  assert.equal(isSafeDocumentId(42), false);
+});

--- a/web/admin/lib/firestore-doc-id.mjs
+++ b/web/admin/lib/firestore-doc-id.mjs
@@ -1,0 +1,23 @@
+/**
+ * Guards identifiers before they are used as Firestore document paths.
+ *
+ * Next.js decodes dynamic route segments, so `params.id` can arrive as
+ * `a/b`. `collection('users').doc('a/b')` then builds an odd-segment path
+ * that throws, or an even-segment path that silently points at a different
+ * document. Encoding is NOT the right fix here: the document id must match
+ * the raw value the backend stored (Firebase uids may legitimately contain
+ * characters like `:` or `@`), so this guard rejects instead of rewriting.
+ *
+ * Mirrors Firestore's own document-id rules: no `/`, no lone `.`/`..`,
+ * no `__*__` reserved ids.
+ */
+export function isSafeDocumentId(id) {
+  return (
+    typeof id === 'string' &&
+    id.length > 0 &&
+    !id.includes('/') &&
+    id !== '.' &&
+    id !== '..' &&
+    !/^__.*__$/.test(id)
+  );
+}


### PR DESCRIPTION
## Summary

Twelve `web/admin` API routes hand caller-controlled identifiers straight to Firestore `doc()` paths or upstream fetch URLs. Next.js decodes dynamic route segments before handlers run, so `GET /api/omi/fair-use/user/a%2Fb` arrives as `params.uid === "a/b"`:

- `doc("a/b")` builds an odd-segment path and throws (500); an even-segment value like `a/b/c/d` silently resolves to a *different* document — including for body-supplied ids (`distributors` PUT) and the `?uid=` query param (`user-notifications`), which never needed `%2F` at all.
- `fetch(`${OMI_API_URL}/v1/announcements/${params.id}`)` corrupts the upstream path.

Two boundary kinds, two fixes:

- **Firestore doc paths / Redis keys** — added `lib/firestore-doc-id.mjs` (`isSafeDocumentId`, plain `.mjs` so `node --test` can run it). Routes now 400 on ids containing `/` (or Firestore's reserved `.`/`..`/`__*__` forms). Rejection, not encoding: the stored doc id and the backend's `fair_use:stage:{uid}` cache key must match the *raw* uid — Firebase custom-auth uids may legitimately contain `:`/`@`, which `encodeURIComponent` would rewrite and silently desync the write. (H/t cubic review.)
- **Upstream URL path segments** (`announcements/[id]` GET/PUT/DELETE, `apps/[app_id]` update POST) — `encodeURIComponent`, matching the existing `lib/services/omi-api/feedback.ts` convention; FastAPI decodes the segment back to the same id.

Also wires a `web-admin-tests` manifest lane (`scripts/run-web-admin-tests.sh`, pure `node --test`, no npm install needed) — the admin vitest suite is not yet CI-run; this lane covers the new guard at minimum.

#### Test plan

- [x] `npx vitest run app/api/__tests__/route-param-encoding.test.ts` — 12 route tests; 9 fail against `origin/main` (raw `a/b` reached `doc()`/fetch), all pass here. Includes the raw-uid passthrough case (`google:abc@x` reaches `doc()` unchanged).
- [x] `node --test web/admin/lib/__tests__/firestore-doc-id.nodetest.mjs` — 5 cases (naming avoids vitest's `*.test.mjs` glob, which cannot run `node:test`).
- [x] `npx vitest run` (full web/admin suite) — 226 pass.
- [x] `npx tsc --noEmit`, `npx eslint` — clean on touched files.
- Note: committed with `OMI_SKIP_WEB_FORMAT=1`; the touched routes predate Prettier formatting, so the semantic diff stays minimal (new files are Prettier-formatted).

Failure-Class: none

Generated with [Devin](https://devin.ai)
