### PR TITLE
fix(personas): encode uid/appId in store-facts integrations URL

### DIFF
--- a/web/personas-open-source/src/app/api/store-facts/route.ts
+++ b/web/personas-open-source/src/app/api/store-facts/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Redis from 'ioredis';
+import { integrationMemoriesUrl } from '@/lib/server/omi-integration-url.mjs';
 
 // ... Redis client config ...
 
@@ -33,7 +34,7 @@ export async function POST(req: Request) {
     // The Omi integration API exposes memories/facts via /user/memories
     // (POST), validated against integration-public-openapi.json. The legacy
     // /user/facts path did not exist on the backend.
-    const url = `https://api.omi.me/v2/integrations/${appId}/user/memories?uid=${uid}`;
+    const url = integrationMemoriesUrl(appId, uid);
     const headers = {
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',

--- a/web/personas-open-source/src/lib/server/omi-integration-url.mjs
+++ b/web/personas-open-source/src/lib/server/omi-integration-url.mjs
@@ -1,0 +1,10 @@
+/**
+ * Builds the Omi integrations endpoint for storing user memories.
+ * Both segments are caller/env-controlled, so each is percent-encoded:
+ * a uid containing `&` or `#` would otherwise corrupt the query string.
+ */
+export function integrationMemoriesUrl(appId, uid) {
+  return `https://api.omi.me/v2/integrations/${encodeURIComponent(
+    appId,
+  )}/user/memories?uid=${encodeURIComponent(uid)}`;
+}

--- a/web/personas-open-source/src/lib/server/omi-integration-url.test.mjs
+++ b/web/personas-open-source/src/lib/server/omi-integration-url.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { integrationMemoriesUrl } from './omi-integration-url.mjs';
+
+test('store-facts URL keeps a normal uid and app id intact', () => {
+  assert.equal(
+    integrationMemoriesUrl('persona-app', 'user-abc123'),
+    'https://api.omi.me/v2/integrations/persona-app/user/memories?uid=user-abc123',
+  );
+});
+
+test('store-facts URL cannot be split by a uid carrying query delimiters', () => {
+  const url = integrationMemoriesUrl('persona-app', 'victim&admin=1');
+  assert.equal(
+    url,
+    'https://api.omi.me/v2/integrations/persona-app/user/memories?uid=victim%26admin%3D1',
+  );
+  const parsed = new URL(url);
+  assert.equal(parsed.searchParams.get('uid'), 'victim&admin=1');
+  assert.equal(parsed.searchParams.get('admin'), null);
+});
+
+test('store-facts URL cannot be cut short by a fragment marker', () => {
+  const parsed = new URL(integrationMemoriesUrl('persona-app', 'user#frag'));
+  assert.equal(parsed.searchParams.get('uid'), 'user#frag');
+  assert.equal(parsed.pathname, '/v2/integrations/persona-app/user/memories');
+});
+
+test('store-facts URL keeps an app id from altering the path', () => {
+  const parsed = new URL(integrationMemoriesUrl('app/extra', 'u1'));
+  assert.equal(parsed.pathname, '/v2/integrations/app%2Fextra/user/memories');
+});


### PR DESCRIPTION
## Summary

`POST /api/store-facts` in `web/personas-open-source` interpolated the request body's `uid` (and env `appId`) straight into the Omi integrations URL:

```ts
const url = `https://api.omi.me/v2/integrations/${appId}/user/memories?uid=${uid}`;
```

`uid` is attacker-controlled JSON input. A value like `victim&admin=1` splits the query — the upstream call lands with `uid=victim` plus an injected `admin=1` param; `user#frag` truncates it. Either way the write targets the wrong user or a malformed request.

Extracted the URL into `src/lib/server/omi-integration-url.mjs` (plain JS so the repo's `node --test` runner can import it, same as the existing `src/lib/server/*.test.mjs` convention) with `encodeURIComponent` on both segments — the same convention `social-profile/route.ts` already uses for `screenname`. Legitimate uids are unaffected (identity on slug-safe characters).

#### Test plan

- [x] `node --test src/lib/server/omi-integration-url.test.mjs` — 4 new tests pass; the raw-interpolation form fails the `&`-injection assertion (a second `admin` param appears).
- [x] `npm test` — all 12 personas tests pass.
- Note: personas' `npm test` lane is not wired into `checks-manifest.yaml` — pre-existing gap, same as web/admin vitest; noted for visibility.

Failure-Class: none

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

