### PR TITLE
fix(python-sdk): send Parakeet finalize when run() is cancelled

### DIFF
--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -59,11 +59,18 @@ def parakeet_ws_url(api_url: str, sample_rate: int = 16000) -> str:
 class ParakeetTranscriber:
     """Hosted Parakeet /v3/stream client (same wire format as backend streaming)."""
 
-    def __init__(self, api_url: Optional[str] = None, *, sample_rate: int = 16000) -> None:
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        *,
+        sample_rate: int = 16000,
+        drain_timeout: float = 5.0,
+    ) -> None:
         self.api_url = api_url or os.getenv("HOSTED_PARAKEET_API_URL") or ""
         if not self.api_url:
             raise ValueError("HOSTED_PARAKEET_API_URL or api_url is required for Parakeet")
         self.sample_rate = sample_rate
+        self.drain_timeout = drain_timeout
 
     async def run(
         self,
@@ -102,11 +109,9 @@ class ParakeetTranscriber:
                         else:
                             print(text)
 
-            tasks = (
-                asyncio.create_task(send_audio()),
-                asyncio.create_task(receive()),
-            )
-            caller_stopped = False
+            send_task = asyncio.create_task(send_audio())
+            recv_task = asyncio.create_task(receive())
+            tasks = (send_task, recv_task)
             try:
                 done, _ = await asyncio.wait(
                     tasks, return_when=asyncio.FIRST_COMPLETED
@@ -114,17 +119,22 @@ class ParakeetTranscriber:
                 for task in done:
                     task.result()
             except asyncio.CancelledError:
-                caller_stopped = True
+                try:
+                    await ws.send("finalize")
+                except Exception:
+                    pass
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(recv_task), timeout=self.drain_timeout
+                    )
+                except Exception:
+                    pass
                 raise
             finally:
                 for task in tasks:
-                    task.cancel()
+                    if not task.done():
+                        task.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
-                if caller_stopped:
-                    try:
-                        await ws.send("finalize")
-                    except Exception:
-                        pass
 
 
 def _extract_text(data: object) -> str:

--- a/sdks/python/omi/stt/parakeet.py
+++ b/sdks/python/omi/stt/parakeet.py
@@ -106,16 +106,25 @@ class ParakeetTranscriber:
                 asyncio.create_task(send_audio()),
                 asyncio.create_task(receive()),
             )
+            caller_stopped = False
             try:
                 done, _ = await asyncio.wait(
                     tasks, return_when=asyncio.FIRST_COMPLETED
                 )
                 for task in done:
                     task.result()
+            except asyncio.CancelledError:
+                caller_stopped = True
+                raise
             finally:
                 for task in tasks:
                     task.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
+                if caller_stopped:
+                    try:
+                        await ws.send("finalize")
+                    except Exception:
+                        pass
 
 
 def _extract_text(data: object) -> str:

--- a/sdks/python/tests/test_parakeet_lifecycle.py
+++ b/sdks/python/tests/test_parakeet_lifecycle.py
@@ -21,13 +21,13 @@ class FakeWebSocket:
         self.messages = list(messages or [])
         self.send_error = send_error
         self.receive_error = receive_error
-        self.sent_chunks: list[bytes] = []
+        self.sent_chunks: list[bytes | str] = []
         self.closed = False
 
     async def recv(self) -> str:
         return self.ready_message
 
-    async def send(self, chunk: bytes) -> None:
+    async def send(self, chunk: bytes | str) -> None:
         if self.send_error:
             raise self.send_error
         self.sent_chunks.append(chunk)
@@ -166,6 +166,23 @@ def test_parakeet_caller_cancellation():
             with pytest.raises(asyncio.CancelledError):
                 await task
 
+        assert fake_ws.closed is True
+        assert fake_ws.sent_chunks[-1] == "finalize"
+
+    asyncio.run(_test())
+
+
+def test_parakeet_server_eof_does_not_send_finalize():
+    """Server close is not client Stop — do not send finalize."""
+    async def _test():
+        fake_ws = FakeWebSocket(messages=[json.dumps({"text": "initial transcript"})])
+        queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        with patch("websockets.connect", return_value=fake_ws):
+            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            await asyncio.wait_for(transcriber.run(queue), timeout=1.0)
+
+        assert "finalize" not in fake_ws.sent_chunks
         assert fake_ws.closed is True
 
     asyncio.run(_test())

--- a/sdks/python/tests/test_parakeet_lifecycle.py
+++ b/sdks/python/tests/test_parakeet_lifecycle.py
@@ -159,7 +159,9 @@ def test_parakeet_caller_cancellation():
         queue: asyncio.Queue[bytes] = asyncio.Queue()
 
         with patch("websockets.connect", return_value=fake_ws):
-            transcriber = ParakeetTranscriber("https://test.parakeet.example")
+            transcriber = ParakeetTranscriber(
+                "https://test.parakeet.example", drain_timeout=0.05
+            )
             task = asyncio.create_task(transcriber.run(queue))
             await asyncio.sleep(0.05)
             task.cancel()


### PR DESCRIPTION
Fixes #13631.

Cancelling `ParakeetTranscriber.run()` tore down the WebSocket without sending Parakeet's `finalize` frame. Remaining transcription results can be dropped. Send `finalize` on caller cancellation, then let the connection close. Server EOF still returns and does not send `finalize`. Related: Python Deepgram #13626; Dart/RN/TS Parakeet `stop()` already send `finalize`.

## Validation

- Reproduced on `origin/main` `d5cbd548f6` with a patched `websockets.connect` fake: cancelling `run()` closed the socket with no `finalize` frame.
- After the fix, `pytest tests/test_parakeet_lifecycle.py` is 7 passed. Caller cancel records `finalize` before close; server EOF does not. No live Parakeet, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

