### PR TITLE
fix(device-ts): drain Parakeet results after finalize on Stop

### DIFF
--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -226,12 +226,55 @@ describe('createParakeetTranscriber', () => {
       drainTimeoutMs: 50,
     });
     transcriber.stop();
+    expect(socketHolder.socket?.readyState).toBe(1);
     socketHolder.socket?.onmessage?.({
       data: JSON.stringify({ text: 'late para' }),
     } as MessageEvent);
     await new Promise((resolve) => setTimeout(resolve, 70));
 
     expect(transcripts).toEqual(['late para']);
+  });
+
+  test('rejects PCM and a second finalize while the socket is draining', () => {
+    const sent: unknown[] = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+      constructor(_url: string) {}
+      send(data: unknown) {
+        sent.push(data);
+      }
+      close() {
+        this.readyState = 3;
+      }
+    }
+
+    const socketHolder: { socket?: FakeWebSocket } = {};
+    class CapturingSocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        socketHolder.socket = this;
+      }
+    }
+
+    const transcriber = createParakeetTranscriber({
+      apiUrl: 'https://parakeet.example',
+      onTranscript: () => {},
+      WebSocketImpl: CapturingSocket as any,
+      drainTimeoutMs: 5000,
+    });
+    socketHolder.socket?.onmessage?.({
+      data: JSON.stringify({ type: 'ready' }),
+    } as MessageEvent);
+    transcriber.appendPcm(new Uint8Array([1, 2]));
+    transcriber.stop();
+    transcriber.appendPcm(new Uint8Array([3, 4]));
+    transcriber.stop();
+
+    expect(sent).toEqual([new Uint8Array([1, 2]), 'finalize']);
+    expect(socketHolder.socket?.readyState).toBe(1);
   });
 
   test('closes the socket when finalize send fails', () => {

--- a/sdks/device/typescript/src/stt/index.test.ts
+++ b/sdks/device/typescript/src/stt/index.test.ts
@@ -163,4 +163,101 @@ describe('createParakeetTranscriber', () => {
 
     expect(openedUrl).toBe('wss://parakeet.example/gateway/v3/stream?region=eu&sample_rate=16000');
   });
+
+  test('sends finalize before closing the socket', async () => {
+    const sent: unknown[] = [];
+    const events: Array<'send' | 'close'> = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+      constructor(_url: string) {}
+      send(data: unknown) {
+        events.push('send');
+        sent.push(data);
+      }
+      close() {
+        events.push('close');
+        this.readyState = 3;
+      }
+    }
+
+    const transcriber = createParakeetTranscriber({
+      apiUrl: 'https://parakeet.example',
+      onTranscript: () => {},
+      WebSocketImpl: FakeWebSocket as any,
+      drainTimeoutMs: 50,
+    });
+    transcriber.stop();
+    expect(events).toEqual(['send']);
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    expect(events).toEqual(['send', 'close']);
+    expect(sent).toEqual(['finalize']);
+  });
+
+  test('drains a trailing transcript after finalize', async () => {
+    const transcripts: string[] = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: Event) => void) | null = null;
+      constructor(_url: string) {}
+      send(_data: unknown) {}
+      close() {
+        this.readyState = 3;
+      }
+    }
+
+    const socketHolder: { socket?: FakeWebSocket } = {};
+    class CapturingSocket extends FakeWebSocket {
+      constructor(url: string) {
+        super(url);
+        socketHolder.socket = this;
+      }
+    }
+
+    const transcriber = createParakeetTranscriber({
+      apiUrl: 'https://parakeet.example',
+      onTranscript: (text) => transcripts.push(text),
+      WebSocketImpl: CapturingSocket as any,
+      drainTimeoutMs: 50,
+    });
+    transcriber.stop();
+    socketHolder.socket?.onmessage?.({
+      data: JSON.stringify({ text: 'late para' }),
+    } as MessageEvent);
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    expect(transcripts).toEqual(['late para']);
+  });
+
+  test('closes the socket when finalize send fails', () => {
+    const events: Array<'send' | 'close'> = [];
+    class FakeWebSocket {
+      binaryType: string = 'blob';
+      readyState = 1;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      constructor(_url: string) {}
+      send(_data: unknown) {
+        events.push('send');
+        throw new Error('synthetic send failure');
+      }
+      close() {
+        events.push('close');
+        this.readyState = 3;
+      }
+    }
+
+    const transcriber = createParakeetTranscriber({
+      apiUrl: 'https://parakeet.example',
+      onTranscript: () => {},
+      WebSocketImpl: FakeWebSocket as any,
+    });
+    transcriber.stop();
+
+    expect(events).toEqual(['send', 'close']);
+  });
 });

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -65,6 +65,8 @@ export function createParakeetTranscriber(opts: {
   sampleRate?: number;
   onTranscript: TranscriptHandler;
   WebSocketImpl?: typeof WebSocket;
+  /** How long Stop waits after finalize before closing. Default 5s. */
+  drainTimeoutMs?: number;
 }): StreamingTranscriber {
   const WS = opts.WebSocketImpl ?? WebSocket;
   const url = parakeetWsUrl(opts.apiUrl, opts.sampleRate ?? 16000);
@@ -90,10 +92,39 @@ export function createParakeetTranscriber(opts: {
       if (ready && ws.readyState === WS.OPEN) ws.send(chunk as any);
     },
     stop() {
+      let sentFinalize = false;
       try {
-        if (ws.readyState === WS.OPEN) ws.send('finalize');
-        ws.close();
-      } catch { /* ignore */ }
+        if (ws.readyState === 1) {
+          ws.send('finalize');
+          sentFinalize = true;
+        }
+      } catch {
+        // finalize is best-effort; still tear down the socket.
+      }
+
+      let finished = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        if (timer !== undefined) clearTimeout(timer);
+        try {
+          ws.close();
+        } catch { /* ignore */ }
+      };
+
+      if (!sentFinalize) {
+        finish();
+        return;
+      }
+
+      const drainTimeoutMs = opts.drainTimeoutMs ?? 5000;
+      timer = setTimeout(finish, drainTimeoutMs);
+      const prevClose = ws.onclose;
+      ws.onclose = (ev) => {
+        finish();
+        if (typeof prevClose === 'function') prevClose.call(ws, ev);
+      };
     },
   };
 }

--- a/sdks/device/typescript/src/stt/index.ts
+++ b/sdks/device/typescript/src/stt/index.ts
@@ -73,6 +73,10 @@ export function createParakeetTranscriber(opts: {
   const ws = new WS(url);
   ws.binaryType = 'arraybuffer';
   let ready = false;
+  let stopped = false;
+  let sentFinalize = false;
+  let finished = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   ws.onmessage = (event: MessageEvent) => {
     if (typeof event.data !== 'string') return;
     try {
@@ -87,12 +91,23 @@ export function createParakeetTranscriber(opts: {
       if (text) opts.onTranscript(text);
     } catch { /* ignore */ }
   };
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    if (timer !== undefined) clearTimeout(timer);
+    try {
+      ws.close();
+    } catch { /* ignore */ }
+  };
   return {
     appendPcm(chunk) {
-      if (ready && ws.readyState === WS.OPEN) ws.send(chunk as any);
+      if (stopped) return;
+      if (ready && ws.readyState === 1) ws.send(chunk as any);
     },
     stop() {
-      let sentFinalize = false;
+      if (stopped) return;
+      stopped = true;
+      ready = false;
       try {
         if (ws.readyState === 1) {
           ws.send('finalize');
@@ -101,17 +116,6 @@ export function createParakeetTranscriber(opts: {
       } catch {
         // finalize is best-effort; still tear down the socket.
       }
-
-      let finished = false;
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      const finish = () => {
-        if (finished) return;
-        finished = true;
-        if (timer !== undefined) clearTimeout(timer);
-        try {
-          ws.close();
-        } catch { /* ignore */ }
-      };
 
       if (!sentFinalize) {
         finish();


### PR DESCRIPTION
Fixes #13633.

`createParakeetTranscriber().stop()` sent `finalize` and closed the WebSocket on the same turn. Remaining transcription results can be dropped. Send `finalize` while the socket is open, keep `onmessage` live for a bounded drain (default 5s, or until the provider closes), then close. `stop()` stays sync `void`. Related: Deepgram #13623, Python Parakeet #13631.

## Validation

- Reproduced on `origin/main` `d5cbd548f6` with an injected `WebSocketImpl`: `stop()` recorded `finalize` and `close()` with no drain window.
- After the fix, Node 22 recorded `finalize` then a 50ms timer close; trailing transcript during drain is delivered; finalize send failure still closes. No live Parakeet, credentials, or audio.

AI-assisted contribution. Bounty eligibility remains a maintainer decision.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

