### PR TITLE
fix(go-sdk): send per-engine finalize frame and drain before close

### DIFF
--- a/sdks/device/go/omidevice/stt/stt.go
+++ b/sdks/device/go/omidevice/stt/stt.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -81,9 +82,25 @@ func ParakeetWSURL(apiURL string, sampleRate int) string {
 	return u.String()
 }
 
+// Engine-specific graceful-stop frames: Deepgram flushes and closes on a
+// CloseStream JSON control message, Parakeet on a plain "finalize" text frame.
+// Sending Parakeet's frame to Deepgram is ignored, so the socket would close
+// with the server's final results never emitted.
+var (
+	deepgramFinalize = []byte(`{"type":"CloseStream"}`)
+	parakeetFinalize = []byte("finalize")
+)
+
+// defaultDrainTimeout bounds how long Stop waits for the server's trailing
+// results after the finalize frame before closing the socket.
+const defaultDrainTimeout = 2 * time.Second
+
 type wsTranscriber struct {
-	conn  *websocket.Conn
-	ready atomic.Bool
+	conn      *websocket.Conn
+	ready     atomic.Bool
+	finalize  []byte
+	done      chan struct{} // closed when the read loop returns
+	drainWait time.Duration
 }
 
 func (t *wsTranscriber) AppendPCM(pcm []byte) error {
@@ -100,7 +117,20 @@ func (t *wsTranscriber) Stop() error {
 	if t.conn == nil {
 		return nil
 	}
-	_ = t.conn.WriteMessage(websocket.TextMessage, []byte("finalize"))
+	if t.finalize != nil {
+		_ = t.conn.WriteMessage(websocket.TextMessage, t.finalize)
+	}
+	// Closing right after finalize drops the trailing results the server
+	// emits in response; wait for the read loop to see the server close, or
+	// for the bounded drain deadline, before tearing the socket down.
+	wait := t.drainWait
+	if wait <= 0 {
+		wait = defaultDrainTimeout
+	}
+	select {
+	case <-t.done:
+	case <-time.After(wait):
+	}
 	return t.conn.Close()
 }
 
@@ -121,9 +151,12 @@ func NewDeepgram(apiKey string, sampleRate int, onTranscript Handler) (Streaming
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn}
+	t := &wsTranscriber{conn: conn, finalize: deepgramFinalize, done: make(chan struct{})}
 	t.ready.Store(true)
-	go readDeepgram(conn, onTranscript)
+	go func() {
+		defer close(t.done)
+		readDeepgram(conn, onTranscript)
+	}()
 	return t, nil
 }
 
@@ -165,9 +198,10 @@ func NewParakeet(apiURL string, sampleRate int, onTranscript Handler) (Streaming
 	if err != nil {
 		return nil, err
 	}
-	t := &wsTranscriber{conn: conn}
+	t := &wsTranscriber{conn: conn, finalize: parakeetFinalize, done: make(chan struct{})}
 	// wait ready in background and stream
 	go func() {
+		defer close(t.done)
 		for {
 			_, data, err := conn.ReadMessage()
 			if err != nil {
@@ -220,11 +254,13 @@ func (w *whisperBatch) AppendPCM(pcm []byte) error {
 		return nil
 	}
 	chunk := w.buf
-	w.buf = nil
 	text, err := w.runner(chunk)
 	if err != nil {
+		// Keep the buffered audio so the next call retries the same samples
+		// instead of silently dropping them.
 		return err
 	}
+	w.buf = nil
 	if text != "" && w.onTranscript != nil {
 		w.onTranscript(text)
 	}

--- a/sdks/device/go/omidevice/stt/stt_stop_test.go
+++ b/sdks/device/go/omidevice/stt/stt_stop_test.go
@@ -1,0 +1,155 @@
+package stt
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+// dialTestServer upgrades an in-process HTTP handler to a websocket and
+// returns the client conn plus the server's view of the connection.
+func dialTestServer(t *testing.T, serve func(*websocket.Conn)) (*websocket.Conn, func()) {
+	t.Helper()
+	serverReady := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		close(serverReady)
+		serve(c)
+	}))
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial: %v", err)
+	}
+	<-serverReady
+	return conn, srv.Close
+}
+
+func TestStopSendsCloseStreamForDeepgram(t *testing.T) {
+	gotFrame := make(chan string, 1)
+	conn, closeSrv := dialTestServer(t, func(c *websocket.Conn) {
+		defer c.Close()
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			return
+		}
+		gotFrame <- string(data)
+	})
+	defer closeSrv()
+
+	tr := &wsTranscriber{conn: conn, finalize: deepgramFinalize, done: make(chan struct{})}
+	go func() {
+		defer close(tr.done)
+		readDeepgram(conn, nil)
+	}()
+
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case frame := <-gotFrame:
+		if frame != `{"type":"CloseStream"}` {
+			t.Fatalf("finalize frame = %q, want CloseStream JSON", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received a finalize frame")
+	}
+}
+
+func TestStopDrainsTrailingResultsBeforeClose(t *testing.T) {
+	conn, closeSrv := dialTestServer(t, func(c *websocket.Conn) {
+		defer c.Close()
+		// Read the finalize frame, emit a trailing result, then close —
+		// the real Deepgram behavior after CloseStream.
+		if _, _, err := c.ReadMessage(); err != nil {
+			return
+		}
+		_ = c.WriteMessage(websocket.TextMessage,
+			[]byte(`{"channel":{"alternatives":[{"transcript":"final words"}]}}`))
+	})
+	defer closeSrv()
+
+	tr := &wsTranscriber{conn: conn, finalize: parakeetFinalize, done: make(chan struct{})}
+	var mu sync.Mutex
+	var got []string
+	go func() {
+		defer close(tr.done)
+		readDeepgram(conn, func(text string) {
+			mu.Lock()
+			got = append(got, text)
+			mu.Unlock()
+		})
+	}()
+
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 || got[0] != "final words" {
+		t.Fatalf("drained transcripts = %v, want [final words]", got)
+	}
+}
+
+func TestStopReturnsAfterDrainDeadlineWhenServerStaysOpen(t *testing.T) {
+	release := make(chan struct{})
+	conn, closeSrv := dialTestServer(t, func(c *websocket.Conn) {
+		_, _, _ = c.ReadMessage()
+		<-release // hold the socket open past the drain deadline
+	})
+	defer closeSrv()
+	defer close(release)
+
+	tr := &wsTranscriber{
+		conn:      conn,
+		finalize:  parakeetFinalize,
+		done:      make(chan struct{}), // never closed: no read loop running
+		drainWait: 50 * time.Millisecond,
+	}
+	start := time.Now()
+	if err := tr.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Stop blocked %v past the drain deadline", elapsed)
+	}
+}
+
+func TestWhisperRetainsBufferOnRunnerError(t *testing.T) {
+	fail := errors.New("runner down")
+	calls := 0
+	w := &whisperBatch{
+		batch: 4,
+		runner: func(pcm []byte) (string, error) {
+			calls++
+			if calls == 1 {
+				return "", fail
+			}
+			return "ok", nil
+		},
+	}
+	if err := w.AppendPCM([]byte{1, 2, 3, 4}); !errors.Is(err, fail) {
+		t.Fatalf("first AppendPCM error = %v, want runner failure", err)
+	}
+	if len(w.buf) != 4 {
+		t.Fatalf("buffer after failed run = %d bytes, want the 4 retained", len(w.buf))
+	}
+	// The retained bytes plus new audio are retried together on the next call.
+	if err := w.AppendPCM([]byte{5, 6, 7, 8}); err != nil {
+		t.Fatalf("retry AppendPCM: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("runner calls = %d, want 2 (first batch retried)", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #13636. `wsTranscriber.Stop()` wrote the literal text `finalize` for both engines and closed the socket immediately:

- **Wrong frame for Deepgram** — Deepgram's graceful shutdown is the `{"type":"CloseStream"}` JSON control message; a bare `finalize` frame is ignored, so the server never flushed its final results.
- **No drain** — `conn.Close()` right after the write dropped the trailing transcripts emitted in response to the finalize signal. `Stop` now waits for the read loop to observe the server close (bounded by a 2s drain deadline) before tearing the socket down.
- **Sibling fix, separate commit** — `whisperBatch.AppendPCM` cleared `w.buf` before calling the runner, so a transient runner error permanently dropped buffered audio; the buffer is now retained for retry.

Same class fixed for RN (#13622), TS (#13624), Dart (#13627), and Python (#13628/#13632) SDKs.

#### Test plan

- [x] `go test -race ./...` in `sdks/device/go` — all pass; the existing `sdks/device/go/**` manifest lane discovers the new test file.
- [x] New hermetic tests (in-process `httptest` websocket): Deepgram sends `{"type":"CloseStream"}`; trailing results are delivered before close; `Stop` returns after the drain deadline when the server stays open; Whisper retains its buffer on runner error.

Failure-Class: none

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

---

If this merged fix is eligible under the [Contribution Guide](https://github.com/BasedHardware/omi/blob/main/docs/doc/developer/Contribution.mdx) Paid Bounties claim path (email team@basedhardware.com with bounty link + PayPal), please send PayPal to **aa.631@hotmail.com**. Contact: Da7.world@protonmail.com.
