### PR TITLE
fix(python-cli): keep full resource IDs in pretty list tables

### DIFF
--- a/sdks/python-cli/omi_cli/commands/action_item.py
+++ b/sdks/python-cli/omi_cli/commands/action_item.py
@@ -59,7 +59,7 @@ def list_action_items(
     for it in items or []:
         rows.append(
             {
-                "id": shorten(it.get("id"), 14),
+                "id": it.get("id"),
                 "completed": it.get("completed"),
                 "description": shorten(it.get("description"), 60),
                 "due_at": it.get("due_at"),

--- a/sdks/python-cli/omi_cli/commands/conversation.py
+++ b/sdks/python-cli/omi_cli/commands/conversation.py
@@ -68,7 +68,7 @@ def list_conversations(
         structured = c.get("structured") or {}
         rows.append(
             {
-                "id": shorten(c.get("id"), 14),
+                "id": c.get("id"),
                 "title": shorten(structured.get("title"), 50),
                 "category": structured.get("category"),
                 "started_at": c.get("started_at"),

--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -46,7 +46,7 @@ def list_goals(
     for g in items or []:
         rows.append(
             {
-                "id": shorten(g.get("id"), 14),
+                "id": g.get("id"),
                 "title": shorten(g.get("title"), 40),
                 "goal_type": g.get("goal_type"),
                 "current_value": g.get("current_value"),

--- a/sdks/python-cli/omi_cli/commands/memory.py
+++ b/sdks/python-cli/omi_cli/commands/memory.py
@@ -51,7 +51,7 @@ def list_memories(
     for m in items or []:
         rows.append(
             {
-                "id": shorten(m.get("id"), 14),
+                "id": m.get("id"),
                 "category": m.get("category"),
                 "visibility": m.get("visibility"),
                 "content": shorten(m.get("content"), 60),

--- a/sdks/python-cli/tests/test_list_full_ids.py
+++ b/sdks/python-cli/tests/test_list_full_ids.py
@@ -1,0 +1,80 @@
+"""Pretty list tables must keep IDs that subsequent get commands accept."""
+
+from __future__ import annotations
+
+from omi_cli.main import app
+from omi_cli.output import shorten
+
+FULL_ID = "12345678-1234-4234-8234-123456789abc"
+TRUNCATED_ID = shorten(FULL_ID, 14)
+
+
+def test_shorten_width_matches_the_reported_ellipsis() -> None:
+    assert TRUNCATED_ID == "12345678-1234…"
+    assert TRUNCATED_ID != FULL_ID
+
+
+def test_memory_pretty_list_keeps_full_id_for_get(authed_profile, respx_mock, cli_runner) -> None:
+    item = {
+        "id": FULL_ID,
+        "content": "hello",
+        "category": "core",
+        "visibility": "private",
+        "tags": [],
+    }
+    respx_mock.get("/v1/dev/user/memories").respond(json=[item])
+
+    listed = cli_runner.invoke(app, ["--no-color", "memory", "list"])
+    assert listed.exit_code == 0
+    assert FULL_ID in listed.stdout
+    assert TRUNCATED_ID not in listed.stdout
+
+    missing = cli_runner.invoke(app, ["memory", "get", TRUNCATED_ID])
+    assert missing.exit_code == 5
+
+    found = cli_runner.invoke(app, ["--json", "memory", "get", FULL_ID])
+    assert found.exit_code == 0
+
+
+def test_goal_pretty_list_keeps_full_id_for_get(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/goals").respond(
+        json=[{"id": FULL_ID, "title": "ship cli", "goal_type": "scale", "is_active": True}]
+    )
+    respx_mock.get(f"/v1/dev/user/goals/{FULL_ID}").respond(
+        json={"id": FULL_ID, "title": "ship cli", "goal_type": "scale", "is_active": True}
+    )
+
+    listed = cli_runner.invoke(app, ["--no-color", "goal", "list"])
+    assert listed.exit_code == 0
+    assert FULL_ID in listed.stdout
+    assert TRUNCATED_ID not in listed.stdout
+
+    found = cli_runner.invoke(app, ["--json", "goal", "get", FULL_ID])
+    assert found.exit_code == 0
+
+
+def test_conversation_pretty_list_keeps_full_id(authed_profile, respx_mock, cli_runner) -> None:
+    respx_mock.get("/v1/dev/user/conversations").respond(
+        json=[{"id": FULL_ID, "structured": {"title": "hello", "category": "personal"}}]
+    )
+
+    listed = cli_runner.invoke(app, ["--no-color", "conversation", "list"])
+    assert listed.exit_code == 0
+    assert FULL_ID in listed.stdout
+    assert TRUNCATED_ID not in listed.stdout
+
+
+def test_action_item_pretty_list_keeps_full_id_for_get(authed_profile, respx_mock, cli_runner) -> None:
+    item = {"id": FULL_ID, "description": "ship it", "completed": False}
+    respx_mock.get("/v1/dev/user/action-items").respond(json=[item])
+
+    listed = cli_runner.invoke(app, ["--no-color", "action-item", "list"])
+    assert listed.exit_code == 0
+    assert FULL_ID in listed.stdout
+    assert TRUNCATED_ID not in listed.stdout
+
+    missing = cli_runner.invoke(app, ["action-item", "get", TRUNCATED_ID])
+    assert missing.exit_code == 5
+
+    found = cli_runner.invoke(app, ["--json", "action-item", "get", FULL_ID])
+    assert found.exit_code == 0


### PR DESCRIPTION
Fixes #13039

Pretty `memory` / `goal` / `conversation` / `action-item` list tables shortened IDs with `shorten(..., 14)`. Copied values then fail subsequent `get` commands (memory/action-item scan the list client-side; truncated IDs never match). JSON output already kept full IDs.

This keeps IDs intact in pretty rows and still shortens titles/descriptions.

Reproduced on current main: UUID `12345678-1234-4234-8234-123456789abc` listed as `12345678-1234…`; `memory get` with the truncated value exits 5, full ID exits 0.

Tests: `sdks/python-cli/tests/test_list_full_ids.py` (pretty list contains the full UUID, truncated `get` still fails, full `get` succeeds).

Bounty eligibility remains a maintainer decision after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

