### PR TITLE
fix(zapier): send the create-memory request body

### DIFF
--- a/plugins/zapier/omi-zap/creates/create_memory.js
+++ b/plugins/zapier/omi-zap/creates/create_memory.js
@@ -1,9 +1,13 @@
 const body = async (z, bundle) => {
-  {
-    {
-      bundle.inputData.source;
-    }
-  }
+  const input = (bundle && bundle.inputData) || {};
+  return {
+    text: input.text,
+    source: input.source,
+    language: input.language,
+    started_at: input.started_at,
+    finished_at: input.finished_at,
+    geolocation: input.geolocation,
+  };
 };
 
 module.exports = {

--- a/plugins/zapier/omi-zap/creates/create_memory.js
+++ b/plugins/zapier/omi-zap/creates/create_memory.js
@@ -1,13 +1,14 @@
 const body = async (z, bundle) => {
   const input = (bundle && bundle.inputData) || {};
-  return {
+  const payload = {
     text: input.text,
     source: input.source,
     language: input.language,
-    started_at: input.started_at,
-    finished_at: input.finished_at,
-    geolocation: input.geolocation,
   };
+  if (input.started_at != null) payload.started_at = input.started_at;
+  if (input.finished_at != null) payload.finished_at = input.finished_at;
+  if (input.geolocation != null) payload.geolocation = input.geolocation;
+  return payload;
 };
 
 module.exports = {

--- a/plugins/zapier/omi-zap/test/creates/create_memory.test.js
+++ b/plugins/zapier/omi-zap/test/creates/create_memory.test.js
@@ -1,20 +1,48 @@
-const zapier = require('zapier-platform-core');
-
-// Use this to make test calls into your app:
-const App = require('../../index');
-const appTester = zapier.createAppTester(App);
-// read the `.env` file into the environment, if available
-zapier.tools.env.inject();
+const createMemory = require('../../creates/create_memory');
 
 describe('creates.create_memory', () => {
-  it('should run', async () => {
-    const bundle = { inputData: {} };
+  const body = createMemory.operation.perform.body;
 
-    const results = await appTester(
-      App.creates['create_memory'].operation.perform,
-      bundle
+  it('returns the backend create-memory contract instead of undefined', async () => {
+    const payload = await body(
+      {},
+      {
+        inputData: {
+          text: 'remember this',
+          source: 'other_text',
+          language: 'en',
+        },
+      }
     );
-    expect(results).toBeDefined();
-    // TODO: add more assertions
+
+    expect(payload).toEqual({
+      text: 'remember this',
+      source: 'other_text',
+      language: 'en',
+      started_at: undefined,
+      finished_at: undefined,
+      geolocation: undefined,
+    });
+  });
+
+  it('forwards optional timestamps and geolocation', async () => {
+    const geo = { latitude: 37.8, longitude: -122.4, address: 'SF' };
+    const payload = await body(
+      {},
+      {
+        inputData: {
+          text: 'walked downtown',
+          source: 'audio_transcript',
+          language: 'en',
+          started_at: '2026-09-12T10:00:00Z',
+          finished_at: '2026-09-12T10:05:00Z',
+          geolocation: geo,
+        },
+      }
+    );
+
+    expect(payload.started_at).toBe('2026-09-12T10:00:00Z');
+    expect(payload.finished_at).toBe('2026-09-12T10:05:00Z');
+    expect(payload.geolocation).toEqual(geo);
   });
 });

--- a/plugins/zapier/omi-zap/test/creates/create_memory.test.js
+++ b/plugins/zapier/omi-zap/test/creates/create_memory.test.js
@@ -19,10 +19,10 @@ describe('creates.create_memory', () => {
       text: 'remember this',
       source: 'other_text',
       language: 'en',
-      started_at: undefined,
-      finished_at: undefined,
-      geolocation: undefined,
     });
+    expect(payload).not.toHaveProperty('started_at');
+    expect(payload).not.toHaveProperty('finished_at');
+    expect(payload).not.toHaveProperty('geolocation');
   });
 
   it('forwards optional timestamps and geolocation', async () => {


### PR DESCRIPTION
Fixes #13541

`plugins/zapier/omi-zap/creates/create_memory.js` defined `perform.body` as an async function that never returned. Zapier therefore POSTed `/zapier/action/memories` with an empty body, and `ZapierActionCreateConversation` (requires `text` and `source`) 422'd every run.

This returns the backend contract (`text`, `source`, `language`, optional timestamps/geolocation). `removeMissingValuesFrom.body` still strips omitted fields.

Reproduced on current main: the body function resolved to `undefined`.

Tests: `plugins/zapier/omi-zap/test/creates/create_memory.test.js` (jest, no live HTTP).

Bounty eligibility remains a maintainer decision after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

