### PR TITLE
fix(github-app): page through repository labels

### DIFF
--- a/plugins/omi-github-app/github_client.py
+++ b/plugins/omi-github-app/github_client.py
@@ -123,28 +123,46 @@ class GitHubClient:
             print(f"❌ Error listing repos: {e}")
             return []
     
+    def _fetch_all_repo_labels(self, access_token: str, repo_full_name: str) -> List[Dict]:
+        """Return every label JSON object, following GitHub `next` pages.
+
+        A non-200 on any page discards partial results, matching
+        :meth:`list_user_repos`.
+        """
+        labels: List[Dict] = []
+        page = 1
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
+
+        while True:
+            response = requests.get(
+                f"{self.api_base}/repos/{repo_full_name}/labels",
+                headers=headers,
+                params={"per_page": 100, "page": page},
+            )
+
+            if response.status_code != 200:
+                print(f"⚠️  Could not fetch labels: {response.status_code}")
+                return []
+
+            labels.extend(response.json())
+
+            if "next" not in response.links:
+                break
+
+            page += 1
+
+        return labels
+
     def get_repo_labels(self, access_token: str, repo_full_name: str) -> List[str]:
         """
         Fetch all labels from a repository.
         Returns list of label names.
         """
         try:
-            response = requests.get(
-                f"{self.api_base}/repos/{repo_full_name}/labels",
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "Accept": "application/vnd.github.v3+json"
-                },
-                params={"per_page": 100}
-            )
-            
-            if response.status_code == 200:
-                labels = response.json()
-                return [label["name"] for label in labels]
-            else:
-                print(f"⚠️  Could not fetch labels: {response.status_code}")
-                return []
-                
+            return [label["name"] for label in self._fetch_all_repo_labels(access_token, repo_full_name)]
         except Exception as e:
             print(f"⚠️  Error fetching labels: {e}")
             return []
@@ -352,29 +370,14 @@ class GitHubClient:
         Returns list of label dicts with name, color, description.
         """
         try:
-            response = requests.get(
-                f"{self.api_base}/repos/{repo_full_name}/labels",
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "Accept": "application/vnd.github.v3+json"
-                },
-                params={"per_page": 100}
-            )
-
-            if response.status_code == 200:
-                labels = response.json()
-                return [
-                    {
-                        "name": label["name"],
-                        "color": label["color"],
-                        "description": label.get("description", "")
-                    }
-                    for label in labels
-                ]
-            else:
-                print(f"⚠️  Could not fetch labels: {response.status_code}")
-                return []
-
+            return [
+                {
+                    "name": label["name"],
+                    "color": label["color"],
+                    "description": label.get("description", ""),
+                }
+                for label in self._fetch_all_repo_labels(access_token, repo_full_name)
+            ]
         except Exception as e:
             print(f"⚠️  Error fetching labels: {e}")
             return []

--- a/plugins/omi-github-app/test_github_client.py
+++ b/plugins/omi-github-app/test_github_client.py
@@ -79,6 +79,71 @@ class GitHubClientTests(unittest.TestCase):
         ), patch.object(github_client, "print"):
             self.assertEqual(client.list_user_repos("token"), [])
 
+    def test_get_repo_labels_follows_next_page(self):
+        client = github_client.GitHubClient()
+        page1 = [{"name": "bug"}, {"name": "enhancement"}]
+        page2 = [{"name": "paid-bounty"}]
+
+        with patch.object(
+            github_client.requests,
+            "get",
+            side_effect=[
+                FakeResponse(page1, links={"next": {"url": "page-2"}}),
+                FakeResponse(page2),
+            ],
+        ) as get:
+            names = client.get_repo_labels("token", "owner/app")
+
+        self.assertEqual(names, ["bug", "enhancement", "paid-bounty"])
+        self.assertEqual(get.call_count, 2)
+        self.assertEqual(
+            get.call_args_list[0].kwargs["params"], {"per_page": 100, "page": 1}
+        )
+        self.assertEqual(
+            get.call_args_list[1].kwargs["params"], {"per_page": 100, "page": 2}
+        )
+        self.assertIn("/repos/owner/app/labels", get.call_args_list[0].args[0])
+
+    def test_get_repo_labels_with_details_follows_next_page(self):
+        client = github_client.GitHubClient()
+        page1 = [{"name": "bug", "color": "d73a4a", "description": "a bug"}]
+        page2 = [{"name": "docs", "color": "0075ca"}]
+
+        with patch.object(
+            github_client.requests,
+            "get",
+            side_effect=[
+                FakeResponse(page1, links={"next": {"url": "page-2"}}),
+                FakeResponse(page2),
+            ],
+        ):
+            details = client.get_repo_labels_with_details("token", "owner/app")
+
+        self.assertEqual(
+            details,
+            [
+                {"name": "bug", "color": "d73a4a", "description": "a bug"},
+                {"name": "docs", "color": "0075ca", "description": ""},
+            ],
+        )
+
+    def test_get_repo_labels_discards_partial_results_on_later_page_error(self):
+        client = github_client.GitHubClient()
+        pages = [
+            FakeResponse([{"name": "bug"}], links={"next": {"url": "page-2"}}),
+            FakeResponse([], status_code=500),
+        ]
+
+        with patch.object(github_client.requests, "get", side_effect=pages), patch.object(
+            github_client, "print"
+        ):
+            self.assertEqual(client.get_repo_labels("token", "owner/app"), [])
+
+        with patch.object(github_client.requests, "get", side_effect=pages), patch.object(
+            github_client, "print"
+        ):
+            self.assertEqual(client.get_repo_labels_with_details("token", "owner/app"), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #13545

`get_repo_labels` and `get_repo_labels_with_details` requested `per_page=100` and ignored GitHub `next` links. Repos with more than 100 labels were truncated for auto-labeling and `list_labels`.

This follows the same page loop as `list_user_repos` (discard partial results on a later-page error).

Reproduced on current main: a single GET with `per_page=100` and no `page` follow-up.

Tests: `plugins/omi-github-app/test_github_client.py` using the existing `FakeResponse` harness.

Bounty eligibility remains a maintainer decision after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

