### PR TITLE
fix(python-cli): edit goal outcome, motivation, and success criteria

### DIFF
--- a/sdks/python-cli/omi_cli/commands/goal.py
+++ b/sdks/python-cli/omi_cli/commands/goal.py
@@ -132,10 +132,33 @@ def update_goal(
     max_value: Optional[float] = typer.Option(None, "--max"),
     unit: Optional[str] = typer.Option(None, "--unit"),
     clear_unit: bool = typer.Option(False, "--clear-unit", help="Remove the existing unit label."),
+    desired_outcome: Optional[str] = typer.Option(
+        None, "--desired-outcome", help="Concrete outcome the user wants."
+    ),
+    why_it_matters: Optional[str] = typer.Option(None, "--why-it-matters", help="Motivation / why it matters."),
+    clear_why_it_matters: bool = typer.Option(
+        False, "--clear-why-it-matters", help="Clear why_it_matters (JSON null)."
+    ),
+    success_criterion: Optional[list[str]] = typer.Option(
+        None, "--success-criterion", help="Replace success_criteria (repeat for multiple)."
+    ),
+    clear_success_criteria: bool = typer.Option(
+        False, "--clear-success-criteria", help="Clear success_criteria (empty list)."
+    ),
 ) -> None:
     ctx = _ctx(typer_ctx)
     if clear_unit and unit is not None:
         raise UsageError(message="Conflicting options", detail="--unit and --clear-unit are mutually exclusive.")
+    if clear_why_it_matters and why_it_matters is not None:
+        raise UsageError(
+            message="Conflicting options",
+            detail="--why-it-matters and --clear-why-it-matters are mutually exclusive.",
+        )
+    if clear_success_criteria and success_criterion is not None:
+        raise UsageError(
+            message="Conflicting options",
+            detail="--success-criterion and --clear-success-criteria are mutually exclusive.",
+        )
     body: dict[str, object] = {}
     if title is not None:
         body["title"] = title
@@ -151,10 +174,24 @@ def update_goal(
         body["unit"] = None
     elif unit is not None:
         body["unit"] = unit
+    if desired_outcome is not None:
+        body["desired_outcome"] = desired_outcome
+    if clear_why_it_matters:
+        body["why_it_matters"] = None
+    elif why_it_matters is not None:
+        body["why_it_matters"] = why_it_matters
+    if clear_success_criteria:
+        body["success_criteria"] = []
+    elif success_criterion is not None:
+        body["success_criteria"] = list(success_criterion)
     if not body:
         raise UsageError(
             message="No fields to update",
-            detail="Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit.",
+            detail=(
+                "Provide one of --title/--target/--current/--min/--max/--unit/--clear-unit/"
+                "--desired-outcome/--why-it-matters/--clear-why-it-matters/"
+                "--success-criterion/--clear-success-criteria."
+            ),
         )
     with ctx.make_client() as client:
         result = client.patch(f"/v1/dev/user/goals/{goal_id}", json_body=body)

--- a/sdks/python-cli/tests/test_goal.py
+++ b/sdks/python-cli/tests/test_goal.py
@@ -207,3 +207,92 @@ def test_goal_update_rejects_set_and_clear_unit(authed_profile, respx_mock, monk
     assert "--unit" in error["detail"]
     assert "--clear-unit" in error["detail"]
     assert not respx_mock.calls
+
+
+def test_goal_update_sends_context_fields(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(
+        json={"id": "g1", "desired_outcome": "ship the cli", "why_it_matters": "users copy IDs"}
+    )
+    result = cli_runner.invoke(
+        app,
+        [
+            "--json",
+            "goal",
+            "update",
+            "g1",
+            "--desired-outcome",
+            "ship the cli",
+            "--why-it-matters",
+            "users copy IDs",
+            "--success-criterion",
+            "pretty list keeps full ids",
+            "--success-criterion",
+            "get accepts copied ids",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content) == {
+        "desired_outcome": "ship the cli",
+        "why_it_matters": "users copy IDs",
+        "success_criteria": ["pretty list keeps full ids", "get accepts copied ids"],
+    }
+
+
+def test_goal_update_clears_optional_context_fields(authed_profile, respx_mock, cli_runner) -> None:
+    route = respx_mock.patch("/v1/dev/user/goals/g1").respond(json={"id": "g1"})
+    result = cli_runner.invoke(
+        app,
+        ["--json", "goal", "update", "g1", "--clear-why-it-matters", "--clear-success-criteria"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content) == {
+        "why_it_matters": None,
+        "success_criteria": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("options", "left", "right"),
+    [
+        (["--why-it-matters", "x", "--clear-why-it-matters"], "--why-it-matters", "--clear-why-it-matters"),
+        (
+            ["--success-criterion", "x", "--clear-success-criteria"],
+            "--success-criterion",
+            "--clear-success-criteria",
+        ),
+    ],
+)
+def test_goal_update_rejects_set_and_clear_context(
+    authed_profile, respx_mock, monkeypatch, capsys, options, left, right
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["omi", "--json", "goal", "update", "g1", *options])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert left in error["detail"]
+    assert right in error["detail"]
+    assert not respx_mock.calls
+
+
+def test_goal_update_preserves_api_validation_error(
+    authed_profile, respx_mock, monkeypatch, capsys
+) -> None:
+    respx_mock.patch("/v1/dev/user/goals/g1").respond(
+        status_code=422, json={"detail": "required goal text cannot be null or blank"}
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["omi", "--json", "goal", "update", "g1", "--desired-outcome", "   "]
+    )
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    error = json.loads(output.err)
+    assert error["error"] == "HTTP 422"
+    assert "required goal text cannot be null or blank" in error["detail"]
+    assert respx_mock.calls
+


### PR DESCRIPTION
Fixes #13103

`UpdateGoalRequest` already accepts `desired_outcome`, `why_it_matters`, and `success_criteria`, but `omi goal update` could not send them.

This adds `--desired-outcome`, `--why-it-matters`, repeated `--success-criterion`, `--clear-why-it-matters` (JSON null), and `--clear-success-criteria` (empty list). Omitted fields stay unchanged. Conflicting set/clear flags are rejected before HTTP. The backend rejects a null/blank `desired_outcome`, so that field is not given a clear flag; a 422 from the API is still surfaced.

Reproduced on current main: the update command only patched title/metrics/unit.

Tests: `sdks/python-cli/tests/test_goal.py` (set, clear, conflict-before-HTTP, 422 detail preserved).

Bounty eligibility remains a maintainer decision after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

