### PR TITLE
fix(plugins): stop double-encoding arXiv search queries

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -14,6 +14,11 @@ checks:
     triggers: ["plugins/omi-usgs-earthquake-app/**"]
     lanes: ["local", "ci"]
     reason: "#13250: execute both production search handlers so valid negative magnitude filters cannot silently become zero"
+  - id: arxiv-search-query-encoding-tests
+    command: ["python3", "plugins/omi-arxiv-app/test_main.py"]
+    triggers: ["plugins/omi-arxiv-app/**"]
+    lanes: ["local", "ci"]
+    reason: "#13574: search_query was pre-encoded with quote_plus before httpx form-encoded it a second time, turning the AND/space separator '+' into a literal '%2B' and emptying multi-word and multi-field arXiv searches"
   - id: linear-graphql-errors-tests
     command: ["python3", "plugins/omi-linear-app/test_graphql_errors.py"]
     triggers: ["plugins/omi-linear-app/**"]

--- a/.github/failure-classes/FC-preencoded-value-reencoded-by-http-client.json
+++ b/.github/failure-classes/FC-preencoded-value-reencoded-by-http-client.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-preencoded-value-reencoded-by-http-client",
+  "violated_contract": "A value handed to an HTTP client's params/data argument must be raw and unencoded, because the client's own transport layer form-encodes it before it goes on the wire. plugins/omi-arxiv-app/main.py built search_query by calling urllib.parse.quote_plus on each field and joining fields with a literal \"+AND+\", then passed that already-encoded string to httpx.AsyncClient.get(..., params=...). httpx encoded it a second time, turning the \"+\" characters that meant \"space\" or \"AND\" into a literal \"%2B\", which arXiv does not treat as a separator. Single-token queries had no \"+\" to corrupt, so the bug shipped unnoticed until a multi-word query, an author name with a space, or a multi-field AND search silently returned zero results.",
+  "canonical_prevention": "Never call quote/quote_plus/urlencode on a value that is also going into a client library's params/data/json argument — pick exactly one layer to own encoding, and it should be the transport layer, not the call site. When a test is needed to prove single encoding, assert on the actual wire form (e.g. via urlencode or by capturing the client's constructed request/URL) rather than on the pre-encoded string alone, since the pre-encoded string looks correct in isolation and only the double-encoded wire form reveals the defect.",
+  "canonical_prevention_artifact": [
+    "plugins/omi-arxiv-app/test_main.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "plugins/omi-arxiv-app/main.py"
+  ],
+  "status": "open"
+}

--- a/plugins/omi-arxiv-app/main.py
+++ b/plugins/omi-arxiv-app/main.py
@@ -12,14 +12,12 @@ import asyncio
 import re
 import time
 from typing import Any, Optional
-from urllib.parse import quote_plus
 import xml.etree.ElementTree as ET
 
 import httpx
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
-
 
 ARXIV_API_URL = "https://export.arxiv.org/api/query"
 REQUEST_TIMEOUT_SECONDS = 12
@@ -220,20 +218,19 @@ def _build_search_query(payload: dict[str, Any]) -> Optional[str]:
     category = _safe_category(payload.get("category"))
     parts = []
     if query:
-        parts.append(f"all:{quote_plus(query)}")
+        parts.append(f"all:{query}")
     if title:
-        parts.append(f"ti:{quote_plus(title)}")
+        parts.append(f"ti:{title}")
     if author:
-        parts.append(f"au:{quote_plus(author)}")
+        parts.append(f"au:{author}")
     if category:
         parts.append(f"cat:{category}")
-    return "+AND+".join(parts) if parts else None
+    return " AND ".join(parts) if parts else None
 
 
 @app.get("/")
 async def root():
-    return HTMLResponse(
-        """
+    return HTMLResponse("""
         <html>
         <head><title>arXiv x Omi</title></head>
         <body style="font-family: sans-serif; max-width: 640px; margin: 48px auto; line-height: 1.5;">
@@ -242,8 +239,7 @@ async def root():
             <p>No sign-in or API key is required.</p>
         </body>
         </html>
-        """
-    )
+        """)
 
 
 @app.get("/health")
@@ -404,7 +400,7 @@ async def search_author(payload: dict[str, Any]):
         entries = _parse_entries(
             await _request_arxiv(
                 {
-                    "search_query": f"au:{quote_plus(author)}",
+                    "search_query": f"au:{author}",
                     "start": 0,
                     "max_results": limit,
                     "sortBy": "submittedDate",

--- a/plugins/omi-arxiv-app/test_main.py
+++ b/plugins/omi-arxiv-app/test_main.py
@@ -1,0 +1,122 @@
+import asyncio
+import sys
+import types
+import unittest
+from urllib.parse import urlencode
+
+
+class DummyFastAPI:
+    def __init__(self, **_kwargs):
+        self.routes = []
+
+    def get(self, path, **_kwargs):
+        return self._route("GET", path)
+
+    def post(self, path, **_kwargs):
+        return self._route("POST", path)
+
+    def _route(self, method, path):
+        def decorator(func):
+            self.routes.append((method, path, func))
+            return func
+
+        return decorator
+
+
+class DummyBaseModel:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def install_dependency_stubs():
+    fastapi = types.ModuleType("fastapi")
+    fastapi.FastAPI = DummyFastAPI
+    sys.modules.setdefault("fastapi", fastapi)
+
+    fastapi_responses = types.ModuleType("fastapi.responses")
+    fastapi_responses.HTMLResponse = lambda *args, **kwargs: None
+    sys.modules.setdefault("fastapi.responses", fastapi_responses)
+    fastapi.responses = fastapi_responses
+
+    pydantic = types.ModuleType("pydantic")
+    pydantic.BaseModel = DummyBaseModel
+    sys.modules.setdefault("pydantic", pydantic)
+
+    httpx = types.ModuleType("httpx")
+    httpx.HTTPError = Exception
+    httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+    httpx.AsyncClient = object
+    sys.modules.setdefault("httpx", httpx)
+
+
+install_dependency_stubs()
+import main
+
+ATOM_NO_ENTRIES = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>"""
+
+
+class ArxivSearchQueryTest(unittest.TestCase):
+    def test_build_search_query_leaves_a_single_space_unencoded(self):
+        # Regression for #13574: main.py must hand httpx a raw, unencoded
+        # query string. httpx's own params encoding turns each space into
+        # a literal "+" exactly once. Pre-encoding here (the old
+        # quote_plus behavior) made httpx encode that "+" a second time
+        # into "%2B", which arXiv does not treat as AND/space.
+        query = main._build_search_query({"query": "machine learning"})
+        self.assertEqual(query, "all:machine learning")
+
+        wire_form = urlencode({"search_query": query})
+        self.assertEqual(wire_form, "search_query=all%3Amachine+learning")
+        self.assertNotIn("%2B", wire_form)
+
+    def test_build_search_query_joins_multiple_fields_with_and(self):
+        query = main._build_search_query({"title": "transformer", "author": "smith"})
+        self.assertEqual(query, "ti:transformer AND au:smith")
+
+        wire_form = urlencode({"search_query": query})
+        self.assertEqual(wire_form, "search_query=ti%3Atransformer+AND+au%3Asmith")
+        self.assertNotIn("%2B", wire_form)
+
+    def test_build_search_query_single_token_is_unaffected(self):
+        query = main._build_search_query({"query": "transformer"})
+        self.assertEqual(query, "all:transformer")
+
+    def test_search_papers_sends_unencoded_query_to_request_layer(self):
+        captured_params = {}
+
+        async def fake_request_arxiv(params):
+            captured_params.update(params)
+            return ATOM_NO_ENTRIES
+
+        original = main._request_arxiv
+        main._request_arxiv = fake_request_arxiv
+        try:
+            result = asyncio.run(main.search_papers({"query": "machine learning"}))
+        finally:
+            main._request_arxiv = original
+
+        self.assertIsNone(result.error)
+        self.assertEqual(captured_params["search_query"], "all:machine learning")
+
+    def test_search_author_sends_unencoded_author_query(self):
+        captured_params = {}
+
+        async def fake_request_arxiv(params):
+            captured_params.update(params)
+            return ATOM_NO_ENTRIES
+
+        original = main._request_arxiv
+        main._request_arxiv = fake_request_arxiv
+        try:
+            result = asyncio.run(main.search_author({"author": "Yoshua Bengio"}))
+        finally:
+            main._request_arxiv = original
+
+        self.assertIsNone(result.error)
+        self.assertEqual(captured_params["search_query"], "au:Yoshua Bengio")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`plugins/omi-arxiv-app/main.py` built `search_query` by calling `urllib.parse.quote_plus` on each field and joining fields with a literal `"+AND+"`, then passed that pre-encoded string to `httpx.AsyncClient.get(..., params=...)`. httpx form-encodes `params` itself, so the `"+"` characters meaning "space" or "AND" got encoded a second time into `"%2B"`. arXiv treats `%2B` as a literal plus, not as AND/space, so it returned an empty Atom feed.

Single-token queries (e.g. `transformer`) had no `+` to corrupt, so they worked — which is why this shipped unnoticed. Any multi-word query, author name with a space, title filter, or combined field search (`query` + `title`, etc.) silently returned zero results.

## Why

Fixes #13574. The issue reproduced the double-encoding against the production query builder:

- `_build_search_query({"query": "machine learning"})` → `all:machine+learning`
- `urlencode({"search_query": ...})` on that pre-encoded string → `search_query=all%3Amachine%2Blearning` (wrong; arXiv's documented format is `all%3Amachine+learning`)

## Fix

Build `search_query` from raw, unencoded text and let httpx apply form encoding exactly once (verified in a sandbox: httpx turns a literal space into `+`, matching arXiv's documented `search_query` format for both the space and the `AND` field separator).

## Testing

Added `plugins/omi-arxiv-app/test_main.py` (follows the existing per-plugin `test_main.py` pattern used by `omi-usgs-earthquake-app`, `omi-hacker-news-app`, etc.) and wired it into `.github/checks-manifest.yaml`. It verifies:

- `_build_search_query` returns raw text with a real space, not `+`
- the resulting wire form (`urlencode`) matches arXiv's documented single-encoded format for both a multi-word query and a multi-field AND query
- `search_papers` and `search_author` hand the request layer the unencoded query (no double-encoding leaks through)

Confirmed the new tests fail against the pre-fix code (4/5 failures, e.g. `'all:machine+learning' != 'all:machine learning'`) and all 5 pass after the fix. Ran `python3 plugins/omi-arxiv-app/test_main.py` and `make preflight` locally — both green.

Failure-Class: new

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

