### PR TITLE
fix(macos): append setup uid via URLComponents, not string concat

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
@@ -3087,7 +3087,7 @@ struct AppDetailSheet: View {
               ForEach(Array(integration.authSteps.enumerated()), id: \.offset) { index, step in
                 Button(action: {
                   if let uid = AuthState.shared.userId,
-                    let url = URL(string: "\(step.url)?uid=\(uid)")
+                    let url = AppSetupURL.withUID(step.url, uid: uid)
                   {
                     NSWorkspace.shared.open(url)
                   }
@@ -3312,7 +3312,7 @@ struct AppDetailSheet: View {
     if let homeUrl = integration?.appHomeUrl, !homeUrl.isEmpty, let url = URL(string: homeUrl) {
       NSWorkspace.shared.open(url)
     } else if let authSteps = integration?.authSteps, !authSteps.isEmpty,
-      let url = URL(string: "\(authSteps[0].url)?uid=\(uid)")
+      let url = AppSetupURL.withUID(authSteps[0].url, uid: uid)
     {
       NSWorkspace.shared.open(url)
     }
@@ -3337,8 +3337,7 @@ struct AppDetailSheet: View {
 
     // Open auth step or setup instructions URL in browser
     if let authSteps = integration?.authSteps, !authSteps.isEmpty {
-      let rawUrl = "\(authSteps[0].url)?uid=\(uid)"
-      if let url = URL(string: rawUrl) {
+      if let url = AppSetupURL.withUID(authSteps[0].url, uid: uid) {
         NSWorkspace.shared.open(url)
       }
     } else if let instructionsPath = integration?.setupInstructionsFilePath, !instructionsPath.isEmpty {

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
@@ -414,7 +414,7 @@ extension APIClient {
     // not-completed (consistent with the invalid-URL and network-failure paths
     // below). Returning true here would wrongly mark an unconfigured app as set up.
     guard !url.isEmpty else { return false }
-    guard let fullUrl = URL(string: "\(url)?uid=\(uid)") else { return false }
+    guard let fullUrl = AppSetupURL.withUID(url, uid: uid) else { return false }
     var request = URLRequest(url: fullUrl)
     request.httpMethod = "GET"
     do {

--- a/desktop/macos/Desktop/Sources/Services/APIClient/AppSetupURL.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/AppSetupURL.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// `uid` hand-off for external-integration setup URLs.
+///
+/// `authSteps[].url` and `setupCompletedUrl` come from third-party app
+/// manifests and may already carry their own query (`?state=...`) or a
+/// fragment. Naively concatenating `"?uid=\(uid)"` onto such a URL produces
+/// `https://x/setup?a=b?uid=u`, where `uid` lands inside another parameter's
+/// value and the provider never sees it — so the browser opens an
+/// unattributed setup page and `isAppSetupCompleted` polls a URL that can
+/// never report completion.
+///
+/// The uid item is appended to the raw `percentEncodedQuery` bytes rather
+/// than through `queryItems`: reading `queryItems` decodes and re-encodes the
+/// existing query, which can rewrite percent-encoded characters a provider
+/// signature depends on. Any `uid` the base already carries is dropped so the
+/// handed-off value is unambiguous.
+enum AppSetupURL {
+  static func withUID(_ base: String, uid: String) -> URL? {
+    guard !base.isEmpty, var components = URLComponents(string: base) else { return nil }
+    var uidComponents = URLComponents()
+    uidComponents.queryItems = [URLQueryItem(name: "uid", value: uid)]
+    guard let encodedUID = uidComponents.percentEncodedQuery else { return nil }
+    let preserved =
+      (components.percentEncodedQuery ?? "")
+      .split(separator: "&")
+      .map(String.init)
+      .filter { $0.split(separator: "=", maxSplits: 1).first != "uid" }
+    components.percentEncodedQuery = (preserved + [encodedUID]).joined(separator: "&")
+    return components.url
+  }
+}

--- a/desktop/macos/Desktop/Tests/AppSetupURLTests.swift
+++ b/desktop/macos/Desktop/Tests/AppSetupURLTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for `AppSetupURL.withUID(_:uid:)`.
+///
+/// `authSteps[].url`/`setupCompletedUrl` come from third-party app manifests.
+/// The previous `"\(url)?uid=\(uid)"` concatenation produced
+/// `https://x/setup?a=b?uid=u` for a query-bearing base — `uid` landed inside
+/// another parameter's value, so the setup page opened unattributed and the
+/// completion poll could never report `is_setup_completed`.
+final class AppSetupURLTests: XCTestCase {
+
+  private func uidValue(in url: URL?) -> String? {
+    url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }?
+      .queryItems?
+      .first(where: { $0.name == "uid" })?
+      .value
+  }
+
+  func testPlainURLGetsQuestionMarkSeparator() throws {
+    let url = try XCTUnwrap(AppSetupURL.withUID("https://example.com/setup", uid: "u1"))
+    XCTAssertEqual(url.absoluteString, "https://example.com/setup?uid=u1")
+  }
+
+  /// The shipped bug: a base that already carries a query must get `&uid=`,
+  /// not a second `?` that swallows the parameter.
+  func testQueryBearingURLKeepsUIDAsItsOwnParameter() throws {
+    let url = try XCTUnwrap(
+      AppSetupURL.withUID("https://example.com/setup?source=omi", uid: "u1"))
+    XCTAssertEqual(uidValue(in: url), "u1")
+    XCTAssertEqual(
+      URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?
+        .first(where: { $0.name == "source" })?
+        .value,
+      "omi")
+  }
+
+  func testFragmentStaysAfterTheQuery() throws {
+    let url = try XCTUnwrap(
+      AppSetupURL.withUID("https://example.com/setup#step2", uid: "u1"))
+    XCTAssertEqual(url.absoluteString, "https://example.com/setup?uid=u1#step2")
+  }
+
+  /// A uid containing query metacharacters must survive the round trip.
+  func testSpecialCharacterUIDRoundTrips() throws {
+    let url = try XCTUnwrap(
+      AppSetupURL.withUID("https://example.com/setup?a=b", uid: "u&x=1#f"))
+    XCTAssertEqual(uidValue(in: url), "u&x=1#f")
+  }
+
+  /// A provider URL can carry an already-encoded query (signed state, etc.).
+  /// Appending uid must not decode/re-encode those bytes.
+  func testExistingPercentEncodedQueryIsPreservedVerbatim() throws {
+    let url = try XCTUnwrap(
+      AppSetupURL.withUID("https://example.com/setup?state=a%2Fb%2Bc", uid: "u1"))
+    XCTAssertEqual(url.absoluteString, "https://example.com/setup?state=a%2Fb%2Bc&uid=u1")
+  }
+
+  /// A base that already carries `uid` must hand off exactly one — ours.
+  func testExistingUIDParameterIsReplacedNotDuplicated() throws {
+    let url = try XCTUnwrap(
+      AppSetupURL.withUID("https://example.com/setup?uid=stale&x=1", uid: "u1"))
+    XCTAssertEqual(
+      URLComponents(url: url, resolvingAgainstBaseURL: false)?
+        .queryItems?
+        .filter { $0.name == "uid" }
+        .map(\.value),
+      ["u1"])
+  }
+
+  func testInvalidBaseResolvesNil() {
+    XCTAssertNil(AppSetupURL.withUID("", uid: "u1"))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260912-app-setup-uid-query.json
+++ b/desktop/macos/changelog/unreleased/20260912-app-setup-uid-query.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed external app setup so sign-in links and completion checks keep working when the provider's URL already carries its own query parameters"
+}

--- a/desktop/macos/e2e/flows/apps.yaml
+++ b/desktop/macos/e2e/flows/apps.yaml
@@ -5,6 +5,7 @@ description: Apps/Integrations marketplace flow — browse apps, filter by categ
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/AppSetupURL.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/AppsCatalogKind.swift
   # S5b is the only place either of these is exercised where it can actually fail. `AppsPage`
@@ -74,6 +75,15 @@ steps:
     log.expect:
       contains:
         - "DISMISSABLE_SHEET: Background tapped, dismissing item"
+
+  - id: S5d
+    name: External integration setup hands off uid in the browser URL
+    # Exercises AppSetupURL.withUID through its real caller: openExternalApp /
+    # navigateToSetup both build the provider URL with it before
+    # NSWorkspace.shared.open.
+    do: "Click a connector row whose app uses external integration auth steps (e.g. Gmail) and choose Connect/Set up. A browser window must open to the provider's URL with `uid=` present as its own query parameter — the URL may already carry the provider's own query, so `uid` must be joined with `&`, never appended after a second `?` or dropped inside another parameter's value. Close the browser without completing setup."
+    expect:
+      interactive_count: { min: 3 }
 
   - id: S6
     name: Return to Home


### PR DESCRIPTION
## Summary

External-integration `authSteps[].url` and `setupCompletedUrl` come from
third-party app manifests and may already carry their own query string or
fragment. All four call sites built `"\(url)?uid=\(uid)"`, producing
`https://provider/setup?a=b?uid=u` for a query-bearing base — `uid` lands
inside another parameter's value, so:

- the browser opens an unattributed setup page (provider never sees `uid`), and
- `isAppSetupCompleted` polls a URL that can never report
  `is_setup_completed`, so the setup flow hangs for that app forever.

`AppSetupURL.withUID` builds through `URLComponents`: it picks the `?`/`&`
separator, keeps the fragment after the query, and percent-encodes the uid
value. Empty/malformed bases still resolve nil, matching the previous
`URL(string:)` fallback at every call site.

## Tests

- `AppSetupURLTests` (5 tests): plain base gets `?uid=`; query-bearing base
  keeps `uid` as its own parameter alongside the existing ones; fragment stays
  after the query; a uid containing `&`/`=`/`#` round-trips through the
  produced URL; empty base resolves nil.

## Verification

- `xcrun swift test --filter 'AppSetupURLTests|APIClientSetupCompletedTests'` — 6/6 pass
- `scripts/swiftlint-wrapper.sh lint` — 0 violations
- `python3 scripts/check_desktop_test_quality.py` — baseline holds
- `check-e2e-flow-coverage.py --strict` — all changed files covered

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

