### PR TITLE
fix(arxiv): stop pre-encoding search_query before httpx params

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -923,6 +923,11 @@ checks:
     triggers: ["plugins/omi-notion-app/**"]
     lanes: ["local", "ci"]
     reason: "#13181 failed content HTTP reads were indistinguishable from empty successful pages; production helper and handler regression"
+  - id: arxiv-search-encoding-tests
+    command: ["python3", "plugins/omi-arxiv-app/test_main.py"]
+    triggers: ["plugins/omi-arxiv-app/**"]
+    lanes: ["local", "ci"]
+    reason: "#13574: search_query was pre-encoded then form-encoded again by httpx, so multi-word and AND queries produced %2B and empty feeds"
 
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"

--- a/plugins/omi-arxiv-app/main.py
+++ b/plugins/omi-arxiv-app/main.py
@@ -12,7 +12,6 @@ import asyncio
 import re
 import time
 from typing import Any, Optional
-from urllib.parse import quote_plus
 import xml.etree.ElementTree as ET
 
 import httpx
@@ -220,14 +219,18 @@ def _build_search_query(payload: dict[str, Any]) -> Optional[str]:
     category = _safe_category(payload.get("category"))
     parts = []
     if query:
-        parts.append(f"all:{quote_plus(query)}")
+        parts.append(f"all:{query}")
     if title:
-        parts.append(f"ti:{quote_plus(title)}")
+        parts.append(f"ti:{title}")
     if author:
-        parts.append(f"au:{quote_plus(author)}")
+        parts.append(f"au:{author}")
     if category:
         parts.append(f"cat:{category}")
-    return "+AND+".join(parts) if parts else None
+    # httpx form-encodes params once on the wire; keeping the raw query lets
+    # spaces become `+` and the AND separators arrive as `+AND+`, which is the
+    # encoding the arXiv API documents. Pre-encoding here double-encodes and
+    # arXiv returns an empty feed.
+    return " AND ".join(parts) if parts else None
 
 
 @app.get("/")
@@ -404,7 +407,7 @@ async def search_author(payload: dict[str, Any]):
         entries = _parse_entries(
             await _request_arxiv(
                 {
-                    "search_query": f"au:{quote_plus(author)}",
+                    "search_query": f"au:{author}",
                     "start": 0,
                     "max_results": limit,
                     "sortBy": "submittedDate",

--- a/plugins/omi-arxiv-app/test_main.py
+++ b/plugins/omi-arxiv-app/test_main.py
@@ -1,0 +1,153 @@
+"""Hermetic arXiv search-encoding regressions.
+
+Imports the production module with framework-only stubs, then exercises the
+real `_build_search_query` and the real `search_papers`/`search_author`
+handlers while capturing the params dict handed to the HTTP layer. The wire
+shape is modeled with `urllib.parse.urlencode`, which is what httpx applies to
+`params=` (space -> `+`, `:` -> `%3A`). No network, credentials, or third-party
+runtime packages are required.
+"""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+from urllib.parse import urlencode
+
+
+def load_app():
+    class FastAPI:
+        def __init__(self, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            return lambda handler: handler
+
+        post = get
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class HTTPError(Exception):
+        pass
+
+    class HTTPStatusError(HTTPError):
+        pass
+
+    httpx = ModuleType("httpx")
+    httpx.AsyncClient = object
+    httpx.HTTPError = HTTPError
+    httpx.HTTPStatusError = HTTPStatusError
+    fastapi = ModuleType("fastapi")
+    fastapi.FastAPI = FastAPI
+    responses = ModuleType("fastapi.responses")
+    responses.HTMLResponse = str
+    pydantic = ModuleType("pydantic")
+    pydantic.BaseModel = BaseModel
+
+    spec = importlib.util.spec_from_file_location("arxiv_app", Path(__file__).with_name("main.py"))
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(
+        sys.modules,
+        {
+            "httpx": httpx,
+            "fastapi": fastapi,
+            "fastapi.responses": responses,
+            "pydantic": pydantic,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+app = load_app()
+
+EMPTY_FEED = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">'
+    "</feed>"
+)
+
+
+def captured_params(payload):
+    """Run the real handler, capture the params dict sent to the HTTP layer."""
+    seen = {}
+
+    async def fake_request(params):
+        seen.update(params)
+        return EMPTY_FEED
+
+    async def run():
+        with patch.object(app, "_request_arxiv", side_effect=fake_request):
+            return await app.search_papers(payload)
+
+    response = asyncio.run(run())
+    return seen, response
+
+
+def wire(search_query):
+    """The encoded `search_query` as it leaves the client (httpx's urlencode)."""
+    return urlencode({"search_query": search_query})
+
+
+class BuildSearchQueryTests(unittest.TestCase):
+    def test_multi_word_query_stays_unencoded(self):
+        self.assertEqual(app._build_search_query({"query": "machine learning"}), "all:machine learning")
+
+    def test_field_parts_join_with_bare_and(self):
+        built = app._build_search_query({"query": "transformer", "title": "attention"})
+        self.assertEqual(built, "all:transformer AND ti:attention")
+
+    def test_empty_payload_resolves_none(self):
+        self.assertIsNone(app._build_search_query({}))
+
+
+class WireEncodingTests(unittest.TestCase):
+    """`+` is the documented arXiv encoding for space and AND separators;
+
+    `%2B` decodes to a literal plus sign, which arXiv does not treat as a
+    separator — so the pre-encoded value must never reach `params=`."""
+
+    def test_multi_word_wire_shape_matches_arxiv_manual(self):
+        _, response = captured_params({"query": "machine learning"})
+        self.assertIsNone(response.error)
+        self.assertEqual(wire(captured_params({"query": "machine learning"})[0]["search_query"]),
+                         "search_query=all%3Amachine+learning")
+
+    def test_combined_fields_wire_shape_matches_arxiv_manual(self):
+        seen, _ = captured_params({"query": "transformer", "title": "attention"})
+        self.assertEqual(
+            wire(seen["search_query"]),
+            "search_query=all%3Atransformer+AND+ti%3Aattention",
+        )
+
+    def test_wire_contains_no_literal_plus_escape(self):
+        seen, _ = captured_params({"query": "machine learning", "author": "john smith"})
+        self.assertNotIn("%2B", wire(seen["search_query"]))
+        self.assertEqual(wire(seen["search_query"]),
+                         "search_query=all%3Amachine+learning+AND+au%3Ajohn+smith")
+
+
+class SearchAuthorTests(unittest.TestCase):
+    def test_author_name_reaches_the_wire_unencoded(self):
+        seen = {}
+
+        async def fake_request(params):
+            seen.update(params)
+            return EMPTY_FEED
+
+        async def run():
+            with patch.object(app, "_request_arxiv", side_effect=fake_request):
+                return await app.search_author({"author": "Yann LeCun"})
+
+        asyncio.run(run())
+        self.assertEqual(seen["search_query"], "au:Yann LeCun")
+        self.assertEqual(wire(seen["search_query"]), "search_query=au%3AYann+LeCun")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-arxiv-app/test_main.py
+++ b/plugins/omi-arxiv-app/test_main.py
@@ -73,7 +73,7 @@ EMPTY_FEED = (
 )
 
 
-def captured_params(payload):
+def captured_params(payload, handler=app.search_papers):
     """Run the real handler, capture the params dict sent to the HTTP layer."""
     seen = {}
 
@@ -83,7 +83,7 @@ def captured_params(payload):
 
     async def run():
         with patch.object(app, "_request_arxiv", side_effect=fake_request):
-            return await app.search_papers(payload)
+            return await handler(payload)
 
     response = asyncio.run(run())
     return seen, response
@@ -113,10 +113,9 @@ class WireEncodingTests(unittest.TestCase):
     separator — so the pre-encoded value must never reach `params=`."""
 
     def test_multi_word_wire_shape_matches_arxiv_manual(self):
-        _, response = captured_params({"query": "machine learning"})
+        seen, response = captured_params({"query": "machine learning"})
         self.assertIsNone(response.error)
-        self.assertEqual(wire(captured_params({"query": "machine learning"})[0]["search_query"]),
-                         "search_query=all%3Amachine+learning")
+        self.assertEqual(wire(seen["search_query"]), "search_query=all%3Amachine+learning")
 
     def test_combined_fields_wire_shape_matches_arxiv_manual(self):
         seen, _ = captured_params({"query": "transformer", "title": "attention"})
@@ -134,17 +133,7 @@ class WireEncodingTests(unittest.TestCase):
 
 class SearchAuthorTests(unittest.TestCase):
     def test_author_name_reaches_the_wire_unencoded(self):
-        seen = {}
-
-        async def fake_request(params):
-            seen.update(params)
-            return EMPTY_FEED
-
-        async def run():
-            with patch.object(app, "_request_arxiv", side_effect=fake_request):
-                return await app.search_author({"author": "Yann LeCun"})
-
-        asyncio.run(run())
+        seen, _ = captured_params({"author": "Yann LeCun"}, handler=app.search_author)
         self.assertEqual(seen["search_query"], "au:Yann LeCun")
         self.assertEqual(wire(seen["search_query"]), "search_query=au%3AYann+LeCun")
 


### PR DESCRIPTION
## Summary

Fixes #13574.

`_build_search_query` ran each term through `quote_plus` and joined fields
with `+AND+`, then handed the result to `httpx`'s `params=` — which
form-encodes again. `all:machine+learning` left the client as
`search_query=all%3Amachine%2Blearning`; arXiv decodes `%2B` to a literal
plus, not a separator, so multi-word queries, spaced author names, and
combined field filters all returned an empty Atom feed. Single-token queries
carried no `+` and kept working, which is why the bug survived.

The fix keeps `search_query` raw (`all:machine learning AND ti:attention`)
and lets httpx encode it once — the wire gets
`all%3Amachine+learning+AND+ti%3Aattention`, the shape the arXiv API manual
documents. Same treatment on the `search_author` `au:` path.

## Tests

`plugins/omi-arxiv-app/test_main.py` (7 tests, registered as
`arxiv-search-encoding-tests` in the checks manifest) drives the real
`_build_search_query` and the real `search_papers`/`search_author` handlers,
capturing the params dict handed to the HTTP layer and asserting the wire
shape via stdlib `urlencode` (the same encoding httpx applies to `params=`:
space→`+`, `:`→`%3A`). 6/7 fail on the pre-fix code; the empty-payload guard
passes on both.

## Verification

- `python3 plugins/omi-arxiv-app/test_main.py` — 7/7 pass
- Same suite against `origin/main`'s `main.py` — 6 failures as expected

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

