### PR TITLE
fix(ms365): encode Graph ids and setup uid before URL interpolation

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: ms365-graph-path-encoding-tests
+    command: ["python3", "plugins/omi-ms365-app/test_graph_paths.py"]
+    triggers: ["plugins/omi-ms365-app/**"]
+    lanes: ["local", "ci"]
+    reason: "Graph resource ids (message/chat/item) can contain /, +, =, #, ?; raw interpolation split the path or truncated the URL, and setup uid could break the HTML href attribute"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-ms365-app/main.py
+++ b/plugins/omi-ms365-app/main.py
@@ -19,6 +19,7 @@ import logging
 import secrets
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -56,7 +57,7 @@ async def root() -> str:
 @app.get("/setup/ms365", response_class=HTMLResponse)
 async def setup_page(uid: str = Query(..., description="OMI user id")) -> str:
     """OMI loads this page inside its in-app webview when the user taps 'Setup'."""
-    redirect = f"/auth/microsoft?uid={uid}"
+    redirect = f"/auth/microsoft?uid={quote(uid, safe='')}"
     return f"""
     <html><body style="font-family: system-ui; max-width: 640px; margin: 40px auto;">
       <h2>Connect Microsoft 365</h2>

--- a/plugins/omi-ms365-app/services/graph_client.py
+++ b/plugins/omi-ms365-app/services/graph_client.py
@@ -15,6 +15,20 @@ GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 MAX_RETRIES = 3
 
 
+def path_segment(value: str) -> str:
+    """Percent-encode one URL path segment.
+
+    Graph resource ids are not URL-safe — message ids are base64 of the store
+    entry id and can contain `/`, `+`, `=`; Teams chat ids contain `:` and `@`;
+    drive item names can contain `#`, `?`, `%`. Interpolating them raw splits
+    the path or truncates the URL. httpx preserves existing percent-escapes,
+    so encoding here reaches the wire exactly once.
+    """
+    from urllib.parse import quote
+
+    return quote(str(value), safe="")
+
+
 class GraphError(Exception):
     def __init__(self, status: int, payload: Any) -> None:
         super().__init__(f"Graph {status}: {payload}")

--- a/plugins/omi-ms365-app/services/mail.py
+++ b/plugins/omi-ms365-app/services/mail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from services.graph_client import GraphClient
+from services.graph_client import GraphClient, path_segment
 
 
 def _slim_message(m: dict[str, Any]) -> dict[str, Any]:
@@ -47,7 +47,7 @@ async def search(user_id: str, query: str, limit: int = 10) -> list[dict[str, An
 
 async def read(user_id: str, message_id: str) -> dict[str, Any]:
     async with GraphClient(user_id) as g:
-        m = await g.get(f"/me/messages/{message_id}")
+        m = await g.get(f"/me/messages/{path_segment(message_id)}")
         return {
             **_slim_message(m),
             "body": (m.get("body") or {}).get("content"),

--- a/plugins/omi-ms365-app/services/sharepoint.py
+++ b/plugins/omi-ms365-app/services/sharepoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from services.graph_client import GraphClient
+from services.graph_client import GraphClient, path_segment
 
 
 def _slim_item(it: dict[str, Any]) -> dict[str, Any]:
@@ -29,7 +29,7 @@ async def search_files(user_id: str, query: str, limit: int = 15) -> list[dict[s
     safe_query = query.replace("'", "''")
     async with GraphClient(user_id) as g:
         data = await g.get(
-            f"/me/drive/root/search(q='{safe_query}')",
+            f"/me/drive/root/search(q='{path_segment(safe_query)}')",
             params={"$top": limit},
         )
         return [_slim_item(i) for i in data.get("value", [])]
@@ -46,7 +46,8 @@ async def upload_text_file(
     folder_path: e.g. "Documents/OMI-Notes" (relative to OneDrive root).
     """
     folder_path = folder_path.strip("/")
-    path = f"/me/drive/root:/{folder_path}/{filename}:/content"
+    encoded_folder = "/".join(path_segment(part) for part in folder_path.split("/") if part)
+    path = f"/me/drive/root:/{encoded_folder}/{path_segment(filename)}:/content"
     async with GraphClient(user_id) as g:
         data = await g.put_bytes(path, content.encode("utf-8"), content_type="text/plain")
         return _slim_item(data) if data else {"status": "uploaded", "name": filename}
@@ -54,9 +55,10 @@ async def upload_text_file(
 
 async def read_file_text(user_id: str, item_id: str) -> dict[str, Any]:
     async with GraphClient(user_id) as g:
-        meta = await g.get(f"/me/drive/items/{item_id}")
+        item_path = path_segment(item_id)
+        meta = await g.get(f"/me/drive/items/{item_path}")
         # Reuse the GraphClient session so we inherit throttling + retry.
-        content = await g.get_bytes(f"/me/drive/items/{item_id}/content")
+        content = await g.get_bytes(f"/me/drive/items/{item_path}/content")
         try:
             text = content.decode("utf-8")
         except UnicodeDecodeError:

--- a/plugins/omi-ms365-app/services/teams.py
+++ b/plugins/omi-ms365-app/services/teams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from services.graph_client import GraphClient
+from services.graph_client import GraphClient, path_segment
 
 
 async def list_recent_chats(user_id: str, limit: int = 15) -> list[dict[str, Any]]:
@@ -24,7 +24,7 @@ async def list_recent_chats(user_id: str, limit: int = 15) -> list[dict[str, Any
 async def send_chat_message(user_id: str, chat_id: str, message: str) -> dict[str, Any]:
     payload = {"body": {"contentType": "text", "content": message}}
     async with GraphClient(user_id) as g:
-        data = await g.post(f"/chats/{chat_id}/messages", json=payload)
+        data = await g.post(f"/chats/{path_segment(chat_id)}/messages", json=payload)
         return {"id": data.get("id"), "chat_id": chat_id, "status": "sent"}
 
 

--- a/plugins/omi-ms365-app/test_graph_paths.py
+++ b/plugins/omi-ms365-app/test_graph_paths.py
@@ -1,0 +1,207 @@
+"""Hermetic MS365 Graph path-encoding regressions.
+
+Graph resource ids are not URL-safe: message ids are base64 of the store
+entry id and can contain `/`, `+`, `=`; Teams chat ids contain `:`/`@`; drive
+item names can contain `#`, `?`, `%`. Interpolating them raw splits the path
+or truncates the URL. This suite stubs the framework layer, loads the real
+service modules, and records the path each operation hands to the Graph
+client. No network or credentials required.
+"""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+from urllib.parse import quote
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+
+
+def _stub(name, **attrs):
+    module = ModuleType(name)
+    module.__dict__.update(attrs)
+    return module
+
+
+class _AsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _Serializer:
+    def dumps(self, value):
+        return "signed"
+
+    def loads(self, value):
+        return value
+
+
+class _Settings:
+    log_level = "INFO"
+    session_secret = "test-secret"
+    app_base_url = "http://localhost:8000"
+    redis_url = None
+
+
+STUBS = {
+    "httpx": _stub("httpx", AsyncClient=_AsyncClient, HTTPError=Exception, HTTPStatusError=Exception),
+    "msal": _stub(
+        "msal", ConfidentialClientApplication=object, SerializableTokenCache=object
+    ),
+    "config": _stub("config", GRAPH_SCOPES=[], get_settings=lambda: _Settings()),
+    "services.storage": _stub("services.storage", get_store=lambda: None),
+    "itsdangerous": _stub(
+        "itsdangerous", BadSignature=Exception, URLSafeSerializer=lambda *a, **k: _Serializer()
+    ),
+    "pydantic_settings": _stub("pydantic_settings", BaseSettings=object, SettingsConfigDict=dict),
+}
+
+
+class RecordingClient:
+    """Stands in for GraphClient and records every path it is asked for."""
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def get(self, path, **kwargs):
+        self.last_path = path
+        return {"value": [], "id": "x"}
+
+    async def post(self, path, **kwargs):
+        self.last_path = path
+        return {"id": "m1"}
+
+    async def put_bytes(self, path, data, content_type=None):
+        self.last_path = path
+        return {"id": "f1"}
+
+    async def get_bytes(self, path):
+        self.last_path = path
+        return b"text"
+
+
+class GraphPathTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._patch = patch.dict(sys.modules, STUBS)
+        cls._patch.start()
+        sys.path.insert(0, str(PLUGIN_DIR))
+        import services.graph_client as graph_client
+        import services.mail as mail
+        import services.sharepoint as sharepoint
+        import services.teams as teams
+
+        cls.graph_client = graph_client
+        cls.mail = mail
+        cls.sharepoint = sharepoint
+        cls.teams = teams
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._patch.stop()
+        sys.path.remove(str(PLUGIN_DIR))
+
+    def run_async(self, coro):
+        return asyncio.run(coro)
+
+    def test_path_segment_encodes_reserved_characters(self):
+        self.assertEqual(self.graph_client.path_segment("AAMk/abc=+"), "AAMk%2Fabc%3D%2B")
+
+    def test_message_id_with_slash_stays_one_segment(self):
+        client = RecordingClient("u1")
+        with patch.object(self.mail, "GraphClient", lambda uid: client):
+            self.run_async(self.mail.read("u1", "AAMkAGI2/body+/AAA="))
+        self.assertEqual(client.last_path, "/me/messages/AAMkAGI2%2Fbody%2B%2FAAA%3D")
+
+    def test_chat_id_reserved_characters_are_encoded(self):
+        client = RecordingClient("u1")
+        with patch.object(self.teams, "GraphClient", lambda uid: client):
+            self.run_async(self.teams.send_chat_message("u1", "19:abc@thread.v2", "hi"))
+        self.assertEqual(client.last_path, "/chats/19%3Aabc%40thread.v2/messages")
+
+    def test_search_query_cannot_break_out_of_odata_literal(self):
+        client = RecordingClient("u1")
+        with patch.object(self.sharepoint, "GraphClient", lambda uid: client):
+            self.run_async(self.sharepoint.search_files("u1", "it's ?done& #1"))
+        self.assertEqual(
+            client.last_path,
+            "/me/drive/root/search(q='it%27%27s%20%3Fdone%26%20%231')",
+        )
+
+    def test_upload_filename_cannot_inject_path_segments(self):
+        client = RecordingClient("u1")
+        with patch.object(self.sharepoint, "GraphClient", lambda uid: client):
+            self.run_async(
+                self.sharepoint.upload_text_file("u1", "Documents/OMI Notes", "a#b?.txt", "x")
+            )
+        self.assertEqual(
+            client.last_path,
+            "/me/drive/root:/Documents/OMI%20Notes/a%23b%3F.txt:/content",
+        )
+
+    def test_item_id_is_encoded_for_reads(self):
+        client = RecordingClient("u1")
+        with patch.object(self.sharepoint, "GraphClient", lambda uid: client):
+            self.run_async(self.sharepoint.read_file_text("u1", "01ABC/def#2"))
+        self.assertEqual(client.last_path, "/me/drive/items/01ABC%2Fdef%232/content")
+
+
+class SetupPageTests(unittest.TestCase):
+    """`setup_page` reflects `uid` into an HTML href and a URL query."""
+
+    def test_uid_cannot_escape_the_href_attribute(self):
+        class FastAPI:
+            def __init__(self, **kwargs):
+                pass
+
+            def get(self, *args, **kwargs):
+                return lambda handler: handler
+
+            def post(self, *args, **kwargs):
+                return lambda handler: handler
+
+        stubs = dict(STUBS)
+        stubs["fastapi"] = _stub(
+            "fastapi",
+            FastAPI=FastAPI,
+            HTTPException=Exception,
+            Query=lambda *a, **k: None,
+            Request=object,
+        )
+        stubs["fastapi.responses"] = _stub(
+            "fastapi.responses",
+            HTMLResponse=str,
+            JSONResponse=dict,
+            RedirectResponse=object,
+        )
+        permissive = lambda *a, **k: None
+        for name in ("auth", "mail", "profile", "calendar", "teams", "sharepoint"):
+            stubs[f"services.{name}"] = _stub(
+                f"services.{name}", __getattr__=lambda attr: permissive
+            )
+        stubs["services.storage"] = _stub(
+            "services.storage", get_store=lambda: None, __getattr__=lambda attr: permissive
+        )
+        stubs["config"] = _stub("config", GRAPH_SCOPES=[], get_settings=lambda: _Settings())
+
+        spec = importlib.util.spec_from_file_location("ms365_main", PLUGIN_DIR / "main.py")
+        module = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, stubs):
+            spec.loader.exec_module(module)
+
+        html = asyncio.run(module.setup_page(uid='x" onmouseover="alert(1)&admin=1'))
+        self.assertNotIn('" onmouseover=', html)
+        self.assertIn(quote('x" onmouseover="alert(1)&admin=1', safe=""), html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/omi-ms365-app/test_graph_paths.py
+++ b/plugins/omi-ms365-app/test_graph_paths.py
@@ -108,7 +108,10 @@ class GraphPathTests(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls._patch.stop()
-        sys.path.remove(str(PLUGIN_DIR))
+        try:
+            sys.path.remove(str(PLUGIN_DIR))
+        except ValueError:
+            pass
 
     def run_async(self, coro):
         return asyncio.run(coro)


### PR DESCRIPTION
## Summary

The MS365 plugin interpolated user-controlled values into Graph URL paths and into an HTML `href` without encoding. Graph resource ids are not URL-safe — message ids are base64 of the store entry id and can contain `/`, `+`, `=`; Teams chat ids contain `:`/`@`; drive item names can contain `#`, `?`, `%` — so raw interpolation splits the path, truncates the URL, or reaches Graph mangled. The setup page additionally reflected `uid` into an HTML attribute, where a quote-containing uid could inject markup.

- Adds `services.graph_client.path_segment()` (`urllib.parse.quote`, `safe=""`) and applies it at every Graph path interpolation: `mail.read`, `teams.send_chat_message`, `sharepoint.read_file_text`, `sharepoint.upload_text_file` (per-component, preserving the `root:/.../:` colon-path separators), and the OData `search(q='...')` literal (single-quote doubling preserved, then percent-encoded).
- `setup_page` now percent-encodes `uid` for the query string, which also keeps the rendered `href` attribute intact.
- httpx preserves existing percent-escapes, so the encoding reaches the wire exactly once.

## Test plan

- [x] `python3 plugins/omi-ms365-app/test_graph_paths.py` — 7/7 hermetic tests pass (stubbed framework layer, real service modules, recorded paths).
- [x] Red/green: same suite against the pre-fix code — 6 failures + 1 error (the `uid` injection visibly emits `" onmouseover=` into the HTML).
- [x] `python3 .github/scripts/pr_preflight.py --lane local --base origin/main` — 14/14 manifest checks pass, including the new `ms365-graph-path-encoding-tests` entry.
- [x] Covered: message id with `/`/`+`/`=`, chat id with `:`/`@`, drive item id with `/`/`#`, filename with `#`/`?`, folder path component encoding, OData quote doubling under encoding, setup `uid` with `"`/`&`/markup payload.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

