### PR TITLE
fix(oauth): encode uid and pick the separator in Notion OAuth state

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: notion-oauth-state-encoding-tests
+    command: ["python3", "plugins/oauth/test_oauth_state.py"]
+    triggers: ["plugins/oauth/**"]
+    lanes: ["local", "ci"]
+    reason: "the Notion OAuth state carried a raw uid — & or # in the uid split the parameter or truncated the URL, and a query-less auth_url got a bare &"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/oauth/client.py
+++ b/plugins/oauth/client.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import requests
 
@@ -98,8 +99,9 @@ class NotionClient:
 
     def get_oauth_url(self, uid: str):
         # Should use encryption on state (with some salt) to prevent attacks
-        state = uid
-        return f"{self.auth_url}&state={state}"
+        parts = urlsplit(self.auth_url or "")
+        query = f"{parts.query}&" if parts.query else ""
+        return urlunsplit(parts._replace(query=f"{query}state={quote(uid, safe='')}"))
 
     def get_database(self, database_id: str, access_token: str):
         resp: requests.Response

--- a/plugins/oauth/test_oauth_state.py
+++ b/plugins/oauth/test_oauth_state.py
@@ -1,0 +1,64 @@
+"""Hermetic Notion OAuth state regressions.
+
+`get_oauth_url` handed `f"{auth_url}&state={uid}"` to the template: a uid
+containing `&`/`#` split `state` into a second parameter or truncated the
+URL, and a `?`-less auth_url got a bare `&`. These tests load the real
+`client.py` with a `requests` stub and exercise `NotionClient.get_oauth_url`
+directly. No network or credentials required.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+from urllib.parse import parse_qsl, urlsplit
+
+
+def _load_client():
+    spec = importlib.util.spec_from_file_location(
+        "oauth_client", Path(__file__).with_name("client.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, {"requests": ModuleType("requests")}):
+        spec.loader.exec_module(module)
+    return module
+
+
+client = _load_client()
+
+AUTH_URL = "https://api.notion.com/v1/oauth/authorize?client_id=abc&response_type=code&owner=user"
+
+
+class OAuthStateTests(unittest.TestCase):
+    def make(self, auth_url=AUTH_URL):
+        return client.NotionClient(auth_url=auth_url)
+
+    def test_uid_with_ampersand_stays_one_state_parameter(self):
+        url = self.make().get_oauth_url("u&admin=1")
+        params = dict(parse_qsl(urlsplit(url).query))
+        self.assertEqual(params["state"], "u&admin=1")
+        self.assertEqual(params["client_id"], "abc")
+
+    def test_uid_with_fragment_characters_is_encoded(self):
+        url = self.make().get_oauth_url("u#frag?x")
+        params = dict(parse_qsl(urlsplit(url).query))
+        self.assertEqual(params["state"], "u#frag?x")
+        self.assertEqual(urlsplit(url).fragment, "")
+
+    def test_existing_query_bytes_are_preserved(self):
+        url = self.make(AUTH_URL + "&redirect_uri=https%3A%2F%2Fcb.example%2Fdone").get_oauth_url("u1")
+        self.assertIn("redirect_uri=https%3A%2F%2Fcb.example%2Fdone&state=u1", url)
+
+    def test_queryless_auth_url_uses_question_mark(self):
+        url = self.make("https://example.com/auth").get_oauth_url("u1")
+        self.assertEqual(url, "https://example.com/auth?state=u1")
+
+    def test_ordinary_uid_unchanged(self):
+        url = self.make().get_oauth_url("firebase-uid-123")
+        self.assertTrue(url.endswith("&state=firebase-uid-123"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`NotionClient.get_oauth_url` built the OAuth authorization URL as `f"{auth_url}&state={uid}"`. The `uid` went in raw — a uid containing `&` or `#` split `state` into a second parameter or truncated the URL — and `&` was hardcoded, so a query-less `auth_url` produced `<url>&state=…`, which providers can't parse. The callback (`callback_auth_notion_crm`) reads the uid back out of `state`, so a corrupted state silently misattributed the stored token or failed the flow entirely.

- `get_oauth_url` now splits the base URL with `urlsplit`, preserves the existing query bytes verbatim, appends `state` with the correct `?`/`&` separator, and percent-encodes the uid once (`quote(safe='')`).
- `parse_qsl` is deliberately not used on the existing query: decoding/re-encoding it could rewrite percent-escapes the provider URL depends on (same boundary discipline as the app-setup `uid` hand-off).
- New hermetic suite `plugins/oauth/test_oauth_state.py` loads the real `client.py` behind a `requests` stub and exercises `get_oauth_url` directly.

## Test plan

- [x] `python3 plugins/oauth/test_oauth_state.py` — 5/5 pass (uid with `&`, uid with `#`/`?`, preserved encoded query bytes, `?` separator for query-less base, ordinary uid unchanged).
- [x] Red/green: 3/5 fail on the pre-fix implementation (raw `&`/`#` corruption, wrong separator); the two byte-compatible cases pin current behavior.
- [x] `pr_preflight --lane local` — all manifest checks pass, including the new `notion-oauth-state-encoding-tests` lane.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

