### PR TITLE
fix(zapier): send uid on trigger unsubscribe so the backend can resolve it

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: zapier-unsubscribe-uid-tests
+    command: ["node", "--test", "plugins/zapier/omi-zap/test/triggers/on_memory_created_descriptor.test.js"]
+    triggers: ["plugins/zapier/**"]
+    lanes: ["local", "ci"]
+    reason: "performUnsubscribe omitted the uid query parameter the DELETE /zapier/trigger/subscribe handler requires — every unsubscribe 422'd and subscriptions leaked"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/zapier/omi-zap/test/triggers/on_memory_created_descriptor.test.js
+++ b/plugins/zapier/omi-zap/test/triggers/on_memory_created_descriptor.test.js
@@ -1,0 +1,31 @@
+// Hermetic descriptor checks for the on_memory_created hook trigger.
+//
+// `performSubscribe`/`performUnsubscribe` are declarative request descriptors
+// consumed verbatim by zapier-platform-core, so the descriptor shape IS the
+// behavior at this seam: the backend `DELETE /zapier/trigger/subscribe`
+// handler requires `uid` as a query parameter and 422s without it, which left
+// every unsubscribe failing and subscriptions leaking. Run with `node --test`.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const trigger = require('../../triggers/on_memory_created.js');
+const { performSubscribe, performUnsubscribe } = trigger.operation;
+
+test('unsubscribe sends the auth uid so the backend can resolve the subscriber', () => {
+  assert.equal(performUnsubscribe.params?.uid, '{{bundle.authData.uid}}');
+});
+
+test('unsubscribe keeps the DELETE shape the backend expects', () => {
+  assert.equal(performUnsubscribe.method, 'DELETE');
+  assert.equal(
+    performUnsubscribe.url,
+    'https://based-hardware--plugins-api.modal.run/zapier/trigger/subscribe',
+  );
+  assert.deepEqual(performUnsubscribe.body, { target_url: '{{bundle.targetUrl}}' });
+});
+
+test('subscribe still carries the uid parameter', () => {
+  assert.equal(performSubscribe.params?.uid, '{{bundle.authData.uid}}');
+  assert.equal(performSubscribe.method, 'POST');
+});

--- a/plugins/zapier/omi-zap/triggers/on_memory_created.js
+++ b/plugins/zapier/omi-zap/triggers/on_memory_created.js
@@ -13,6 +13,7 @@ module.exports = {
         Accept: 'application/json',
       },
       method: 'DELETE',
+      params: { uid: '{{bundle.authData.uid}}' },
       removeMissingValuesFrom: { body: false, params: false },
       url: 'https://based-hardware--plugins-api.modal.run/zapier/trigger/subscribe',
     },


### PR DESCRIPTION
## Summary

The `on_memory_created` hook trigger's `performUnsubscribe` request descriptor never sent `uid`, while `performSubscribe` does. The backend `DELETE /zapier/trigger/subscribe` handler declares `uid: str` as a required query parameter, so every unsubscribe from Zapier returned 422 — hooks could never be removed and `zapier_subscribes:{uid}` entries leaked.

- Adds `params: { uid: '{{bundle.authData.uid}}' }` to `performUnsubscribe`, matching the subscribe descriptor.
- New hermetic `node:test` suite asserts the unsubscribe descriptor carries the uid param and keeps the DELETE shape the backend expects; no zapier-platform-core install needed (the descriptor module has no imports).

## Test plan

- [x] `node --test plugins/zapier/omi-zap/test/triggers/on_memory_created_descriptor.test.js` — 3/3 pass.
- [x] Red/green: uid assertion fails on the pre-fix descriptor.
- [x] `pr_preflight --lane local` — all manifest checks pass, including the new `zapier-unsubscribe-uid-tests` lane.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

