### PR TITLE
fix(hume-ai): sanitize uid before it becomes a WAV filename

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: hume-audio-uid-filename-tests
+    command: ["python3", "plugins/hume-ai/test_audio_path_safety.py"]
+    triggers: ["plugins/hume-ai/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "POST /audio interpolated the client-controlled uid query param into the WAV filename, so ../ in uid wrote outside audio_files/; regression keeps every generated path inside the audio dir"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/hume-ai/main.py
+++ b/plugins/hume-ai/main.py
@@ -4,6 +4,7 @@ Main file with API endpoints only. Helper functions are in app.py
 """
 
 import os
+import re
 import tempfile
 from datetime import datetime
 from typing import Optional
@@ -135,7 +136,10 @@ async def handle_audio_stream(
         audio_dir.mkdir(exist_ok=True)
 
         timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S_%f")
-        filename = f"{uid}_{timestamp}.wav"
+        # uid is client-controlled — strip anything outside [A-Za-z0-9_-] so it
+        # cannot carry path separators or .. into the on-disk filename.
+        safe_uid = re.sub(r"[^A-Za-z0-9_-]", "_", uid)
+        filename = f"{safe_uid}_{timestamp}.wav"
         local_file_path = audio_dir / filename
 
         # Write WAV file with header

--- a/plugins/hume-ai/test_audio_path_safety.py
+++ b/plugins/hume-ai/test_audio_path_safety.py
@@ -1,0 +1,188 @@
+"""Hermetic regression tests: POST /audio must not let a client-controlled
+`uid` query param carry path separators or `..` into the on-disk filename.
+
+The real handler writes `audio_files/{uid}_{timestamp}.wav`. Without
+sanitization, `uid=../escape` writes outside `audio_files/`.
+
+Run: python3 plugins/hume-ai/test_audio_path_safety.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+from unittest import mock
+
+MAIN_PATH = Path(__file__).resolve().parent / "main.py"
+
+
+class _HTTPException(Exception):
+    def __init__(self, status_code=None, detail=None):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _identity_decorator(*args, **kwargs):
+    def wrap(fn):
+        return fn
+
+    return wrap
+
+
+def _install_stubs():
+    fastapi = types.ModuleType("fastapi")
+
+    class _FastAPI:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        on_event = staticmethod(_identity_decorator)
+        post = staticmethod(_identity_decorator)
+        get = staticmethod(_identity_decorator)
+        websocket = staticmethod(_identity_decorator)
+
+    fastapi.FastAPI = _FastAPI
+    fastapi.Request = object
+    fastapi.Query = lambda default=None, **kw: default
+    fastapi.HTTPException = _HTTPException
+
+    responses = types.ModuleType("fastapi.responses")
+
+    class _JSONResponse:
+        def __init__(self, status_code=200, content=None, **kw):
+            self.status_code = status_code
+            self.content = content
+
+    responses.JSONResponse = _JSONResponse
+    responses.HTMLResponse = _JSONResponse
+
+    templating = types.ModuleType("fastapi.templating")
+    templating.Jinja2Templates = lambda *a, **kw: mock.Mock()
+
+    uvicorn = types.ModuleType("uvicorn")
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **kw: None
+
+    # The sibling helper module pulls in the `hume` SDK; stub it with the
+    # real state dict shape plus permissive callables for the rest.
+    app_helpers = types.ModuleType("app")
+    app_helpers.audio_stats = {
+        "total_requests": 0,
+        "successful_analyses": 0,
+        "failed_analyses": 0,
+        "last_request_time": None,
+        "last_uid": None,
+        "recent_emotions": [],
+        "emotion_counts": {},
+        "rizz_score": 75,
+        "recent_notifications": [],
+        "last_notification_time": None,
+    }
+    app_helpers.EMOTION_CONFIG = {}
+    app_helpers.create_wav_header = lambda sample_rate, n: b"RIFF"
+
+    def _any(name):
+        return mock.AsyncMock() if name != "load_emotion_config" else mock.Mock()
+
+    app_helpers.__getattr__ = _any
+
+    stubs = {
+        "fastapi": fastapi,
+        "fastapi.responses": responses,
+        "fastapi.templating": templating,
+        "uvicorn": uvicorn,
+        "dotenv": dotenv,
+        "app": app_helpers,
+    }
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    return saved
+
+
+def _load_main():
+    saved = _install_stubs()
+    try:
+        spec = importlib.util.spec_from_file_location("hume_main_under_test", MAIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+
+
+class _Request:
+    def __init__(self, body=b"pcm-bytes"):
+        self._body = body
+
+    async def body(self):
+        return self._body
+
+
+def _post_audio(module, cwd, uid):
+    prev = os.getcwd()
+    os.chdir(cwd)
+    try:
+        return asyncio.run(
+            module.handle_audio_stream(
+                request=_Request(),
+                sample_rate=16000,
+                uid=uid,
+                analyze_emotion=False,
+                send_notification=False,
+                emotion_filters=None,
+            )
+        )
+    finally:
+        os.chdir(prev)
+
+
+def test_traversal_uid_stays_inside_audio_dir():
+    module = _load_main()
+    with tempfile.TemporaryDirectory() as tmp:
+        resp = _post_audio(module, tmp, "../escape")
+        audio_dir = Path(tmp, "audio_files").resolve()
+        written = Path(resp.content["local_file_path"]).resolve()
+        assert audio_dir in written.parents, f"wrote outside audio_files: {written}"
+        assert not list(Path(tmp).glob("escape_*.wav")), "traversal file exists outside audio_files"
+        assert Path(resp.content["filename"]).name == resp.content["filename"]
+
+
+def test_absolute_and_separator_uids_are_sanitized():
+    module = _load_main()
+    for uid in ["/abs/path", "..", "a/b\\c", "..%2f.."]:
+        with tempfile.TemporaryDirectory() as tmp:
+            resp = _post_audio(module, tmp, uid)
+            filename = resp.content["filename"]
+            assert Path(filename).name == filename, f"unsafe filename for uid={uid!r}: {filename}"
+            assert ".." not in filename
+
+
+def test_normal_uid_and_response_shape_unchanged():
+    module = _load_main()
+    with tempfile.TemporaryDirectory() as tmp:
+        resp = _post_audio(module, tmp, "user_123")
+        filename = resp.content["filename"]
+        assert filename.startswith("user_123_") and filename.endswith(".wav")
+        assert (Path(tmp, "audio_files") / filename).is_file()
+        assert resp.content["uid"] == "user_123"
+        assert resp.content["sample_rate"] == 16000
+
+
+if __name__ == "__main__":
+    tests = [
+        test_traversal_uid_stays_inside_audio_dir,
+        test_absolute_and_separator_uids_are_sanitized,
+        test_normal_uid_and_response_shape_unchanged,
+    ]
+    for t in tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"{len(tests)}/{len(tests)} tests passed")

--- a/plugins/hume-ai/test_audio_path_safety.py
+++ b/plugins/hume-ai/test_audio_path_safety.py
@@ -157,7 +157,8 @@ def test_traversal_uid_stays_inside_audio_dir():
 
 def test_absolute_and_separator_uids_are_sanitized():
     module = _load_main()
-    for uid in ["/abs/path", "..", "a/b\\c", "..%2f.."]:
+    # %2f is URL-decoded to / by the framework before the handler sees uid
+    for uid in ["/abs/path", "..", "a/b\\c", "../../"]:
         with tempfile.TemporaryDirectory() as tmp:
             resp = _post_audio(module, tmp, uid)
             filename = resp.content["filename"]


### PR DESCRIPTION
## Summary

`POST /audio` in `plugins/hume-ai` interpolated the client-controlled `uid` query param straight into the WAV filename: `audio_files/{uid}_{timestamp}.wav`. A `uid` containing `/` or `..` wrote the file outside `audio_files/` — a path traversal on a client-facing upload endpoint — and the escaped path was then passed to `analyze_audio_with_hume` and echoed back in `local_file_path`.

The fix strips characters outside `[A-Za-z0-9_-]` before building the filename. The raw `uid` is still used for stats, notifications, and the response payload — only the filesystem component is sanitized.

## Verification

`plugins/hume-ai/test_audio_path_safety.py` (new, hermetic, registered as `hume-audio-uid-filename-tests` in `.github/checks-manifest.yaml`) loads `main.py` with stubbed FastAPI/app helpers and invokes the real `handle_audio_stream` handler:

- `uid=../escape`: on the old code the file lands next to `audio_files/` as `escape_*.wav` (test fails); with the fix it stays inside `audio_files/`
- `/abs/path`, `..`, `a/b\\c`, `..%2f..` all produce single-component filenames with no `..`
- `uid=user_123` still yields `user_123_<ts>.wav` and the same response shape

3/3 pass on the fix; the traversal test fails on the original code.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

