### PR TITLE
fix(shopify): validate shop domain before using it as a URL host

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: shopify-oauth-shop-host-tests
+    command: ["python3", "plugins/omi-shopify-app/test_shop_host.py"]
+    triggers: ["plugins/omi-shopify-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the client-controlled shop param was used as the OAuth token-exchange host, sending client_secret/code to an attacker domain; the auth flow also produced open-redirect authorization URLs via # or / smuggling"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -80,7 +80,7 @@ templates = Jinja2Templates(directory=templates_dir)
 # Helper Functions
 # ============================================
 
-_SHOP_DOMAIN_RE = re.compile(r"[a-z0-9][a-z0-9-]*\.myshopify\.com")
+_SHOP_DOMAIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.myshopify\.com")
 
 
 def _normalize_shop_domain(shop: Optional[str]) -> Optional[str]:

--- a/plugins/omi-shopify-app/main.py
+++ b/plugins/omi-shopify-app/main.py
@@ -5,6 +5,7 @@ This app provides Shopify integration through OAuth authentication
 and chat tools for analytics, orders, and customer management.
 """
 import os
+import re
 import hmac
 import hashlib
 import urllib.parse
@@ -78,6 +79,24 @@ templates = Jinja2Templates(directory=templates_dir)
 # ============================================
 # Helper Functions
 # ============================================
+
+_SHOP_DOMAIN_RE = re.compile(r"[a-z0-9][a-z0-9-]*\.myshopify\.com")
+
+
+def _normalize_shop_domain(shop: Optional[str]) -> Optional[str]:
+    """Return a canonical <store>.myshopify.com domain, or None otherwise.
+
+    `shop` is client-controlled on /auth/shopify and the OAuth callback, and
+    is used as a URL host — without validation an attacker host receives the
+    client secret during code exchange and the resulting access token.
+    """
+    shop = (shop or "").strip().lower()
+    if not shop:
+        return None
+    if not shop.endswith(".myshopify.com"):
+        shop = f"{shop}.myshopify.com"
+    return shop if _SHOP_DOMAIN_RE.fullmatch(shop) else None
+
 
 def get_auth_header(access_token: str) -> Dict[str, str]:
     """Get authorization header for Shopify API requests."""
@@ -280,10 +299,12 @@ async def shopify_auth(uid: str, shop: Optional[str] = None):
     if not shop:
         # Return a page to enter shop domain
         raise HTTPException(status_code=400, detail="Shop domain is required. Use /auth/shopify?uid=...&shop=your-store.myshopify.com")
-    
-    # Ensure shop domain is properly formatted
-    if not shop.endswith('.myshopify.com'):
-        shop = f"{shop}.myshopify.com"
+
+    # shop becomes a URL host below — reject anything that is not a
+    # <store>.myshopify.com domain so the redirect stays on Shopify.
+    shop = _normalize_shop_domain(shop)
+    if shop is None:
+        raise HTTPException(status_code=400, detail="Invalid shop domain. Expected <store>.myshopify.com")
     
     # Build OAuth URL
     scopes = ",".join(SHOPIFY_SCOPES)
@@ -329,7 +350,17 @@ async def shopify_callback(
         })
     
     uid = state
-    
+
+    # shop is a client-controlled callback param used as the token-exchange
+    # host — an attacker host would receive client_id/client_secret/code.
+    shop = _normalize_shop_domain(shop)
+    if shop is None:
+        return templates.TemplateResponse("setup.html", {
+            "request": request,
+            "authenticated": False,
+            "error": "Invalid shop domain"
+        })
+
     # Exchange code for access token
     token_url = f"https://{shop}/admin/oauth/access_token"
     

--- a/plugins/omi-shopify-app/test_shop_host.py
+++ b/plugins/omi-shopify-app/test_shop_host.py
@@ -1,0 +1,160 @@
+"""Hermetic regression: the Shopify `shop` param becomes a URL host on both
+/auth/shopify and /auth/shopify/callback. Without validation, a callback with
+shop=evil.com POSTs client_id/client_secret/code to the attacker, and
+shop=evil.com# on /auth/shopify produces an open-redirect authorization URL.
+
+Run: python3 plugins/omi-shopify-app/test_shop_host.py
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+MAIN_PATH = Path(__file__).resolve().parent / "main.py"
+
+
+class _HTTPException(Exception):
+    def __init__(self, status_code=None, detail=None):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _decorator(*args, **kwargs):
+    return lambda fn: fn
+
+
+def _stub(name, **attrs):
+    module = types.ModuleType(name)
+
+    def _missing(attr):
+        return mock.Mock(name=f"{name}.{attr}")
+
+    module.__getattr__ = _missing
+    module.__dict__.update(attrs)
+    return module
+
+
+def _install_stubs():
+    fastapi = _stub(
+        "fastapi",
+        FastAPI=lambda *a, **k: mock.Mock(get=_decorator, post=_decorator, mount=lambda *a, **k: None),
+        HTTPException=_HTTPException,
+        Request=object,
+        Query=lambda default=None, **kw: default,
+        Form=lambda default=None, **kw: default,
+    )
+    responses = _stub(
+        "fastapi.responses",
+        HTMLResponse=mock.Mock(name="HTMLResponse"),
+        RedirectResponse=lambda url=None, **kw: types.SimpleNamespace(url=url),
+        JSONResponse=mock.Mock(name="JSONResponse"),
+    )
+    staticfiles = _stub("fastapi.staticfiles", StaticFiles=lambda *a, **k: None)
+    templating = _stub(
+        "fastapi.templating",
+        Jinja2Templates=lambda *a, **k: mock.Mock(
+            TemplateResponse=lambda template, ctx: types.SimpleNamespace(template=template, context=ctx)
+        ),
+    )
+    dotenv = _stub("dotenv", load_dotenv=lambda *a, **k: None)
+    db = _stub("db")
+    models = _stub("models")
+
+    stubs = {
+        "fastapi": fastapi,
+        "fastapi.responses": responses,
+        "fastapi.staticfiles": staticfiles,
+        "fastapi.templating": templating,
+        "dotenv": dotenv,
+        "db": db,
+        "models": models,
+    }
+    return stubs
+
+
+def _load_main():
+    stubs = _install_stubs()
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("shopify_main_under_test", MAIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _callback(module, shop):
+    posts = []
+    get_urls = []
+
+    class _Resp:
+        status_code = 400
+
+        def json(self):
+            return {}
+
+    fake_requests = types.SimpleNamespace(
+        post=lambda url, **kw: (posts.append(url), _Resp())[1],
+        get=lambda url, **kw: (get_urls.append(url), _Resp())[1],
+    )
+    with mock.patch.object(module, "requests", fake_requests):
+        result = asyncio.run(
+            module.shopify_callback(
+                request=mock.Mock(), code="authcode", state="uid1", shop=shop, hmac="x"
+            )
+        )
+    return result, posts, get_urls
+
+
+def test_callback_rejects_attacker_host_before_token_exchange():
+    module = _load_main()
+    _, posts, gets = _callback(module, "evil.com")
+    assert not posts, f"token exchange sent to attacker host: {posts}"
+    assert not gets
+
+
+def test_callback_rejects_fragment_and_path_smuggling():
+    module = _load_main()
+    for shop in ["evil.com#.myshopify.com", "evil.com/x.myshopify.com", "evil.com?.myshopify.com"]:
+        _, posts, _ = _callback(module, shop)
+        assert not posts, f"host smuggled via {shop!r}: {posts}"
+
+
+def test_callback_accepts_real_shop_domain():
+    module = _load_main()
+    _, posts, _ = _callback(module, "mystore.myshopify.com")
+    assert posts == ["https://mystore.myshopify.com/admin/oauth/access_token"]
+
+
+def test_auth_flow_rejects_non_shopify_host():
+    module = _load_main()
+    for shop in ["evil.com#", "evil.com/x", "@evil.com"]:
+        try:
+            asyncio.run(module.shopify_auth(uid="u1", shop=shop))
+            raise AssertionError(f"shop={shop!r} was not rejected")
+        except _HTTPException as e:
+            assert e.status_code == 400
+
+
+def test_auth_flow_normalizes_bare_store_name():
+    module = _load_main()
+    resp = asyncio.run(module.shopify_auth(uid="u1", shop="mystore"))
+    assert resp.url.startswith("https://mystore.myshopify.com/admin/oauth/authorize?"), resp.url
+    resp = asyncio.run(module.shopify_auth(uid="u1", shop="mystore.myshopify.com"))
+    assert resp.url.startswith("https://mystore.myshopify.com/admin/oauth/authorize?"), resp.url
+
+
+if __name__ == "__main__":
+    tests = [
+        test_callback_rejects_attacker_host_before_token_exchange,
+        test_callback_rejects_fragment_and_path_smuggling,
+        test_callback_accepts_real_shop_domain,
+        test_auth_flow_rejects_non_shopify_host,
+        test_auth_flow_normalizes_bare_store_name,
+    ]
+    for t in tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"{len(tests)}/{len(tests)} tests passed")

--- a/plugins/omi-shopify-app/test_shop_host.py
+++ b/plugins/omi-shopify-app/test_shop_host.py
@@ -72,6 +72,7 @@ def _install_stubs():
         "dotenv": dotenv,
         "db": db,
         "models": models,
+        "requests": _stub("requests"),
     }
     return stubs
 
@@ -146,6 +147,16 @@ def test_auth_flow_normalizes_bare_store_name():
     assert resp.url.startswith("https://mystore.myshopify.com/admin/oauth/authorize?"), resp.url
 
 
+def test_auth_flow_rejects_malformed_dns_label():
+    module = _load_main()
+    for shop in ["foo-.myshopify.com", "-foo.myshopify.com", "a" * 64 + ".myshopify.com"]:
+        try:
+            asyncio.run(module.shopify_auth(uid="u1", shop=shop))
+            raise AssertionError(f"shop={shop!r} was not rejected")
+        except _HTTPException as e:
+            assert e.status_code == 400
+
+
 if __name__ == "__main__":
     tests = [
         test_callback_rejects_attacker_host_before_token_exchange,
@@ -153,6 +164,7 @@ if __name__ == "__main__":
         test_callback_accepts_real_shop_domain,
         test_auth_flow_rejects_non_shopify_host,
         test_auth_flow_normalizes_bare_store_name,
+        test_auth_flow_rejects_malformed_dns_label,
     ]
     for t in tests:
         t()


### PR DESCRIPTION
## Summary

The client-controlled `shop` query parameter was interpolated into a URL host in the Shopify OAuth flow:

- **`/auth/shopify/callback`** — `token_url = f"https://{shop}/admin/oauth/access_token"`. A forged callback (`?code=x&state=y&shop=evil.com`) makes the server POST `client_id`, `client_secret`, and the authorization `code` to an attacker-controlled host, and the follow-up `shop.json` request would send the resulting access token there too.
- **`/auth/shopify`** — the `endswith('.myshopify.com')` check is bypassable: `shop=evil.com#` becomes `evil.com#.myshopify.com`, producing an authorize URL whose host is `evil.com` (the rest is a fragment) — an open redirect that phishes the OAuth authorization page. Same for `/`, `?`, `@` smuggling.

`_normalize_shop_domain` now requires a single-label `<store>.myshopify.com` host (bare store names still get the suffix). Invalid values get a 400 on `/auth/shopify` and an error page on the callback — no outbound request is made to a non-Shopify host.

## Verification

`plugins/omi-shopify-app/test_shop_host.py` (new, hermetic, registered as `shopify-oauth-shop-host-tests` in `.github/checks-manifest.yaml`) loads `main.py` with stubbed FastAPI/db/models and runs the real handlers:

- `shop=evil.com` on the callback: old code POSTs the secret payload to `https://evil.com/admin/oauth/access_token` (test fails); fixed code makes no outbound request
- `evil.com#.myshopify.com`, `evil.com/x.myshopify.com`, `evil.com?.myshopify.com` all rejected pre-exchange
- `shop=mystore.myshopify.com` still reaches `https://mystore.myshopify.com/admin/oauth/access_token`
- `shop=evil.com#`, `evil.com/x`, `@evil.com` get 400 on `/auth/shopify`; `mystore` and `mystore.myshopify.com` still produce correct authorize redirects

5/5 pass on the fix; the exfiltration test fails on the original code.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

