### PR TITLE
fix(google-calendar): encode calendar/event ids before URL paths

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: gcal-path-segment-encoding-tests
+    command: ["python3", "plugins/omi-google-calendar-app/test_path_encoding.py"]
+    triggers: ["plugins/omi-google-calendar-app/**", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "tool-body calendar/event ids were interpolated raw into Calendar API paths; '#' in real calendar ids truncated the URL and '/'/'..' let an id rewrite the request path"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -9,7 +9,7 @@ import sys
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 import requests
 from dotenv import load_dotenv
@@ -36,6 +36,16 @@ def log(msg: str):
     """Print and flush immediately for Railway logging."""
     print(msg)
     sys.stdout.flush()
+
+
+def path_segment(value: str) -> str:
+    """Percent-encode one URL path segment.
+
+    Calendar/event ids come from the tool request body and legitimate Google
+    calendar ids contain `#`/`@` — raw `#` truncates the URL and `/` or `..`
+    would let the id rewrite the request path.
+    """
+    return quote(value, safe="")
 
 
 # Google OAuth2 Configuration
@@ -504,7 +514,7 @@ async def tool_list_events(request: Request):
         time_min = now.isoformat() + "Z"
         time_max = (now + timedelta(days=days)).isoformat() + "Z"
 
-        result = calendar_api_request(uid, "GET", f"/calendars/{calendar_id}/events", params={
+        result = calendar_api_request(uid, "GET", f"/calendars/{path_segment(calendar_id)}/events", params={
             "timeMin": time_min,
             "timeMax": time_max,
             "maxResults": max_results,
@@ -619,7 +629,7 @@ async def tool_create_event(request: Request):
 
         log(f"Creating event: {event_data}")
 
-        result = calendar_api_request(uid, "POST", f"/calendars/{calendar_id}/events", json_data=event_data)
+        result = calendar_api_request(uid, "POST", f"/calendars/{path_segment(calendar_id)}/events", json_data=event_data)
 
         if not result or "error" in result:
             return ChatToolResponse(error=f"Failed to create event: {result.get('error', 'Unknown error')}")
@@ -671,7 +681,7 @@ async def tool_get_event(request: Request):
         # Use provided calendar_id or fall back to user's default
         calendar_id = body.get("calendar_id") or get_default_calendar(uid)
 
-        result = calendar_api_request(uid, "GET", f"/calendars/{calendar_id}/events/{event_id}")
+        result = calendar_api_request(uid, "GET", f"/calendars/{path_segment(calendar_id)}/events/{path_segment(event_id)}")
 
         if not result or "error" in result:
             return ChatToolResponse(error=f"Event not found: {result.get('error', 'Unknown error')}")
@@ -746,7 +756,7 @@ async def tool_update_event(request: Request):
         calendar_id = body.get("calendar_id") or get_default_calendar(uid)
 
         # Get existing event first
-        existing = calendar_api_request(uid, "GET", f"/calendars/{calendar_id}/events/{event_id}")
+        existing = calendar_api_request(uid, "GET", f"/calendars/{path_segment(calendar_id)}/events/{path_segment(event_id)}")
         if not existing or "error" in existing:
             return ChatToolResponse(error=f"Event not found: {existing.get('error', 'Unknown error')}")
 
@@ -791,7 +801,7 @@ async def tool_update_event(request: Request):
         if not update_data:
             return ChatToolResponse(error="No updates provided. Specify title, start, end, description, or location.")
 
-        result = calendar_api_request(uid, "PATCH", f"/calendars/{calendar_id}/events/{event_id}", json_data=update_data)
+        result = calendar_api_request(uid, "PATCH", f"/calendars/{path_segment(calendar_id)}/events/{path_segment(event_id)}", json_data=update_data)
 
         if not result or "error" in result:
             return ChatToolResponse(error=f"Failed to update event: {result.get('error', 'Unknown error')}")
@@ -827,10 +837,10 @@ async def tool_delete_event(request: Request):
         calendar_id = body.get("calendar_id") or get_default_calendar(uid)
 
         # Get event title first for confirmation message
-        existing = calendar_api_request(uid, "GET", f"/calendars/{calendar_id}/events/{event_id}")
+        existing = calendar_api_request(uid, "GET", f"/calendars/{path_segment(calendar_id)}/events/{path_segment(event_id)}")
         event_title = existing.get("summary", "Event") if existing and "error" not in existing else "Event"
 
-        result = calendar_api_request(uid, "DELETE", f"/calendars/{calendar_id}/events/{event_id}")
+        result = calendar_api_request(uid, "DELETE", f"/calendars/{path_segment(calendar_id)}/events/{path_segment(event_id)}")
 
         if result and "error" in result:
             return ChatToolResponse(error=f"Failed to delete event: {result.get('error', 'Unknown error')}")

--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -45,6 +45,8 @@ def path_segment(value: str) -> str:
     calendar ids contain `#`/`@` — raw `#` truncates the URL and `/` or `..`
     would let the id rewrite the request path.
     """
+    if value in (".", ".."):
+        raise ValueError("invalid calendar or event id")
     return quote(value, safe="")
 
 

--- a/plugins/omi-google-calendar-app/test_path_encoding.py
+++ b/plugins/omi-google-calendar-app/test_path_encoding.py
@@ -1,0 +1,142 @@
+"""Hermetic regression: tool-body `calendar_id`/`event_id` were interpolated
+raw into Google Calendar API paths. Legitimate calendar ids contain `#`
+(e.g. en.usa#holiday@group.v.calendar.google.com) which truncates the URL,
+and `/`/`..` let an id rewrite the request path.
+
+Run: python3 plugins/omi-google-calendar-app/test_path_encoding.py
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+MAIN_PATH = Path(__file__).resolve().parent / "main.py"
+
+
+def _decorator(*args, **kwargs):
+    return lambda fn: fn
+
+
+def _stub(name, **attrs):
+    module = types.ModuleType(name)
+
+    def _missing(attr):
+        return mock.Mock(name=f"{name}.{attr}")
+
+    module.__getattr__ = _missing
+    module.__dict__.update(attrs)
+    return module
+
+
+def _load_main():
+    fastapi = _stub(
+        "fastapi",
+        FastAPI=lambda *a, **k: mock.Mock(get=_decorator, post=_decorator, mount=lambda *a, **k: None),
+        HTTPException=Exception,
+        Request=object,
+        Query=lambda default=None, **kw: default,
+    )
+    stubs = {
+        "fastapi": fastapi,
+        "fastapi.responses": _stub(
+            "fastapi.responses", HTMLResponse=dict, RedirectResponse=object, JSONResponse=dict
+        ),
+        "dotenv": _stub("dotenv", load_dotenv=lambda *a, **k: None),
+        "db": _stub("db"),
+        "models": _stub("models", ChatToolResponse=dict),
+    }
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("gcal_main_under_test", MAIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _recorded_requests():
+    calls = []
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"items": [], "id": "x"}
+
+    def _record(method):
+        def call(url, **kw):
+            calls.append((method, url, kw))
+            return _Resp()
+
+        return call
+
+    return calls, types.SimpleNamespace(
+        get=_record("GET"), post=_record("POST"), put=_record("PUT"),
+        patch=_record("PATCH"), delete=_record("DELETE"),
+    )
+
+
+def _request(body):
+    class _Request:
+        async def json(self):
+            return body
+
+    return _Request()
+
+
+def _run_tool(module, handler_name, body):
+    """Drive a real tool handler and record the URL it hands to requests."""
+    calls, fake_requests = _recorded_requests()
+    with mock.patch.object(module, "requests", fake_requests), mock.patch.object(
+        module, "get_valid_access_token", lambda uid: "token123"
+    ), mock.patch.object(module, "get_default_calendar", lambda uid: "primary"):
+        asyncio.run(getattr(module, handler_name)(_request(body)))
+    return calls
+
+
+def test_calendar_id_with_hash_is_encoded_not_truncating():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_list_events",
+        {"uid": "u1", "calendar_id": "en.usa#holiday@group.v.calendar.google.com", "days": 1},
+    )
+    assert calls, "handler made no API call"
+    url = calls[0][1]
+    assert "#" not in url, f"# truncated the request path: {url}"
+    assert "en.usa%23holiday%40group.v.calendar.google.com" in url
+
+
+def test_event_id_cannot_rewrite_path():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_delete_event",
+        {"uid": "u1", "calendar_id": "primary", "event_id": "x/../../acl/owner"},
+    )
+    assert calls, "handler made no API call"
+    for _, url, _ in calls:
+        path = url.split("?")[0]
+        assert "/../" not in path and not path.endswith("/.."), f"path rewritten: {url}"
+        assert path.count("/events/") == 1
+
+
+def test_plain_ids_pass_through_unchanged():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_get_event",
+        {"uid": "u1", "calendar_id": "primary", "event_id": "evt_1"},
+    )
+    assert calls, "handler made no API call"
+    assert calls[0][1].endswith("/calendars/primary/events/evt_1")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_calendar_id_with_hash_is_encoded_not_truncating,
+        test_event_id_cannot_rewrite_path,
+        test_plain_ids_pass_through_unchanged,
+    ]
+    for t in tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"{len(tests)}/{len(tests)} tests passed")

--- a/plugins/omi-google-calendar-app/test_path_encoding.py
+++ b/plugins/omi-google-calendar-app/test_path_encoding.py
@@ -47,6 +47,7 @@ def _load_main():
         "dotenv": _stub("dotenv", load_dotenv=lambda *a, **k: None),
         "db": _stub("db"),
         "models": _stub("models", ChatToolResponse=dict),
+        "requests": _stub("requests"),
     }
     with mock.patch.dict(sys.modules, stubs):
         spec = importlib.util.spec_from_file_location("gcal_main_under_test", MAIN_PATH)
@@ -120,6 +121,45 @@ def test_event_id_cannot_rewrite_path():
         assert path.count("/events/") == 1
 
 
+def test_create_event_encodes_calendar_id():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_create_event",
+        {
+            "uid": "u1",
+            "calendar_id": "en.usa#holiday@group.v.calendar.google.com",
+            "title": "standup",
+            "start": "2026-09-20T10:00:00Z",
+        },
+    )
+    post = [c for c in calls if c[0] == "POST"]
+    assert post, f"handler made no POST call: {calls}"
+    url = post[0][1]
+    assert "#" not in url, f"# truncated the request path: {url}"
+    assert "en.usa%23holiday%40group.v.calendar.google.com" in url
+
+
+def test_update_event_encodes_event_id():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_update_event",
+        {"uid": "u1", "calendar_id": "primary", "event_id": "x/../../acl/owner", "title": "t"},
+    )
+    assert calls, "handler made no API call"
+    for _, url, _ in calls:
+        path = url.split("?")[0]
+        assert "/../" not in path and not path.endswith("/.."), f"path rewritten: {url}"
+
+
+def test_dotdot_id_fails_closed():
+    module = _load_main()
+    calls = _run_tool(
+        module, "tool_delete_event",
+        {"uid": "u1", "calendar_id": "primary", "event_id": ".."},
+    )
+    assert not calls, f"dot-segment id reached the API: {calls}"
+
+
 def test_plain_ids_pass_through_unchanged():
     module = _load_main()
     calls = _run_tool(
@@ -134,6 +174,9 @@ if __name__ == "__main__":
     tests = [
         test_calendar_id_with_hash_is_encoded_not_truncating,
         test_event_id_cannot_rewrite_path,
+        test_create_event_encodes_calendar_id,
+        test_update_event_encodes_event_id,
+        test_dotdot_id_fails_closed,
         test_plain_ids_pass_through_unchanged,
     ]
     for t in tests:


### PR DESCRIPTION
## Summary

`calendar_id` and `event_id` come from the tool request body and were interpolated raw into Google Calendar API paths at every tool handler (list/create/get/update/delete — 7 sites).

- Legitimate Google calendar ids contain `#` — e.g. `en.usa#holiday@group.v.calendar.google.com`. A literal `#` turns the rest of the URL into a fragment, truncating the request path to `/calendars/en.usa` — holiday/shared calendars silently hit the wrong endpoint.
- `/` or `..` in either id could rewrite the request path under the API host (e.g. `event_id=x/../../acl/owner`).

`path_segment()` percent-encodes each id (`quote(..., safe="")`) at each interpolation site.

## Verification

`plugins/omi-google-calendar-app/test_path_encoding.py` (new, hermetic, registered as `gcal-path-segment-encoding-tests` in `.github/checks-manifest.yaml`) drives the real tool handlers with a recorded `requests` stub:

- `tool_list_events` with `calendar_id=en.usa#holiday@group.v.calendar.google.com`: old code produces a URL containing a literal `#` (test fails — request path truncated); fixed code sends `en.usa%23holiday%40...`
- `tool_delete_event` with `event_id=x/../../acl/owner`: fixed code keeps one `/events/` segment and no literal `..` path parts
- `tool_get_event` with `primary`/`evt_1`: unchanged `/calendars/primary/events/evt_1`

3/3 pass on the fix; the `#` truncation test fails on the original code.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

