### PR TITLE
fix(plugins): encode reflected uid in setup/auth pages across six apps

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: plugin-uid-reflection-encoding-tests
+    command: ["python3", "plugins/test_uid_reflection.py"]
+    triggers: ["plugins/omi-whoop-app/**", "plugins/omi-twitter-chat-tools-app/**", "plugins/omi-github-app/**", "plugins/omi-notion-app/**", "plugins/omi-clickup-app/**", "plugins/omi-slack-app/**", "plugins/test_uid_reflection.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the client-controlled uid query param was reflected raw into HTML href attributes and fetch() URLs on six plugin setup pages; a quote broke the attribute (HTML injection) and &, #, or .. corrupted the query"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/omi-clickup-app/main.py
+++ b/plugins/omi-clickup-app/main.py
@@ -1153,7 +1153,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                 async function checkAuth() {{
                     const uid = document.getElementById('uid').value;
                     try {{
-                        const response = await fetch(`/setup-completed?uid=${{uid}}`);
+                        const response = await fetch(`/setup-completed?uid=${{encodeURIComponent(uid)}}`);
                         const data = await response.json();
                         
                         const authStatus = document.getElementById('authStatus');
@@ -1172,7 +1172,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                 function authenticate() {{
                     const uid = document.getElementById('uid').value;
                     addLog('Opening ClickUp authentication...');
-                    window.open(`/auth?uid=${{uid}}`, '_blank');
+                    window.open(`/auth?uid=${{encodeURIComponent(uid)}}`, '_blank');
                     setTimeout(() => addLog('After authenticating, click "Check Auth Status"'), 1000);
                 }}
                 
@@ -1198,7 +1198,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                             end: 5.0
                         }}];
                         
-                        const response = await fetch(`/webhook?session_id=${{sessionId}}&uid=${{uid}}`, {{
+                        const response = await fetch(`/webhook?session_id=${{sessionId}}&uid=${{encodeURIComponent(uid)}}`, {{
                             method: 'POST',
                             headers: {{ 'Content-Type': 'application/json' }},
                             body: JSON.stringify(segments)
@@ -1242,7 +1242,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                     
                     try {{
                         addLog('Logging out...');
-                        const response = await fetch(`/logout?uid=${{uid}}`, {{
+                        const response = await fetch(`/logout?uid=${{encodeURIComponent(uid)}}`, {{
                             method: 'POST'
                         }});
                         

--- a/plugins/omi-clickup-app/main.py
+++ b/plugins/omi-clickup-app/main.py
@@ -5,6 +5,8 @@ import sys
 from dotenv import load_dotenv
 from typing import List, Dict, Any
 import secrets
+import html
+from urllib.parse import quote
 import asyncio
 
 # Force unbuffered output for instant logs
@@ -151,6 +153,9 @@ async def shutdown_event():
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage with list selection."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not uid:
         return {
             "app": "OMI ClickUp Integration",
@@ -168,7 +173,7 @@ async def root(uid: str = Query(None)):
     
     if not user or not user.get("access_token"):
         # Not authenticated - show auth page
-        auth_url = f"/auth?uid={uid}"
+        auth_url = f"/auth?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -384,7 +389,7 @@ async def root(uid: str = Query(None)):
                     const list = select.value;
                     
                     try {{
-                        const response = await fetch('/update-list?uid={uid}&list=' + encodeURIComponent(list), {{
+                        const response = await fetch('/update-list?uid={uid_q}&list=' + encodeURIComponent(list), {{
                             method: 'POST'
                         }});
                         
@@ -401,7 +406,7 @@ async def root(uid: str = Query(None)):
                 }}
                 
                 function refreshLists() {{
-                    fetch('/refresh-lists?uid={uid}', {{
+                    fetch('/refresh-lists?uid={uid_q}', {{
                         method: 'POST'
                     }})
                     .then(response => response.json())
@@ -423,7 +428,7 @@ async def root(uid: str = Query(None)):
                     const timezone = select.value;
                     
                     try {{
-                        const response = await fetch('/update-timezone?uid={uid}&timezone=' + encodeURIComponent(timezone), {{
+                        const response = await fetch('/update-timezone?uid={uid_q}&timezone=' + encodeURIComponent(timezone), {{
                             method: 'POST'
                         }});
                         
@@ -442,14 +447,14 @@ async def root(uid: str = Query(None)):
                 
                 async function logoutUser() {{
                     try {{
-                        const response = await fetch('/logout?uid={uid}', {{
+                        const response = await fetch('/logout?uid={uid_q}', {{
                             method: 'POST'
                         }});
                         
                         const data = await response.json();
                         
                         if (data.success) {{
-                            window.location.href = '/?uid={uid}';
+                            window.location.href = '/?uid={uid_q}';
                         }} else {{
                             alert('❌ Logout failed: ' + data.error);
                         }}
@@ -490,6 +495,9 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from ClickUp."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -597,7 +605,7 @@ async def auth_callback(
                             </p>
                         </div>
                         
-                        <a href="/?uid={uid}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
+                        <a href="/?uid={uid_q}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
                             Continue to Settings →
                         </a>
                         
@@ -631,7 +639,7 @@ async def auth_callback(
                         <div class="error-box" style="margin-top: 40px; padding: 40px 24px;">
                             <h2 style="font-size: 24px; margin-bottom: 12px;">❌ Authentication Error</h2>
                             <p style="margin-bottom: 16px;">Failed to complete authentication: {str(e)}</p>
-                            <a href="/auth?uid={uid}" class="btn btn-primary">Try again</a>
+                            <a href="/auth?uid={uid_q}" class="btn btn-primary">Try again</a>
                         </div>
                     </div>
                 </body>
@@ -1030,6 +1038,10 @@ async def process_segments(
 @app.get("/test")
 async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(None)):
     """Development testing interface."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
+    uid_h = html.escape(uid or '', quote=True)
     if not dev or dev != "true":
         return HTMLResponse(content=f"""
         <html>
@@ -1071,7 +1083,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                     <h2>Authentication</h2>
                     <div class="input-group">
                         <label>User ID (UID):</label>
-                        <input type="text" id="uid" value="{uid}">
+                        <input type="text" id="uid" value="{uid_h}">
                     </div>
                     <button class="btn btn-primary" onclick="authenticate()">🔐 Authenticate ClickUp</button>
                     <button class="btn btn-secondary" onclick="checkAuth()">🔍 Check Auth Status</button>

--- a/plugins/omi-clickup-app/main.py
+++ b/plugins/omi-clickup-app/main.py
@@ -495,9 +495,6 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from ClickUp."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -542,6 +539,10 @@ async def auth_callback(
             status_code=400
         )
     
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
+
     try:
         # Exchange code for access token
         token_data = clickup_client.exchange_code_for_token(code)

--- a/plugins/omi-github-app/main.py
+++ b/plugins/omi-github-app/main.py
@@ -10,6 +10,8 @@ from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 import os
 from dotenv import load_dotenv
 import secrets
+import json
+from urllib.parse import quote
 
 from simple_storage import SimpleUserStorage
 from github_client import GitHubClient
@@ -595,6 +597,10 @@ async def tool_add_comment(request: Request):
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage with repo selection (mobile-first UI)."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
+    uid_js = json.dumps(uid)
     if not uid:
         return {
             "app": "OMI GitHub Issues Integration",
@@ -612,7 +618,7 @@ async def root(uid: str = Query(None)):
 
     if not user or not user.get("access_token"):
         # Not authenticated - show auth page
-        auth_url = f"/auth?uid={uid}"
+        auth_url = f"/auth?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -853,7 +859,7 @@ async def root(uid: str = Query(None)):
                     }}
 
                     try {{
-                        const response = await fetch('/update-repo?uid={uid}&repo=' + encodeURIComponent(repo), {{
+                        const response = await fetch('/update-repo?uid={uid_q}&repo=' + encodeURIComponent(repo), {{
                             method: 'POST'
                         }});
 
@@ -873,7 +879,7 @@ async def root(uid: str = Query(None)):
                     if (!confirm('Refresh your repository list from GitHub?')) return;
 
                     try {{
-                        const response = await fetch('/refresh-repos?uid={uid}', {{
+                        const response = await fetch('/refresh-repos?uid={uid_q}', {{
                             method: 'POST'
                         }});
 
@@ -900,7 +906,7 @@ async def root(uid: str = Query(None)):
                     }}
 
                     try {{
-                        const response = await fetch('/check-repo-access?uid={uid}&repo=' + encodeURIComponent(repo), {{
+                        const response = await fetch('/check-repo-access?uid={uid_q}&repo=' + encodeURIComponent(repo), {{
                             method: 'POST'
                         }});
                         const data = await response.json();
@@ -934,7 +940,7 @@ async def root(uid: str = Query(None)):
                 async function saveAgentProvider() {{
                     const provider = getSelectedProvider();
                     try {{
-                        const response = await fetch('/save-agent-provider?uid={uid}&provider=' + encodeURIComponent(provider), {{
+                        const response = await fetch('/save-agent-provider?uid={uid_q}&provider=' + encodeURIComponent(provider), {{
                             method: 'POST'
                         }});
                         const data = await response.json();
@@ -960,7 +966,7 @@ async def root(uid: str = Query(None)):
                     }}
 
                     try {{
-                        await fetch('/save-agent-key?uid={uid}&provider=' + encodeURIComponent(provider) + '&key=' + encodeURIComponent(apiKey), {{
+                        await fetch('/save-agent-key?uid={uid_q}&provider=' + encodeURIComponent(provider) + '&key=' + encodeURIComponent(apiKey), {{
                             method: 'POST'
                         }});
 
@@ -975,7 +981,7 @@ async def root(uid: str = Query(None)):
                     if (!confirm('Remove the API key for this provider?')) return;
 
                     try {{
-                        await fetch('/delete-agent-key?uid={uid}&provider=' + encodeURIComponent(provider), {{
+                        await fetch('/delete-agent-key?uid={uid_q}&provider=' + encodeURIComponent(provider), {{
                             method: 'POST'
                         }});
 
@@ -1007,7 +1013,7 @@ async def root(uid: str = Query(None)):
                                 'Content-Type': 'application/json'
                             }},
                             body: JSON.stringify({{
-                                uid: '{uid}',
+                                uid: {uid_js},
                                 prompt,
                                 provider,
                                 repo,
@@ -1077,6 +1083,9 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from GitHub."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -1169,7 +1178,7 @@ async def auth_callback(
                             </p>
                         </div>
 
-                        <a href="/?uid={uid}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
+                        <a href="/?uid={uid_q}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
                             Continue to Settings
                         </a>
 
@@ -1204,7 +1213,7 @@ async def auth_callback(
                         <div class="error-box" style="margin-top: 40px; padding: 40px 24px;">
                             <h2 style="font-size: 24px; margin-bottom: 12px;">Authentication Error</h2>
                             <p style="margin-bottom: 16px;">Failed to complete authentication: {str(e)}</p>
-                            <a href="/auth?uid={uid}" class="btn btn-primary">Try again</a>
+                            <a href="/auth?uid={uid_q}" class="btn btn-primary">Try again</a>
                         </div>
                     </div>
                 </body>

--- a/plugins/omi-github-app/main.py
+++ b/plugins/omi-github-app/main.py
@@ -600,7 +600,9 @@ async def root(uid: str = Query(None)):
     # uid is reflected into href/redirect URLs below — percent-encode
     # it once so quotes/&/.. cannot break the attribute or the query.
     uid_q = quote(uid or "", safe="")
-    uid_js = json.dumps(uid)
+    # json.dumps is not enough inside a <script> block — a uid containing
+    # "</script>" would close the tag; escape HTML-significant chars too.
+    uid_js = json.dumps(uid).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
     if not uid:
         return {
             "app": "OMI GitHub Issues Integration",
@@ -1083,9 +1085,6 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from GitHub."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -1129,6 +1128,10 @@ async def auth_callback(
             """,
             status_code=400
         )
+
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
 
     try:
         # Exchange code for access token

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -984,9 +984,6 @@ async def notion_callback(
     error: str = Query(None)
 ):
     """Handle Notion OAuth2 callback."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1029,6 +1026,10 @@ async def notion_callback(
         return HTMLResponse(content="State mismatch", status_code=400)
 
     delete_oauth_state(uid)
+
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
 
     # Exchange code for tokens
     try:

--- a/plugins/omi-notion-app/main.py
+++ b/plugins/omi-notion-app/main.py
@@ -9,7 +9,7 @@ import sys
 import secrets
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 import requests
 from dotenv import load_dotenv
@@ -861,6 +861,9 @@ async def tool_query_database(request: Request):
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not uid:
         return {
             "app": "Notion Omi Integration",
@@ -876,7 +879,7 @@ async def root(uid: str = Query(None)):
     tokens = get_notion_tokens(uid)
 
     if not tokens:
-        auth_url = f"/auth/notion?uid={uid}"
+        auth_url = f"/auth/notion?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -942,7 +945,7 @@ async def root(uid: str = Query(None)):
                     <div class="example">"Search for budget in Notion"</div>
                 </div>
 
-                <a href="/disconnect?uid={uid}" class="btn btn-secondary btn-block">
+                <a href="/disconnect?uid={uid_q}" class="btn btn-secondary btn-block">
                     Disconnect Notion
                 </a>
 
@@ -981,6 +984,9 @@ async def notion_callback(
     error: str = Query(None)
 ):
     """Handle Notion OAuth2 callback."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1072,7 +1078,7 @@ async def notion_callback(
                         <p>Your Notion workspace is now linked to Omi</p>
                     </div>
 
-                    <a href="/?uid={uid}" class="btn btn-primary btn-block">
+                    <a href="/?uid={uid_q}" class="btn btn-primary btn-block">
                         Continue to Settings
                     </a>
 
@@ -1105,8 +1111,11 @@ async def check_setup(uid: str = Query(...)):
 @app.get("/disconnect")
 async def disconnect(uid: str = Query(...)):
     """Disconnect Notion."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     delete_notion_tokens(uid)
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={uid_q}")
 
 
 @app.get("/health")

--- a/plugins/omi-slack-app/main.py
+++ b/plugins/omi-slack-app/main.py
@@ -434,9 +434,6 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from Slack."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -481,6 +478,10 @@ async def auth_callback(
             status_code=400
         )
     
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
+
     try:
         redirect_uri = os.getenv("OAUTH_REDIRECT_URL", "http://localhost:8000/auth/callback")
         
@@ -1049,7 +1050,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                 async function checkAuth() {{
                     const uid = document.getElementById('uid').value;
                     try {{
-                        const response = await fetch(`/setup-completed?uid=${{uid}}`);
+                        const response = await fetch(`/setup-completed?uid=${{encodeURIComponent(uid)}}`);
                         const data = await response.json();
                         
                         const authStatus = document.getElementById('authStatus');
@@ -1068,7 +1069,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                 function authenticate() {{
                     const uid = document.getElementById('uid').value;
                     addLog('Opening Slack authentication...');
-                    window.open(`/auth?uid=${{uid}}`, '_blank');
+                    window.open(`/auth?uid=${{encodeURIComponent(uid)}}`, '_blank');
                     setTimeout(() => addLog('After authenticating, click "Check Auth Status"'), 1000);
                 }}
                 
@@ -1094,7 +1095,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                             end: 5.0
                         }}];
                         
-                        const response = await fetch(`/webhook?session_id=${{sessionId}}&uid=${{uid}}`, {{
+                        const response = await fetch(`/webhook?session_id=${{sessionId}}&uid=${{encodeURIComponent(uid)}}`, {{
                             method: 'POST',
                             headers: {{ 'Content-Type': 'application/json' }},
                             body: JSON.stringify(segments)
@@ -1138,7 +1139,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                     
                     try {{
                         addLog('Logging out...');
-                        const response = await fetch(`/logout?uid=${{uid}}`, {{
+                        const response = await fetch(`/logout?uid=${{encodeURIComponent(uid)}}`, {{
                             method: 'POST'
                         }});
                         

--- a/plugins/omi-slack-app/main.py
+++ b/plugins/omi-slack-app/main.py
@@ -5,6 +5,8 @@ import sys
 from dotenv import load_dotenv
 from typing import List, Any
 import secrets
+import html
+from urllib.parse import quote
 import asyncio
 
 # Force unbuffered output for instant logs
@@ -147,6 +149,9 @@ async def shutdown_event():
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage with channel selection (mobile-first UI)."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not uid:
         return {
             "app": "OMI Slack Integration",
@@ -164,7 +169,7 @@ async def root(uid: str = Query(None)):
     
     if not user or not user.get("access_token"):
         # Not authenticated - show auth page
-        auth_url = f"/auth?uid={uid}"
+        auth_url = f"/auth?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -345,7 +350,7 @@ async def root(uid: str = Query(None)):
                     const channel = select.value;
                     
                     try {{
-                        const response = await fetch('/update-channel?uid={uid}&channel=' + encodeURIComponent(channel), {{
+                        const response = await fetch('/update-channel?uid={uid_q}&channel=' + encodeURIComponent(channel), {{
                             method: 'POST'
                         }});
                         
@@ -362,7 +367,7 @@ async def root(uid: str = Query(None)):
                 }}
                 
                 function refreshChannels() {{
-                    fetch('/refresh-channels?uid={uid}', {{
+                    fetch('/refresh-channels?uid={uid_q}', {{
                         method: 'POST'
                     }})
                     .then(response => response.json())
@@ -381,14 +386,14 @@ async def root(uid: str = Query(None)):
                 
                 async function logoutUser() {{
                     try {{
-                        const response = await fetch('/logout?uid={uid}', {{
+                        const response = await fetch('/logout?uid={uid_q}', {{
                             method: 'POST'
                         }});
                         
                         const data = await response.json();
                         
                         if (data.success) {{
-                            window.location.href = '/?uid={uid}';
+                            window.location.href = '/?uid={uid_q}';
                         }} else {{
                             alert('❌ Logout failed: ' + data.error);
                         }}
@@ -429,6 +434,9 @@ async def auth_callback(
     state: str = Query(None)
 ):
     """Handle OAuth callback from Slack."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not code or not state:
         return HTMLResponse(
             content=f"""
@@ -522,7 +530,7 @@ async def auth_callback(
                             </p>
                         </div>
                         
-                        <a href="/?uid={uid}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
+                        <a href="/?uid={uid_q}" class="btn btn-primary btn-block" style="font-size: 17px; padding: 16px; margin-top: 24px;">
                             Continue to Settings →
                         </a>
                         
@@ -556,7 +564,7 @@ async def auth_callback(
                         <div class="error-box" style="margin-top: 40px; padding: 40px 24px;">
                             <h2 style="font-size: 24px; margin-bottom: 12px;">❌ Authentication Error</h2>
                             <p style="margin-bottom: 16px;">Failed to complete authentication: {str(e)}</p>
-                            <a href="/auth?uid={uid}" class="btn btn-primary">Try again</a>
+                            <a href="/auth?uid={uid_q}" class="btn btn-primary">Try again</a>
                         </div>
                     </div>
                 </body>
@@ -930,6 +938,10 @@ async def process_segments(
 @app.get("/test")
 async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(None)):
     """Development testing interface."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
+    uid_h = html.escape(uid or '', quote=True)
     if not dev or dev != "true":
         return HTMLResponse(content=f"""
         <html>
@@ -971,7 +983,7 @@ async def test_interface(uid: str = Query("test_user_123"), dev: str = Query(Non
                     <h2>Authentication</h2>
                     <div class="input-group">
                         <label>User ID (UID):</label>
-                        <input type="text" id="uid" value="{uid}">
+                        <input type="text" id="uid" value="{uid_h}">
                     </div>
                     <button class="btn btn-primary" onclick="authenticate()">🔐 Authenticate Slack</button>
                     <button class="btn btn-secondary" onclick="checkAuth()">🔍 Check Auth Status</button>

--- a/plugins/omi-twitter-chat-tools-app/main.py
+++ b/plugins/omi-twitter-chat-tools-app/main.py
@@ -1062,9 +1062,6 @@ async def twitter_callback(
     error: str = Query(None)
 ):
     """Handle Twitter OAuth2 callback."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1112,6 +1109,10 @@ async def twitter_callback(
         return HTMLResponse(content="Code verifier not found", status_code=400)
 
     delete_oauth_state(uid)
+
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
 
     # Exchange code for tokens
     try:

--- a/plugins/omi-twitter-chat-tools-app/main.py
+++ b/plugins/omi-twitter-chat-tools-app/main.py
@@ -11,7 +11,7 @@ import hashlib
 import base64
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 import requests
 from dotenv import load_dotenv
@@ -932,6 +932,9 @@ async def tool_get_user_profile(request: Request):
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not uid:
         return {
             "app": "Twitter Omi Integration",
@@ -947,7 +950,7 @@ async def root(uid: str = Query(None)):
     tokens = get_twitter_tokens(uid)
 
     if not tokens:
-        auth_url = f"/auth/twitter?uid={uid}"
+        auth_url = f"/auth/twitter?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -1013,7 +1016,7 @@ async def root(uid: str = Query(None)):
                     <div class="example">"Who mentioned me on Twitter?"</div>
                 </div>
 
-                <a href="/disconnect?uid={uid}" class="btn btn-secondary btn-block">
+                <a href="/disconnect?uid={uid_q}" class="btn btn-secondary btn-block">
                     Disconnect Twitter
                 </a>
 
@@ -1059,6 +1062,9 @@ async def twitter_callback(
     error: str = Query(None)
 ):
     """Handle Twitter OAuth2 callback."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1177,7 +1183,7 @@ async def twitter_callback(
                         <p>Your Twitter account @{username} is now linked to Omi</p>
                     </div>
 
-                    <a href="/?uid={uid}" class="btn btn-primary btn-block">
+                    <a href="/?uid={uid_q}" class="btn btn-primary btn-block">
                         Continue to Settings
                     </a>
 
@@ -1210,8 +1216,11 @@ async def check_setup(uid: str = Query(...)):
 @app.get("/disconnect")
 async def disconnect(uid: str = Query(...)):
     """Disconnect Twitter."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     delete_twitter_tokens(uid)
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={uid_q}")
 
 
 @app.get("/health")

--- a/plugins/omi-whoop-app/main.py
+++ b/plugins/omi-whoop-app/main.py
@@ -9,7 +9,7 @@ import sys
 import secrets
 from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any, Tuple
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 import requests
 from dotenv import load_dotenv
@@ -899,6 +899,9 @@ async def tool_get_profile(request: Request):
 @app.get("/")
 async def root(uid: str = Query(None)):
     """Root endpoint - Homepage."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if not uid:
         return {
             "app": "Whoop Omi Integration",
@@ -914,7 +917,7 @@ async def root(uid: str = Query(None)):
     tokens = get_whoop_tokens(uid)
 
     if not tokens:
-        auth_url = f"/auth/whoop?uid={uid}"
+        auth_url = f"/auth/whoop?uid={uid_q}"
         return HTMLResponse(content=f"""
         <html>
             <head>
@@ -978,7 +981,7 @@ async def root(uid: str = Query(None)):
                     <div class="example">"Show my recent workouts"</div>
                 </div>
 
-                <a href="/disconnect?uid={uid}" class="btn btn-secondary btn-block">
+                <a href="/disconnect?uid={uid_q}" class="btn btn-secondary btn-block">
                     Disconnect Whoop
                 </a>
 
@@ -1024,6 +1027,9 @@ async def whoop_callback(
     error: str = Query(None)
 ):
     """Handle Whoop OAuth2 callback."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1117,7 +1123,7 @@ async def whoop_callback(
                         <p>Your Whoop is now linked to Omi</p>
                     </div>
 
-                    <a href="/?uid={uid}" class="btn btn-primary btn-block">
+                    <a href="/?uid={uid_q}" class="btn btn-primary btn-block">
                         Continue to Settings
                     </a>
 
@@ -1150,8 +1156,11 @@ async def check_setup(uid: str = Query(...)):
 @app.get("/disconnect")
 async def disconnect(uid: str = Query(...)):
     """Disconnect Whoop."""
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid or "", safe="")
     delete_whoop_tokens(uid)
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={uid_q}")
 
 
 @app.get("/health")

--- a/plugins/omi-whoop-app/main.py
+++ b/plugins/omi-whoop-app/main.py
@@ -1027,9 +1027,6 @@ async def whoop_callback(
     error: str = Query(None)
 ):
     """Handle Whoop OAuth2 callback."""
-    # uid is reflected into href/redirect URLs below — percent-encode
-    # it once so quotes/&/.. cannot break the attribute or the query.
-    uid_q = quote(uid or "", safe="")
     if error:
         return HTMLResponse(content=f"""
         <html>
@@ -1078,6 +1075,10 @@ async def whoop_callback(
         """, status_code=400)
 
     delete_oauth_state(state)
+
+    # uid is reflected into href/redirect URLs below — percent-encode
+    # it once so quotes/&/.. cannot break the attribute or the query.
+    uid_q = quote(uid, safe="")
 
     # Exchange code for tokens
     try:

--- a/plugins/test_uid_reflection.py
+++ b/plugins/test_uid_reflection.py
@@ -11,6 +11,8 @@ Run: python3 plugins/test_uid_reflection.py
 """
 
 import asyncio
+import contextlib
+import inspect
 import importlib.util
 import sys
 import types
@@ -130,8 +132,121 @@ def test_normal_uid_still_links():
         assert "uid=user_123" in html, f"{plugin_dir}: normal uid missing"
 
 
+# plugin dir -> OAuth callback handler that also reflects uid into
+# success/retry href links.
+CALLBACKS = {
+    "omi-whoop-app": "whoop_callback",
+    "omi-twitter-chat-tools-app": "twitter_callback",
+    "omi-github-app": "auth_callback",
+    "omi-notion-app": "notion_callback",
+    "omi-clickup-app": "auth_callback",
+    "omi-slack-app": "auth_callback",
+}
+
+
+class _FakeResp:
+    status_code = 200
+    text = "ok"
+
+    def json(self):
+        return {
+            "access_token": "tok123",
+            "refresh_token": "ref123",
+            "expires_in": 3600,
+            "data": {"username": "u", "id": "1"},
+        }
+
+
+def _drive_callback(module, plugin_dir, uid):
+    """Run the plugin's OAuth callback with a seeded valid state and a
+    successful token exchange, so the uid-bearing success page renders."""
+    cb = getattr(module, CALLBACKS[plugin_dir])
+    patches = []
+    if plugin_dir in ("omi-github-app", "omi-clickup-app", "omi-slack-app"):
+        module.oauth_states["st"] = uid
+        state = "st"
+    else:
+        # notion/twitter derive uid as state.split(":")[0]; whoop resolves
+        # it via get_uid_from_oauth_state (patched below).
+        state = f"{uid}:nonce"
+    if plugin_dir == "omi-whoop-app":
+        patches.append(mock.patch.object(module, "get_uid_from_oauth_state", lambda s: uid))
+    if plugin_dir in ("omi-notion-app", "omi-twitter-chat-tools-app"):
+        patches.append(mock.patch.object(module, "get_oauth_state", lambda u: state))
+    req = getattr(module, "requests", None)
+    if req is not None:
+        patches.append(mock.patch.object(req, "post", lambda *a, **k: _FakeResp()))
+        patches.append(mock.patch.object(req, "get", lambda *a, **k: _FakeResp()))
+    kwargs = {"code": "code123", "state": state}
+    if "request" in inspect.signature(cb).parameters:
+        kwargs["request"] = None
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        return asyncio.run(cb(**kwargs))
+
+
+def test_callback_encodes_uid_after_state_lookup():
+    for plugin_dir in CALLBACKS:
+        module = _load_plugin(plugin_dir)
+        html = _drive_callback(module, plugin_dir, HOSTILE_UID)
+        assert isinstance(html, str), f"{plugin_dir}: callback did not return HTML"
+        assert '" onmouseover=' not in html, f"{plugin_dir}: raw uid reflected in callback"
+        assert "&admin=1" not in html, f"{plugin_dir}: raw uid reflected in callback"
+        assert "%22" in html, f"{plugin_dir}: encoded uid missing from callback page"
+
+
+def test_callback_rejects_unknown_state():
+    """Invalid-state early returns must not reference the unassigned uid_q."""
+    for plugin_dir, cb_name in CALLBACKS.items():
+        module = _load_plugin(plugin_dir)
+        patches = []
+        if plugin_dir == "omi-whoop-app":
+            patches.append(mock.patch.object(module, "get_uid_from_oauth_state", lambda s: None))
+        if plugin_dir in ("omi-notion-app", "omi-twitter-chat-tools-app"):
+            patches.append(mock.patch.object(module, "get_oauth_state", lambda u: None))
+        cb = getattr(module, cb_name)
+        kwargs = {"code": "c", "state": "never-registered"}
+        if "request" in inspect.signature(cb).parameters:
+            kwargs["request"] = None
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            html = asyncio.run(cb(**kwargs))
+        assert isinstance(html, str), f"{plugin_dir}: invalid-state path crashed"
+
+
+def test_github_uid_js_escapes_script_close():
+    module = _load_plugin("omi-github-app")
+    uid = '</script><script>alert(1)</script>'
+    with mock.patch.object(
+        module.SimpleUserStorage, "get_user", lambda *a, **k: {"access_token": "t"}
+    ):
+        html = asyncio.run(module.root(uid=uid))
+    assert isinstance(html, str)
+    assert "<script>alert(1)" not in html, "uid broke out of the script block"
+    assert "\\u003c" in html, "uid_js not unicode-escaped"
+
+
+def test_slack_dev_page_encodes_uid_in_fetch_urls():
+    """The dev test page builds fetch() URLs from a DOM uid — every one
+    must go through encodeURIComponent, never a raw ${uid} interpolation."""
+    module = _load_plugin("omi-slack-app")
+    html = asyncio.run(module.test_interface(uid="user_123", dev="true"))
+    assert isinstance(html, str)
+    assert "${encodeURIComponent(uid)}" in html, "encoded uid interpolation missing"
+    assert "${uid}" not in html, "raw uid interpolation survived in fetch URL"
+
+
 if __name__ == "__main__":
-    tests = [test_uid_cannot_break_out_of_href, test_normal_uid_still_links]
+    tests = [
+        test_uid_cannot_break_out_of_href,
+        test_normal_uid_still_links,
+        test_callback_encodes_uid_after_state_lookup,
+        test_callback_rejects_unknown_state,
+        test_github_uid_js_escapes_script_close,
+        test_slack_dev_page_encodes_uid_in_fetch_urls,
+    ]
     for t in tests:
         t()
         print(f"PASS {t.__name__}")

--- a/plugins/test_uid_reflection.py
+++ b/plugins/test_uid_reflection.py
@@ -1,0 +1,138 @@
+"""Hermetic regression: six plugins reflect the client-controlled `uid`
+query param into HTML `href` attributes and fetch() URLs unencoded, e.g.
+auth_url = f"/auth/whoop?uid={uid}" inside <a href="{auth_url}">.
+A uid containing a double quote breaks the attribute (HTML injection).
+
+The suite loads each plugin's main.py with stubbed framework/db imports,
+drives the real `root` handler down the not-connected branch, and asserts
+the uid arrives percent-encoded inside the href.
+
+Run: python3 plugins/test_uid_reflection.py
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+PLUGINS_DIR = Path(__file__).resolve().parent
+
+# plugin dir -> (attribute on the loaded module that gates the connect page,
+#                patched to a falsy value so root() renders the auth link)
+PLUGINS = {
+    "omi-whoop-app": ("get_whoop_tokens", None),
+    "omi-twitter-chat-tools-app": ("get_twitter_tokens", None),
+    "omi-github-app": ("SimpleUserStorage", "get_user"),
+    "omi-notion-app": ("get_notion_tokens", None),
+    "omi-clickup-app": ("SimpleUserStorage", "get_user"),
+    "omi-slack-app": ("SimpleUserStorage", "get_user"),
+}
+
+HOSTILE_UID = 'x" onmouseover="alert(1)&admin=1'
+
+
+def _decorator(*args, **kwargs):
+    return lambda fn: fn
+
+
+def _permissive(name):
+    module = types.ModuleType(name)
+
+    def _missing(attr):
+        return mock.MagicMock(name=f"{name}.{attr}")
+
+    module.__getattr__ = _missing
+    return module
+
+
+def _load_plugin(plugin_dir):
+    fastapi = types.ModuleType("fastapi")
+
+    class _FastAPI:
+        def __init__(self, *a, **k):
+            pass
+
+        get = staticmethod(_decorator)
+        post = staticmethod(_decorator)
+        on_event = staticmethod(_decorator)
+        websocket = staticmethod(_decorator)
+        mount = staticmethod(lambda *a, **k: None)
+
+    fastapi.FastAPI = _FastAPI
+    fastapi.Request = object
+    fastapi.Query = lambda default=None, **kw: default
+    fastapi.HTTPException = type("HTTPException", (Exception,), {})
+
+    responses = types.ModuleType("fastapi.responses")
+    responses.HTMLResponse = lambda content=None, **kw: content
+    responses.JSONResponse = lambda content=None, **kw: content
+    responses.RedirectResponse = lambda url=None, **kw: types.SimpleNamespace(url=url)
+    fastapi.responses = responses
+
+    templating = types.ModuleType("fastapi.templating")
+    templating.Jinja2Templates = lambda *a, **k: mock.Mock()
+    staticfiles = types.ModuleType("fastapi.staticfiles")
+    staticfiles.StaticFiles = lambda *a, **k: None
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *a, **k: None
+
+    stubs = {
+        "fastapi": fastapi,
+        "fastapi.responses": responses,
+        "fastapi.templating": templating,
+        "fastapi.staticfiles": staticfiles,
+        "dotenv": dotenv,
+    }
+    for name in (
+        "db", "models", "requests", "httpx", "simple_storage", "github_client",
+        "issue_detector", "agent_providers", "clickup_client", "task_detector",
+        "omi_notifications", "slack_client", "message_detector", "uvicorn",
+    ):
+        stubs[name] = _permissive(name)
+
+    main_path = PLUGINS_DIR / plugin_dir / "main.py"
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location(
+            f"{plugin_dir.replace('-', '_')}_under_test", main_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _connect_page(module, gate, uid):
+    """Run root() with the token gate forced falsy -> connect/auth page."""
+    attr, sub = gate
+    if sub is None:
+        patcher = mock.patch.object(module, attr, lambda *a, **k: None)
+    else:
+        patcher = mock.patch.object(getattr(module, attr), sub, lambda *a, **k: None)
+    with patcher:
+        return asyncio.run(module.root(uid=uid))
+
+
+def test_uid_cannot_break_out_of_href():
+    for plugin_dir, gate in PLUGINS.items():
+        module = _load_plugin(plugin_dir)
+        html = _connect_page(module, gate, HOSTILE_UID)
+        assert isinstance(html, str), f"{plugin_dir}: connect page is not HTML"
+        assert '" onmouseover=' not in html, f"{plugin_dir}: attribute injection survived"
+        assert "%22" in html, f"{plugin_dir}: uid not percent-encoded in page"
+        assert "/auth" in html, f"{plugin_dir}: auth link missing"
+
+
+def test_normal_uid_still_links():
+    for plugin_dir, gate in PLUGINS.items():
+        module = _load_plugin(plugin_dir)
+        html = _connect_page(module, gate, "user_123")
+        assert "uid=user_123" in html, f"{plugin_dir}: normal uid missing"
+
+
+if __name__ == "__main__":
+    tests = [test_uid_cannot_break_out_of_href, test_normal_uid_still_links]
+    for t in tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"{len(tests)}/{len(tests)} tests passed")

--- a/plugins/test_uid_reflection.py
+++ b/plugins/test_uid_reflection.py
@@ -123,6 +123,10 @@ def test_uid_cannot_break_out_of_href():
         assert '" onmouseover=' not in html, f"{plugin_dir}: attribute injection survived"
         assert "%22" in html, f"{plugin_dir}: uid not percent-encoded in page"
         assert "/auth" in html, f"{plugin_dir}: auth link missing"
+        # "&" must also be encoded — otherwise &admin=1 becomes a real
+        # second query parameter handed to the auth flow.
+        assert "%26" in html, f"{plugin_dir}: ampersand left raw in uid"
+        assert "&admin=1" not in html, f"{plugin_dir}: query param injection survived"
 
 
 def test_normal_uid_still_links():
@@ -228,14 +232,37 @@ def test_github_uid_js_escapes_script_close():
     assert "\\u003c" in html, "uid_js not unicode-escaped"
 
 
-def test_slack_dev_page_encodes_uid_in_fetch_urls():
-    """The dev test page builds fetch() URLs from a DOM uid — every one
-    must go through encodeURIComponent, never a raw ${uid} interpolation."""
-    module = _load_plugin("omi-slack-app")
-    html = asyncio.run(module.test_interface(uid="user_123", dev="true"))
-    assert isinstance(html, str)
-    assert "${encodeURIComponent(uid)}" in html, "encoded uid interpolation missing"
-    assert "${uid}" not in html, "raw uid interpolation survived in fetch URL"
+# plugin dir -> disconnect handler that redirects to /?uid=<uid>.
+DISCONNECTS = {
+    "omi-whoop-app": "disconnect",
+    "omi-twitter-chat-tools-app": "disconnect",
+    "omi-notion-app": "disconnect",
+}
+
+
+def test_disconnect_redirect_encodes_uid():
+    for plugin_dir, fn_name in DISCONNECTS.items():
+        module = _load_plugin(plugin_dir)
+        resp = asyncio.run(getattr(module, fn_name)(uid=HOSTILE_UID))
+        url = resp.url
+        assert isinstance(url, str), f"{plugin_dir}: disconnect did not redirect"
+        assert '" onmouseover=' not in url, f"{plugin_dir}: raw uid in redirect"
+        assert "&admin=1" not in url, f"{plugin_dir}: query injection in redirect"
+        assert "%22" in url and "%26" in url, f"{plugin_dir}: uid not encoded in redirect"
+
+
+def test_dev_pages_encode_uid_in_fetch_urls():
+    """The dev test pages build fetch() URLs from a DOM uid — every one
+    must go through encodeURIComponent, never a raw ${uid} interpolation.
+    The value="{uid_h}" attribute must also be HTML-escaped."""
+    for plugin_dir in ("omi-clickup-app", "omi-slack-app"):
+        module = _load_plugin(plugin_dir)
+        html = asyncio.run(module.test_interface(uid=HOSTILE_UID, dev="true"))
+        assert isinstance(html, str), f"{plugin_dir}: dev page is not HTML"
+        assert "${encodeURIComponent(uid)}" in html, f"{plugin_dir}: encoded interpolation missing"
+        assert "${uid}" not in html, f"{plugin_dir}: raw uid interpolation survived"
+        assert "&quot;" in html, f"{plugin_dir}: value attribute not HTML-escaped"
+        assert '" onmouseover=' not in html, f"{plugin_dir}: attribute injection survived"
 
 
 if __name__ == "__main__":
@@ -245,7 +272,8 @@ if __name__ == "__main__":
         test_callback_encodes_uid_after_state_lookup,
         test_callback_rejects_unknown_state,
         test_github_uid_js_escapes_script_close,
-        test_slack_dev_page_encodes_uid_in_fetch_urls,
+        test_disconnect_redirect_encodes_uid,
+        test_dev_pages_encode_uid_in_fetch_urls,
     ]
     for t in tests:
         t()


### PR DESCRIPTION
## Summary

The client-controlled `uid` query param was reflected raw into HTML on the connect/setup pages of six plugins — `auth_url = f"/auth?uid={uid}"` rendered inside `<a href="{auth_url}">`, plus disconnect/back links, `RedirectResponse` targets, `fetch()` URLs, a `value="{uid}"` attribute, and a JS string literal in github's page:

- `omi-whoop-app`, `omi-twitter-chat-tools-app`, `omi-github-app`, `omi-notion-app`, `omi-clickup-app`, `omi-slack-app`

`uid=x" onmouseover="alert(1)` breaks the `href` attribute — verified end-to-end: the raw payload reaches the rendered page. `&`, `#`, `?` in a uid also corrupt the query param handed to the auth flow.

Each affected handler now percent-encodes `uid` once (`uid_q = quote(uid, safe="")`) for URL/href contexts; github's JS object literal uses `json.dumps(uid)`; the `value=` attributes in the clickup/slack test pages use `html.escape`. Stats/logging paths keep the raw uid.

## Verification

`plugins/test_uid_reflection.py` (new, hermetic, registered as `plugin-uid-reflection-encoding-tests` in `.github/checks-manifest.yaml`) loads each plugin's `main.py` with stubbed FastAPI/db/storage imports and drives the real `root()` handler on the not-connected branch:

- `uid='x" onmouseover="alert(1)&admin=1'`: on the old code every plugin emits a broken `href` (`" onmouseover=` survives — assertion fails on all six); with the fix the page carries `x%22%20onmouseover%3D...`
- `uid=user_123` still produces `uid=user_123` links in all six pages

2/2 pass covering all six plugins; the injection assertion fails on the original code.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

