### PR TITLE
fix(plugins): encode uid in linear/hive/manual-import URL contexts

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: plugin-uid-query-encoding-extra-tests
+    command: ["python3", "plugins/test_uid_reflection_extra.py"]
+    triggers: ["plugins/omi-linear-app/**", "plugins/omi-hive-app/**", "plugins/import/manual-import/**", "plugins/test_uid_reflection_extra.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the client-controlled uid/user_id was interpolated raw into linear's setup oauth_url + template hrefs, hive's redirect Location headers, and manual-import's API query; & or # in the value corrupted the query string (verified param injection)"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/import/manual-import/app.py
+++ b/plugins/import/manual-import/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify, send_from_directory
 import requests
+from urllib.parse import quote
 import json
 import os
 import re
@@ -308,7 +309,7 @@ def submit_memories():
                 time.sleep(0.5)  # Half second delay between requests
 
             # Send the request to OMI API with dynamic user_id (still using the facts endpoint)
-            response = requests.post(f"{API_URL}?uid={user_id}", headers=headers, data=json.dumps(memory_data))
+            response = requests.post(f"{API_URL}?uid={quote(user_id, safe='')}", headers=headers, data=json.dumps(memory_data))
 
             # Record result
             result = {

--- a/plugins/omi-hive-app/main.py
+++ b/plugins/omi-hive-app/main.py
@@ -8,6 +8,7 @@ import os
 from typing import Optional, Dict, Any, List
 
 import requests
+from urllib.parse import quote
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request, Query, Form
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
@@ -566,7 +567,7 @@ async def connect_api_key(
     if not user_info:
         # Return to setup page with error
         return RedirectResponse(
-            url=f"/?uid={uid}&error=Invalid+API+key.+Please+check+and+try+again.",
+            url=f"/?uid={quote(uid, safe='')}&error=Invalid+API+key.+Please+check+and+try+again.",
             status_code=303
         )
     
@@ -579,7 +580,7 @@ async def connect_api_key(
         workspace_id=user_info.get("workspace_id"),
     )
     
-    return RedirectResponse(url=f"/?uid={uid}", status_code=303)
+    return RedirectResponse(url=f"/?uid={quote(uid, safe='')}", status_code=303)
 
 
 @app.get("/setup/hive", tags=["setup"])
@@ -600,7 +601,7 @@ async def set_default_project(uid: str, project_id: str, project_name: str):
 async def disconnect_hive(uid: str):
     """Disconnect Hive account."""
     delete_hive_credentials(uid)
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={quote(uid, safe='')}")
 
 
 # ============================================

--- a/plugins/omi-linear-app/main.py
+++ b/plugins/omi-linear-app/main.py
@@ -324,14 +324,16 @@ async def home(request: Request, uid: Optional[str] = None):
         teams = get_user_teams(uid)
         default_team = get_default_team(uid)
     
+    uid_q = urllib.parse.quote(uid, safe="")
     return templates.TemplateResponse("setup.html", {
         "request": request,
         "uid": uid,
+        "uid_q": uid_q,
         "authenticated": authenticated,
         "user_profile": user_profile,
         "teams": teams,
         "default_team": default_team,
-        "oauth_url": f"/auth/linear?uid={uid}"
+        "oauth_url": f"/auth/linear?uid={uid_q}"
     })
 
 
@@ -405,7 +407,7 @@ async def linear_callback(request: Request, code: str = None, state: str = None,
     )
     
     # Redirect to home with uid
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={urllib.parse.quote(uid, safe='')}")
 
 
 @app.get("/setup/linear", tags=["setup"])
@@ -426,7 +428,7 @@ async def set_default_team(uid: str, team_id: str, team_name: str):
 async def disconnect_linear(uid: str):
     """Disconnect Linear account."""
     delete_linear_tokens(uid)
-    return RedirectResponse(url=f"/?uid={uid}")
+    return RedirectResponse(url=f"/?uid={urllib.parse.quote(uid, safe='')}")
 
 
 # ============================================

--- a/plugins/omi-linear-app/templates/setup.html
+++ b/plugins/omi-linear-app/templates/setup.html
@@ -499,10 +499,10 @@
             </p>
 
             <div class="action-buttons">
-                <a href="/auth/linear?uid={{ uid }}" class="btn btn-outline btn-small">
+                <a href="/auth/linear?uid={{ uid_q }}" class="btn btn-outline btn-small">
                     🔄 Reconnect
                 </a>
-                <a href="/disconnect?uid={{ uid }}" class="btn btn-danger btn-small">
+                <a href="/disconnect?uid={{ uid_q }}" class="btn btn-danger btn-small">
                     Disconnect
                 </a>
             </div>

--- a/plugins/test_uid_reflection_extra.py
+++ b/plugins/test_uid_reflection_extra.py
@@ -1,0 +1,211 @@
+"""Hermetic regression: client-controlled `uid`/`user_id` values were
+interpolated raw into setup-page auth URLs, redirect Location headers, and an
+outbound API query in three more plugins (linear, hive, manual-import). A `&`
+or `#` in uid corrupted the query string (e.g. injecting an `error` param),
+and the linear setup template rendered the raw value into href targets.
+
+Run: python3 plugins/test_uid_reflection_extra.py
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+from urllib.parse import quote
+
+PLUGINS = Path(__file__).resolve().parent
+HOSTILE_UID = 'x&error=injected#frag'
+NORMAL_UID = "user_123"
+
+
+def _decorator(*args, **kwargs):
+    return lambda fn: fn
+
+
+def _stub(name, **attrs):
+    module = types.ModuleType(name)
+
+    def _missing(attr):
+        return mock.Mock(name=f"{name}.{attr}")
+
+    module.__getattr__ = _missing
+    module.__dict__.update(attrs)
+    return module
+
+
+class _Redirect:
+    def __init__(self, url=None, status_code=None, **kw):
+        self.url = url
+        self.status_code = status_code
+
+
+class _HTTPException(Exception):
+    def __init__(self, status_code=None, detail=None, **kw):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _fastapi_stubs():
+    """Stubs shared by the FastAPI plugins (linear, hive)."""
+    fastapi = _stub(
+        "fastapi",
+        FastAPI=lambda *a, **k: mock.Mock(
+            get=_decorator, post=_decorator, mount=lambda *a, **k: None,
+            websocket=_decorator, on_event=lambda *a, **k: _decorator,
+        ),
+        HTTPException=_HTTPException,
+        Request=object,
+        Query=lambda default=None, **kw: default,
+        Form=lambda default=None, **kw: default,
+    )
+    responses = _stub(
+        "fastapi.responses",
+        HTMLResponse=dict,
+        RedirectResponse=_Redirect,
+        JSONResponse=dict,
+    )
+    staticfiles = _stub("fastapi.staticfiles", StaticFiles=lambda *a, **k: None)
+    templating = _stub(
+        "fastapi.templating",
+        Jinja2Templates=lambda *a, **k: types.SimpleNamespace(
+            TemplateResponse=lambda template, ctx: types.SimpleNamespace(
+                template=template, context=ctx
+            )
+        ),
+    )
+    return {
+        "fastapi": fastapi,
+        "fastapi.responses": responses,
+        "fastapi.staticfiles": staticfiles,
+        "fastapi.templating": templating,
+        "dotenv": _stub("dotenv", load_dotenv=lambda *a, **k: None),
+        "db": _stub("db"),
+        "models": _stub("models", ChatToolResponse=dict),
+        "requests": _stub("requests"),
+    }
+
+
+def _load(module_name, path, stubs):
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def _load_linear():
+    return _load("linear_main_under_test", PLUGINS / "omi-linear-app" / "main.py", _fastapi_stubs())
+
+
+def _load_hive():
+    return _load("hive_main_under_test", PLUGINS / "omi-hive-app" / "main.py", _fastapi_stubs())
+
+
+def _load_manual_import(recorded):
+    """Stub flask/requests/openai so submit_memories runs its real path."""
+
+    class _Flask:
+        def __init__(self, *a, **k):
+            pass
+
+        route = staticmethod(_decorator)
+
+    flask = _stub(
+        "flask",
+        Flask=_Flask,
+        request=types.SimpleNamespace(json=None),
+        jsonify=lambda obj=None, *a, **k: obj,
+        send_from_directory=lambda *a, **k: None,
+    )
+
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+        def json(self):
+            return {}
+
+    def _post(url, **kw):
+        recorded.append(url)
+        return _Resp()
+
+    stubs = {
+        "flask": flask,
+        "requests": _stub("requests", post=_post),
+        "openai": _stub("openai"),
+        "httpx": _stub("httpx"),
+        "dotenv": _stub("dotenv", load_dotenv=lambda *a, **k: None),
+    }
+    module = _load("manual_import_under_test", PLUGINS / "import" / "manual-import" / "app.py", stubs)
+    return module, flask
+
+
+def test_linear_setup_oauth_url_encodes_uid():
+    module = _load_linear()
+    with mock.patch.object(module, "get_linear_tokens", lambda uid: None):
+        resp = asyncio.run(module.home(request=object(), uid=HOSTILE_UID))
+    ctx = resp.context
+    expected = f"/auth/linear?uid={quote(HOSTILE_UID, safe='')}"
+    assert ctx["oauth_url"] == expected, ctx["oauth_url"]
+    # the template must render the encoded value into the href targets
+    template = (PLUGINS / "omi-linear-app" / "templates" / "setup.html").read_text()
+    assert "uid={{ uid_q }}" in template
+    assert "uid={{ uid }}" not in template
+
+
+def test_linear_disconnect_redirect_encodes_uid():
+    module = _load_linear()
+    resp = asyncio.run(module.disconnect_linear(uid=HOSTILE_UID))
+    assert resp.url == f"/?uid={quote(HOSTILE_UID, safe='')}", resp.url
+
+
+def test_hive_redirects_encode_uid():
+    module = _load_hive()
+    with mock.patch.object(module, "verify_api_key", lambda key: None):
+        resp = asyncio.run(module.connect_api_key(uid=HOSTILE_UID, api_key="bad"))
+    assert resp.url.startswith(f"/?uid={quote(HOSTILE_UID, safe='')}&"), resp.url
+    assert HOSTILE_UID not in resp.url
+
+    resp = asyncio.run(module.disconnect_hive(uid=HOSTILE_UID))
+    assert resp.url == f"/?uid={quote(HOSTILE_UID, safe='')}", resp.url
+
+
+def test_manual_import_encodes_uid_in_api_query():
+    recorded = []
+    module, flask = _load_manual_import(recorded)
+    flask.request.json = {
+        "uid": HOSTILE_UID,
+        "memories": ["a single memory that is well over twenty characters"],
+        "use_ai": False,
+    }
+    module.submit_memories()
+    assert recorded, "handler made no API call"
+    for url in recorded:
+        assert f"uid={quote(HOSTILE_UID, safe='')}" in url, url
+        assert HOSTILE_UID not in url
+
+
+def test_normal_uid_unchanged():
+    module = _load_linear()
+    resp = asyncio.run(module.disconnect_linear(uid=NORMAL_UID))
+    assert resp.url == "/?uid=user_123", resp.url
+    hive = _load_hive()
+    resp = asyncio.run(hive.disconnect_hive(uid=NORMAL_UID))
+    assert resp.url == "/?uid=user_123", resp.url
+
+
+if __name__ == "__main__":
+    tests = [
+        test_linear_setup_oauth_url_encodes_uid,
+        test_linear_disconnect_redirect_encodes_uid,
+        test_hive_redirects_encode_uid,
+        test_manual_import_encodes_uid_in_api_query,
+        test_normal_uid_unchanged,
+    ]
+    for t in tests:
+        t()
+        print(f"PASS {t.__name__}")
+    print(f"{len(tests)}/{len(tests)} tests passed")


### PR DESCRIPTION
## Summary

Follow-up to the setup-page `uid` reflection fix — same defect class in three more plugins:

- **omi-linear-app**: `oauth_url` built as `f"/auth/linear?uid={uid}"` and rendered into `href` targets in `setup.html`; two post-OAuth/disconnect redirects used `/?uid={uid}` raw. `&`/`#` in uid corrupted the query (verified: `uid=x&error=injected#frag` produced `/auth/linear?uid=x&error=injected#frag`).
- **omi-hive-app**: three `RedirectResponse(url=f"/?uid={uid}...")` sites, including the API-key error path — a `&` in uid injected extra query params into the setup page URL.
- **import/manual-import**: `user_id` interpolated raw into the OMI API POST query.

Fix: `urllib.parse.quote(value, safe="")` in each URL context; the linear template now renders a `uid_q` context var for href query params while `uid` stays for display.

Failure-Class: none

## Test plan

- [x] `python3 plugins/test_uid_reflection_extra.py` — 5/5 pass, hermetic (FastAPI/Flask/requests/openai stubbed); drives the real `home`, `connect_api_key`, `disconnect_*`, and `submit_memories` handlers
- [x] Verified on pre-fix code: `/auth/linear?uid=x&error=injected#frag` (injection survives)
- [x] Registered as `plugin-uid-query-encoding-extra-tests` in `.github/checks-manifest.yaml` (local + ci lanes)

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

