### PR TITLE
fix(windows): append uid to external-app setup URLs without corrupting queries

### DIFF
--- a/desktop/windows/changelog/unreleased/2026-09-external-app-setup-url.json
+++ b/desktop/windows/changelog/unreleased/2026-09-external-app-setup-url.json
@@ -1,0 +1,5 @@
+{
+  "changes": [
+    "External-app setup links now keep their existing query string intact when your user id is attached — integrations whose setup URL already carried parameters could silently fail to connect."
+  ]
+}

--- a/desktop/windows/src/renderer/src/lib/appInstall.test.ts
+++ b/desktop/windows/src/renderer/src/lib/appInstall.test.ts
@@ -51,6 +51,40 @@ describe('setupUrl', () => {
     expect(setupUrl(null, 'u')).toBeNull()
     expect(setupUrl(undefined, 'u')).toBeNull()
   })
+
+  it('appends uid with & when the step url already has a query', () => {
+    const integration = {
+      auth_steps: [{ name: 'Connect', url: 'https://ex.com/setup?ref=omi&lang=en' }]
+    }
+    expect(setupUrl(integration as ExternalIntegration, 'user-1')).toBe(
+      'https://ex.com/setup?ref=omi&lang=en&uid=user-1'
+    )
+  })
+
+  it('encodes a uid containing query/fragment characters', () => {
+    const integration = { auth_steps: [{ name: 'Connect', url: 'https://ex.com/setup' }] }
+    expect(setupUrl(integration as ExternalIntegration, 'a&b#c')).toBe(
+      'https://ex.com/setup?uid=a%26b%23c'
+    )
+  })
+
+  it('preserves existing query bytes verbatim (signed urls) and drops a stale uid', () => {
+    const integration = {
+      auth_steps: [{ name: 'Connect', url: 'https://ex.com/setup?sig=a+b%2Fc&uid=stale&x=1' }]
+    }
+    expect(setupUrl(integration as ExternalIntegration, 'u')).toBe(
+      'https://ex.com/setup?sig=a+b%2Fc&x=1&uid=u'
+    )
+  })
+
+  it('keeps the fragment after the appended uid', () => {
+    const integration = {
+      auth_steps: [{ name: 'Connect', url: 'https://ex.com/setup?a=1#section' }]
+    }
+    expect(setupUrl(integration as ExternalIntegration, 'u')).toBe(
+      'https://ex.com/setup?a=1&uid=u#section'
+    )
+  })
 })
 
 describe('isSetupCompleted', () => {

--- a/desktop/windows/src/renderer/src/lib/appInstall.ts
+++ b/desktop/windows/src/renderer/src/lib/appInstall.ts
@@ -22,6 +22,28 @@ export function worksExternally(app: { capabilities?: Array<string> | null }): b
   return (app.capabilities ?? []).includes('external_integration')
 }
 
+// Append `uid` to a developer-authored setup URL without corrupting an
+// existing query: `?uid=` glued onto a URL that already has a query string
+// produces `?a=1?uid=...` (the uid never reaches the developer's endpoint),
+// and a raw uid containing `&`/`#` injects or truncates params. Preserve the
+// existing query bytes verbatim (re-encoding breaks provider-signed URLs),
+// drop any pre-existing uid param so it can't be duplicated, then append the
+// encoded value. Mirrors macOS's AppSetupURL.withUID.
+export function urlWithUidParam(rawUrl: string, uid: string): string {
+  const hashIndex = rawUrl.indexOf('#')
+  const fragment = hashIndex >= 0 ? rawUrl.slice(hashIndex) : ''
+  const head = hashIndex >= 0 ? rawUrl.slice(0, hashIndex) : rawUrl
+  const qIndex = head.indexOf('?')
+  const encoded = `uid=${encodeURIComponent(uid)}`
+  if (qIndex < 0) return `${head}?${encoded}${fragment}`
+  const base = head.slice(0, qIndex)
+  const kept = head
+    .slice(qIndex + 1)
+    .split('&')
+    .filter((kv) => kv !== '' && kv.split('=', 1)[0] !== 'uid')
+  return `${base}?${[...kept, encoded].join('&')}${fragment}`
+}
+
 // The URL to open in the browser so the user can complete setup. macOS opens
 // `{authSteps[0].url}?uid={uid}` when an auth step exists, else the raw
 // `setupInstructionsFilePath` (with NO uid appended). Null when neither is set.
@@ -30,7 +52,7 @@ export function setupUrl(
   uid: string
 ): string | null {
   const stepUrl = integration?.auth_steps?.[0]?.url
-  if (stepUrl) return `${stepUrl}?uid=${uid}`
+  if (stepUrl) return urlWithUidParam(stepUrl, uid)
   const instructions = integration?.setup_instructions_file_path
   return instructions ? instructions : null
 }


### PR DESCRIPTION
## Summary

`setupUrl()` in `desktop/windows/src/renderer/src/lib/appInstall.ts` built the external-integration setup URL as `` `${stepUrl}?uid=${uid}` `` — the raw-concatenation bug already fixed on macOS in #13650 (`AppSetupURL.withUID`):

- A step URL that already carries a query (`...?ref=x`) produced `...?ref=x?uid=u` — the uid never reaches the developer's endpoint and setup polling can never flip, so the install dead-ends.
- A uid containing `&`/`#` injected or truncated query params.
- Existing query bytes were at risk of re-serialization (breaks provider-signed URLs).

`urlWithUidParam` preserves the existing query verbatim, drops a stale `uid` param so it can't duplicate, appends the `encodeURIComponent`d uid, and keeps the fragment last — the reviewed macOS semantics.

Failure-Class: none

## Test plan

- [x] `vitest run src/renderer/src/lib/appInstall.test.ts` — 20/20 pass (4 new cases: existing query, `&`/`#` uid, signed-URL byte preservation + stale-uid drop, fragment placement)
- [x] All 4 new cases fail on the pre-fix implementation
- [x] `tsc --noEmit -p tsconfig.web.json` clean; prettier + eslint clean
- [x] Changelog fragment added (user-visible: setup links with existing params now connect)

Generated with [Devin](https://devin.ai)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

