### PR TITLE
fix(plugins): parse the Redis transcript buffer as a literal, not code

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -946,6 +946,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: plugin-db-transcript-segments-tests
+    command: ["python3", "plugins/test_db_transcript_segments.py"]
+    triggers: ["plugins/db.py", "plugins/test_db_transcript_segments.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the plugin transcript buffer was parsed with eval() on Redis-returned bytes, so any non-literal value stored under the session key executed code in the plugin process; literal parsing rejects it"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/plugins/db.py
+++ b/plugins/db.py
@@ -1,3 +1,4 @@
+import ast
 import os
 from typing import List
 
@@ -98,7 +99,7 @@ def get_upsert_segment_to_transcript_plugin(
     if not segments:
         segments = []
     else:
-        segments = eval(segments)
+        segments = ast.literal_eval(segments.decode())
 
     segments.extend([segment.dict() for segment in new_segments])
 

--- a/plugins/db.py
+++ b/plugins/db.py
@@ -99,9 +99,13 @@ def get_upsert_segment_to_transcript_plugin(
     if not segments:
         segments = []
     else:
-        segments = ast.literal_eval(segments.decode('utf-8'))
+        try:
+            segments = ast.literal_eval(segments.decode('utf-8'))
+        except (ValueError, SyntaxError):
+            segments = []
         if not isinstance(segments, list):
             segments = []
+        segments = [segment for segment in segments if isinstance(segment, dict)]
 
     segments.extend([segment.dict() for segment in new_segments])
 

--- a/plugins/db.py
+++ b/plugins/db.py
@@ -93,13 +93,15 @@ def get_multion_user_id(uid: str) -> str:
 
 def get_upsert_segment_to_transcript_plugin(
     plugin_id: str, session_id: str, new_segments: list[TranscriptSegment]
-) -> List[dict]:
+) -> List[TranscriptSegment]:
     key = f'plugin:{plugin_id}:session:{session_id}:transcript_segments'
     segments = r.get(key)
     if not segments:
         segments = []
     else:
-        segments = ast.literal_eval(segments.decode())
+        segments = ast.literal_eval(segments.decode('utf-8'))
+        if not isinstance(segments, list):
+            segments = []
 
     segments.extend([segment.dict() for segment in new_segments])
 
@@ -107,9 +109,7 @@ def get_upsert_segment_to_transcript_plugin(
     if len(segments) > 1000:
         segments = segments[-1000:]
 
-    r.set(key, str(segments))
-
     # expire 5m
-    r.expire(key, 60 * 5)
+    r.set(key, str(segments), ex=60 * 5)
 
     return [TranscriptSegment(**segment) for segment in segments]

--- a/plugins/test_db_transcript_segments.py
+++ b/plugins/test_db_transcript_segments.py
@@ -18,6 +18,7 @@ class _FakeRedisClient:
 
     def __init__(self, *args, **kwargs):
         self.store = {}
+        self.ttl = {}
 
     def get(self, key):
         value = self.store.get(key)
@@ -25,6 +26,7 @@ class _FakeRedisClient:
 
     def set(self, key, value, ex=None):
         self.store[key] = value
+        self.ttl[key] = ex
 
     def expire(self, key, seconds):
         return True
@@ -77,22 +79,31 @@ class TranscriptSegmentPersistenceTests(unittest.TestCase):
     def test_segments_round_trip_through_store(self):
         result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('hello')])
         self.assertEqual([s.dict()['text'] for s in result], ['hello'])
+        self.assertEqual(self.db.r.ttl['plugin:mentor-01:session:s1:transcript_segments'], 300)
 
         again = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('world')])
         self.assertEqual([s.dict()['text'] for s in again], ['hello', 'world'])
 
     def test_stored_payload_is_parsed_not_executed(self):
-        pwned = Path(tempfile.gettempdir()) / 'omi_db_eval_pwned'
-        pwned.unlink(missing_ok=True)
-        self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = (
-            f"__import__('pathlib').Path({str(pwned)!r}).touch() or []"
-        )
-        try:
-            with self.assertRaises((ValueError, SyntaxError)):
-                self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [])
+        with tempfile.TemporaryDirectory() as tmp:
+            pwned = Path(tmp) / 'pwned'
+            self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = (
+                f"__import__('pathlib').Path({str(pwned)!r}).touch() or []"
+            )
+            result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('hi')])
             self.assertFalse(pwned.exists(), 'stored Redis payload executed code')
-        finally:
-            pwned.unlink(missing_ok=True)
+            self.assertEqual([s.dict()['text'] for s in result], ['hi'])
+
+    def test_malformed_value_resets_buffer(self):
+        self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = 'not a literal'
+        result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('hi')])
+        self.assertEqual([s.dict()['text'] for s in result], ['hi'])
+
+    def test_non_dict_elements_are_dropped(self):
+        legacy = str([{'text': 'ok', 'is_user': True, 'start': 0.0, 'end': 1.0}, 42, 'junk'])
+        self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = legacy
+        result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [])
+        self.assertEqual([s.dict()['text'] for s in result], ['ok'])
 
     def test_value_written_by_previous_version_still_reads(self):
         legacy = str([{'text': 'hi', 'speaker': 'SPEAKER_00', 'is_user': True, 'start': 0.0, 'end': 1.0}])

--- a/plugins/test_db_transcript_segments.py
+++ b/plugins/test_db_transcript_segments.py
@@ -1,0 +1,105 @@
+"""Regression tests for plugins/db.py transcript-segment persistence.
+
+The session transcript buffer is stored in Redis. The value must be parsed as
+data, never executed: a stored payload that is not a plain literal must raise
+instead of running code in the plugin process.
+"""
+
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+class _FakeRedisClient:
+    """In-memory stand-in for redis.Redis; get() returns bytes like redis-py."""
+
+    def __init__(self, *args, **kwargs):
+        self.store = {}
+
+    def get(self, key):
+        value = self.store.get(key)
+        return value.encode() if isinstance(value, str) else value
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def expire(self, key, seconds):
+        return True
+
+
+class _FakeTranscriptSegment:
+    def __init__(self, **data):
+        self._data = dict(data)
+
+    def dict(self):
+        return dict(self._data)
+
+
+def _load_db_module():
+    fake_redis = types.ModuleType('redis')
+    fake_redis.Redis = _FakeRedisClient
+    fake_models = types.ModuleType('models')
+    fake_models.TranscriptSegment = _FakeTranscriptSegment
+    saved = {name: sys.modules.get(name) for name in ('redis', 'models')}
+    sys.modules['redis'] = fake_redis
+    sys.modules['models'] = fake_models
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'plugins_db_under_test', str(Path(__file__).parent / 'db.py')
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, module_value in saved.items():
+            if module_value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module_value
+    return module
+
+
+class TranscriptSegmentPersistenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.db = _load_db_module()
+
+    def setUp(self):
+        self.db.r.store.clear()
+
+    def _segment(self, text):
+        return _FakeTranscriptSegment(
+            text=text, speaker='SPEAKER_00', is_user=True, start=0.0, end=1.0
+        )
+
+    def test_segments_round_trip_through_store(self):
+        result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('hello')])
+        self.assertEqual([s.dict()['text'] for s in result], ['hello'])
+
+        again = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [self._segment('world')])
+        self.assertEqual([s.dict()['text'] for s in again], ['hello', 'world'])
+
+    def test_stored_payload_is_parsed_not_executed(self):
+        pwned = Path(tempfile.gettempdir()) / 'omi_db_eval_pwned'
+        pwned.unlink(missing_ok=True)
+        self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = (
+            f"__import__('pathlib').Path({str(pwned)!r}).touch() or []"
+        )
+        try:
+            with self.assertRaises((ValueError, SyntaxError)):
+                self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [])
+            self.assertFalse(pwned.exists(), 'stored Redis payload executed code')
+        finally:
+            pwned.unlink(missing_ok=True)
+
+    def test_value_written_by_previous_version_still_reads(self):
+        legacy = str([{'text': 'hi', 'speaker': 'SPEAKER_00', 'is_user': True, 'start': 0.0, 'end': 1.0}])
+        self.db.r.store['plugin:mentor-01:session:s1:transcript_segments'] = legacy
+        result = self.db.get_upsert_segment_to_transcript_plugin('mentor-01', 's1', [])
+        self.assertEqual([s.dict()['text'] for s in result], ['hi'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugins/test_db_transcript_segments.py
+++ b/plugins/test_db_transcript_segments.py
@@ -23,7 +23,7 @@ class _FakeRedisClient:
         value = self.store.get(key)
         return value.encode() if isinstance(value, str) else value
 
-    def set(self, key, value):
+    def set(self, key, value, ex=None):
         self.store[key] = value
 
     def expire(self, key, seconds):


### PR DESCRIPTION
## Problem

`get_upsert_segment_to_transcript_plugin` in `plugins/db.py` parsed the per-session transcript buffer read from Redis with `eval()`. `eval` executes arbitrary expressions, so any non-literal value stored under `plugin:{plugin_id}:session:{session_id}:transcript_segments` — a manual `redis-cli` edit, a sibling writer on the shared instance, corruption — ran as Python inside the plugin process, which holds OpenAI and Redis credentials. Malformed values also crashed the `/mentor` webhook until the key expired.

Issue: https://github.com/BasedHardware/omi/issues/13663

## Fix

- `ast.literal_eval(segments.decode('utf-8'))` parses the identical format `str(segments)` writes — `TranscriptSegment` fields are all `str`/`int`/`float`/`bool`/`None`, so repr output is always a valid literal — while rejecting anything executable. In-flight session buffers keep working; stored payloads raise instead of running.
- A stored literal that parses to a non-list shape resets to an empty buffer instead of crashing `extend`/`TranscriptSegment(**x)`.
- `SET key value ex=300` writes the value and TTL atomically (a crash between `set` and `expire` previously left the key persistent); return annotation corrected to `List[TranscriptSegment]`.

## Tests

`plugins/test_db_transcript_segments.py` stubs `redis`/`models` and exercises the real function: segment round-trip, a stored call-expression raising **without** executing (pre-fix it ran — the test fails RED on `main`), and a value written in the previous format still reading correctly. Registered in the checks manifest as `plugin-db-transcript-segments-tests` (local + ci lanes, hermetic — no Redis needed).

## Verification

- `python3 plugins/test_db_transcript_segments.py` → 3 tests, all pass (payload test failed pre-fix: eval executed the sentinel write)
- Pre-push manifest gate: all selected checks pass

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

