### PR TITLE
feat(backend): page prod Redis used_memory at 90% from notifications-job

### DIFF
--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -231,6 +231,64 @@ jobs:
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --format='value(notificationChannels)' | grep -q .
 
+      - name: Provision prod Redis used_memory 90% alarm
+        if: github.event.inputs.environment == 'prod'
+        env:
+          ALERT_CHANNELS: ${{ vars.SYNC_BACKFILL_ALERT_NOTIFICATION_CHANNELS }}
+        run: |
+          set -euo pipefail
+          test -n "$ALERT_CHANNELS"
+          metric='redis_memory_90'
+          display_name='Prod Redis used_memory ≥ 90%'
+          documentation='Prod Redis Cloud used_memory crossed 90% of the 12 GiB Essentials cap (INFO omits maxmemory). Writes fail closed under noeviction. Inspect notifications-job redis_memory_threshold logs. Same class as the unbounded users:{uid}:filters:* fill.'
+          log_filter='resource.type="cloud_run_job" resource.labels.job_name="notifications-job" "redis_memory_threshold threshold=90"'
+
+          if gcloud logging metrics describe "$metric" --project="${{ vars.GCP_PROJECT_ID }}" >/dev/null 2>&1; then
+            gcloud logging metrics update "$metric" \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --description="$display_name" \
+              --log-filter="$log_filter"
+          else
+            gcloud logging metrics create "$metric" \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --description="$display_name" \
+              --log-filter="$log_filter"
+          fi
+
+          policy="$(
+            gcloud monitoring policies list \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --filter="displayName=\"${display_name}\"" \
+              --format='value(name)' \
+              --limit=1
+          )"
+          if [[ -z "$policy" ]]; then
+            policy="$(
+              gcloud monitoring policies create \
+                --project="${{ vars.GCP_PROJECT_ID }}" \
+                --display-name="$display_name" \
+                --condition-display-name="$display_name" \
+                --condition-filter="metric.type=\"logging.googleapis.com/user/${metric}\" AND resource.type=\"cloud_run_job\"" \
+                --duration=0s \
+                --if='> 0' \
+                --trigger-count=1 \
+                --combiner=OR \
+                --notification-channels="$ALERT_CHANNELS" \
+                --documentation="$documentation" \
+                --format='value(name)'
+            )"
+          else
+            gcloud monitoring policies update "$policy" \
+              --project="${{ vars.GCP_PROJECT_ID }}" \
+              --enabled \
+              --set-notification-channels="$ALERT_CHANNELS" \
+              --documentation="$documentation"
+          fi
+          test -n "$policy"
+          gcloud monitoring policies describe "$policy" \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --format='value(notificationChannels)' | grep -q .
+
       - name: Generate deployment summary
         if: always() && github.event.inputs.environment == 'prod'
         uses: ./.github/actions/deployment-summary

--- a/backend/tests/unit/test_notifications_job_orchestrator.py
+++ b/backend/tests/unit/test_notifications_job_orchestrator.py
@@ -48,8 +48,9 @@ def test_notifications_job_orders_primary_notifications_then_health_then_x_flex(
     started_at = source.index("job_started_at = time.monotonic()")
     notifications = source.index("await start_cron_notification_job()")
     materialization_health = source.index("await run_blocking(db_executor, run_scheduled_check)")
+    redis_memory = source.index("await run_blocking(db_executor, run_redis_memory_check)")
     x_sync = source.index("await run_x_sync_job(job_started_at=job_started_at)")
-    assert started_at < notifications < materialization_health < x_sync
+    assert started_at < notifications < materialization_health < redis_memory < x_sync
 
 
 def test_notifications_job_deploy_routes_materialization_decision_review():
@@ -58,6 +59,8 @@ def test_notifications_job_deploy_routes_materialization_decision_review():
 
     assert 'chat_first_materialization_health review=true' in workflow
     assert 'chat_first_materialization_review_due' in workflow
+    assert 'redis_memory_threshold threshold=90' in workflow
+    assert 'redis_memory_90' in workflow
     assert '--notification-channels="$ALERT_CHANNELS"' in workflow
     assert '--set-notification-channels="$ALERT_CHANNELS"' in workflow
 

--- a/backend/tests/unit/test_redis_memory_health.py
+++ b/backend/tests/unit/test_redis_memory_health.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+
+from utils.redis_memory_health import (
+    HEALTH_LOG_MARKER,
+    REDIS_CLOUD_MAXMEMORY_BYTES,
+    THRESHOLD_RATIO,
+    run_scheduled_check,
+    used_memory_ratio,
+)
+
+
+class _FakeRedis:
+    def __init__(self, used: int | None = None, error: Exception | None = None):
+        self._used = used
+        self._error = error
+
+    def info(self, section: str) -> dict[str, int]:
+        assert section == 'memory'
+        if self._error is not None:
+            raise self._error
+        assert self._used is not None
+        return {'used_memory': self._used}
+
+
+def test_ratio_uses_12gib_sku_ceiling() -> None:
+    assert REDIS_CLOUD_MAXMEMORY_BYTES == 12 * 1024**3
+    assert used_memory_ratio(REDIS_CLOUD_MAXMEMORY_BYTES) == 1.0
+    assert used_memory_ratio(int(REDIS_CLOUD_MAXMEMORY_BYTES * 0.64)) < THRESHOLD_RATIO
+
+
+def test_logs_only_when_at_or_above_90_percent(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger='utils.redis_memory_health'):
+        run_scheduled_check(redis_client=_FakeRedis(used=REDIS_CLOUD_MAXMEMORY_BYTES))
+        assert f'{HEALTH_LOG_MARKER} threshold=90' in caplog.text
+        caplog.clear()
+        run_scheduled_check(redis_client=_FakeRedis(used=int(REDIS_CLOUD_MAXMEMORY_BYTES * 0.64)))
+        assert HEALTH_LOG_MARKER not in caplog.text
+
+
+def test_fail_open_on_redis_error(caplog) -> None:
+    with caplog.at_level(logging.ERROR, logger='utils.redis_memory_health'):
+        run_scheduled_check(redis_client=_FakeRedis(error=RuntimeError('down')))
+        assert 'redis_memory_health failed' in caplog.text

--- a/backend/utils/other/jobs.py
+++ b/backend/utils/other/jobs.py
@@ -3,6 +3,7 @@ import time
 from utils.executors import db_executor, run_blocking
 from utils.other.notifications import should_run_job as should_run_daily_notification_job
 from utils.other.notifications import start_cron_job as start_cron_notification_job
+from utils.redis_memory_health import run_scheduled_check as run_redis_memory_check
 from utils.task_intelligence.chat_first_materialization_health import run_scheduled_check
 from utils.x_connector import should_run_x_sync_job, run_x_sync_job
 
@@ -16,6 +17,9 @@ async def start_job():
     # Weekly and read-only. Keep the collection-group scan off the event loop;
     # its bounded aggregate log is the source for the routed Cloud Monitoring alarm.
     await run_blocking(db_executor, run_scheduled_check)
+
+    # Read-only Redis INFO. Log line is the Cloud Monitoring 90% used_memory alarm.
+    await run_blocking(db_executor, run_redis_memory_check)
 
     # X (Twitter) connector — incremental background sync every few hours.
     if should_run_x_sync_job():

--- a/backend/utils/redis_memory_health.py
+++ b/backend/utils/redis_memory_health.py
@@ -1,0 +1,44 @@
+"""Read-only prod Redis used_memory probe for Cloud Monitoring.
+
+Redis Cloud Essentials omits ``maxmemory`` from INFO. Compare against the
+known 12 GiB SKU ceiling. Fail-open: never fail notifications-job.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Redis Cloud Single-Zone_Persistence_12GB. INFO has no maxmemory field.
+REDIS_CLOUD_MAXMEMORY_BYTES = 12 * 1024**3
+THRESHOLD_RATIO = 0.90
+HEALTH_LOG_MARKER = 'redis_memory_threshold'
+
+
+def used_memory_ratio(used: int, cap: int = REDIS_CLOUD_MAXMEMORY_BYTES) -> float:
+    if cap <= 0:
+        raise ValueError('cap must be positive')
+    return used / cap
+
+
+def run_scheduled_check(*, redis_client: Any = None) -> None:
+    try:
+        client = redis_client
+        if client is None:
+            from database.redis_db import r as client
+        info = client.info('memory')
+        used = int(info['used_memory'])
+        ratio = used_memory_ratio(used)
+        if ratio < THRESHOLD_RATIO:
+            return
+        logger.warning(
+            '%s threshold=90 used=%s cap=%s ratio=%.4f',
+            HEALTH_LOG_MARKER,
+            used,
+            REDIS_CLOUD_MAXMEMORY_BYTES,
+            ratio,
+        )
+    except Exception:
+        logger.exception('redis_memory_health failed')


### PR DESCRIPTION
## Product invariants affected

- INV-DATA-1

Path glob only: this PR does not change production-family routing, Firebase/Firestore projects, or serving authorities. It adds a fail-open Redis `INFO memory` probe to `notifications-job` and a prod Cloud Monitoring policy.

## Summary
Move the prod Redis 90% used_memory page off the laptop and onto GCP.

`notifications-job` already runs every minute in Cloud Run with Redis credentials. It now does a fail-open `INFO memory` probe and logs `redis_memory_threshold threshold=90` when used_memory is ≥ 90% of the 12 GiB Redis Cloud Essentials cap (INFO omits `maxmemory`). Prod deploy of this job provisions the log-based metric `redis_memory_90` and a Cloud Monitoring policy to the same email channels as the sync-backfill 90% budget alarm.

Does not scrape Cloud Run `/metrics` (that endpoint is not ingested). Does not add a new Cloud Run Job.

## Test Plan
- [x] `pytest tests/unit/test_redis_memory_health.py tests/unit/test_notifications_job_orchestrator.py`
- [ ] After merge: dispatch `gcp_notifications_job.yml` development, then prod (provisions the metric/policy only on prod)
- [ ] Pause the Air Hermes cron `5470d4b3cb3e` once the GCP policy exists


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

