### PR TITLE
fix(backend): round-trip Vertex functionCall through the gateway

### DIFF
--- a/.github/failure-classes/FC-gateway-vertex-drops-function-calls.json
+++ b/.github/failure-classes/FC-gateway-vertex-drops-function-calls.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-gateway-vertex-drops-function-calls",
+  "violated_contract": "An OpenAI-compatible adapter that forwards function tools to a native Gemini/Vertex generateContent upstream must return those tool calls on the caller wire. A 200 with billed output tokens is not success if functionCall parts were translated into empty or text-only assistant content, because desktop Insight/Task assistants only act on functionCall and will emit no Advice Generated or Task Extracted.",
+  "canonical_prevention": "Vertex response and SSE normalizers must emit OpenAI tool_calls (and finish_reason tool_calls) from Gemini functionCall parts, including functionCall-only candidates with no text. Prove it with a hermetic generateContent and SSE fixture that would have stayed red when the adapter copied text only.",
+  "canonical_prevention_artifact": [
+    "backend/llm_gateway/gateway/vertex_wire.py",
+    "backend/tests/unit/test_llm_gateway_vertex_provider.py"
+  ],
+  "evidence_prs": [],
+  "scope_hints": [
+    "backend/llm_gateway/gateway/vertex_wire.py",
+    "backend/llm_gateway/gateway/providers.py",
+    "backend/utils/llm/desktop_gemini_gateway.py"
+  ],
+  "status": "open"
+}

--- a/backend/llm_gateway/gateway/vertex_wire.py
+++ b/backend/llm_gateway/gateway/vertex_wire.py
@@ -423,7 +423,17 @@ def _vertex_to_openai_response(
         candidates[0] if isinstance(candidates, list) and candidates and isinstance(candidates[0], Mapping) else None
     )
     content = _vertex_candidate_text(candidate)
-    finish_reason = _vertex_finish_reason(candidate.get('finishReason') if candidate is not None else 'SAFETY')
+    tool_calls = _vertex_tool_calls(candidate)
+    finish_reason = _vertex_finish_reason(
+        candidate.get('finishReason') if candidate is not None else 'SAFETY',
+        has_tool_calls=bool(tool_calls),
+    )
+    message: dict[str, Any] = {
+        'role': 'assistant',
+        'content': content if content else None if tool_calls else content,
+    }
+    if tool_calls:
+        message['tool_calls'] = tool_calls
     normalized: dict[str, Any] = {
         'id': str(response.get('responseId') or 'vertex_gateway'),
         'object': 'chat.completion',
@@ -432,7 +442,7 @@ def _vertex_to_openai_response(
         'choices': [
             {
                 'index': 0,
-                'message': {'role': 'assistant', 'content': content},
+                'message': message,
                 'finish_reason': finish_reason,
             }
         ],
@@ -455,10 +465,23 @@ def _vertex_to_openai_stream_chunk(
     if candidate is None and usage is None:
         return None, False
     text = _vertex_candidate_text(candidate)
+    tool_calls = _vertex_tool_calls(candidate)
     raw_finish_reason = candidate.get('finishReason') if candidate is not None else None
-    finish_reason = _vertex_finish_reason(raw_finish_reason) if raw_finish_reason else None
-    if not text and finish_reason is None and usage is None:
+    finish_reason = (
+        _vertex_finish_reason(raw_finish_reason, has_tool_calls=bool(tool_calls)) if raw_finish_reason else None
+    )
+    if finish_reason is None and tool_calls:
+        finish_reason = 'tool_calls'
+    if not text and not tool_calls and finish_reason is None and usage is None:
         return None, False
+    delta: dict[str, Any] = {}
+    if text:
+        delta['content'] = text
+    if tool_calls:
+        delta['tool_calls'] = [
+            {'index': index, 'id': call['id'], 'type': 'function', 'function': call['function']}
+            for index, call in enumerate(tool_calls)
+        ]
     body: dict[str, Any] = {
         'id': str(response.get('responseId') or 'vertex_gateway'),
         'object': 'chat.completion.chunk',
@@ -468,7 +491,7 @@ def _vertex_to_openai_stream_chunk(
             [
                 {
                     'index': 0,
-                    'delta': {'content': text} if text else {},
+                    'delta': delta,
                     'finish_reason': finish_reason,
                 }
             ]
@@ -481,28 +504,56 @@ def _vertex_to_openai_stream_chunk(
     return _openai_sse(body), finish_reason is not None
 
 
-def _vertex_candidate_text(candidate: Mapping[str, Any] | None) -> str:
+def _vertex_candidate_parts(candidate: Mapping[str, Any] | None) -> list[Any]:
     if candidate is None:
-        return ''
+        return []
     content = candidate.get('content')
     if not isinstance(content, Mapping):
-        return ''
+        return []
     parts = content.get('parts')
-    if not isinstance(parts, list):
-        return ''
+    return parts if isinstance(parts, list) else []
+
+
+def _vertex_candidate_text(candidate: Mapping[str, Any] | None) -> str:
     text_parts: list[str] = []
-    for part in parts:
+    for part in _vertex_candidate_parts(candidate):
         if isinstance(part, Mapping) and isinstance(part.get('text'), str):
             text_parts.append(part['text'])
     return ''.join(text_parts)
 
 
-def _vertex_finish_reason(value: object) -> str:
+def _vertex_tool_calls(candidate: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    """Vertex functionCall parts -> OpenAI tool_calls. Text-only candidates return []."""
+    tool_calls: list[dict[str, Any]] = []
+    for part in _vertex_candidate_parts(candidate):
+        if not isinstance(part, Mapping):
+            continue
+        call = part.get('functionCall') or part.get('function_call')
+        if not isinstance(call, Mapping):
+            continue
+        name = call.get('name')
+        if not isinstance(name, str) or not name:
+            continue
+        raw_args = call.get('args')
+        arguments = dict(cast(Mapping[str, Any], raw_args)) if isinstance(raw_args, Mapping) else {}
+        tool_calls.append(
+            {
+                'id': f'call_{name}_{len(tool_calls)}',
+                'type': 'function',
+                'function': {'name': name, 'arguments': json.dumps(arguments, separators=(',', ':'))},
+            }
+        )
+    return tool_calls
+
+
+def _vertex_finish_reason(value: object, *, has_tool_calls: bool = False) -> str:
     normalized = str(value or '').upper()
     if normalized in {'MAX_TOKENS', 'LENGTH'}:
         return 'length'
     if normalized in {'SAFETY', 'BLOCKLIST', 'PROHIBITED_CONTENT', 'SPII', 'RECITATION'}:
         return 'content_filter'
+    if has_tool_calls:
+        return 'tool_calls'
     return 'stop'
 
 

--- a/backend/tests/unit/test_llm_gateway_vertex_provider.py
+++ b/backend/tests/unit/test_llm_gateway_vertex_provider.py
@@ -721,3 +721,117 @@ def test_vertex_tools_and_tool_config_translate_to_gemini_native():
     assert model_turn['parts'] == [{'functionCall': {'name': 'take_photo', 'args': {'q': 'the park'}}}]
     assert tool_turn['role'] == 'user'
     assert tool_turn['parts'] == [{'functionResponse': {'name': 'take_photo', 'response': {'status': 'ok'}}}]
+
+
+@pytest.mark.asyncio
+async def test_vertex_function_call_only_response_emits_openai_tool_calls(monkeypatch):
+    """#13666: Insight/Task die if Vertex functionCall parts are dropped as empty text."""
+    monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'test-project')
+    monkeypatch.setenv('GCP_LOCATION', 'us-central1')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                'responseId': 'vertex-tool-call',
+                'modelVersion': 'gemini-2.5-pro',
+                'candidates': [
+                    {
+                        'content': {
+                            'parts': [
+                                {
+                                    'functionCall': {
+                                        'name': 'extract_task',
+                                        'args': {'title': 'Email Sam the deck', 'confidence': 0.9},
+                                    }
+                                }
+                            ]
+                        },
+                        'finishReason': 'STOP',
+                    }
+                ],
+                'usageMetadata': {
+                    'promptTokenCount': 200,
+                    'candidatesTokenCount': 40,
+                    'totalTokenCount': 240,
+                },
+            },
+        )
+
+    provider = VertexGeminiProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        access_token_supplier=_access_token,
+    )
+    response = await provider.create_chat_completion(
+        {
+            'model': 'gemini-2.5-pro',
+            'messages': [{'role': 'user', 'content': 'extract'}],
+            'tools': [
+                {
+                    'type': 'function',
+                    'function': {'name': 'extract_task', 'parameters': {'type': 'object'}},
+                }
+            ],
+            'tool_choice': 'required',
+        },
+        provider_ref=ProviderRef(provider='gemini', model='gemini-2.5-pro'),
+        credentials=_omi_credentials(),
+        timeout_ms=8000,
+    )
+
+    choice = response['choices'][0]
+    message = choice['message']
+    assert choice['finish_reason'] == 'tool_calls'
+    assert message.get('content') in (None, '')
+    assert message['tool_calls'][0]['type'] == 'function'
+    assert message['tool_calls'][0]['function']['name'] == 'extract_task'
+    assert json.loads(message['tool_calls'][0]['function']['arguments']) == {
+        'title': 'Email Sam the deck',
+        'confidence': 0.9,
+    }
+
+
+@pytest.mark.asyncio
+async def test_vertex_function_call_sse_emits_openai_tool_call_delta(monkeypatch):
+    monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'test-project')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=(
+                b'data: {"responseId":"tool","candidates":[{"content":{"parts":'
+                b'[{"functionCall":{"name":"no_advice","args":{"context_summary":"idle"}}}]},'
+                b'"finishReason":"STOP"}]}\n\n'
+            ),
+            headers={'content-type': 'text/event-stream'},
+        )
+
+    provider = VertexGeminiProvider(
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        access_token_supplier=_access_token,
+    )
+    chunks = [
+        chunk
+        async for chunk in provider.stream_chat_completion(
+            {
+                'model': 'gemini-2.5-flash-lite',
+                'messages': [{'role': 'user', 'content': 'hello'}],
+                'stream': True,
+                'tools': [
+                    {
+                        'type': 'function',
+                        'function': {'name': 'no_advice', 'parameters': {'type': 'object'}},
+                    }
+                ],
+                'tool_choice': 'required',
+            },
+            provider_ref=ProviderRef(provider='gemini', model='gemini-2.5-flash-lite'),
+            credentials=_omi_credentials(),
+            timeout_ms=8000,
+        )
+    ]
+    streamed = b''.join(chunks)
+    assert b'"finish_reason":"tool_calls"' in streamed
+    assert b'"name":"no_advice"' in streamed
+    assert b'"tool_calls"' in streamed
+    assert streamed.endswith(b'data: [DONE]\n\n')


### PR DESCRIPTION
## What changed and why

Gateway Vertex `generateContent` already forwarded OpenAI `tools` to Gemini, but `_vertex_to_openai_response` / `_vertex_to_openai_stream_chunk` copied **text only**. Company-paid desktop Insight/Task (`sendImageToolLoop`) only act on `functionCall`, so after #12337 hopped them through the gateway they got HTTP 200s with billed tokens and emitted **zero** `Advice Generated` / `Task Extracted` (#13666). JSON-schema Memory/Suggestion still worked because they parse text.

This round-trips Vertex `functionCall` parts to OpenAI `tool_calls` (and `finish_reason: tool_calls`), including functionCall-only candidates. Desktop BFF translation already maps that back to Gemini. No client change. Do not flip `OMI_LLM_GATEWAY_FEATURE_MODE`.

Closes #13666

## Product invariants affected

none

## How it was verified

```
backend/.venv/bin/python -m pytest \
  backend/tests/unit/test_llm_gateway_vertex_provider.py \
  backend/tests/unit/test_desktop_gemini_gateway.py -q
```

36 passed, including the new functionCall-only generateContent and SSE regressions.

Could not exercise live prod desktop Insight/Task in this PR; that path is the GKE LLM gateway. After merge, ship **llm-gateway** (not Cloud Run-only) so desktop-backend's existing hop sees the translator.

## Tests

`test_vertex_function_call_only_response_emits_openai_tool_calls` and `test_vertex_function_call_sse_emits_openai_tool_call_delta` in `backend/tests/unit/test_llm_gateway_vertex_provider.py`. A Vertex candidate with only `functionCall` (no text) must emit OpenAI `tool_calls`. That is the test that would have stayed red on #12337.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: an OpenAI-compatible Vertex adapter that advertises function tools must return those tool calls, not a 200 with empty/text-only content. Canonical guard: response + SSE normalizers emit `tool_calls` from Gemini `functionCall` parts; the two new hermetic tests are the prevention artifact. Registry file: `.github/failure-classes/FC-gateway-vertex-drops-function-calls.json`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

