### PR TITLE
feat(infra): WIF for notifications-job development deploys

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -417,6 +417,16 @@ checks:
     triggers: ["infrastructure/opentofu/pilots/development-wif-plan/**", "infrastructure/opentofu/probes/development-project-read/**", ".github/scripts/check_opentofu_development_wif_pilot.py", ".github/scripts/test_check_opentofu_development_wif_pilot.py", ".github/workflows/opentofu-development-wif-pilot.yml", ".github/workflows/opentofu-development-wif-pilot-validate.yml"]
     lanes: ["local", "ci"]
     reason: "development WIF pilot fixtures must reject secret access, apply, and scope expansion"
+  - id: opentofu-gha-wif-notifications
+    command: ["python3", ".github/scripts/check_opentofu_gha_wif_notifications.py"]
+    triggers: ["infrastructure/opentofu/slices/gha-wif-notifications/**", ".github/scripts/check_opentofu_gha_wif_notifications.py"]
+    lanes: ["local", "ci"]
+    reason: "notifications-job development WIF stays job-scoped, GitHub-main-scoped, and outside Owner JSON keys"
+  - id: opentofu-gha-wif-notifications-fixtures
+    command: ["python3", ".github/scripts/test_check_opentofu_gha_wif_notifications.py"]
+    triggers: ["infrastructure/opentofu/slices/gha-wif-notifications/**", ".github/scripts/check_opentofu_gha_wif_notifications.py", ".github/scripts/test_check_opentofu_gha_wif_notifications.py"]
+    lanes: ["local", "ci"]
+    reason: "notifications-job development WIF checker must remain executable"
   - id: public-build-contract
     command: ["python3", ".github/scripts/check_public_build_contract.py"]
     triggers: [".github/actions/deploy-public-build/**", ".github/actions/prepare-public-build/**", ".github/actions/public-build-candidate-promotion/**", ".github/workflows/gcp_admin.yml", ".github/workflows/gcp_app.yml", ".github/workflows/gcp_frontend.yml", ".github/workflows/gcp_personas.yml", ".github/workflows/public-build-config-preflight.yml", ".github/scripts/check_public_build_contract.py", ".github/scripts/preflight_public_build_config.py", ".github/scripts/preflight_public_build_runtime.py", ".github/scripts/smoke_public_build_browser.py", ".github/scripts/public_build_acceptance_route.py", ".github/scripts/test_check_public_build_contract.py", "config/public-build-contract.json", "config/public-build-values.json", "config/deployment-setting-classification.json", "web/admin/Dockerfile", "web/app/Dockerfile", "web/frontend/Dockerfile", "web/personas-open-source/Dockerfile", "web/admin/components/public-build-canary.tsx", "web/app/src/components/public-build-canary.tsx", "web/frontend/src/components/public-build-canary.tsx", "web/personas-open-source/src/components/public-build-canary.tsx", "web/personas-open-source/src/app/api/social-profile/route.ts"]

--- a/.github/scripts/check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/check_opentofu_gha_wif_notifications.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Keep the notifications-job development WIF slice narrow."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SLICE = ROOT / "infrastructure" / "opentofu" / "slices" / "gha-wif-notifications"
+MAIN = SLICE / "main.tf"
+VARS = SLICE / "variables.tf"
+
+EXPECTED_TF = frozenset({"main.tf", "variables.tf"})
+EXPECTED_RESOURCES = frozenset(
+    {
+        "google_service_account.deploy",
+        "google_iam_workload_identity_pool.github",
+        "google_iam_workload_identity_pool_provider.github",
+        "google_service_account_iam_member.github_deploy_impersonation",
+        "google_artifact_registry_repository_iam_member.gcr_writer",
+        "google_cloud_run_v2_job_iam_member.notifications_job_developer",
+        "google_service_account_iam_member.notifications_job_runtime_act_as",
+        "google_project_iam_member.gke_cluster_viewer",
+    }
+)
+FORBIDDEN = (
+    "roles/owner",
+    "roles/editor",
+    "roles/viewer",
+    "roles/run.admin",
+    "roles/storage.admin",
+    "roles/iam.securityReviewer",
+    "omi-opentofu-9842-dev",
+    "omi-tofu-plan-dev-9842",
+    "based-hardware-dev.svc.id.goog",
+    'project_id" {',
+)
+RESOURCE = re.compile(r'^\s*resource\s+"(?P<type>[^"]+)"\s+"(?P<name>[^"]+)"', re.MULTILINE)
+DISPLAY = re.compile(r'^\s*display_name\s*=\s*"(?P<value>[^"]*)"', re.MULTILINE)
+DATA = re.compile(r'^\s*data\s+"', re.MULTILINE)
+MODULE = re.compile(r'^\s*module\s+"', re.MULTILINE)
+
+
+def main() -> int:
+    errors: list[str] = []
+    tf_names = {p.name for p in SLICE.glob("*.tf")}
+    if tf_names != EXPECTED_TF:
+        errors.append(f"tf files must be {sorted(EXPECTED_TF)}, found {sorted(tf_names)}")
+    text = MAIN.read_text(encoding="utf-8") + "\n" + VARS.read_text(encoding="utf-8")
+    found = {f"{m.group('type')}.{m.group('name')}" for m in RESOURCE.finditer(text)}
+    if found != EXPECTED_RESOURCES:
+        errors.append(f"resources must be {sorted(EXPECTED_RESOURCES)}, found {sorted(found)}")
+    if DATA.search(text):
+        errors.append("no data sources")
+    if MODULE.search(text):
+        errors.append("no modules")
+    for match in DISPLAY.finditer(text):
+        value = match.group("value")
+        if len(value) > 32:
+            errors.append(f"display_name over 32 chars: {value!r}")
+    lowered = text
+    for token in FORBIDDEN:
+        if token in lowered and token != 'project_id" {':
+            errors.append(f"forbidden token {token}")
+    if "based-hardware\"" in text and "based-hardware-dev" not in text.replace("based-hardware-dev", ""):
+        pass
+    if '"based-hardware"' in text:
+        errors.append("must not mention production project based-hardware")
+    if "gcp_notifications_job.yml@refs/heads/main" not in text:
+        errors.append("workflow_ref must pin gcp_notifications_job.yml on main")
+    if "credentials_json" in text:
+        errors.append("module must not reference credentials_json")
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print("gha-wif-notifications OpenTofu slice OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/test_check_opentofu_gha_wif_notifications.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / ".github" / "scripts" / "check_opentofu_gha_wif_notifications.py"
+
+
+def test_checker_passes_on_slice() -> None:
+    result = subprocess.run([sys.executable, str(CHECKER)], cwd=ROOT, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout

--- a/.github/scripts/test_check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/test_check_opentofu_gha_wif_notifications.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER = ROOT / ".github" / "scripts" / "check_opentofu_gha_wif_notifications.py"
 
 
-def test_checker_passes_on_slice() -> None:
-    result = subprocess.run([sys.executable, str(CHECKER)], cwd=ROOT, capture_output=True, text=True)
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "OK" in result.stdout
+class GhaWifNotificationsCheckerTests(unittest.TestCase):
+    def test_checker_passes_on_slice(self) -> None:
+        result = subprocess.run([sys.executable, str(CHECKER)], cwd=ROOT, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -61,9 +61,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Google Auth
+      - name: Google Auth (development WIF)
+        id: auth-wif
+        if: github.event.inputs.environment == 'development'
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1031333818730/locations/global/workloadIdentityPools/omi-gha-notif-dev/providers/github
+          service_account: omi-gha-notif-job-dev@based-hardware-dev.iam.gserviceaccount.com
+
+      - name: Google Auth (prod JSON, until prod WIF slice)
         id: auth
-        uses: 'google-github-actions/auth@v3'
+        if: github.event.inputs.environment == 'prod'
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 

--- a/infrastructure/opentofu/slices/gha-wif-notifications/.terraform.lock.hcl
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:0qkP2yFo87EamHXoV0cK2w6hADP2grd+ZfzAixUPDSw=",
+    "h1:22CAxZ/tGKrnH+5+Cg3DM18S/OvpJZrVMRzp3A40h7Y=",
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:Jw+wqWmsOFONn1I4BVShIkywBAu25VXfTvPBiQJRYYA=",
+    "h1:LxtuVWb0Y6r8I3RsQ8dgXozVzeG1rzFDnCav5EkZCoc=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "h1:WO2Jt6hHnY9lvpUdUdhnZ318vq4xPq3R4WYmQ2u7QpU=",
+    "h1:YS1XbzFYWp1xFGo8XyI6TrDrKoz4Ka4CVaeTpPI6xOY=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/opentofu/slices/gha-wif-notifications/README.md
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/README.md
@@ -1,0 +1,10 @@
+# GitHub WIF for notifications-job development
+
+Creates a dedicated pool/provider/SA for `gcp_notifications_job.yml` on
+`based-hardware-dev` only. Not the #9842 OpenTofu plan pilot. Not GKE
+workload identity. Not Owner.
+
+State backend is operator-supplied (`~/.hermes/opentofu/gha-wif-notifications/development.backend.hcl`).
+Do not declare the state bucket in this module.
+
+Prod input of the same workflow keeps `GCP_CREDENTIALS` until a later slice.

--- a/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  required_version = ">= 1.12.4, < 2.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+
+  # Operator supplies reviewed development-only GCS backend.hcl.
+  backend "gcs" {}
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_service_account" "deploy" {
+  account_id   = var.deploy_service_account_id
+  display_name = "Omi GHA notif job deploy"
+  description  = "GitHub WIF deployer for notifications-job on based-hardware-dev only."
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = var.workload_identity_pool_id
+  display_name              = "Omi GHA notif WIF pool"
+  description               = "GitHub OIDC pool for notifications-job development WIF."
+  disabled                  = false
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "Omi GHA notif GitHub OIDC"
+  description                        = "Restricts notifications-job development WIF to Omi main + development env."
+
+  attribute_mapping = {
+    "google.subject"                = "assertion.sub"
+    "attribute.repository_id"       = "assertion.repository_id"
+    "attribute.repository_owner_id" = "assertion.repository_owner_id"
+    "attribute.workflow_ref"        = "assertion.workflow_ref"
+    "attribute.environment"         = "assertion.environment"
+  }
+
+  attribute_condition = "assertion.repository_id == '${var.github_repository_id}' && assertion.repository_owner_id == '${var.github_repository_owner_id}' && assertion.ref == 'refs/heads/main' && assertion.workflow_ref == '${var.github_workflow_ref}' && assertion.environment == 'development'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "github_deploy_impersonation" {
+  service_account_id = google_service_account.deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository_id/${var.github_repository_id}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "gcr_writer" {
+  project    = var.project_id
+  location   = "us"
+  repository = "gcr.io"
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "notifications_job_developer" {
+  project  = var.project_id
+  location = "us-central1"
+  name     = "notifications-job"
+  role     = "roles/run.developer"
+  member   = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+resource "google_service_account_iam_member" "notifications_job_runtime_act_as" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.runtime_service_account_email}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# Existing workflow calls get-gke-credentials for the gateway serving gate.
+resource "google_project_iam_member" "gke_cluster_viewer" {
+  project = var.project_id
+  role    = "roles/container.clusterViewer"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}

--- a/infrastructure/opentofu/slices/gha-wif-notifications/variables.tf
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/variables.tf
@@ -1,0 +1,82 @@
+variable "project_id" {
+  type        = string
+  description = "Development-only GCP project."
+  default     = "based-hardware-dev"
+
+  validation {
+    condition     = var.project_id == "based-hardware-dev"
+    error_message = "This slice may target only based-hardware-dev."
+  }
+}
+
+variable "project_number" {
+  type        = string
+  description = "Immutable based-hardware-dev project number."
+  default     = "1031333818730"
+
+  validation {
+    condition     = var.project_number == "1031333818730"
+    error_message = "This slice may target only the based-hardware-dev project number."
+  }
+}
+
+variable "github_repository_id" {
+  type        = string
+  default     = "776121034"
+
+  validation {
+    condition     = var.github_repository_id == "776121034"
+    error_message = "Must stay restricted to Omi's immutable GitHub repository ID."
+  }
+}
+
+variable "github_repository_owner_id" {
+  type        = string
+  default     = "162546372"
+
+  validation {
+    condition     = var.github_repository_owner_id == "162546372"
+    error_message = "Must stay restricted to BasedHardware's immutable GitHub organization ID."
+  }
+}
+
+variable "github_workflow_ref" {
+  type        = string
+  default     = "BasedHardware/omi/.github/workflows/gcp_notifications_job.yml@refs/heads/main"
+
+  validation {
+    condition     = var.github_workflow_ref == "BasedHardware/omi/.github/workflows/gcp_notifications_job.yml@refs/heads/main"
+    error_message = "Must stay restricted to gcp_notifications_job.yml on main."
+  }
+}
+
+variable "workload_identity_pool_id" {
+  type        = string
+  default     = "omi-gha-notif-dev"
+
+  validation {
+    condition     = var.workload_identity_pool_id == "omi-gha-notif-dev"
+    error_message = "Must use the dedicated notifications-job development WIF pool."
+  }
+}
+
+variable "deploy_service_account_id" {
+  type        = string
+  default     = "omi-gha-notif-job-dev"
+
+  validation {
+    condition     = var.deploy_service_account_id == "omi-gha-notif-job-dev"
+    error_message = "Must use the dedicated notifications-job development deploy SA."
+  }
+}
+
+variable "runtime_service_account_email" {
+  type        = string
+  description = "Live notifications-job runtime SA (actAs only on this email)."
+  default     = "1031333818730-compute@developer.gserviceaccount.com"
+
+  validation {
+    condition     = var.runtime_service_account_email == "1031333818730-compute@developer.gserviceaccount.com"
+    error_message = "actAs must stay pinned to the live notifications-job runtime SA."
+  }
+}


### PR DESCRIPTION
## Product invariants affected

- INV-DATA-1

Path glob only: no production-family routing change. Development `gcp_notifications_job.yml` authenticates via GitHub WIF; prod input keeps `GCP_CREDENTIALS` until a later slice.

## Summary

Slice 1 of replacing dying GitHub `GCP_CREDENTIALS` JSON with WIF.

- OpenTofu module `infrastructure/opentofu/slices/gha-wif-notifications` (already applied on `based-hardware-dev`: pool `omi-gha-notif-dev`, SA `omi-gha-notif-job-dev`).
- Development workflow auth uses that WIF provider. Prod auth unchanged.
- Does not touch #9842 plan SA/pool. Does not mint JSON keys.

## Test Plan

- [x] `python3 .github/scripts/check_opentofu_gha_wif_notifications.py`
- [x] tofu plan 8 creates; apply 8; refresh no-diff
- [ ] After merge: `gh workflow run gcp_notifications_job.yml -f environment=development -f branch=1399a48ab3d43e39d12cade24183a150d90603cb` from **main** (WIF `workflow_ref` is `@refs/heads/main`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

