### PR TITLE
fix(infra): container.viewer for notifications-job WIF kubectl

### DIFF
--- a/.github/scripts/check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/check_opentofu_gha_wif_notifications.py
@@ -23,6 +23,7 @@ EXPECTED_RESOURCES = frozenset(
         "google_cloud_run_v2_job_iam_member.notifications_job_developer",
         "google_service_account_iam_member.notifications_job_runtime_act_as",
         "google_project_iam_member.gke_viewer",
+        "google_project_iam_member.compute_network_viewer",
     }
 )
 FORBIDDEN = (

--- a/.github/scripts/check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/check_opentofu_gha_wif_notifications.py
@@ -24,6 +24,9 @@ EXPECTED_RESOURCES = frozenset(
         "google_service_account_iam_member.notifications_job_runtime_act_as",
         "google_project_iam_member.gke_viewer",
         "google_project_iam_member.compute_network_viewer",
+        "google_project_iam_member.run_developer",
+        "google_project_iam_member.compute_network_user",
+        "google_secret_manager_secret_iam_member.gateway_token",
     }
 )
 FORBIDDEN = (

--- a/.github/scripts/check_opentofu_gha_wif_notifications.py
+++ b/.github/scripts/check_opentofu_gha_wif_notifications.py
@@ -22,7 +22,7 @@ EXPECTED_RESOURCES = frozenset(
         "google_artifact_registry_repository_iam_member.gcr_writer",
         "google_cloud_run_v2_job_iam_member.notifications_job_developer",
         "google_service_account_iam_member.notifications_job_runtime_act_as",
-        "google_project_iam_member.gke_cluster_viewer",
+        "google_project_iam_member.gke_viewer",
     }
 )
 FORBIDDEN = (

--- a/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
@@ -84,3 +84,10 @@ resource "google_project_iam_member" "gke_viewer" {
   role    = "roles/container.viewer"
   member  = "serviceAccount:${google_service_account.deploy.email}"
 }
+
+# Gateway serving gate: addresses.describe + forwarding-rules.list
+resource "google_project_iam_member" "compute_network_viewer" {
+  project = var.project_id
+  role    = "roles/compute.networkViewer"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}

--- a/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
@@ -78,9 +78,9 @@ resource "google_service_account_iam_member" "notifications_job_runtime_act_as" 
   member             = "serviceAccount:${google_service_account.deploy.email}"
 }
 
-# Existing workflow calls get-gke-credentials for the gateway serving gate.
-resource "google_project_iam_member" "gke_cluster_viewer" {
+# kubectl get deployment for the gateway serving gate (clusterViewer is credentials only).
+resource "google_project_iam_member" "gke_viewer" {
   project = var.project_id
-  role    = "roles/container.clusterViewer"
+  role    = "roles/container.viewer"
   member  = "serviceAccount:${google_service_account.deploy.email}"
 }

--- a/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
+++ b/infrastructure/opentofu/slices/gha-wif-notifications/main.tf
@@ -91,3 +91,25 @@ resource "google_project_iam_member" "compute_network_viewer" {
   role    = "roles/compute.networkViewer"
   member  = "serviceAccount:${google_service_account.deploy.email}"
 }
+
+# Throwaway llm-gateway-vpc-probe-* jobs are created at deploy time.
+resource "google_project_iam_member" "run_developer" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# Probe job --network/--subnet attach.
+resource "google_project_iam_member" "compute_network_user" {
+  project = var.project_id
+  role    = "roles/compute.networkUser"
+  member  = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# Probe --set-secrets=OMI_LLM_GATEWAY_SERVICE_TOKEN
+resource "google_secret_manager_secret_iam_member" "gateway_token" {
+  project   = var.project_id
+  secret_id = "OMI_LLM_GATEWAY_SERVICE_TOKEN"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.deploy.email}"
+}


### PR DESCRIPTION
## Product invariants affected

- INV-DATA-1

## Failure-Class
Failure-Class: none

## Summary
WIF auth succeeded. Gateway gate failed `kubectl get deployment` because `clusterViewer` is credentials-only. Live IAM already uses `roles/container.viewer`. This PR matches git to that apply.

## Test Plan
- Re-dispatched development notifications-job after apply


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

