### PR TITLE
fix(web): consolidate app-store hardware product branding (#5855)

### DIFF
--- a/.github/agent-docs/pricing-scheme-touchpoint-inventory.md
+++ b/.github/agent-docs/pricing-scheme-touchpoint-inventory.md
@@ -90,9 +90,10 @@ This repo already has an in-flight catalog migration — `.github/agent-docs/pla
 
 | Location | Kind | Needs update when prices/tiers change? |
 |---|---|---|
-| `web/frontend/src/app/components/product-banner/types.ts` (line 23) `PRODUCT_INFO.price` | hardcoded_amount | Yes, if the $89 hardware price changes (device price, not subscription) |
-| `web/frontend/src/app/apps/utils/metadata.ts` (line 104) | hardcoded_amount | Yes — independent duplicate of the $89 device price for SEO JSON-LD |
-| `web/frontend/src/app/apps/[id]/page.tsx` (line 118) | hardcoded_amount | Yes — third independent duplicate of the $89 device price |
+| `web/frontend/src/constants/app-store-hardware-product.ts` `APP_STORE_HARDWARE_PRODUCT` | hardcoded_amount | Yes, if the $89 hardware price or storefront URL changes (device price, not subscription) |
+| `web/frontend/src/app/components/product-banner/types.ts` `PRODUCT_INFO` | reads_live_no_update_needed | No — re-exports banner fields from `APP_STORE_HARDWARE_PRODUCT` |
+| `web/frontend/src/app/apps/utils/metadata.ts` product JSON-LD | reads_live_no_update_needed | No — reads `APP_STORE_HARDWARE_PRODUCT` for SEO schema |
+| `web/frontend/src/app/apps/[id]/page.tsx` Product schema | reads_live_no_update_needed | No — reads `APP_STORE_HARDWARE_PRODUCT` for structured data |
 | `web/frontend/src/app/unlimited/page.tsx` (line 6,39,41) | plan_name_or_tier_copy | Yes — stale "Omi Unlimited" landing page name vs. current catalog naming (unlimited_v2 vs deprecated Neo) |
 | `src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs` | test_fixture | Yes — static string tripwire on the `/unlimited` route name, breaks if route is renamed |
 | `web/frontend/src/app/apps/utils/metadata.ts` (line 214-215) `generateAppListSchema` | other | No — correctly hardcoded $0 for free-to-list marketplace apps |

--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -66,6 +66,10 @@ jobs:
           npm run lint
           npm run lint:format -- --check
 
+      - name: Run Frontend Tests
+        if: needs.changes.outputs.has_frontend == 'true'
+        run: bash scripts/run-web-frontend-tests.sh
+
       - name: Lint Personas
         if: needs.changes.outputs.has_personas == 'true'
         working-directory: ./web/personas-open-source

--- a/web/frontend/src/__tests__/app-store-hardware-product.test.mjs
+++ b/web/frontend/src/__tests__/app-store-hardware-product.test.mjs
@@ -23,7 +23,7 @@ const FORBIDDEN_PATTERNS = [
 function stripLineComments(source) {
   return source
     .split('\n')
-    .map((line) => line.replace(/\/\/.*$/, ''))
+    .map((line) => line.replace(/(?<!:)\/\/.*$/, ''))
     .join('\n');
 }
 
@@ -66,13 +66,51 @@ describe('app-store hardware product (Fixes #5855 guard)', () => {
       'utf8',
     );
 
-    for (const source of [bannerTypes, metadata, appDetail]) {
-      assert.match(source, /APP_STORE_HARDWARE_PRODUCT/);
+    for (const property of [
+      'APP_STORE_HARDWARE_PRODUCT.name',
+      'APP_STORE_HARDWARE_PRODUCT.displayPrice',
+      'APP_STORE_HARDWARE_PRODUCT.marketplaceOrderUrl',
+      'APP_STORE_HARDWARE_PRODUCT.shipping',
+      'APP_STORE_HARDWARE_PRODUCT.images',
+    ]) {
+      assert.match(
+        bannerTypes,
+        new RegExp(property.replace('.', '\\.')),
+        `product-banner/types.ts must reference ${property}`,
+      );
+    }
+
+    for (const property of [
+      'APP_STORE_HARDWARE_PRODUCT.name',
+      'APP_STORE_HARDWARE_PRODUCT.description',
+      'APP_STORE_HARDWARE_PRODUCT.schemaPrice',
+      'APP_STORE_HARDWARE_PRODUCT.currency',
+      'APP_STORE_HARDWARE_PRODUCT.storeUrl',
+    ]) {
+      assert.match(
+        metadata,
+        new RegExp(property.replace('.', '\\.')),
+        `apps/utils/metadata.ts must reference ${property}`,
+      );
+    }
+
+    for (const property of [
+      'APP_STORE_HARDWARE_PRODUCT.name',
+      'APP_STORE_HARDWARE_PRODUCT.description',
+      'APP_STORE_HARDWARE_PRODUCT.schemaPrice',
+      'APP_STORE_HARDWARE_PRODUCT.currency',
+    ]) {
+      assert.match(
+        appDetail,
+        new RegExp(property.replace('.', '\\.')),
+        `apps/[id]/page.tsx must reference ${property}`,
+      );
     }
   });
 
   it('does not reintroduce discontinued Duo Dev Kit pricing or product slugs on app-store surfaces', () => {
     const surfaces = [
+      constantsPath,
       ...collectSourceFiles(appsDir),
       ...collectSourceFiles(productBannerDir),
     ];

--- a/web/frontend/src/__tests__/app-store-hardware-product.test.mjs
+++ b/web/frontend/src/__tests__/app-store-hardware-product.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const appsDir = path.join(frontendRoot, 'app/apps');
+const productBannerDir = path.join(frontendRoot, 'app/components/product-banner');
+const constantsPath = path.join(
+  frontendRoot,
+  'constants/app-store-hardware-product.ts',
+);
+
+const FORBIDDEN_PATTERNS = [
+  /duo dev kit/i,
+  /69\.99/,
+  /\$69(?:\.99)?(?!\d)/,
+  /products\/omi-dev-kit-2/i,
+  /products\/friend-dev-kit-2/i,
+];
+
+function stripLineComments(source) {
+  return source
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
+function collectSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (/\.(tsx?|jsx?)$/.test(entry)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('app-store hardware product (Fixes #5855 guard)', () => {
+  it('defines current Omi branding and $89 storefront URLs', () => {
+    const source = readFileSync(constantsPath, 'utf8');
+    assert.match(source, /name:\s*'Omi'/);
+    assert.match(source, /displayPrice:\s*'\$89'/);
+    assert.match(source, /schemaPrice:\s*'89'/);
+    assert.match(source, /storeUrl:\s*'https:\/\/www\.omi\.me\/'/);
+    assert.doesNotMatch(source, /duo dev kit/i);
+    assert.doesNotMatch(source, /69\.99/);
+  });
+
+  it('keeps marketplace CTAs wired through the shared constant', () => {
+    const bannerTypes = readFileSync(
+      path.join(productBannerDir, 'types.ts'),
+      'utf8',
+    );
+    const metadata = readFileSync(
+      path.join(frontendRoot, 'app/apps/utils/metadata.ts'),
+      'utf8',
+    );
+    const appDetail = readFileSync(
+      path.join(frontendRoot, 'app/apps/[id]/page.tsx'),
+      'utf8',
+    );
+
+    for (const source of [bannerTypes, metadata, appDetail]) {
+      assert.match(source, /APP_STORE_HARDWARE_PRODUCT/);
+    }
+  });
+
+  it('does not reintroduce discontinued Duo Dev Kit pricing or product slugs on app-store surfaces', () => {
+    const surfaces = [
+      ...collectSourceFiles(appsDir),
+      ...collectSourceFiles(productBannerDir),
+    ];
+
+    for (const filePath of surfaces) {
+      const withoutComments = stripLineComments(readFileSync(filePath, 'utf8'));
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        assert.doesNotMatch(
+          withoutComments,
+          pattern,
+          `${path.relative(frontendRoot, filePath)} must not match ${pattern}`,
+        );
+      }
+    }
+  });
+});

--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import { ProductBanner } from '@/src/app/components/product-banner';
+import { APP_STORE_HARDWARE_PRODUCT } from '@/src/constants/app-store-hardware-product';
 import { PRODUCT_INFO } from '@/src/app/components/product-banner/types';
 import { getAppById, getAppsByCategory } from '@/src/lib/api/apps';
 import envConfig from '@/src/constants/envConfig';
@@ -107,16 +108,16 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
       {
         '@context': 'https://schema.org',
         '@type': 'Product',
-        name: 'Omi',
-        description: 'AI-powered wearable. Real-time AI voice assistant.',
+        name: APP_STORE_HARDWARE_PRODUCT.name,
+        description: APP_STORE_HARDWARE_PRODUCT.description,
         brand: {
           '@type': 'Brand',
           name: 'OMI',
         },
         offers: {
           '@type': 'Offer',
-          price: '89',
-          priceCurrency: 'USD',
+          price: APP_STORE_HARDWARE_PRODUCT.schemaPrice,
+          priceCurrency: APP_STORE_HARDWARE_PRODUCT.currency,
           availability: 'https://schema.org/InStock',
           url: PRODUCT_INFO.url,
           priceValidUntil: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)

--- a/web/frontend/src/app/apps/utils/metadata.ts
+++ b/web/frontend/src/app/apps/utils/metadata.ts
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { APP_STORE_HARDWARE_PRODUCT } from '@/src/constants/app-store-hardware-product';
 import envConfig from '@/src/constants/envConfig';
 import { getCategoryMetadata as getUICategoryMetadata } from './category';
 
@@ -99,11 +100,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
 };
 
 const productInfo = {
-  name: 'Omi',
-  description: 'AI-powered wearable. Real-time AI voice assistant.',
-  price: '89',
-  currency: 'USD',
-  url: 'https://www.omi.me/',
+  name: APP_STORE_HARDWARE_PRODUCT.name,
+  description: APP_STORE_HARDWARE_PRODUCT.description,
+  price: APP_STORE_HARDWARE_PRODUCT.schemaPrice,
+  currency: APP_STORE_HARDWARE_PRODUCT.currency,
+  url: APP_STORE_HARDWARE_PRODUCT.storeUrl,
 };
 
 const appStoreInfo = {

--- a/web/frontend/src/app/components/product-banner/types.ts
+++ b/web/frontend/src/app/components/product-banner/types.ts
@@ -1,3 +1,5 @@
+import { APP_STORE_HARDWARE_PRODUCT } from '@/src/constants/app-store-hardware-product';
+
 export interface ProductBannerBase {
   className?: string;
   onClick?: () => void;
@@ -19,13 +21,9 @@ export interface CategoryBannerProps extends ProductBannerBase {
 }
 
 export const PRODUCT_INFO = {
-  name: 'Omi',
-  price: '$89',
-  // Canonical storefront (legacy omi-dev-kit-2 / friend-dev-kit-2 slugs redirect into the storefront).
-  url: 'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
-  shipping: 'Ships Worldwide',
-  images: {
-    primary: '/omi_1.webp',
-    secondary: '/omi_2.webp',
-  },
+  name: APP_STORE_HARDWARE_PRODUCT.name,
+  price: APP_STORE_HARDWARE_PRODUCT.displayPrice,
+  url: APP_STORE_HARDWARE_PRODUCT.marketplaceOrderUrl,
+  shipping: APP_STORE_HARDWARE_PRODUCT.shipping,
+  images: APP_STORE_HARDWARE_PRODUCT.images,
 } as const;

--- a/web/frontend/src/constants/app-store-hardware-product.ts
+++ b/web/frontend/src/constants/app-store-hardware-product.ts
@@ -1,0 +1,16 @@
+/** Canonical Omi hardware branding for h.omi.me app-store surfaces (banners, CTAs, JSON-LD). */
+export const APP_STORE_HARDWARE_PRODUCT = {
+  name: 'Omi',
+  displayPrice: '$89',
+  schemaPrice: '89',
+  currency: 'USD',
+  description: 'AI-powered wearable. Real-time AI voice assistant.',
+  storeUrl: 'https://www.omi.me/',
+  marketplaceOrderUrl:
+    'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
+  shipping: 'Ships Worldwide',
+  images: {
+    primary: '/omi_1.webp',
+    secondary: '/omi_2.webp',
+  },
+} as const;


### PR DESCRIPTION
## What changed and why

Fixes #5855. Upstream `main` already updated marketplace copy away from Duo Dev Kit / $69.99 (#7735, #11696), but name, price, and storefront URL still lived in three independent literals. This PR makes `APP_STORE_HARDWARE_PRODUCT` the single source of truth for h.omi.me app-store banners, SEO JSON-LD, and app-detail Product schema, and adds a node:test guard so discontinued branding or pricing cannot creep back onto those surfaces.

## Product invariants affected

none

## How it was verified

- `bash scripts/run-web-frontend-tests.sh` — full suite (89 tests on this branch; David noted ~74/76 with 2 failures pre-existing on `main`: `shared-conversation-chat-contract.test.mjs`, `wrapped-unlimited-deeplink-parity.test.mjs`).
- `.github/workflows/web-checks.yml` — **Frontend Lint** job now runs the same script on PRs when `web/frontend` (or the workflow) changes.
- `cd web/frontend && npm run lint` on touched TS/TSX files — clean.
- Confirmed on current `BasedHardware/omi` main: no `Duo Dev Kit`, `69.99`, or legacy dev-kit product hrefs under `web/frontend/src/app/apps/` or `product-banner/` before this change (values were already Omi / $89 / `https://www.omi.me/`).

## Tests

- Added `web/frontend/src/__tests__/app-store-hardware-product.test.mjs`: asserts canonical constants, import wiring, and forbids `Duo Dev Kit`, `$69.99`, and legacy product slugs in app-store source trees.

## Failure class (fixes)

Failure-Class: none