### PR TITLE
fix(plugins): bind mentor transcript buffer to authenticated uid

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -966,6 +966,12 @@ checks:
     lanes: ["local", "ci"]
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
+  - id: plugin-mentor-session-auth-tests
+    command: ["python3", "plugins/test_mentor_session_auth.py"]
+    triggers: ["plugins/basic/mentor.py", "plugins/basic/mentor_webhook_auth.py", "plugins/test_mentor_session_auth.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "POST /mentor trusted client session_id for the shared Redis transcript buffer without auth, so callers could read or poison another user's buffer"
+
 exempt:
   - path: ".github/scripts/check-desktop-beta-freshness.py"
     reason: "hourly doctor job hits the public beta appcast; behavioral coverage is desktop-beta-freshness-tests"

--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -967,8 +967,8 @@ checks:
     reason: "a 'hey omi' trigger segment without a comma dropped the entire spoken question; the next segment was answered instead"
 
   - id: plugin-mentor-session-auth-tests
-    command: ["python3", "plugins/test_mentor_session_auth.py"]
-    triggers: ["plugins/basic/mentor.py", "plugins/basic/mentor_webhook_auth.py", "plugins/test_mentor_session_auth.py", ".github/checks-manifest.yaml"]
+    command: ["bash", "scripts/run-plugin-mentor-session-auth-tests.sh"]
+    triggers: ["plugins/basic/mentor.py", "plugins/basic/mentor_webhook_auth.py", "plugins/test_mentor_session_auth.py", "scripts/run-plugin-mentor-session-auth-tests.sh", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "POST /mentor trusted client session_id for the shared Redis transcript buffer without auth, so callers could read or poison another user's buffer"
 

--- a/plugins/basic/mentor.py
+++ b/plugins/basic/mentor.py
@@ -1,7 +1,8 @@
 import re
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 
+from .mentor_webhook_auth import require_mentor_webhook_auth
 from models import TranscriptSegment, ProactiveNotificationEndpointResponse, RealtimePluginRequest
 from db import get_upsert_segment_to_transcript_plugin
 
@@ -20,20 +21,26 @@ scan_segment_session = {}
     response_model=ProactiveNotificationEndpointResponse,
     response_model_exclude_none=True,
 )
-def mentoring(data: RealtimePluginRequest):
+def mentoring(
+    data: RealtimePluginRequest,
+    uid: str = Depends(require_mentor_webhook_auth),
+):
     def normalize(text):
         return re.sub(r' +', ' ', re.sub(r'[,?.!]', ' ', text)).lower().strip()
 
-    session_id = data.session_id
-    segments = get_upsert_segment_to_transcript_plugin('mentor-01', session_id, data.segments)
-    if len(segments) <= len(data.segments) or session_id not in scan_segment_session:
-        scan_segment_session[session_id] = 0
-    scan_segment = scan_segment_session[session_id]
+    if data.session_id != uid:
+        raise HTTPException(status_code=403, detail='session_id must match uid')
+
+    buffer_id = uid
+    segments = get_upsert_segment_to_transcript_plugin('mentor-01', buffer_id, data.segments)
+    if len(segments) <= len(data.segments) or buffer_id not in scan_segment_session:
+        scan_segment_session[buffer_id] = 0
+    scan_segment = scan_segment_session[buffer_id]
 
     # 1. Detect codewords. You could either use a simple regexp or call LLMs to trigger the step 2.
     codewords = ['hey Omi what do you think']
     scan_segments = segments[scan_segment:]
-    print(session_id, "scan_segment", len(scan_segments), scan_segment)
+    print(buffer_id, "scan_segment", len(scan_segments), scan_segment)
     if len(scan_segments) == 0:
         return {}
     text_lower = normalize(" ".join([segment.text for segment in scan_segments]))
@@ -44,7 +51,7 @@ def mentoring(data: RealtimePluginRequest):
     # 2. Generate mentoring prompt
     # Omi will replace {{user_name}} in your prompt with the user's name
     # Omi will replace {{user_facts}} in your prompt  with the user's known facts.
-    scan_segment_session[session_id] = len(segments)
+    scan_segment_session[buffer_id] = len(segments)
     transcript = TranscriptSegment.segments_as_string(segments)
 
     user_name = "{{user_name}}"
@@ -97,7 +104,7 @@ def mentoring(data: RealtimePluginRequest):
     # 3. Respond with the format {notification: {prompt, params, context}}
     #   - context: {question, filters: {people, topics, entities}} | None
     return {
-        'session_id': data.session_id,
+        'session_id': uid,
         'notification': {
             'prompt': prompt,
             'params': ['user_name', 'user_facts', 'user_context', 'user_chat'],

--- a/plugins/basic/mentor_webhook_auth.py
+++ b/plugins/basic/mentor_webhook_auth.py
@@ -1,0 +1,43 @@
+import hmac
+import os
+
+from fastapi import HTTPException, Query, Request
+
+_MENTOR_WEBHOOK_SECRET_ENV = 'BASIC_MENTOR_WEBHOOK_SECRET'
+_QUERY_TOKEN_PARAM = 'mentor_webhook_token'
+
+
+def _configured_secret() -> str | None:
+    secret = os.getenv(_MENTOR_WEBHOOK_SECRET_ENV)
+    if secret is None:
+        return None
+    secret = secret.strip()
+    return secret or None
+
+
+def _presented_token(request: Request) -> str | None:
+    auth = request.headers.get('Authorization')
+    if auth and auth.startswith('Bearer '):
+        token = auth[7:].strip()
+        if token:
+            return token
+    query_token = request.query_params.get(_QUERY_TOKEN_PARAM)
+    if query_token and query_token.strip():
+        return query_token.strip()
+    return None
+
+
+def require_mentor_webhook_auth(
+    request: Request,
+    uid: str = Query(..., min_length=1),
+) -> str:
+    """Bind mentor realtime webhooks to an authenticated caller and explicit uid."""
+    secret = _configured_secret()
+    if secret is None:
+        raise HTTPException(status_code=503, detail='mentor webhook auth is not configured')
+
+    token = _presented_token(request)
+    if not token or not hmac.compare_digest(token, secret):
+        raise HTTPException(status_code=401, detail='unauthorized')
+
+    return uid.strip()

--- a/plugins/basic/mentor_webhook_auth.py
+++ b/plugins/basic/mentor_webhook_auth.py
@@ -17,10 +17,10 @@ def _configured_secret() -> str | None:
 
 def _presented_token(request: Request) -> str | None:
     auth = request.headers.get('Authorization')
-    if auth and auth.startswith('Bearer '):
-        token = auth[7:].strip()
-        if token:
-            return token
+    if auth:
+        scheme, _, credentials = auth.partition(' ')
+        if scheme.lower() == 'bearer' and credentials.strip():
+            return credentials.strip()
     query_token = request.query_params.get(_QUERY_TOKEN_PARAM)
     if query_token and query_token.strip():
         return query_token.strip()
@@ -40,4 +40,8 @@ def require_mentor_webhook_auth(
     if not token or not hmac.compare_digest(token, secret):
         raise HTTPException(status_code=401, detail='unauthorized')
 
-    return uid.strip()
+    trimmed_uid = uid.strip()
+    if not trimmed_uid:
+        raise HTTPException(status_code=422, detail='uid must not be empty')
+
+    return trimmed_uid

--- a/plugins/test_mentor_session_auth.py
+++ b/plugins/test_mentor_session_auth.py
@@ -160,6 +160,16 @@ class MentorSessionAuthTests(unittest.TestCase):
         else:
             os.environ['BASIC_MENTOR_WEBHOOK_SECRET'] = self._old_secret
 
+    def test_fails_closed_when_webhook_secret_unconfigured(self):
+        os.environ.pop('BASIC_MENTOR_WEBHOOK_SECRET', None)
+        response = self.client.post(
+            '/mentor?uid=user-a',
+            headers={'Authorization': f'Bearer {TEST_SECRET}'},
+            json={'session_id': 'user-a', 'segments': [_segment('hey Omi what do you think')]},
+        )
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(self.store.buffers, {})
+
     def test_unauthenticated_cross_session_write_is_blocked(self):
         response = self.client.post(
             '/mentor?uid=victim-uid',

--- a/plugins/test_mentor_session_auth.py
+++ b/plugins/test_mentor_session_auth.py
@@ -1,0 +1,209 @@
+"""Hermetic tests for mentor webhook session identity and auth (#13665)."""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+try:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except ModuleNotFoundError:
+    FastAPI = None
+    TestClient = None
+
+PLUGINS_ROOT = Path(__file__).resolve().parent
+TEST_SECRET = 'test-mentor-webhook-secret'
+
+
+def _make_transcript_segment_model():
+    from pydantic import BaseModel
+
+    class FakeTranscriptSegment(BaseModel):
+        text: str = ''
+        speaker: str = 'SPEAKER_00'
+        is_user: bool = True
+        start: float = 0.0
+        end: float = 0.0
+
+        def dict(self):
+            return self.model_dump()
+
+        @staticmethod
+        def segments_as_string(segments):
+            return '\n'.join(segment.text for segment in segments)
+
+    return FakeTranscriptSegment
+
+
+class _RecordingTranscriptStore:
+    def __init__(self):
+        self.buffers = {}
+
+    def upsert(self, plugin_id, buffer_id, new_segments):
+        key = f'{plugin_id}:{buffer_id}'
+        existing = list(self.buffers.get(key, []))
+        for segment in new_segments:
+            existing.append(segment.dict() if hasattr(segment, 'dict') else dict(segment))
+        self.buffers[key] = existing
+        segment_model = _make_transcript_segment_model()
+        return [segment_model(**segment) for segment in existing]
+
+
+def _load_mentor_app(*, transcript_store: _RecordingTranscriptStore):
+    fake_redis = types.ModuleType('redis')
+
+    class _FakeRedisClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_redis.Redis = _FakeRedisClient
+
+    saved = {name: sys.modules.get(name) for name in ('redis', 'db', 'basic', 'basic.mentor_webhook_auth', 'basic.mentor')}
+    sys.modules['redis'] = fake_redis
+    sys.path.insert(0, str(PLUGINS_ROOT))
+
+    basic_pkg = types.ModuleType('basic')
+    basic_pkg.__path__ = [str(PLUGINS_ROOT / 'basic')]
+    sys.modules['basic'] = basic_pkg
+
+    auth_spec = importlib.util.spec_from_file_location(
+        'basic.mentor_webhook_auth', PLUGINS_ROOT / 'basic' / 'mentor_webhook_auth.py'
+    )
+    auth_module = importlib.util.module_from_spec(auth_spec)
+    sys.modules['basic.mentor_webhook_auth'] = auth_module
+    auth_spec.loader.exec_module(auth_module)
+
+    from pydantic import BaseModel, Field
+    from typing import List
+
+    fake_segment = _make_transcript_segment_model()
+
+    fake_db = types.ModuleType('db')
+    fake_db.get_upsert_segment_to_transcript_plugin = transcript_store.upsert
+    sys.modules['db'] = fake_db
+
+    class RealtimePluginRequest(BaseModel):
+        session_id: str
+        segments: List[fake_segment]
+
+    class ProactiveNotificationResponse(BaseModel):
+        prompt: str = Field(default='')
+        params: List[str] = Field(default=[])
+
+    class ProactiveNotificationEndpointResponse(BaseModel):
+        message: str = Field(default='')
+        notification: ProactiveNotificationResponse | None = Field(default=None)
+
+    fake_models = types.ModuleType('models')
+    fake_models.TranscriptSegment = fake_segment
+    fake_models.RealtimePluginRequest = RealtimePluginRequest
+    fake_models.ProactiveNotificationEndpointResponse = ProactiveNotificationEndpointResponse
+    fake_models.ProactiveNotificationResponse = ProactiveNotificationResponse
+    sys.modules['models'] = fake_models
+
+    mentor_spec = importlib.util.spec_from_file_location(
+        'basic.mentor', PLUGINS_ROOT / 'basic' / 'mentor.py', submodule_search_locations=[str(PLUGINS_ROOT / 'basic')]
+    )
+    mentor_module = importlib.util.module_from_spec(mentor_spec)
+    sys.modules['basic.mentor'] = mentor_module
+    mentor_spec.loader.exec_module(mentor_module)
+
+    app = FastAPI()
+    app.include_router(mentor_module.router)
+    return app, mentor_module
+
+
+def _restore_modules(saved):
+    for name, module_value in saved.items():
+        if module_value is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module_value
+
+
+def _segment(text: str):
+    return {
+        'text': text,
+        'speaker': 'SPEAKER_00',
+        'is_user': True,
+        'start': 0.0,
+        'end': 1.0,
+    }
+
+
+@unittest.skipIf(TestClient is None, 'fastapi/httpx test dependencies are not installed')
+class MentorSessionAuthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._saved_modules = {name: sys.modules.get(name) for name in ('redis', 'db', 'basic', 'basic.mentor_webhook_auth', 'basic.mentor', 'models')}
+
+    @classmethod
+    def tearDownClass(cls):
+        _restore_modules(cls._saved_modules)
+        if str(PLUGINS_ROOT) in sys.path:
+            sys.path.remove(str(PLUGINS_ROOT))
+
+    def setUp(self):
+        self._old_secret = os.environ.get('BASIC_MENTOR_WEBHOOK_SECRET')
+        os.environ['BASIC_MENTOR_WEBHOOK_SECRET'] = TEST_SECRET
+        self.store = _RecordingTranscriptStore()
+        self.app, self.mentor_module = _load_mentor_app(transcript_store=self.store)
+        self.mentor_module.scan_segment_session.clear()
+        self.client = TestClient(self.app)
+
+    def tearDown(self):
+        if self._old_secret is None:
+            os.environ.pop('BASIC_MENTOR_WEBHOOK_SECRET', None)
+        else:
+            os.environ['BASIC_MENTOR_WEBHOOK_SECRET'] = self._old_secret
+
+    def test_unauthenticated_cross_session_write_is_blocked(self):
+        response = self.client.post(
+            '/mentor?uid=victim-uid',
+            json={'session_id': 'victim-uid', 'segments': [_segment('hey Omi what do you think poisoned')]},
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(self.store.buffers, {})
+
+    def test_session_id_must_match_authenticated_uid(self):
+        response = self.client.post(
+            '/mentor?uid=caller-uid',
+            headers={'Authorization': f'Bearer {TEST_SECRET}'},
+            json={'session_id': 'victim-uid', 'segments': [_segment('hey Omi what do you think')]},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.store.buffers, {})
+
+    def test_cross_session_read_is_blocked(self):
+        self.store.buffers['mentor-01:victim-uid'] = [_segment('victim secret hey Omi what do you think')]
+        response = self.client.post(
+            '/mentor?uid=attacker-uid',
+            headers={'Authorization': f'Bearer {TEST_SECRET}'},
+            json={'session_id': 'victim-uid', 'segments': [_segment('noise')]},
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn('notification', response.json())
+
+    def test_authenticated_matching_uid_can_write_and_read_own_buffer(self):
+        first = self.client.post(
+            '/mentor?uid=user-a&mentor_webhook_token=' + TEST_SECRET,
+            json={'session_id': 'user-a', 'segments': [_segment('planning a launch')]},
+        )
+        self.assertEqual(first.status_code, 200)
+
+        second = self.client.post(
+            '/mentor?uid=user-a&mentor_webhook_token=' + TEST_SECRET,
+            json={'session_id': 'user-a', 'segments': [_segment('hey Omi what do you think about timing')]},
+        )
+        self.assertEqual(second.status_code, 200)
+        body = second.json()
+        self.assertIn('notification', body)
+        self.assertIn('planning a launch', body['notification']['prompt'])
+        self.assertEqual(list(self.store.buffers.keys()), ['mentor-01:user-a'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/run-plugin-mentor-session-auth-tests.sh
+++ b/scripts/run-plugin-mentor-session-auth-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Hermetic mentor webhook auth tests need FastAPI TestClient (fastapi + httpx).
+# Hygiene runs manifest checks on stdlib Python only; install pinned deps here
+# so plugin-mentor-session-auth-tests executes instead of skipIf-vacuous green.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+python_version="$(tr -d '[:space:]' < "$repo_root/backend/.python-version")"
+test_file="$repo_root/plugins/test_mentor_session_auth.py"
+
+pinned_deps=(
+  "fastapi==0.121.0"
+  "httpx==0.28.1"
+  "pydantic==2.13.4"
+  "starlette==0.49.1"
+)
+
+run_with_uv() {
+  local -a with_args=()
+  for dep in "${pinned_deps[@]}"; do
+    with_args+=(--with "$dep")
+  done
+  uv run --no-project --python "$python_version" "${with_args[@]}" -- python "$test_file"
+}
+
+run_with_venv() {
+  local python_bin="$1"
+  if ! "$python_bin" -c "from fastapi.testclient import TestClient" 2>/dev/null; then
+    echo "FAIL: $python_bin lacks fastapi/httpx; install deps or use uv for plugin-mentor-session-auth-tests." >&2
+    exit 1
+  fi
+  "$python_bin" "$test_file"
+}
+
+if command -v uv >/dev/null 2>&1; then
+  run_with_uv
+  exit 0
+fi
+
+# shellcheck source=dev-harness/_resolve_python.sh
+source "$repo_root/scripts/dev-harness/_resolve_python.sh"
+if venv_python="$(dev_harness_canonical_python 2>/dev/null || true)" && [[ -n "$venv_python" ]]; then
+  run_with_venv "$venv_python"
+  exit 0
+fi
+
+echo "FAIL: plugin-mentor-session-auth-tests requires uv or backend/.venv with fastapi/httpx." >&2
+exit 1


### PR DESCRIPTION
Fixes #13665

## Problem

`POST /mentor` in `plugins/basic/mentor.py` used the client-supplied `session_id` as the sole Redis transcript-buffer identity. The route had no caller authentication, so anyone who knew (or guessed) another session id could read accumulated transcript text from the returned mentor prompt and append poison segments into that buffer.

## Fix

- Require `BASIC_MENTOR_WEBHOOK_SECRET` on the plugins service. Callers must present it via `Authorization: Bearer …` or the `mentor_webhook_token` query param (so the Omi realtime webhook URL can carry `?mentor_webhook_token=…&uid=…` as backend already appends `uid`).
- Require `uid` query param and reject requests where `session_id != uid`.
- Key Redis transcript buffers and in-process scan state by authenticated `uid`, not an unbound client `session_id`.

## Deploy note

After merge, set `BASIC_MENTOR_WEBHOOK_SECRET` on the Cloud Run **plugins** service and add `mentor_webhook_token=<same value>` to the Omi Mentor app webhook URL in the app store config. Until both are set, `/mentor` returns 503 (fail closed).

## Tests

- `python3 plugins/test_mentor_session_auth.py` — hermetic FastAPI tests (no Redis): unauthenticated write blocked, cross-session read/write blocked (403), authenticated matching uid succeeds.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

