### PR TITLE
fix(ci): shell-comparable JSON boolean for Agent VM SHA reuse guard

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -17,6 +18,47 @@ def _ordered(text: str, fragments: tuple[str, ...], *, workflow: str) -> list[st
     if locations != sorted(locations):
         return [f"{workflow}: release steps are not ordered as {fragments!r}"]
     return []
+
+
+_BROKEN_REUSE_EXTRACT = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
+_SHELL_SAFE_JSON_DUMPS_REUSE = 'json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
+_REUSE_COMPARES_TO_JSON_TRUE = re.compile(
+    r'\[\[\s*(?:["\']?\$\{reuse\}|["\']?\$reuse["\']?)\s*==\s*["\']true["\']\s*\]\]',
+)
+_AGENT_VM_RESOLVER = "resolve_agent_vm_sha_release.py"
+
+
+def _agent_vm_resolver_step_contexts(text: str) -> list[str]:
+    """Return workflow step blocks that invoke the SHA-keyed Agent VM resolver."""
+    contexts: list[str] = []
+    start = 0
+    while True:
+        idx = text.find(_AGENT_VM_RESOLVER, start)
+        if idx < 0:
+            break
+        block_start = text.rfind("\n      - ", 0, idx)
+        if block_start < 0:
+            block_start = 0
+        block_end = text.find("\n      - ", idx)
+        if block_end < 0:
+            block_end = len(text)
+        contexts.append(text[block_start:block_end])
+        start = idx + len(_AGENT_VM_RESOLVER)
+    return contexts
+
+
+def _context_has_shell_safe_reuse_extract(context: str) -> bool:
+    if _SHELL_SAFE_JSON_DUMPS_REUSE in context and "reuse=" in context:
+        return True
+    if "reuse=" not in context:
+        return False
+    return bool(
+        re.search(
+            r'reuse\s*=\s*"\$\([^)]*workflow_json_field_for_shell\.py[^)]*\breuse\b',
+            context,
+            flags=re.DOTALL,
+        )
+    )
 
 
 def _step_block(text: str, name: str) -> str | None:
@@ -181,20 +223,16 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         if fragment not in text:
             errors.append(f"{workflow}: missing release boundary {fragment!r}")
 
-    broken_reuse_extract = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
-    if broken_reuse_extract in text:
-        errors.append(
-            f"{workflow}: Agent VM SHA reuse guard must not print a JSON boolean with Python repr "
-            '(use json.dumps or .github/scripts/workflow_json_field_for_shell.py)'
-        )
-    if 'if [[ "$reuse" == "true" ]]' in text and "resolve_agent_vm_sha_release.py" in text:
-        shell_safe_reuse = (
-            'json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])',
-            "workflow_json_field_for_shell.py",
-        )
-        if not any(marker in text for marker in shell_safe_reuse):
+    for context in _agent_vm_resolver_step_contexts(text):
+        if _BROKEN_REUSE_EXTRACT in context:
             errors.append(
-                f"{workflow}: reuse branch compares to JSON true but no shell-safe reuse extraction is present"
+                f"{workflow}: Agent VM SHA reuse guard must not print a JSON boolean with Python repr "
+                '(use json.dumps or .github/scripts/workflow_json_field_for_shell.py)'
+            )
+        if _REUSE_COMPARES_TO_JSON_TRUE.search(context) and not _context_has_shell_safe_reuse_extract(context):
+            errors.append(
+                f"{workflow}: reuse branch compares to JSON true but no shell-safe reuse extraction is present "
+                "in the Agent VM resolver step"
             )
 
     # Bound to the step, not to the file. attach_cloud_run_gmp_sidecar.py made

--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -181,6 +181,22 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
         if fragment not in text:
             errors.append(f"{workflow}: missing release boundary {fragment!r}")
 
+    broken_reuse_extract = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
+    if broken_reuse_extract in text:
+        errors.append(
+            f"{workflow}: Agent VM SHA reuse guard must not print a JSON boolean with Python repr "
+            '(use json.dumps or .github/scripts/workflow_json_field_for_shell.py)'
+        )
+    if 'if [[ "$reuse" == "true" ]]' in text and "resolve_agent_vm_sha_release.py" in text:
+        shell_safe_reuse = (
+            'json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])',
+            "workflow_json_field_for_shell.py",
+        )
+        if not any(marker in text for marker in shell_safe_reuse):
+            errors.append(
+                f"{workflow}: reuse branch compares to JSON true but no shell-safe reuse extraction is present"
+            )
+
     # Bound to the step, not to the file. attach_cloud_run_gmp_sidecar.py made
     # --expected-env-state required and only the backend caller was updated;
     # argparse exits before the attach runs, so both desktop deploy paths failed

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -596,6 +596,21 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
                     self.assertNotEqual(result.returncode, 0)
                     self.assertIn("expected exactly one desktop-backend-1 container image", result.stderr)
 
+    def test_agent_vm_sha_reuse_guard_rejects_python_repr_boolean(self) -> None:
+        broken = (
+            "resolve_agent_vm_sha_release.py\n"
+            'reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
+            '"$RUNNER_TEMP/agent-vm-sha-release.json")"\n'
+            'if [[ "$reuse" == "true" ]]; then\n'
+        )
+        errors = POLICY.validate_deploy_workflow(broken, production=False)
+        self.assertTrue(any("Python repr" in error for error in errors))
+
+    def test_live_desktop_backend_workflows_do_not_use_python_repr_reuse_extract(self) -> None:
+        broken = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
+        self.assertNotIn(broken, self.dev)
+        self.assertNotIn(broken, self.prod)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_check_desktop_backend_release_policy.py
+++ b/.github/scripts/test_check_desktop_backend_release_policy.py
@@ -598,13 +598,71 @@ class DesktopBackendReleasePolicyTests(unittest.TestCase):
 
     def test_agent_vm_sha_reuse_guard_rejects_python_repr_boolean(self) -> None:
         broken = (
-            "resolve_agent_vm_sha_release.py\n"
-            'reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
+            "      - name: Resolve Agent VM SHA release\n"
+            "        run: |\n"
+            "          python backend/scripts/resolve_agent_vm_sha_release.py\n"
+            '          reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
             '"$RUNNER_TEMP/agent-vm-sha-release.json")"\n'
-            'if [[ "$reuse" == "true" ]]; then\n'
+            '          if [[ "$reuse" == "true" ]]; then\n'
         )
         errors = POLICY.validate_deploy_workflow(broken, production=False)
         self.assertTrue(any("Python repr" in error for error in errors))
+
+    def test_agent_vm_sha_reuse_guard_catches_dollar_brace_reuse_compare(self) -> None:
+        broken = (
+            "      - name: Resolve Agent VM SHA release\n"
+            "        run: |\n"
+            "          python backend/scripts/resolve_agent_vm_sha_release.py\n"
+            '          reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
+            '"$RUNNER_TEMP/agent-vm-sha-release.json")"\n'
+            '          if [[ "${reuse}" == "true" ]]; then\n'
+        )
+        errors = POLICY.validate_deploy_workflow(broken, production=False)
+        self.assertTrue(any("Python repr" in error for error in errors))
+
+    def test_agent_vm_sha_reuse_guard_rejects_unrelated_helper_mention(self) -> None:
+        broken = (
+            "      - name: Other step\n"
+            "        run: python .github/scripts/workflow_json_field_for_shell.py\n"
+            "      - name: Resolve Agent VM SHA release\n"
+            "        run: |\n"
+            "          python backend/scripts/resolve_agent_vm_sha_release.py\n"
+            '          reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
+            '"$RUNNER_TEMP/agent-vm-sha-release.json")"\n'
+            '          if [[ "$reuse" == "true" ]]; then\n'
+        )
+        errors = POLICY.validate_deploy_workflow(broken, production=False)
+        self.assertTrue(any("Python repr" in error for error in errors))
+        self.assertTrue(any("shell-safe reuse extraction" in error for error in errors))
+
+    def _agent_vm_resolver_step(self, *, reuse_extract: str, reuse_compare: str = 'if [[ "$reuse" == "true" ]]; then') -> str:
+        return (
+            "      - name: Resolve Agent VM SHA release\n"
+            "        run: |\n"
+            "          python backend/scripts/resolve_agent_vm_sha_release.py\n"
+            f"          {reuse_extract}\n"
+            f"          {reuse_compare}\n"
+        )
+
+    def test_agent_vm_sha_reuse_guard_accepts_json_dumps_extract(self) -> None:
+        snippet = (
+            'reuse="$(python3 -c \'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"]))\' '
+            '"$RUNNER_TEMP/agent-vm-sha-release.json")"'
+        )
+        text = self._agent_vm_resolver_step(reuse_extract=snippet)
+        errors = POLICY.validate_deploy_workflow(text, production=False)
+        reuse_errors = [error for error in errors if "reuse" in error.lower() or "Python repr" in error]
+        self.assertEqual(reuse_errors, [])
+
+    def test_agent_vm_sha_reuse_guard_accepts_workflow_json_field_helper(self) -> None:
+        snippet = (
+            'reuse="$(python3 .github/scripts/workflow_json_field_for_shell.py '
+            '"$RUNNER_TEMP/agent-vm-sha-release.json" reuse)"'
+        )
+        text = self._agent_vm_resolver_step(reuse_extract=snippet)
+        errors = POLICY.validate_deploy_workflow(text, production=False)
+        reuse_errors = [error for error in errors if "reuse" in error.lower() or "Python repr" in error]
+        self.assertEqual(reuse_errors, [])
 
     def test_live_desktop_backend_workflows_do_not_use_python_repr_reuse_extract(self) -> None:
         broken = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'

--- a/.github/scripts/workflow_json_field_for_shell.py
+++ b/.github/scripts/workflow_json_field_for_shell.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Emit a JSON document field as a shell-comparable token.
+
+Workflows must not use ``print(json.load(...)["field"])`` for booleans: Python
+prints ``True``/``False``, which never matches ``[[ "$value" == "true" ]]``.
+``json.dumps`` preserves JSON literals (``true``/``false``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: workflow_json_field_for_shell.py <json-path> <field-name>", file=sys.stderr)
+        return 2
+    path, field = sys.argv[1], sys.argv[2]
+    document = json.load(open(path, encoding="utf-8"))
+    if field not in document:
+        print(f"missing field {field!r} in {path}", file=sys.stderr)
+        return 1
+    print(json.dumps(document[field]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/workflow_json_field_for_shell.py
+++ b/.github/scripts/workflow_json_field_for_shell.py
@@ -17,11 +17,20 @@ def main() -> int:
         print("usage: workflow_json_field_for_shell.py <json-path> <field-name>", file=sys.stderr)
         return 2
     path, field = sys.argv[1], sys.argv[2]
-    document = json.load(open(path, encoding="utf-8"))
+    with open(path, encoding="utf-8") as json_file:
+        document = json.load(json_file)
     if field not in document:
         print(f"missing field {field!r} in {path}", file=sys.stderr)
         return 1
-    print(json.dumps(document[field]))
+    value = document[field]
+    if type(value) not in (bool, int, float, type(None)):
+        print(
+            f"field {field!r} in {path} must be a JSON boolean, number, or null for shell comparison "
+            f"(got {type(value).__name__})",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(value))
     return 0
 
 

--- a/backend/scripts/resolve_agent_vm_sha_release.py
+++ b/backend/scripts/resolve_agent_vm_sha_release.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Decide whether a source-SHA Agent VM release already exists and must be reused.
+
+Protected prod workflow 32012710785 rebuilt the same source SHA with a new
+image digest, then ``gcloud storage cp --no-clobber`` kept the prior
+``startup.sh`` and ``cmp`` failed. The SHA-keyed object is the immutable
+release; reruns must adopt its digest instead of publishing a competing one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+IMAGE_DIGEST = re.compile(r'^.+@sha256:[0-9a-f]{64}$')
+SOURCE_SHA = re.compile(r'^[0-9a-f]{40}$')
+STARTUP_DIGEST = re.compile(r'^image_digest="([^"]+@sha256:[0-9a-f]{64})"$', re.MULTILINE)
+INCIDENT = (
+    'SCA-323 / workflow 32012710785: a same-SHA Agent VM rebuild produced a new '
+    'digest, --no-clobber kept the existing startup.sh, and cmp failed.'
+)
+
+GcloudRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+class ResolveError(Exception):
+    """A deterministic SHA-keyed release resolution failure."""
+
+
+@dataclass(frozen=True)
+class ShaReleasePlan:
+    reuse: bool
+    image_digest: str | None = None
+    boot_image: str | None = None
+    startup_present: bool = False
+    manifest_present: bool = False
+    reason: str = ''
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            'reuse': self.reuse,
+            'image_digest': self.image_digest,
+            'boot_image': self.boot_image,
+            'startup_present': self.startup_present,
+            'manifest_present': self.manifest_present,
+            'reason': self.reason,
+        }
+
+
+def _run_gcloud(args: Sequence[str], *, runner: GcloudRunner | None = None) -> subprocess.CompletedProcess[str]:
+    command = ['gcloud', *args]
+    if runner is not None:
+        return runner(command)
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def _fail(message: str) -> None:
+    raise ResolveError(f'{message} {INCIDENT}')
+
+
+def object_exists(uri: str, *, runner: GcloudRunner | None = None) -> bool:
+    result = _run_gcloud(['storage', 'objects', 'describe', uri], runner=runner)
+    return result.returncode == 0
+
+
+def download_text(uri: str, destination: Path, *, runner: GcloudRunner | None = None) -> str:
+    result = _run_gcloud(['storage', 'cp', uri, str(destination)], runner=runner)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or '').strip() or f'exit {result.returncode}'
+        _fail(f'could not read immutable Agent VM object {uri} ({detail}).')
+    return destination.read_text(encoding='utf-8')
+
+
+def digest_from_startup(startup: str) -> str:
+    match = STARTUP_DIGEST.search(startup)
+    if match is None or not IMAGE_DIGEST.fullmatch(match.group(1)):
+        _fail(
+            'existing SHA-keyed startup.sh does not embed an immutable image_digest; refusing to rebuild a competing digest.'
+        )
+    return match.group(1)
+
+
+def plan_from_existing(
+    *,
+    startup: str | None,
+    manifest_text: str | None,
+    expected_source_sha: str,
+) -> ShaReleasePlan:
+    if not SOURCE_SHA.fullmatch(expected_source_sha):
+        _fail(f'source SHA {expected_source_sha!r} is not a lowercase 40-character SHA.')
+    if manifest_text is None and startup is None:
+        return ShaReleasePlan(reuse=False, reason='no SHA-keyed Agent VM artifacts exist yet')
+    if manifest_text is None:
+        digest = digest_from_startup(startup or '')
+        return ShaReleasePlan(
+            reuse=True,
+            image_digest=digest,
+            boot_image=None,
+            startup_present=True,
+            manifest_present=False,
+            reason='existing SHA-keyed startup.sh; reuse its digest and do not rebuild a competing image',
+        )
+    if startup is None:
+        _fail('SHA-keyed manifest.json exists without startup.sh; the release pair is inconsistent.')
+    try:
+        manifest = json.loads(manifest_text)
+    except json.JSONDecodeError as exc:
+        _fail(f'SHA-keyed manifest.json is not JSON: {exc}.')
+    if not isinstance(manifest, Mapping):
+        _fail('SHA-keyed manifest.json must be an object.')
+    source_sha = str(manifest.get('sourceSha') or '')
+    if source_sha != expected_source_sha:
+        _fail(f'SHA-keyed manifest sourceSha {source_sha!r} does not match {expected_source_sha!r}.')
+    digest = str(manifest.get('imageDigest') or '')
+    if not IMAGE_DIGEST.fullmatch(digest):
+        _fail('SHA-keyed manifest.json is missing an immutable imageDigest.')
+    startup_digest = digest_from_startup(startup)
+    if startup_digest != digest:
+        _fail(
+            f'SHA-keyed startup.sh digest {startup_digest} does not match manifest imageDigest {digest}; '
+            'refusing to invent a third digest.'
+        )
+    boot_image = str(manifest.get('bootImage') or '').strip() or None
+    return ShaReleasePlan(
+        reuse=True,
+        image_digest=digest,
+        boot_image=boot_image,
+        startup_present=True,
+        manifest_present=True,
+        reason='existing SHA-keyed manifest and startup.sh; reuse that digest',
+    )
+
+
+def resolve_sha_release(
+    *,
+    startup_uri: str,
+    manifest_uri: str,
+    expected_source_sha: str,
+    workdir: Path,
+    runner: GcloudRunner | None = None,
+) -> ShaReleasePlan:
+    startup_present = object_exists(startup_uri, runner=runner)
+    manifest_present = object_exists(manifest_uri, runner=runner)
+    startup = download_text(startup_uri, workdir / 'startup.sh', runner=runner) if startup_present else None
+    manifest_text = download_text(manifest_uri, workdir / 'manifest.json', runner=runner) if manifest_present else None
+    return plan_from_existing(
+        startup=startup,
+        manifest_text=manifest_text,
+        expected_source_sha=expected_source_sha,
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    command = argparse.ArgumentParser(description=__doc__)
+    command.add_argument('--startup-uri', required=True)
+    command.add_argument('--manifest-uri', required=True)
+    command.add_argument('--expected-source-sha', required=True)
+    command.add_argument('--workdir', type=Path, required=True)
+    command.add_argument('--output', type=Path)
+    return command
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        args.workdir.mkdir(parents=True, exist_ok=True)
+        plan = resolve_sha_release(
+            startup_uri=args.startup_uri,
+            manifest_uri=args.manifest_uri,
+            expected_source_sha=args.expected_source_sha,
+            workdir=args.workdir,
+        )
+    except ResolveError as exc:
+        print(f'ERROR: {exc}', file=sys.stderr)
+        return 1
+    payload = json.dumps(plan.as_dict(), indent=2, sort_keys=True) + '\n'
+    if args.output is not None:
+        args.output.write_text(payload, encoding='utf-8')
+    sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/scripts/resolve_agent_vm_sha_release.py
+++ b/backend/scripts/resolve_agent_vm_sha_release.py
@@ -66,7 +66,14 @@ def _fail(message: str) -> None:
 
 def object_exists(uri: str, *, runner: GcloudRunner | None = None) -> bool:
     result = _run_gcloud(['storage', 'objects', 'describe', uri], runner=runner)
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    detail = (result.stderr or result.stdout or '').strip() or f'exit {result.returncode}'
+    detail_upper = detail.upper()
+    if '404' in detail or 'NOT_FOUND' in detail_upper or 'not found' in detail.lower():
+        return False
+    _fail(f'could not inspect immutable Agent VM object {uri} ({detail}).')
+    return False  # unreachable; keeps type checkers satisfied after _fail
 
 
 def download_text(uri: str, destination: Path, *, runner: GcloudRunner | None = None) -> str:

--- a/backend/tests/unit/test_resolve_agent_vm_sha_release.py
+++ b/backend/tests/unit/test_resolve_agent_vm_sha_release.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -120,6 +121,16 @@ def test_startup_and_manifest_digest_mismatch_fails_closed():
         )
 
 
+def test_object_exists_fails_closed_on_non_not_found_errors():
+    resolve = load_resolve()
+
+    def deny_access(_command: list[str]) -> SimpleNamespace:
+        return SimpleNamespace(returncode=1, stdout='', stderr='PERMISSION_DENIED: access denied')
+
+    with pytest.raises(resolve.ResolveError, match='could not inspect'):
+        resolve.object_exists('gs://bucket/object', runner=deny_access)
+
+
 def test_live_resolve_reuses_existing_objects(tmp_path: Path):
     resolve = load_resolve()
     startup_uri = f'gs://based-hardware-agent/agent-vm/releases/{SOURCE_SHA}/startup.sh'
@@ -156,7 +167,7 @@ HELPER_REUSE_SHELL = 'reuse="$(python3 "$REPO/.github/scripts/workflow_json_fiel
 def _reuse_branch_taken(*, extract_snippet: str, plan_path: Path) -> bool:
     script = f"""
 set -euo pipefail
-PLAN="{plan_path}"
+PLAN={shlex.quote(str(plan_path))}
 {extract_snippet}
 if [[ "$reuse" == "true" ]]; then
   echo reuse-branch

--- a/backend/tests/unit/test_resolve_agent_vm_sha_release.py
+++ b/backend/tests/unit/test_resolve_agent_vm_sha_release.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+REPO_DIR = BACKEND_DIR.parent
+SCRIPT = BACKEND_DIR / 'scripts' / 'resolve_agent_vm_sha_release.py'
+SOURCE_SHA = '99dbbb26c18efdb3b896aba3eb91d66302ba008f'
+DIGEST_A = 'gcr.io/based-hardware/agent-vm@sha256:' + 'a' * 64
+DIGEST_B = 'gcr.io/based-hardware/agent-vm@sha256:' + 'b' * 64
+BOOT_IMAGE = 'projects/based-hardware/global/images/omi-agent-20260805'
+
+
+def load_resolve():
+    spec = importlib.util.spec_from_file_location('resolve_agent_vm_sha_release', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def startup_for(digest: str) -> str:
+    return f'image="{digest}"\nimage_digest="{digest}"\n'
+
+
+def manifest_for(digest: str, *, source_sha: str = SOURCE_SHA) -> str:
+    return json.dumps(
+        {
+            'schemaVersion': 1,
+            'environment': 'production',
+            'sourceSha': source_sha,
+            'imageDigest': digest,
+            'startupUri': f'gs://based-hardware-agent/agent-vm/releases/{source_sha}/startup.sh',
+            'startupSha256': 'c' * 64,
+            'bootImage': BOOT_IMAGE,
+            'serviceAccount': 'omi-agent-vm-bootstrap@based-hardware.iam.gserviceaccount.com',
+        }
+    )
+
+
+class FakeGcloud:
+    def __init__(self, objects: dict[str, str]) -> None:
+        self.objects = objects
+        self.commands: list[list[str]] = []
+
+    def __call__(self, command: list[str]) -> SimpleNamespace:
+        self.commands.append(command)
+        if command[1:4] == ['storage', 'objects', 'describe']:
+            uri = command[4]
+            if uri in self.objects:
+                return SimpleNamespace(returncode=0, stdout='present\n', stderr='')
+            return SimpleNamespace(returncode=1, stdout='', stderr='NOT_FOUND')
+        if command[1:3] == ['storage', 'cp']:
+            uri, dest = command[3], command[4]
+            if uri not in self.objects:
+                return SimpleNamespace(returncode=1, stdout='', stderr='NOT_FOUND')
+            Path(dest).write_text(self.objects[uri], encoding='utf-8')
+            return SimpleNamespace(returncode=0, stdout='', stderr='')
+        raise AssertionError(f'unexpected gcloud command: {command}')
+
+
+def test_missing_artifacts_allow_a_first_publish():
+    resolve = load_resolve()
+    plan = resolve.plan_from_existing(startup=None, manifest_text=None, expected_source_sha=SOURCE_SHA)
+    assert plan.reuse is False
+    assert plan.image_digest is None
+
+
+def test_existing_manifest_and_startup_reuse_that_digest():
+    resolve = load_resolve()
+    plan = resolve.plan_from_existing(
+        startup=startup_for(DIGEST_A),
+        manifest_text=manifest_for(DIGEST_A),
+        expected_source_sha=SOURCE_SHA,
+    )
+    assert plan.reuse is True
+    assert plan.image_digest == DIGEST_A
+    assert plan.boot_image == BOOT_IMAGE
+    assert '32012710785' in resolve.INCIDENT
+
+
+def test_orphan_startup_reuses_embedded_digest_without_a_competing_rebuild():
+    resolve = load_resolve()
+    plan = resolve.plan_from_existing(
+        startup=startup_for(DIGEST_A),
+        manifest_text=None,
+        expected_source_sha=SOURCE_SHA,
+    )
+    assert plan.reuse is True
+    assert plan.image_digest == DIGEST_A
+    assert plan.boot_image is None
+    assert plan.manifest_present is False
+
+
+def test_manifest_without_startup_fails_closed():
+    resolve = load_resolve()
+    with pytest.raises(resolve.ResolveError, match='inconsistent'):
+        resolve.plan_from_existing(
+            startup=None,
+            manifest_text=manifest_for(DIGEST_A),
+            expected_source_sha=SOURCE_SHA,
+        )
+
+
+def test_startup_and_manifest_digest_mismatch_fails_closed():
+    resolve = load_resolve()
+    with pytest.raises(resolve.ResolveError, match='does not match manifest'):
+        resolve.plan_from_existing(
+            startup=startup_for(DIGEST_A),
+            manifest_text=manifest_for(DIGEST_B),
+            expected_source_sha=SOURCE_SHA,
+        )
+
+
+def test_live_resolve_reuses_existing_objects(tmp_path: Path):
+    resolve = load_resolve()
+    startup_uri = f'gs://based-hardware-agent/agent-vm/releases/{SOURCE_SHA}/startup.sh'
+    manifest_uri = f'gs://based-hardware-agent/agent-vm/releases/{SOURCE_SHA}/manifest.json'
+    runner = FakeGcloud(
+        {
+            startup_uri: startup_for(DIGEST_A),
+            manifest_uri: manifest_for(DIGEST_A),
+        }
+    )
+    plan = resolve.resolve_sha_release(
+        startup_uri=startup_uri,
+        manifest_uri=manifest_uri,
+        expected_source_sha=SOURCE_SHA,
+        workdir=tmp_path,
+        runner=runner,
+    )
+    assert plan.reuse is True
+    assert plan.image_digest == DIGEST_A
+    assert any(command[1:4] == ['storage', 'objects', 'describe'] for command in runner.commands)
+
+
+BROKEN_REUSE_SHELL = (
+    'reuse="$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])\' '
+    '"$PLAN")"'
+)
+FIXED_REUSE_SHELL = (
+    'reuse="$(python3 -c \'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"]))\' '
+    '"$PLAN")"'
+)
+HELPER_REUSE_SHELL = 'reuse="$(python3 "$REPO/.github/scripts/workflow_json_field_for_shell.py" "$PLAN" reuse)"'
+
+
+def _reuse_branch_taken(*, extract_snippet: str, plan_path: Path) -> bool:
+    script = f"""
+set -euo pipefail
+PLAN="{plan_path}"
+{extract_snippet}
+if [[ "$reuse" == "true" ]]; then
+  echo reuse-branch
+else
+  echo rebuild-branch
+fi
+"""
+    completed = subprocess.run(['bash', '-c', script], capture_output=True, text=True, check=True)
+    return completed.stdout.strip() == 'reuse-branch'
+
+
+def test_workflow_reuse_shell_contract_takes_reuse_branch_when_resolver_reuses(tmp_path: Path):
+    resolve = load_resolve()
+    plan_path = tmp_path / 'agent-vm-sha-release.json'
+    plan_path.write_text(
+        json.dumps(
+            {
+                'reuse': True,
+                'image_digest': DIGEST_A,
+                'boot_image': BOOT_IMAGE,
+                'manifest_present': True,
+                'startup_present': True,
+                'reason': 'existing SHA-keyed manifest and startup.sh; reuse that digest',
+            }
+        ),
+        encoding='utf-8',
+    )
+    assert not _reuse_branch_taken(extract_snippet=BROKEN_REUSE_SHELL, plan_path=plan_path)
+    assert _reuse_branch_taken(extract_snippet=FIXED_REUSE_SHELL, plan_path=plan_path)
+    helper_snippet = HELPER_REUSE_SHELL.replace('$REPO', str(REPO_DIR))
+    assert _reuse_branch_taken(extract_snippet=helper_snippet, plan_path=plan_path)
+    assert '32012710785' in resolve.INCIDENT
+
+
+def test_desktop_backend_workflows_do_not_use_python_repr_for_reuse_boolean():
+    broken = 'print(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"])'
+    for workflow_name in ('desktop_backend_prod.yml', 'desktop_backend_auto_dev.yml'):
+        text = (REPO_DIR / '.github/workflows' / workflow_name).read_text(encoding='utf-8')
+        assert broken not in text


### PR DESCRIPTION
Fixes #11758

## Investigation

- Confirmed **no open PR** references #11758.
- On current `main` (`bc37c8a76a`), neither `.github/workflows/desktop_backend_auto_dev.yml` nor `.github/workflows/desktop_backend_prod.yml` contains the `reuse="$(python3 -c '…print(json.load…["reuse"])…')"` snippet. Cloud Agent VM deploy steps were removed in #11795; the bug existed on `4f8da45f8747` (issue evidence) through that retirement.
- The failure mode remains real whenever that shell contract is reintroduced: `print()` on a JSON boolean emits Python `True`, which never matches `[[ "$reuse" == "true" ]]`.

## Fix

- Add `.github/scripts/workflow_json_field_for_shell.py` to emit JSON fields with `json.dumps` for shell comparisons.
- Restore `backend/scripts/resolve_agent_vm_sha_release.py` and extend `backend/tests/unit/test_resolve_agent_vm_sha_release.py` with a **behavioral** regression that runs the workflow one-liners in bash against resolver-shaped output:
  - broken `print(json.load…["reuse"])` → rebuild branch
  - fixed `print(json.dumps(json.load…["reuse"]))` and the helper → reuse branch
- Ratchet `check-desktop-backend-release-policy.py` to reject the Python-repr reuse extract when Agent VM resolver steps are present.

**If Agent VM deploy steps are restored**, both desktop-backend workflows must use one of:

```bash
reuse="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8"))["reuse"]))' "$RUNNER_TEMP/agent-vm-sha-release.json")"
```

or:

```bash
reuse="$(python3 .github/scripts/workflow_json_field_for_shell.py "$RUNNER_TEMP/agent-vm-sha-release.json" reuse)"
```

## Verification

```bash
backend/.venv/bin/python -m pytest backend/tests/unit/test_resolve_agent_vm_sha_release.py -v
python3 .github/scripts/check-desktop-backend-release-policy.py
python3 .github/scripts/test_check_desktop_backend_release_policy.py
```

All passed locally (8 pytest cases; 32 policy unittest cases).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/13686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

