### PR TITLE
docs(hardware): add speaker upgrade & audio output mod guide

### DIFF
--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.532",
+      "date": "2026-06-25",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.530",
       "date": "2026-06-25",
       "changes": [


### PR DESCRIPTION
## Description

Standalone, docs-only PR adding a hardware modification guide for upgrading the Omi buzzer to a dynamic micro-speaker and I2S Class-D amplifier for AI speech output.

### Changes:
- **`docs/doc/hardware/SpeakerMod.mdx`**:
  - Explains buzzer frequency resonance vs. linear voice reproduction and nRF5340 GPIO current limits.
  - Recommended BOM: `MAX98357A` I2S Mono Class-D amplifier + `1511` (15x11mm, 8Ω/1W) or 10–12mm micro-speaker.
  - Pinout and schematic wiring diagram for nRF5340 I2S lines (`BCLK`, `LRCLK`, `DOUT`) and power.
  - Devicetree overlay using modern Zephyr / nRF Connect SDK `pinctrl` (`&pinctrl` / `&i2s0`) and `prj.conf` flags.
  - Enclosure acoustic porting and gasket sealing recommendations.

*Note: Clean standalone PR with no app/workspace modifications.*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/15073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

